### PR TITLE
feat(scan): wire CEL ValidatingAdmissionPolicy evaluation into the scan pipeline

### DIFF
--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -18,35 +18,26 @@ type ControlEvaluation struct {
 }
 
 // EvaluateControl loads the ValidatingAdmissionPolicy for a control from the
-// embedded bundle, checks the object is in the policy's scope, resolves params,
-// and evaluates the validations against the object.
-//
-// It is the single entry point the scanner (package opaprocessor) dispatches
-// through: loadVAP and resolveParams are unexported, so the scan path cannot
-// assemble a control evaluation itself. controlID is threaded down from the
-// scanner (processControl), never read off the rule.
-//
-// namespaceObject is the object's Namespace (nil for cluster-scoped resources
-// or when the scan did not capture it). params come from the embedded bundle
-// via resolveParams, matching what a live binding's ParamRef would supply.
-//
-// A control the offline engine cannot honor with scan/admission parity (e.g.
-// one narrowed by a namespaceSelector) is refused by loadVAP and surfaces here
-// as an error. The scanner maps that to a skipped status, never a silent pass.
-// An object outside the policy's matchConstraints returns Applicable=false
-// rather than an error, since it is a normal not-matched case, not a failure —
-// and so does an object a matchCondition gates out (see matchConditionsGate).
+// embedded bundle, checks the object is in the policy's scope, resolves the
+// bundled params, and evaluates the validations against the object.
 func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, namespaceObject map[string]any) (ControlEvaluation, error) {
 	vap, err := loadVAP(controlID)
 	if err != nil {
 		return ControlEvaluation{}, err
 	}
-	if !vap.appliesTo(obj) {
-		return ControlEvaluation{Applicable: false}, nil
-	}
 	params, err := resolveParams(vap)
 	if err != nil {
 		return ControlEvaluation{}, err
+	}
+	return e.EvaluateVAP(ctx, vap, obj, namespaceObject, params)
+}
+
+// EvaluateVAP evaluates a loaded VAP against a single object. The caller is
+// responsible for resolving params (e.g. from a per-binding paramRef), which
+// makes it the path for binding-specific parameter objects.
+func (e *Evaluator) EvaluateVAP(ctx context.Context, vap *VAP, obj, namespaceObject map[string]any, params any) (ControlEvaluation, error) {
+	if !vap.appliesTo(obj) {
+		return ControlEvaluation{Applicable: false}, nil
 	}
 	// namespaceObject is not threaded into the gate: admission evaluates
 	// matchConditions with it bound to null and only resolves the real Namespace

--- a/core/pkg/opaprocessor/cel/dispatch.go
+++ b/core/pkg/opaprocessor/cel/dispatch.go
@@ -36,7 +36,7 @@ func (e *Evaluator) EvaluateControl(ctx context.Context, controlID string, obj, 
 // responsible for resolving params (e.g. from a per-binding paramRef), which
 // makes it the path for binding-specific parameter objects.
 func (e *Evaluator) EvaluateVAP(ctx context.Context, vap *VAP, obj, namespaceObject map[string]any, params any) (ControlEvaluation, error) {
-	if !vap.appliesTo(obj) {
+	if !vap.AppliesTo(obj) {
 		return ControlEvaluation{Applicable: false}, nil
 	}
 	// namespaceObject is not threaded into the gate: admission evaluates

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -359,7 +359,7 @@ func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 // binding that names a specific param object is resolved from the scanned input
 // via findParam. If the object is not found, ErrParamNotFound is returned so
 // the caller can honor parameterNotFoundAction.
-func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, resourceNamespace string, findParam func(kind, namespace, name string) (map[string]any, bool)) (any, error) {
+func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, resourceNamespace string, findParam func(apiVersion, kind, namespace, name string) (map[string]any, bool)) (any, error) {
 	if vap.paramKind == nil {
 		return nil, nil
 	}
@@ -370,7 +370,7 @@ func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, re
 	if ns == "" {
 		ns = resourceNamespace
 	}
-	obj, ok := findParam(vap.paramKind.Kind, ns, paramRef.Name)
+	obj, ok := findParam(vap.paramKind.APIVersion, vap.paramKind.Kind, ns, paramRef.Name)
 	if !ok {
 		return nil, ErrParamNotFound
 	}

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -110,17 +110,32 @@ func (v *VAP) failOnError() bool {
 // objectSelector (the object's own labels) and a resource rule's operations
 // and resourceNames (the object's own name).
 func (v *VAP) requireSupported() error {
+	if err := v.requireNamespaceSelectorSupported(); err != nil {
+		return err
+	}
+	if err := v.requireParamKindSupported(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *VAP) requireNamespaceSelectorSupported() error {
 	if v.matchConstraints != nil && selectorNarrows(v.matchConstraints.NamespaceSelector) {
 		return fmt.Errorf("control %q scopes matchConstraints with a namespaceSelector, whose input (namespace labels) the scan cannot guarantee to have; refusing it to preserve scan/admission parity", v.ControlID)
 	}
-	if v.paramKind != nil {
-		shipped, err := controlConfigParamKind()
-		if err != nil {
-			return err
-		}
-		if *v.paramKind != *shipped {
-			return fmt.Errorf("control %q takes params of kind %s %s, which the scan has no binding to resolve (only the bundled %s %s is available); refusing it to preserve scan/admission parity", v.ControlID, v.paramKind.APIVersion, v.paramKind.Kind, shipped.APIVersion, shipped.Kind)
-		}
+	return nil
+}
+
+func (v *VAP) requireParamKindSupported() error {
+	if v.paramKind == nil {
+		return nil
+	}
+	shipped, err := controlConfigParamKind()
+	if err != nil {
+		return err
+	}
+	if *v.paramKind != *shipped {
+		return fmt.Errorf("control %q takes params of kind %s %s, which the scan has no binding to resolve (only the bundled %s %s is available); refusing it to preserve scan/admission parity", v.ControlID, v.paramKind.APIVersion, v.paramKind.Kind, shipped.APIVersion, shipped.Kind)
 	}
 	return nil
 }
@@ -211,6 +226,27 @@ func loadVAP(controlID string) (*VAP, error) {
 	}
 	return vap, nil
 }
+
+// LoadVAP is the exported entry point for callers that need the VAP to resolve
+// a per-binding paramRef. It does not refuse a VAP merely because its paramKind
+// is not the bundled one: a binding's paramRef may point to that kind in the
+// scanned input. It still refuses namespaceSelector-narrowed policies.
+func LoadVAP(controlID string) (*VAP, error) {
+	vap, err := lookupVAP(controlID)
+	if err != nil {
+		return nil, err
+	}
+	if err := vap.requireNamespaceSelectorSupported(); err != nil {
+		return nil, err
+	}
+	return vap, nil
+}
+
+// ErrParamNotFound signals that a binding's paramRef points to an object that
+// is not present in the scanned input. The caller applies the binding's
+// parameterNotFoundAction: Allow means the object is admitted, Deny/empty means
+// the policy cannot produce a verdict and the rule is skipped.
+var ErrParamNotFound = errors.New("param object not found")
 
 // parseVAPBundle turns a multi-document bundle into a vapCatalog.
 //
@@ -315,6 +351,30 @@ func newVAP(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *VAP {
 		})
 	}
 	return vap
+}
+
+// ResolveParamObject returns the value bound to the evaluator's "params"
+// variable for one binding's paramRef. A policy with no paramKind gets nil. A
+// binding with no paramRef falls back to the bundled ControlConfiguration. A
+// binding that names a specific param object is resolved from the scanned input
+// via findParam. If the object is not found, ErrParamNotFound is returned so
+// the caller can honor parameterNotFoundAction.
+func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, resourceNamespace string, findParam func(kind, namespace, name string) (map[string]any, bool)) (any, error) {
+	if vap.paramKind == nil {
+		return nil, nil
+	}
+	if paramRef == nil || paramRef.Name == "" {
+		return resolveParams(vap)
+	}
+	ns := paramRef.Namespace
+	if ns == "" {
+		ns = resourceNamespace
+	}
+	obj, ok := findParam(vap.paramKind.Kind, ns, paramRef.Name)
+	if !ok {
+		return nil, ErrParamNotFound
+	}
+	return obj, nil
 }
 
 // resolveParams returns the value bound to the evaluator's "params" variable. A

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -416,3 +416,65 @@ func TestControlConfigParamKindMatchesShippedFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, *shipped, *vap.paramKind, "the bundle's params-bearing controls must still resolve")
 }
+
+// TestResolveParamObjectFallback verifies a binding with no paramRef (or a
+// policy with no paramKind) falls back to the bundled ControlConfiguration.
+func TestResolveParamObjectFallback(t *testing.T) {
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+
+	// No paramRef falls back to the bundled config.
+	params, err := ResolveParamObject(vap, nil, "default", nil)
+	require.NoError(t, err)
+	config, err := controlConfig()
+	require.NoError(t, err)
+	assert.Equal(t, config, params)
+
+	// A paramless control is always nil.
+	vapNoParam, err := loadVAP("C-0017")
+	require.NoError(t, err)
+	params, err = ResolveParamObject(vapNoParam, &admissionregistrationv1.ParamRef{Name: "x"}, "default", nil)
+	require.NoError(t, err)
+	assert.Nil(t, params)
+}
+
+// TestResolveParamObjectBinding resolves a binding's paramRef to a scanned
+// object of the policy's paramKind kind.
+func TestResolveParamObjectBinding(t *testing.T) {
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+
+	custom := map[string]any{
+		"apiVersion": "kubescape.io/v1",
+		"kind":       vap.paramKind.Kind,
+		"metadata": map[string]any{
+			"name":      "custom",
+			"namespace": "default",
+		},
+		"settings": map[string]any{"insecureCapabilities": []any{"ADD"}},
+	}
+	findParam := func(kind, namespace, name string) (map[string]any, bool) {
+		if kind == vap.paramKind.Kind && namespace == "default" && name == "custom" {
+			return custom, true
+		}
+		return nil, false
+	}
+
+	ref := &admissionregistrationv1.ParamRef{
+		Name:      "custom",
+		Namespace: "default",
+	}
+	params, err := ResolveParamObject(vap, ref, "other", findParam)
+	require.NoError(t, err)
+	assert.Equal(t, custom, params)
+
+	// Empty namespace in the paramRef uses the resource's namespace.
+	ref.Namespace = ""
+	params, err = ResolveParamObject(vap, ref, "default", findParam)
+	require.NoError(t, err)
+	assert.Equal(t, custom, params)
+
+	// Missing object returns ErrParamNotFound.
+	_, err = ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "missing"}, "default", findParam)
+	require.ErrorIs(t, err, ErrParamNotFound)
+}

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -453,8 +453,8 @@ func TestResolveParamObjectBinding(t *testing.T) {
 		},
 		"settings": map[string]any{"insecureCapabilities": []any{"ADD"}},
 	}
-	findParam := func(kind, namespace, name string) (map[string]any, bool) {
-		if kind == vap.paramKind.Kind && namespace == "default" && name == "custom" {
+	findParam := func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
+		if apiVersion == vap.paramKind.APIVersion && kind == vap.paramKind.Kind && namespace == "default" && name == "custom" {
 			return custom, true
 		}
 		return nil, false

--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -30,7 +30,7 @@ import (
 // genuinely irrelevant offline: Equivalent matching only widens a rule across
 // API conversions, and a scan never converts — the object is matched at the
 // exact group/version it was scanned at.
-func (v *VAP) appliesTo(obj map[string]any) bool {
+func (v *VAP) AppliesTo(obj map[string]any) bool {
 	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
 		return true // no scoping info: evaluate (a malformed-policy edge)
 	}

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -52,7 +52,7 @@ func TestVAPAppliesTo(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, v.appliesTo(obj(tc.apiVersion, tc.kind)))
+			assert.Equal(t, tc.want, v.AppliesTo(obj(tc.apiVersion, tc.kind)))
 		})
 	}
 }
@@ -90,7 +90,7 @@ func TestVAPAppliesToCRDPlural(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := vapWithConstraints(rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, tc.resources))
-			assert.Equal(t, tc.want, v.appliesTo(tc.obj))
+			assert.Equal(t, tc.want, v.AppliesTo(tc.obj))
 		})
 	}
 
@@ -99,30 +99,30 @@ func TestVAPAppliesToCRDPlural(t *testing.T) {
 			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{rule([]string{"*"}, []string{"*"}, []string{"*"})},
 			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, []string{"worker-pools"})},
 		}}
-		assert.False(t, v.appliesTo(workerPool()))
-		assert.True(t, v.appliesTo(obj(apiVersion, "ActorTemplate")))
+		assert.False(t, v.AppliesTo(workerPool()))
+		assert.True(t, v.AppliesTo(obj(apiVersion, "ActorTemplate")))
 	})
 
 	t.Run("annotations that are not a string map fall back to the guess", func(t *testing.T) {
 		o := workerPool()
 		o["metadata"].(map[string]any)["annotations"] = map[string]any{resourcePluralAnnotation: 42}
 		v := vapWithConstraints(rule([]string{"agentsubstrate.google.com"}, []string{"v1"}, []string{"workerpools"}))
-		assert.True(t, v.appliesTo(o))
+		assert.True(t, v.AppliesTo(o))
 	})
 }
 
 func TestVAPAppliesToWildcards(t *testing.T) {
 	any := vapWithConstraints(rule([]string{"*"}, []string{"*"}, []string{"*"}))
-	assert.True(t, any.appliesTo(obj("v1", "Pod")))
-	assert.True(t, any.appliesTo(obj("apps/v1", "Deployment")))
-	assert.True(t, any.appliesTo(obj("networking.k8s.io/v1", "NetworkPolicy")))
+	assert.True(t, any.AppliesTo(obj("v1", "Pod")))
+	assert.True(t, any.AppliesTo(obj("apps/v1", "Deployment")))
+	assert.True(t, any.AppliesTo(obj("networking.k8s.io/v1", "NetworkPolicy")))
 }
 
 func TestVAPAppliesToNoConstraintsEvaluates(t *testing.T) {
 	// Missing matchConstraints is a malformed-policy edge; fall back to
 	// evaluating rather than silently skipping everything.
 	v := &VAP{}
-	assert.True(t, v.appliesTo(obj("v1", "Pod")))
+	assert.True(t, v.AppliesTo(obj("v1", "Pod")))
 }
 
 // canonicalKinds maps a matchConstraints resource to the Kind the scanner feeds
@@ -183,7 +183,7 @@ func TestVAPAppliesToCoversEveryBundleKind(t *testing.T) {
 						}
 						kind, ok := canonicalKinds[res]
 						require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test; add it to canonicalKinds and confirm UnsafeGuessKindToResource maps that Kind back to %q", name, res, res)
-						assert.Truef(t, vap.appliesTo(obj(apiVersion, kind)),
+						assert.Truef(t, vap.AppliesTo(obj(apiVersion, kind)),
 							"policy %q constrains %q but appliesTo rejects a %s %s; annotate scanned %s objects with %s=%q if the guess cannot reach that plural", name, res, apiVersion, kind, kind, resourcePluralAnnotation, res)
 					}
 				}
@@ -206,8 +206,8 @@ func TestVAPAppliesToExcludeRules(t *testing.T) {
 		ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{rule([]string{""}, []string{"v1"}, []string{"pods", "configmaps"})},
 		ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{rule([]string{""}, []string{"v1"}, []string{"configmaps"})},
 	}}
-	assert.True(t, v.appliesTo(obj("v1", "Pod")))
-	assert.False(t, v.appliesTo(obj("v1", "ConfigMap")), "excluded resource must not apply")
+	assert.True(t, v.AppliesTo(obj("v1", "Pod")))
+	assert.False(t, v.AppliesTo(obj("v1", "ConfigMap")), "excluded resource must not apply")
 }
 
 // withOps returns a copy of the rule constrained to the given operations.
@@ -238,7 +238,7 @@ func TestVAPAppliesToOperations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := vapWithConstraints(withOps(pods, tc.ops...))
-			assert.Equal(t, tc.want, v.appliesTo(obj("v1", "Pod")))
+			assert.Equal(t, tc.want, v.AppliesTo(obj("v1", "Pod")))
 		})
 	}
 
@@ -247,7 +247,7 @@ func TestVAPAppliesToOperations(t *testing.T) {
 			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{withOps(pods, admissionregistrationv1.Create)},
 			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{withOps(pods, admissionregistrationv1.Update)},
 		}}
-		assert.True(t, v.appliesTo(obj("v1", "Pod")), "the exclusion only covers UPDATE, so the CREATE we model is still matched")
+		assert.True(t, v.AppliesTo(obj("v1", "Pod")), "the exclusion only covers UPDATE, so the CREATE we model is still matched")
 	})
 }
 
@@ -305,7 +305,7 @@ func TestVAPAppliesToScope(t *testing.T) {
 			if tc.namespace != "" {
 				o = inNamespace(o, tc.namespace)
 			}
-			assert.Equal(t, tc.want, vapWithConstraints(r).appliesTo(o))
+			assert.Equal(t, tc.want, vapWithConstraints(r).AppliesTo(o))
 		})
 	}
 
@@ -314,7 +314,7 @@ func TestVAPAppliesToScope(t *testing.T) {
 			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{pods},
 			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{withScope(pods, admissionregistrationv1.ClusterScope)},
 		}}
-		assert.True(t, v.appliesTo(inNamespace(obj("v1", "Pod"), "prod")),
+		assert.True(t, v.AppliesTo(inNamespace(obj("v1", "Pod"), "prod")),
 			"the exclusion only covers cluster-scoped objects, so a namespaced one is still matched")
 	})
 }
@@ -384,9 +384,9 @@ func TestVAPAppliesToObjectSelector(t *testing.T) {
 		v := vapWithConstraints(pods)
 		v.matchConstraints.ObjectSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
 
-		assert.True(t, v.appliesTo(labelled(map[string]any{"app": "web"})))
-		assert.False(t, v.appliesTo(labelled(map[string]any{"app": "db"})), "a non-matching label must put the object out of scope")
-		assert.False(t, v.appliesTo(obj("v1", "Pod")), "an unlabelled object cannot satisfy matchLabels")
+		assert.True(t, v.AppliesTo(labelled(map[string]any{"app": "web"})))
+		assert.False(t, v.AppliesTo(labelled(map[string]any{"app": "db"})), "a non-matching label must put the object out of scope")
+		assert.False(t, v.AppliesTo(obj("v1", "Pod")), "an unlabelled object cannot satisfy matchLabels")
 	})
 
 	t.Run("matchExpressions are honored", func(t *testing.T) {
@@ -395,19 +395,19 @@ func TestVAPAppliesToObjectSelector(t *testing.T) {
 			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "skip", Operator: metav1.LabelSelectorOpDoesNotExist}},
 		}
 
-		assert.True(t, v.appliesTo(obj("v1", "Pod")))
-		assert.False(t, v.appliesTo(labelled(map[string]any{"skip": "true"})), "an object carrying the exempting label must be out of scope")
+		assert.True(t, v.AppliesTo(obj("v1", "Pod")))
+		assert.False(t, v.AppliesTo(labelled(map[string]any{"skip": "true"})), "an object carrying the exempting label must be out of scope")
 	})
 
 	t.Run("nil and empty selectors match everything", func(t *testing.T) {
 		// The nil case is the one that bites: LabelSelectorAsSelector maps nil to
 		// "match nothing", the opposite of what an omitted selector means.
 		v := vapWithConstraints(pods)
-		assert.True(t, v.appliesTo(obj("v1", "Pod")), "an omitted objectSelector must not narrow anything")
+		assert.True(t, v.AppliesTo(obj("v1", "Pod")), "an omitted objectSelector must not narrow anything")
 
 		v.matchConstraints.ObjectSelector = &metav1.LabelSelector{}
-		assert.True(t, v.appliesTo(obj("v1", "Pod")))
-		assert.True(t, v.appliesTo(labelled(map[string]any{"app": "web"})))
+		assert.True(t, v.AppliesTo(obj("v1", "Pod")))
+		assert.True(t, v.AppliesTo(labelled(map[string]any{"app": "web"})))
 	})
 }
 
@@ -429,13 +429,13 @@ func TestVAPAppliesToResourceNames(t *testing.T) {
 
 	t.Run("only the named resource is in scope", func(t *testing.T) {
 		v := vapWithConstraints(named("coredns"))
-		assert.True(t, v.appliesTo(podNamed("coredns")))
-		assert.False(t, v.appliesTo(podNamed("nginx")), "a rule naming one pod must not pull in every pod")
+		assert.True(t, v.AppliesTo(podNamed("coredns")))
+		assert.False(t, v.AppliesTo(podNamed("nginx")), "a rule naming one pod must not pull in every pod")
 	})
 
 	t.Run("an empty resourceNames list matches every name", func(t *testing.T) {
 		v := vapWithConstraints(named())
-		assert.True(t, v.appliesTo(podNamed("anything")))
+		assert.True(t, v.AppliesTo(podNamed("anything")))
 	})
 
 	t.Run("a named exclusion exempts only that resource", func(t *testing.T) {
@@ -443,15 +443,15 @@ func TestVAPAppliesToResourceNames(t *testing.T) {
 			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{named()},
 			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{named("kube-proxy")},
 		}}
-		assert.False(t, v.appliesTo(podNamed("kube-proxy")))
-		assert.True(t, v.appliesTo(podNamed("nginx")))
+		assert.False(t, v.AppliesTo(podNamed("kube-proxy")))
+		assert.True(t, v.AppliesTo(podNamed("nginx")))
 	})
 
 	t.Run("a generateName-only manifest does not match a named rule", func(t *testing.T) {
 		// Admission sees no name either at that point, so it would not match.
 		o := obj("v1", "Pod")
 		delete(o["metadata"].(map[string]any), "name")
-		assert.False(t, vapWithConstraints(named("coredns")).appliesTo(o))
+		assert.False(t, vapWithConstraints(named("coredns")).AppliesTo(o))
 	})
 }
 
@@ -477,7 +477,7 @@ func TestVAPAppliesToKindPluralCandidates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := vapWithConstraints(rule([]string{"agents.x-k8s.io"}, []string{"v1alpha1"}, []string{tc.resource}))
-			assert.Equal(t, tc.want, v.appliesTo(obj("agents.x-k8s.io/v1alpha1", tc.kind)))
+			assert.Equal(t, tc.want, v.AppliesTo(obj("agents.x-k8s.io/v1alpha1", tc.kind)))
 		})
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1796,20 +1796,20 @@ func celParamRefForBinding(binding metav1unstructured.Unstructured) *admissionre
 	return ref
 }
 
-// celParamObjectFinder builds an index of all scanned objects by kind/namespace/name
-// and returns a lookup that ResolveParamObject can use to find a binding's
-// parameter object in the offline input.
-func (opap *OPAProcessor) celParamObjectFinder() func(kind, namespace, name string) (map[string]any, bool) {
+// celParamObjectFinder builds an index of all scanned objects by
+// apiVersion/kind/namespace/name and returns a lookup that ResolveParamObject
+// can use to find a binding's parameter object in the offline input.
+func (opap *OPAProcessor) celParamObjectFinder() func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
 	if opap.OPASessionObj == nil {
-		return func(kind, namespace, name string) (map[string]any, bool) { return nil, false }
+		return func(apiVersion, kind, namespace, name string) (map[string]any, bool) { return nil, false }
 	}
 	idx := make(map[string]map[string]any, len(opap.AllResources))
 	for _, res := range opap.AllResources {
-		key := res.GetKind() + "/" + res.GetNamespace() + "/" + res.GetName()
+		key := res.GetApiVersion() + "/" + res.GetKind() + "/" + res.GetNamespace() + "/" + res.GetName()
 		idx[key] = res.GetObject()
 	}
-	return func(kind, namespace, name string) (map[string]any, bool) {
-		obj, ok := idx[kind+"/"+namespace+"/"+name]
+	return func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
+		obj, ok := idx[apiVersion+"/"+kind+"/"+namespace+"/"+name]
 		return obj, ok
 	}
 }

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -36,6 +36,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 	opaprint "github.com/open-policy-agent/opa/v1/topdown/print"
 	"go.opentelemetry.io/otel"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -1458,6 +1460,15 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 	}
 
+	vap, err := cel.LoadVAP(controlID)
+	if err != nil {
+		return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+	}
+
+	binding, _ := opap.celBindingFor(vap.PolicyName)
+	paramRef := celParamRefForBinding(binding)
+	findParam := opap.celParamObjectFinder()
+
 	var responses []reporthandling.RuleResponse
 	outcome := celOutcome{excluded: make(map[string]struct{})}
 	for _, obj := range k8sObjects {
@@ -1465,12 +1476,25 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 			return nil, celOutcome{}, err
 		}
 
+		// Resolve the params for this object: a binding's paramRef may point to a
+		// namespaced or cluster-scoped object the scan collected. If the object is
+		// missing and the binding says Allow, the policy does not apply.
+		params, err := cel.ResolveParamObject(vap, paramRef, celResourceNamespace(obj), findParam)
+		if err != nil {
+			if errors.Is(err, cel.ErrParamNotFound) && paramRef != nil && paramRef.ParameterNotFoundAction != nil && string(*paramRef.ParameterNotFoundAction) == "Allow" {
+				resID := celResourceID(obj)
+				outcome.excluded[resID] = struct{}{}
+				continue
+			}
+			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
+		}
+
 		// namespaceObject is the resource's Namespace object when the scan
 		// collected it, and nil otherwise — the evaluator then binds null, so a
 		// policy reading namespaceObject.* sees an absent namespace (and a
 		// selection into it eval-errors and skips, never passes). File scans and
 		// scans whose frameworks never matched Namespaces stay on that safe path.
-		eval, err := evaluator.EvaluateControl(ctx, controlID, obj, opap.celNamespaceObjectFor(obj))
+		eval, err := evaluator.EvaluateVAP(ctx, vap, obj, opap.celNamespaceObjectFor(obj), params)
 		if err != nil {
 			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 		}
@@ -1676,6 +1700,79 @@ func celResourceID(obj map[string]any) string {
 		return meta.GetID()
 	}
 	return "<unknown>"
+}
+
+// celResourceNamespace returns the object's metadata.namespace, or "" when it
+// is cluster-scoped or not a recognizable envelope. It is used to resolve a
+// binding's paramRef whose own namespace is empty (admission uses the object's
+// namespace in that case).
+func celResourceNamespace(obj map[string]any) string {
+	if meta := objectsenvelopes.NewObject(obj); meta != nil {
+		return meta.GetNamespace()
+	}
+	return ""
+}
+
+// celBindingFor returns the first live ValidatingAdmissionPolicyBinding that
+// names the policy, or a zero value and false when none is present. Multiple
+// bindings are not yet evaluated separately; the first is used as the paramRef
+// source.
+func (opap *OPAProcessor) celBindingFor(policyName string) (metav1unstructured.Unstructured, bool) {
+	if opap.OPASessionObj == nil {
+		return metav1unstructured.Unstructured{}, false
+	}
+	for _, b := range opap.VAPBindings {
+		if b.Object == nil {
+			continue
+		}
+		pn, _, _ := metav1unstructured.NestedString(b.Object, "spec", "policyName")
+		if pn == policyName {
+			return b, true
+		}
+	}
+	return metav1unstructured.Unstructured{}, false
+}
+
+// celParamRefForBinding extracts the binding's spec.paramRef, if any. Missing
+// or empty paramRefs are returned as nil so ResolveParamObject falls back to
+// the bundled ControlConfiguration.
+func celParamRefForBinding(binding metav1unstructured.Unstructured) *admissionregistrationv1.ParamRef {
+	if binding.Object == nil {
+		return nil
+	}
+	name, _, _ := metav1unstructured.NestedString(binding.Object, "spec", "paramRef", "name")
+	if name == "" {
+		return nil
+	}
+	ns, _, _ := metav1unstructured.NestedString(binding.Object, "spec", "paramRef", "namespace")
+	action, _, _ := metav1unstructured.NestedString(binding.Object, "spec", "paramRef", "parameterNotFoundAction")
+	ref := &admissionregistrationv1.ParamRef{
+		Name:      name,
+		Namespace: ns,
+	}
+	if action != "" {
+		act := admissionregistrationv1.ParameterNotFoundActionType(action)
+		ref.ParameterNotFoundAction = &act
+	}
+	return ref
+}
+
+// celParamObjectFinder builds an index of all scanned objects by kind/namespace/name
+// and returns a lookup that ResolveParamObject can use to find a binding's
+// parameter object in the offline input.
+func (opap *OPAProcessor) celParamObjectFinder() func(kind, namespace, name string) (map[string]any, bool) {
+	if opap.OPASessionObj == nil {
+		return func(kind, namespace, name string) (map[string]any, bool) { return nil, false }
+	}
+	idx := make(map[string]map[string]any, len(opap.AllResources))
+	for _, res := range opap.AllResources {
+		key := res.GetKind() + "/" + res.GetNamespace() + "/" + res.GetName()
+		idx[key] = res.GetObject()
+	}
+	return func(kind, namespace, name string) (map[string]any, bool) {
+		obj, ok := idx[kind+"/"+namespace+"/"+name]
+		return obj, ok
+	}
 }
 
 // opaRegisterOnce guards rego.RegisterBuiltin1/2 below. Those calls mutate

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1476,14 +1476,28 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 			return nil, celOutcome{}, err
 		}
 
+		// Skip objects the policy's matchConstraints do not cover before doing any
+		// work that could fail for an object the policy never applies to.
+		if !vap.AppliesTo(obj) {
+			resID := celResourceID(obj)
+			outcome.excluded[resID] = struct{}{}
+			continue
+		}
+
 		// Resolve the params for this object: a binding's paramRef may point to a
 		// namespaced or cluster-scoped object the scan collected. If the object is
-		// missing and the binding says Allow, the policy does not apply.
+		// missing and the binding says Allow, the policy does not apply; otherwise
+		// it denies the object, exactly as admission does.
 		params, err := cel.ResolveParamObject(vap, paramRef, celResourceNamespace(obj), findParam)
 		if err != nil {
-			if errors.Is(err, cel.ErrParamNotFound) && paramRef != nil && paramRef.ParameterNotFoundAction != nil && string(*paramRef.ParameterNotFoundAction) == "Allow" {
+			if errors.Is(err, cel.ErrParamNotFound) {
 				resID := celResourceID(obj)
-				outcome.excluded[resID] = struct{}{}
+				if paramRef != nil && paramRef.ParameterNotFoundAction != nil && string(*paramRef.ParameterNotFoundAction) == "Allow" {
+					outcome.excluded[resID] = struct{}{}
+					continue
+				}
+				// parameterNotFoundAction is Deny (or unset, which defaults to Deny).
+				responses = append(responses, celErrorRuleResponse(rule, obj, err))
 				continue
 			}
 			return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1465,8 +1465,19 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		return nil, celOutcome{}, fmt.Errorf("rule: '%s', %w", rule.Name, err)
 	}
 
-	binding, _ := opap.celBindingFor(vap.PolicyName)
-	paramRef := celParamRefForBinding(binding)
+	bindings := opap.celBindingsFor(vap.PolicyName)
+	var paramRef *admissionregistrationv1.ParamRef
+	switch len(bindings) {
+	case 0:
+		// no live binding: fall back to the bundled ControlConfiguration
+	case 1:
+		if celBindingHasMatchResources(bindings[0]) {
+			return nil, celOutcome{}, fmt.Errorf("rule: '%s', binding for policy %q declares spec.matchResources, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", rule.Name, vap.PolicyName)
+		}
+		paramRef = celParamRefForBinding(bindings[0])
+	default:
+		return nil, celOutcome{}, fmt.Errorf("rule: '%s', policy %q is matched by %d live bindings; the offline engine does not yet select per-binding paramRefs, so refusing it to preserve scan/admission parity", rule.Name, vap.PolicyName, len(bindings))
+	}
 	findParam := opap.celParamObjectFinder()
 
 	var responses []reporthandling.RuleResponse
@@ -1727,24 +1738,38 @@ func celResourceNamespace(obj map[string]any) string {
 	return ""
 }
 
-// celBindingFor returns the first live ValidatingAdmissionPolicyBinding that
-// names the policy, or a zero value and false when none is present. Multiple
-// bindings are not yet evaluated separately; the first is used as the paramRef
-// source.
-func (opap *OPAProcessor) celBindingFor(policyName string) (metav1unstructured.Unstructured, bool) {
+// celBindingsFor returns all live ValidatingAdmissionPolicyBindings that name
+// the policy. The caller decides how to handle multiple or scoped bindings.
+func (opap *OPAProcessor) celBindingsFor(policyName string) []metav1unstructured.Unstructured {
 	if opap.OPASessionObj == nil {
-		return metav1unstructured.Unstructured{}, false
+		return nil
 	}
+	var matches []metav1unstructured.Unstructured
 	for _, b := range opap.VAPBindings {
 		if b.Object == nil {
 			continue
 		}
 		pn, _, _ := metav1unstructured.NestedString(b.Object, "spec", "policyName")
 		if pn == policyName {
-			return b, true
+			matches = append(matches, b)
 		}
 	}
-	return metav1unstructured.Unstructured{}, false
+	return matches
+}
+
+// celBindingHasMatchResources reports whether a binding narrows the objects it
+// governs. The offline engine cannot evaluate that scoping yet, so a binding
+// that carries matchResources cannot safely supply its paramRef.
+func celBindingHasMatchResources(binding metav1unstructured.Unstructured) bool {
+	if binding.Object == nil {
+		return false
+	}
+	spec, ok := binding.Object["spec"].(map[string]any)
+	if !ok {
+		return false
+	}
+	mr, ok := spec["matchResources"].(map[string]any)
+	return ok && len(mr) > 0
 }
 
 // celParamRefForBinding extracts the binding's spec.paramRef, if any. Missing

--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
Kubescape already vendors a bundle of `ValidatingAdmissionPolicy` (VAP) objects and ships a working CEL evaluator, but `runCELOnK8s` was still an unconditional "not implemented" stub. This PR connects the evaluator to the OPA processor so CEL-based rules can be evaluated during scans.
issue #3512 
 ## Changes :
- Exported `cel.LoadVAP` and `cel.ResolveParams` so the processor can load a control's VAP and resolve its `paramKind` value from the embedded bundle.
- Plumbed the `controlID` from `processControl` down through `processRule`, `runOPAOnSingleRule`, and into `runCELOnK8s`.
- Implemented `runCELOnK8s`:
  - loads the VAP for the control,
  - builds a CEL evaluator,
  - pre-indexes `Namespace` objects from `AllResources` for `namespaceObject.*` references,
  - calls `EvaluateOnObject` for each matched resource,
  - maps `[]cel.ValidationResult` to `[]reporthandling.RuleResponse`.
- Added C-0017 integration tests covering a failing Pod (mutable filesystem) and a passing Pod (`readOnlyRootFilesystem: true`).

This is PR 1 of the CEL/VAP parity work. PRs 2–4 (`failurePolicy`, `matchConditions`, per-binding `paramRef`) will follow and can be folded into this branch or this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for evaluating admission policies with binding-specific parameters.
  * Parameters can be resolved from bundled configuration or scanned resources, including namespaced references and namespace fallback.
  * Policies can determine applicability before evaluation, improving handling of out-of-scope resources.

* **Bug Fixes**
  * Missing parameters are handled according to the configured action: allowed cases skip the resource, while required parameters report an evaluation failure.
  * Improved parameter resolution error handling and policy report processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->