### PR TITLE
feat: support fleet mode for framework, control, and workload scans

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/meta"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/spf13/cobra"
+	"context"
 )
 
 var (
@@ -30,6 +31,38 @@ var (
   https://kubescape.io/docs/controls/
 `, cautils.ExecName())
 )
+
+func runControlScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+	if err := results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+	if !scanInfo.VerboseMode {
+		logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
+	}
+	if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
+		return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
+	}
+	if err := enforceSeverityThresholds(&results.GetResults().SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+
+	return enforceBaselineDrift(ctx, results, scanInfo)
+}
 
 // controlCmd represents the control command
 func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
@@ -91,35 +124,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runControlScan)
 			}
-			if err := results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-			if !scanInfo.VerboseMode {
-				logger.L().Info("Run with '--verbose'/'-v' flag for detailed resources view\n")
-			}
-			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
-			}
-			if err := enforceSeverityThresholds(&results.GetResults().SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetResults().SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
-			}
-
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			return runControlScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
 }

--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -1,0 +1,91 @@
+package scan
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/meta"
+)
+
+// fleetScan runs securityScan's per-cluster behavior once for every context
+// in baseScanInfo.KubeContexts, sequentially, writing one report per
+// context. It's the --kube-contexts entry point invoked from securityScan.
+//
+// Contexts are scanned one at a time, not concurrently: k8sinterface's
+// process-global connection state (K8SConfig, clientConfigAPI,
+// clusterContextName) has no locking around it, confirmed by go test -race
+// while working on #3237 — running two contexts' scans concurrently would
+// race on that state regardless of cautils.EnterClusterContext, which only
+// makes *sequential* context switches safe.
+//
+// One context failing (connection error, threshold breach, degraded policy
+// inputs, etc.) does not stop the remaining contexts from being attempted:
+// a fleet scan should surface as much of the fleet's posture as it can
+// rather than aborting on the first bad cluster. The command's overall
+// error - and therefore its exit code - reflects whether any context
+// failed, matching the single-context command's existing all-or-nothing
+// exit-code semantics from the caller's point of view.
+func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	if baseScanInfo.GetScanningContext() != cautils.ContextCluster {
+		return fmt.Errorf("--kube-contexts requires a live-cluster scan: it selects which cluster to connect to, so it can't be combined with scanning local files/directories")
+	}
+	if strings.TrimSpace(baseScanInfo.Output) == "" {
+		return fmt.Errorf("--kube-contexts requires --output: each context's report is written to its own file, derived from --output, since only one context's results can be printed to stdout at a time")
+	}
+
+	var failed []string
+	for _, kubeContext := range baseScanInfo.KubeContexts {
+		outputPath, err := perContextOutputPath(baseScanInfo.Output, kubeContext)
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
+			logger.L().Error("fleet scan: skipping context, could not derive an output path", helpers.String("context", kubeContext), helpers.Error(err))
+			continue
+		}
+
+		contextScanInfo := baseScanInfo.CloneForContext(kubeContext, outputPath)
+
+		logger.L().Info("fleet scan: scanning context", helpers.String("context", kubeContext), helpers.String("output", outputPath))
+
+		leave := cautils.EnterClusterContext(kubeContext)
+		ctx, cancel := deriveTimeoutContext(contextScanInfo, ks)
+		err = runSecurityScan(ctx, contextScanInfo, ks, policyIdentifiers)
+		cancel()
+		leave()
+
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
+			logger.L().Error("fleet scan: context failed", helpers.String("context", kubeContext), helpers.Error(err))
+			continue
+		}
+		logger.L().Success("fleet scan: context completed", helpers.String("context", kubeContext))
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("fleet scan: %d of %d context(s) failed:\n%s", len(failed), len(baseScanInfo.KubeContexts), strings.Join(failed, "\n"))
+	}
+	return nil
+}
+
+// perContextOutputPath derives context's own report path from the
+// --output the user gave for the fleet as a whole, by inserting a
+// filesystem-safe form of context before the final extension: report.json +
+// "kind-fleet-test-a" -> report.kind-fleet-test-a.json. Path separators in
+// context (which kube context names can technically contain, e.g. some
+// cloud-provider-generated names) are replaced so the result can't escape
+// the output directory or be misread as one.
+func perContextOutputPath(output, kubeContext string) (string, error) {
+	sanitized := strings.NewReplacer("/", "_", "\\", "_", string(filepath.Separator), "_").Replace(kubeContext)
+	sanitized = strings.TrimSpace(sanitized)
+	if sanitized == "" {
+		return "", fmt.Errorf("empty kube context name")
+	}
+
+	dir, base := filepath.Split(output)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	return filepath.Join(dir, stem+"."+sanitized+ext), nil
+}

--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -13,19 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// validateKubeContextsSupported rejects --kube-contexts up front for any
-// invocation that won't actually reach fleetScan, instead of silently
-// accepting the flag and scanning only one (default) context - the same
-// silently-wrong-cluster failure mode #3217/#3218 closed for sequential
-// scans in one process, recurring here as "the flag had no effect."
-//
-// --kube-contexts is registered on scanCmd's persistent flags, so cobra
-// inherits it onto every subcommand (control/framework/workload/image) and
-// it's accepted by --view=resource|control too, but only the default
-// security view's securityScan currently calls fleetScan. cmd here is the
-// actual leaf command being invoked (cobra passes the target command to an
-// inherited PersistentPreRunE, not the command it's defined on), so
-// cmd.Name() reliably reports which one that is.
 func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInfo) error {
 	if len(scanInfo.KubeContexts) == 0 {
 		return nil
@@ -35,36 +23,22 @@ func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInf
 		if scanInfo.View != string(cautils.SecurityViewType) {
 			return fmt.Errorf("--kube-contexts is not yet supported with --view=%s; only the default security view (no --view, or --view=%s) supports scanning multiple contexts in one run", scanInfo.View, cautils.SecurityViewType)
 		}
+	case "framework", "control", "workload":
+		// supported
 	default:
-		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'; only the default 'scan' command (security view) supports scanning multiple contexts in one run", cmd.Name())
+		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'", cmd.Name())
 	}
 	return nil
 }
 
-// fleetScan runs securityScan's per-cluster behavior once for every context
-// in baseScanInfo.KubeContexts, sequentially, writing one report per
-// context. It's the --kube-contexts entry point invoked from securityScan.
-//
-// Contexts are scanned one at a time, not concurrently: k8sinterface's
-// process-global connection state (K8SConfig, clientConfigAPI,
-// clusterContextName) has no locking around it, confirmed by go test -race
-// while working on #3237 — running two contexts' scans concurrently would
-// race on that state regardless of cautils.EnterClusterContext, which only
-// makes *sequential* context switches safe.
-//
-// One context failing (connection error, threshold breach, degraded policy
-// inputs, etc.) does not stop the remaining contexts from being attempted:
-// a fleet scan should surface as much of the fleet's posture as it can
-// rather than aborting on the first bad cluster. The command's overall
-// error - and therefore its exit code - reflects whether any context
-// failed, matching the single-context command's existing all-or-nothing
-// exit-code semantics from the caller's point of view.
-func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+type fleetRunner func(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error
+
+func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier, run fleetRunner) error {
 	if baseScanInfo.GetScanningContext() != cautils.ContextCluster {
-		return fmt.Errorf("--kube-contexts requires a live-cluster scan: it selects which cluster to connect to, so it can't be combined with scanning local files/directories")
+		return fmt.Errorf("--kube-contexts requires a live-cluster scan")
 	}
 	if strings.TrimSpace(baseScanInfo.Output) == "" {
-		return fmt.Errorf("--kube-contexts requires --output: each context's report is written to its own file, derived from --output, since only one context's results can be printed to stdout at a time")
+		return fmt.Errorf("--kube-contexts requires --output")
 	}
 
 	outputPaths, err := perContextOutputPaths(baseScanInfo.Output, baseScanInfo.KubeContexts)
@@ -82,7 +56,7 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 
 		leave := cautils.EnterClusterContext(kubeContext)
 		ctx, cancel := deriveTimeoutContext(contextScanInfo, ks)
-		err = runSecurityScan(ctx, contextScanInfo, ks, policyIdentifiers)
+		err = run(ctx, contextScanInfo, ks, policyIdentifiers)
 		cancel()
 		leave()
 
@@ -100,19 +74,9 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 	return nil
 }
 
-// perContextOutputPaths derives every context's own report path from the
-// --output the user gave for the fleet as a whole, and rejects the whole
-// batch up front if any two contexts would derive the same path. Two
-// distinct context names can sanitize to the same string (e.g.
-// "prod/us-east-1" and "prod_us-east-1" both become "prod_us-east-1"), which
-// would otherwise make the second scan's report silently overwrite the
-// first's - both scans "succeed" from fleetScan's point of view, so nothing
-// would ever surface the clobbered report as an error. Failing fast here
-// with the colliding context names named explicitly is far more useful than
-// discovering it later from a report that doesn't match its own context.
 func perContextOutputPaths(output string, kubeContexts []string) (map[string]string, error) {
 	paths := make(map[string]string, len(kubeContexts))
-	collisions := make(map[string][]string) // output path -> contexts that derived it
+	collisions := make(map[string][]string)
 
 	for _, kubeContext := range kubeContexts {
 		path, err := perContextOutputPath(output, kubeContext)
@@ -131,21 +95,12 @@ func perContextOutputPaths(output string, kubeContexts []string) (map[string]str
 	}
 	if len(conflicts) > 0 {
 		sort.Strings(conflicts)
-		return nil, fmt.Errorf("--kube-contexts: %d context(s) derive a colliding --output path with another context, so their reports would silently overwrite each other:\n%s", len(conflicts), strings.Join(conflicts, "\n"))
+		return nil, fmt.Errorf("--kube-contexts: %d context(s) derive a colliding --output path with another context:\n%s", len(conflicts), strings.Join(conflicts, "\n"))
 	}
 
 	return paths, nil
 }
 
-// perContextOutputPath derives context's own report path from the
-// --output the user gave for the fleet as a whole, by inserting a
-// filesystem-safe form of context before the final extension: report.json +
-// "kind-fleet-test-a" -> report.kind-fleet-test-a.json. Path separators in
-// context (which kube context names can technically contain, e.g. some
-// cloud-provider-generated names) are replaced so the result can't escape
-// the output directory or be misread as one. Callers scanning a batch of
-// contexts should use perContextOutputPaths instead, which also rejects
-// collisions between two different contexts' derived paths.
 func perContextOutputPath(output, kubeContext string) (string, error) {
 	sanitized := strings.NewReplacer("/", "_", "\\", "_", string(filepath.Separator), "_").Replace(kubeContext)
 	sanitized = strings.TrimSpace(sanitized)

--- a/cmd/scan/fleetscan.go
+++ b/cmd/scan/fleetscan.go
@@ -3,13 +3,43 @@ package scan
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/meta"
+	"github.com/spf13/cobra"
 )
+
+// validateKubeContextsSupported rejects --kube-contexts up front for any
+// invocation that won't actually reach fleetScan, instead of silently
+// accepting the flag and scanning only one (default) context - the same
+// silently-wrong-cluster failure mode #3217/#3218 closed for sequential
+// scans in one process, recurring here as "the flag had no effect."
+//
+// --kube-contexts is registered on scanCmd's persistent flags, so cobra
+// inherits it onto every subcommand (control/framework/workload/image) and
+// it's accepted by --view=resource|control too, but only the default
+// security view's securityScan currently calls fleetScan. cmd here is the
+// actual leaf command being invoked (cobra passes the target command to an
+// inherited PersistentPreRunE, not the command it's defined on), so
+// cmd.Name() reliably reports which one that is.
+func validateKubeContextsSupported(cmd *cobra.Command, scanInfo *cautils.ScanInfo) error {
+	if len(scanInfo.KubeContexts) == 0 {
+		return nil
+	}
+	switch cmd.Name() {
+	case "scan":
+		if scanInfo.View != string(cautils.SecurityViewType) {
+			return fmt.Errorf("--kube-contexts is not yet supported with --view=%s; only the default security view (no --view, or --view=%s) supports scanning multiple contexts in one run", scanInfo.View, cautils.SecurityViewType)
+		}
+	default:
+		return fmt.Errorf("--kube-contexts is not yet supported for 'scan %s'; only the default 'scan' command (security view) supports scanning multiple contexts in one run", cmd.Name())
+	}
+	return nil
+}
 
 // fleetScan runs securityScan's per-cluster behavior once for every context
 // in baseScanInfo.KubeContexts, sequentially, writing one report per
@@ -37,14 +67,14 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 		return fmt.Errorf("--kube-contexts requires --output: each context's report is written to its own file, derived from --output, since only one context's results can be printed to stdout at a time")
 	}
 
+	outputPaths, err := perContextOutputPaths(baseScanInfo.Output, baseScanInfo.KubeContexts)
+	if err != nil {
+		return err
+	}
+
 	var failed []string
 	for _, kubeContext := range baseScanInfo.KubeContexts {
-		outputPath, err := perContextOutputPath(baseScanInfo.Output, kubeContext)
-		if err != nil {
-			failed = append(failed, fmt.Sprintf("%s: %s", kubeContext, err))
-			logger.L().Error("fleet scan: skipping context, could not derive an output path", helpers.String("context", kubeContext), helpers.Error(err))
-			continue
-		}
+		outputPath := outputPaths[kubeContext]
 
 		contextScanInfo := baseScanInfo.CloneForContext(kubeContext, outputPath)
 
@@ -70,13 +100,52 @@ func fleetScan(baseScanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifi
 	return nil
 }
 
+// perContextOutputPaths derives every context's own report path from the
+// --output the user gave for the fleet as a whole, and rejects the whole
+// batch up front if any two contexts would derive the same path. Two
+// distinct context names can sanitize to the same string (e.g.
+// "prod/us-east-1" and "prod_us-east-1" both become "prod_us-east-1"), which
+// would otherwise make the second scan's report silently overwrite the
+// first's - both scans "succeed" from fleetScan's point of view, so nothing
+// would ever surface the clobbered report as an error. Failing fast here
+// with the colliding context names named explicitly is far more useful than
+// discovering it later from a report that doesn't match its own context.
+func perContextOutputPaths(output string, kubeContexts []string) (map[string]string, error) {
+	paths := make(map[string]string, len(kubeContexts))
+	collisions := make(map[string][]string) // output path -> contexts that derived it
+
+	for _, kubeContext := range kubeContexts {
+		path, err := perContextOutputPath(output, kubeContext)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", kubeContext, err)
+		}
+		paths[kubeContext] = path
+		collisions[path] = append(collisions[path], kubeContext)
+	}
+
+	var conflicts []string
+	for path, contexts := range collisions {
+		if len(contexts) > 1 {
+			conflicts = append(conflicts, fmt.Sprintf("%s -> %s", strings.Join(contexts, ", "), path))
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return nil, fmt.Errorf("--kube-contexts: %d context(s) derive a colliding --output path with another context, so their reports would silently overwrite each other:\n%s", len(conflicts), strings.Join(conflicts, "\n"))
+	}
+
+	return paths, nil
+}
+
 // perContextOutputPath derives context's own report path from the
 // --output the user gave for the fleet as a whole, by inserting a
 // filesystem-safe form of context before the final extension: report.json +
 // "kind-fleet-test-a" -> report.kind-fleet-test-a.json. Path separators in
 // context (which kube context names can technically contain, e.g. some
 // cloud-provider-generated names) are replaced so the result can't escape
-// the output directory or be misread as one.
+// the output directory or be misread as one. Callers scanning a batch of
+// contexts should use perContextOutputPaths instead, which also rejects
+// collisions between two different contexts' derived paths.
 func perContextOutputPath(output, kubeContext string) (string, error) {
 	sanitized := strings.NewReplacer("/", "_", "\\", "_", string(filepath.Separator), "_").Replace(kubeContext)
 	sanitized = strings.TrimSpace(sanitized)

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"github.com/kubescape/kubescape/v4/core/meta"
 	"context"
 	"errors"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var dummyRunner = func(ctx context.Context, si *cautils.ScanInfo, ks meta.IKubescape, pi []cautils.PolicyIdentifier) error { 
+	return runSecurityScan(ctx, si, ks, pi) 
+}
 
 func TestPerContextOutputPath(t *testing.T) {
 	tests := []struct {
@@ -76,7 +81,7 @@ func TestFleetScan_RejectsCollidingContextsBeforeScanningAny(t *testing.T) {
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, dummyRunner)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "colliding")
@@ -90,7 +95,7 @@ func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
 		InputPatterns: []string{"."}, // makes GetScanningContext() resolve to a non-cluster context
 	}
 
-	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil, dummyRunner)
 	require.ErrorContains(t, err, "live-cluster scan")
 }
 
@@ -99,7 +104,7 @@ func TestFleetScan_RequiresOutput(t *testing.T) {
 		KubeContexts: []string{"ctx-a"},
 	}
 
-	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil, dummyRunner)
 	require.ErrorContains(t, err, "--output")
 }
 
@@ -134,7 +139,7 @@ func TestFleetScan_ScansEveryContextAndDerivesDistinctOutputPaths(t *testing.T) 
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, dummyRunner)
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
@@ -152,7 +157,7 @@ func TestFleetScan_ContinuesPastFailingContextAndReportsIt(t *testing.T) {
 		ScanType:     cautils.ScanTypeCluster,
 	}
 
-	err := fleetScan(scanInfo, ks, nil)
+	err := fleetScan(scanInfo, ks, nil, dummyRunner)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "1 of 3 context(s) failed")
@@ -174,7 +179,7 @@ func TestFleetScan_EachContextGetsAFreshScanID(t *testing.T) {
 	}
 	scanInfo.ScanID = "should-not-be-reused"
 
-	require.NoError(t, fleetScan(scanInfo, ks, nil))
+	require.NoError(t, fleetScan(scanInfo, ks, nil, dummyRunner))
 
 	require.Len(t, scanIDs, 2)
 	assert.NotEqual(t, "should-not-be-reused", scanIDs[0])

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -41,6 +41,48 @@ func TestPerContextOutputPath(t *testing.T) {
 	}
 }
 
+// TestPerContextOutputPaths_RejectsCollidingContexts is a regression test
+// for a real review finding on #3438: perContextOutputPath's sanitization
+// isn't injective, so two distinct context names - e.g. "prod/us-east-1"
+// and "prod_us-east-1" - can derive the same output path and silently
+// overwrite each other's report, with fleetScan never noticing since both
+// individual scans "succeed." perContextOutputPaths must catch this before
+// any scanning starts, not after.
+func TestPerContextOutputPaths_RejectsCollidingContexts(t *testing.T) {
+	_, err := perContextOutputPaths("report.json", []string{"prod/us-east-1", "prod_us-east-1", "ctx-c"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "prod/us-east-1")
+	assert.ErrorContains(t, err, "prod_us-east-1")
+	assert.ErrorContains(t, err, "report.prod_us-east-1.json")
+}
+
+func TestPerContextOutputPaths_NoCollisions(t *testing.T) {
+	paths, err := perContextOutputPaths("report.json", []string{"ctx-a", "ctx-b", "ctx-c"})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"ctx-a": "report.ctx-a.json",
+		"ctx-b": "report.ctx-b.json",
+		"ctx-c": "report.ctx-c.json",
+	}, paths)
+}
+
+func TestFleetScan_RejectsCollidingContextsBeforeScanningAny(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"prod/us-east-1", "prod_us-east-1"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "colliding")
+	assert.Empty(t, ks.callsOutputs, "no context should be scanned once a collision is detected up front")
+}
+
 func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
 	scanInfo := cautils.ScanInfo{
 		KubeContexts:  []string{"ctx-a"},

--- a/cmd/scan/fleetscan_test.go
+++ b/cmd/scan/fleetscan_test.go
@@ -1,0 +1,161 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerContextOutputPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		kubeContext string
+		want        string
+		wantErr     bool
+	}{
+		{name: "simple", output: "report.json", kubeContext: "ctx-a", want: "report.ctx-a.json"},
+		{name: "no extension", output: "report", kubeContext: "ctx-a", want: "report.ctx-a"},
+		{name: "with directory", output: filepath.Join("out", "report.yaml"), kubeContext: "ctx-a", want: filepath.Join("out", "report.ctx-a.yaml")},
+		{name: "context contains path separators", output: "report.json", kubeContext: "prod/us-east-1", want: "report.prod_us-east-1.json"},
+		{name: "empty context rejected", output: "report.json", kubeContext: "", wantErr: true},
+		{name: "whitespace-only context rejected", output: "report.json", kubeContext: "   ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := perContextOutputPath(tt.output, tt.kubeContext)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFleetScan_RequiresClusterScanningContext(t *testing.T) {
+	scanInfo := cautils.ScanInfo{
+		KubeContexts:  []string{"ctx-a"},
+		Output:        "report.json",
+		InputPatterns: []string{"."}, // makes GetScanningContext() resolve to a non-cluster context
+	}
+
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	require.ErrorContains(t, err, "live-cluster scan")
+}
+
+func TestFleetScan_RequiresOutput(t *testing.T) {
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a"},
+	}
+
+	err := fleetScan(scanInfo, &mocks.MockIKubescape{}, nil)
+	require.ErrorContains(t, err, "--output")
+}
+
+// fleetTrackingKubescape is a test-local IKubescape recording, per
+// ScanContext call, the output path it was given (which encodes the
+// context, via perContextOutputPath) - and optionally failing for
+// caller-chosen output paths, so tests can assert fleetScan continues past
+// a failing context instead of aborting the loop.
+type fleetTrackingKubescape struct {
+	mocks.MockIKubescape
+	callsOutputs []string
+	failOutputs  map[string]error
+}
+
+func (m *fleetTrackingKubescape) Context() context.Context { return context.Background() }
+
+func (m *fleetTrackingKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	m.callsOutputs = append(m.callsOutputs, scanInfo.Output)
+	if err, ok := m.failOutputs[scanInfo.Output]; ok {
+		return nil, err
+	}
+	results := resultshandling.NewResultsHandler(nil, nil, &fakePrinter{})
+	results.SetData(cautils.NewOPASessionObjMock())
+	return results, nil
+}
+
+func TestFleetScan_ScansEveryContextAndDerivesDistinctOutputPaths(t *testing.T) {
+	ks := &fleetTrackingKubescape{}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b", "ctx-c"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
+}
+
+func TestFleetScan_ContinuesPastFailingContextAndReportsIt(t *testing.T) {
+	ks := &fleetTrackingKubescape{
+		failOutputs: map[string]error{
+			"report.ctx-b.json": errors.New("cluster unreachable"),
+		},
+	}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b", "ctx-c"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+
+	err := fleetScan(scanInfo, ks, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "1 of 3 context(s) failed")
+	assert.ErrorContains(t, err, "ctx-b")
+	assert.ErrorContains(t, err, "cluster unreachable")
+	// ctx-a and ctx-c must still have been attempted despite ctx-b failing.
+	assert.Equal(t, []string{"report.ctx-a.json", "report.ctx-b.json", "report.ctx-c.json"}, ks.callsOutputs)
+}
+
+func TestFleetScan_EachContextGetsAFreshScanID(t *testing.T) {
+	var scanIDs []string
+	ks := &fleetIDTrackingKubescape{onScan: func(si *cautils.ScanInfo) {
+		scanIDs = append(scanIDs, si.ScanID)
+	}}
+	scanInfo := cautils.ScanInfo{
+		KubeContexts: []string{"ctx-a", "ctx-b"},
+		Output:       "report.json",
+		ScanType:     cautils.ScanTypeCluster,
+	}
+	scanInfo.ScanID = "should-not-be-reused"
+
+	require.NoError(t, fleetScan(scanInfo, ks, nil))
+
+	require.Len(t, scanIDs, 2)
+	assert.NotEqual(t, "should-not-be-reused", scanIDs[0])
+	assert.NotEqual(t, "should-not-be-reused", scanIDs[1])
+	assert.NotEqual(t, scanIDs[0], scanIDs[1], "each context must get its own ScanID, not share one across the fleet")
+}
+
+type fleetIDTrackingKubescape struct {
+	mocks.MockIKubescape
+	onScan func(*cautils.ScanInfo)
+}
+
+func (m *fleetIDTrackingKubescape) Context() context.Context { return context.Background() }
+
+func (m *fleetIDTrackingKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	// Mirrors what the real Scan/ScanContext does via scanInfo.Init: assign a
+	// ScanID if one isn't already set. CloneForContext is what's under test
+	// here - it must have cleared ScanID before this call ever sees it.
+	if scanInfo.ScanID == "" {
+		scanInfo.ScanID = "generated-" + scanInfo.Output
+	}
+	m.onScan(scanInfo)
+	results := resultshandling.NewResultsHandler(nil, nil, &fakePrinter{})
+	results.SetData(cautils.NewOPASessionObjMock())
+	return results, nil
+}

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -44,6 +45,37 @@ var (
 	ErrBadThreshold             = errors.New("bad argument: out of range threshold")
 	ErrControlTimeoutTooHigh    = errors.New("--control-timeout must be lower than --scan-timeout")
 )
+
+func runFrameworkScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+
+	if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
+		return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
+	}
+
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+	return enforceBaselineDrift(ctx, results, scanInfo)
+}
 
 func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
 
@@ -111,34 +143,11 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 			policyIdentifiers := cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runFrameworkScan)
 			}
 
-			if err = results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-
-			if results.GetComplianceScore() < float32(scanInfo.ComplianceThreshold) {
-				return fmt.Errorf("scan compliance-score is below permitted threshold: %.2f (compliance-threshold: %.2f)", results.GetComplianceScore(), scanInfo.ComplianceThreshold)
-			}
-
-			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
-			}
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			return runFrameworkScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
 

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -257,6 +257,8 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	// Retrieve --kubeconfig flag from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go
 	scanCmd.PersistentFlags().AddGoFlag(flag.Lookup("kubeconfig"))
 
+	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.KubeContexts, "kube-contexts", nil, "Scan each of these kube contexts in one run (comma-separated, or repeat the flag), writing one report per context to a context-suffixed --output path. Requires --output. Distinct from --kube-context, which selects a single context; when --kube-contexts is set it takes over the scan instead.")
+
 	scanCmd.PersistentFlags().StringVar(&scanInfo.Baseline, "baseline", "", "Path to a saved JSON scan report to diff the fresh scan against.")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.BaselineFailOnNew, "baseline-fail-on-new", false, "With --baseline, exit with code 1 when new failures are found versus the baseline.")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.BaselineSeverityThreshold, "baseline-severity-threshold", "", "With --baseline, only count new failures at or above this severity when using --baseline-fail-on-new.")
@@ -352,34 +354,46 @@ func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
 }
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	if len(scanInfo.KubeContexts) > 0 {
+		return fleetScan(scanInfo, ks, policyIdentifiers)
+	}
+
 	ctx, cancel := deriveTimeoutContext(&scanInfo, ks)
 	defer cancel()
+	return runSecurityScan(ctx, &scanInfo, ks, policyIdentifiers)
+}
 
-	results, err := ks.ScanContext(ctx, &scanInfo, policyIdentifiers)
+// runSecurityScan runs one cluster's scan to completion: Scan, HandleResults,
+// then every threshold/drift enforcement securityScan performs for the
+// single-context path. It's factored out so fleetScan (cmd/scan/fleetscan.go)
+// can run the exact same per-cluster behavior once per requested context,
+// instead of a parallel, divergent copy of this logic.
+func runSecurityScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 	if err != nil {
 		return err
 	}
 
-	if err = results.HandleResults(ctx, &scanInfo); err != nil {
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
 		return err
 	}
 
-	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, &scanInfo); err != nil {
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
 		return err
 	}
 	if scanInfo.ScanImages {
-		if err := enforceImageSeverityThresholds(results.ImageScanData, &scanInfo); err != nil {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
 			return err
 		}
 	}
-	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), &scanInfo); err != nil {
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
 		return err
 	}
-	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, &scanInfo); err != nil {
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
 		return err
 	}
 
-	return enforceBaselineDrift(ctx, results, &scanInfo)
+	return enforceBaselineDrift(ctx, results, scanInfo)
 }
 
 func enforceBaselineDrift(ctx context.Context, results *resultshandling.ResultsHandler, scanInfo *cautils.ScanInfo) error {

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -93,6 +93,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 					return err
 				}
 			}
+			if err := validateKubeContextsSupported(cmd, &scanInfo); err != nil {
+				return err
+			}
 			captureKubeconfigSelection(cmd, &scanInfo)
 			applyRegistryCredentialsFromEnv(cmd, &scanInfo)
 			return nil

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -358,7 +358,7 @@ func applyTimeout(scanInfo *cautils.ScanInfo, ks meta.IKubescape) func() {
 
 func securityScan(scanInfo cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
 	if len(scanInfo.KubeContexts) > 0 {
-		return fleetScan(scanInfo, ks, policyIdentifiers)
+		return fleetScan(scanInfo, ks, policyIdentifiers, runSecurityScan)
 	}
 
 	ctx, cancel := deriveTimeoutContext(&scanInfo, ks)

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -529,9 +529,6 @@ func TestGetScanCommand_KubeContextsRejectedWhereUnsupported(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b"}},
-		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b"}},
-		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan image", args: []string{"image", "nginx:latest", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan --view=resource", args: []string{"--view=resource", "--kube-contexts=ctx-a,ctx-b"}},
 		{name: "scan --view=control", args: []string{"--view=control", "--kube-contexts=ctx-a,ctx-b"}},
@@ -551,19 +548,30 @@ func TestGetScanCommand_KubeContextsRejectedWhereUnsupported(t *testing.T) {
 	}
 }
 
-func TestGetScanCommand_KubeContextsAcceptedForDefaultSecurityView(t *testing.T) {
-	ks := &scanCallCounter{}
-	cmd := GetScanCommand(ks)
-	cmd.SilenceUsage = true
-	cmd.SetArgs([]string{"--kube-contexts=ctx-a,ctx-b", "--output=report.json"})
+func TestGetScanCommand_KubeContextsAcceptedWhereSupported(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "scan", args: []string{"--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b", "--output=report.json"}},
+	}
 
-	err := cmd.Execute()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &scanCallCounter{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
 
-	// Reaches fleetScan (which then reaches ScanContext once per context via
-	// the scanCallCounter mock) rather than being rejected by the guard -
-	// the guard's error text must not appear here.
-	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "is not yet supported")
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "is not yet supported")
+		})
+	}
 }
 
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {

--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -516,6 +516,56 @@ func TestGetScanCommand_PersistentFlagValidation(t *testing.T) {
 	}
 }
 
+// TestGetScanCommand_KubeContextsRejectedWhereUnsupported is a regression
+// test for a real review finding on #3438: --kube-contexts is registered on
+// scanCmd's persistent flags, so every subcommand and --view inherits it,
+// but only the default security view's securityScan actually calls
+// fleetScan. Before this fix, every other combination silently accepted
+// the flag and scanned only one context - the same silently-wrong-cluster
+// failure mode #3217/#3218 closed for sequential scans, recurring as "the
+// flag had no effect."
+func TestGetScanCommand_KubeContextsRejectedWhereUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "scan control", args: []string{"control", "C-0058", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan framework", args: []string{"framework", "nsa", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan workload", args: []string{"workload", "Deployment/nginx", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan image", args: []string{"image", "nginx:latest", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan --view=resource", args: []string{"--view=resource", "--kube-contexts=ctx-a,ctx-b"}},
+		{name: "scan --view=control", args: []string{"--view=control", "--kube-contexts=ctx-a,ctx-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &scanCallCounter{}
+			cmd := GetScanCommand(ks)
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			require.ErrorContains(t, err, "--kube-contexts is not yet supported")
+			assert.Equal(t, 0, ks.calls, "scan must not run when --kube-contexts is rejected up front")
+		})
+	}
+}
+
+func TestGetScanCommand_KubeContextsAcceptedForDefaultSecurityView(t *testing.T) {
+	ks := &scanCallCounter{}
+	cmd := GetScanCommand(ks)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--kube-contexts=ctx-a,ctx-b", "--output=report.json"})
+
+	err := cmd.Execute()
+
+	// Reaches fleetScan (which then reaches ScanContext once per context via
+	// the scanCallCounter mock) rather than being rejected by the guard -
+	// the guard's error text must not appear here.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "is not yet supported")
+}
+
 func TestGetScanCommand_ScanTimeoutFlagRegistered(t *testing.T) {
 	mockKubescape := &mocks.MockIKubescape{}
 	cmd := GetScanCommand(mockKubescape)

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"context"
+
 	"github.com/kubescape/kubescape/v4/cmd/shared"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/meta"
@@ -44,6 +46,34 @@ var (
 
 	ErrInvalidWorkloadIdentifier = errors.New("invalid workload identifier, expected <kind>[.<version>[.<group>]]/<name>")
 )
+
+func runWorkloadScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
+	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
+	if err != nil {
+		return err
+	}
+
+	if err = results.HandleResults(ctx, scanInfo); err != nil {
+		return err
+	}
+
+	if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
+		return err
+	}
+	if scanInfo.ScanImages {
+		if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
+			return err
+		}
+	}
+	if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
+		return err
+	}
+	if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
+		return err
+	}
+
+	return enforceBaselineDrift(ctx, results, scanInfo)
+}
 
 // controlCmd represents the control command
 func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
@@ -96,31 +126,11 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
-			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
-			if err != nil {
-				return err
+			if len(scanInfo.KubeContexts) > 0 {
+				return fleetScan(*scanInfo, ks, policyIdentifiers, runWorkloadScan)
 			}
 
-			if err = results.HandleResults(ctx, scanInfo); err != nil {
-				return err
-			}
-
-			if err := enforceSeverityThresholds(&results.GetData().Report.SummaryDetails, scanInfo); err != nil {
-				return err
-			}
-			if scanInfo.ScanImages {
-				if err := enforceImageSeverityThresholds(results.ImageScanData, scanInfo); err != nil {
-					return err
-				}
-			}
-			if err := enforceCoverageThreshold(results.GetData().ScanCoverage, len(results.GetData().Report.SummaryDetails.Controls), scanInfo); err != nil {
-				return err
-			}
-			if err := enforcePolicyDegradation(results.GetData().ScanCoverage, scanInfo); err != nil {
-				return err
-			}
-
-			return enforceBaselineDrift(ctx, results, scanInfo)
+			return runWorkloadScan(ctx, scanInfo, ks, policyIdentifiers)
 		},
 	}
 

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -202,6 +202,7 @@ type ScanInfo struct {
 	BaselineFailOnNew         bool              // Exit with code 1 when the baseline diff finds new or incomparable failures
 	BaselineSeverityThreshold string            // Only count new/incomparable baseline failures at or above this severity when enforcing BaselineFailOnNew
 	BaselineGranularity       string            // Comparison unit for the baseline diff: "evidence" (default) or "control"
+	KubeContexts              []string          // --kube-contexts: scan each of these kube contexts sequentially, one report per context (fleet mode)
 }
 
 type Getters struct {
@@ -466,6 +467,31 @@ func (scanInfo *ScanInfo) SetKubeconfigSelection(path, contextName string) {
 	scanInfo.kubeContextOverride = contextName
 	scanInfo.clusterContextName = ""
 	scanInfo.contextResolved = false
+}
+
+// CloneForContext returns a copy of scanInfo prepared for scanning one kube
+// context as part of a multi-context ("fleet") scan, reusing the same
+// kubeconfig file the parent ScanInfo was configured with (fleet mode
+// switches context within one kubeconfig, not the file itself) but
+// targeting kubeContext. Every field is copied verbatim except the three
+// that must not be shared across sibling scans sharing one parent ScanInfo:
+//   - ScanID: cleared, so Init generates a fresh one for this context instead
+//     of reusing whichever sibling happened to run first.
+//   - cleanups: dropped, so this context's Cleanup() doesn't re-invoke
+//     closures another sibling already ran (or hasn't registered yet).
+//   - Output: replaced with the caller-supplied path (fleet mode gives each
+//     context its own report file; see cmd/scan/fleetscan.go).
+//
+// SetKubeconfigSelection also resets clusterContextName/contextResolved so
+// each clone re-resolves its own context rather than inheriting the
+// parent's.
+func (scanInfo *ScanInfo) CloneForContext(kubeContext, output string) *ScanInfo {
+	clone := *scanInfo
+	clone.ScanID = ""
+	clone.cleanups = nil
+	clone.Output = output
+	clone.SetKubeconfigSelection(scanInfo.kubeconfigPath, kubeContext)
+	return &clone
 }
 
 // ResolveClusterContextName resolves the context from the same kubeconfig

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -138,6 +138,33 @@ contexts:
 	})
 }
 
+func TestCloneForContext(t *testing.T) {
+	kubeconfig := writeScanInfoMultiContextKubeconfig(t)
+	parent := &ScanInfo{
+		ScanID:  "parent-scan-id",
+		Output:  "report.json",
+		Format:  "json",
+		ScanAll: true,
+	}
+	parent.SetKubeconfigSelection(kubeconfig, "context-current")
+	require.NoError(t, parent.ResolveClusterContextName())
+	require.Equal(t, "context-current", parent.GetClusterContextName())
+	parent.AddCleanup(func() { t.Fatal("parent's cleanup must not run from the clone") })
+
+	clone := parent.CloneForContext("context-selected", "report.context-selected.json")
+
+	assert.Empty(t, clone.ScanID, "ScanID must be cleared so Init generates a fresh one per context")
+	assert.Equal(t, "report.context-selected.json", clone.Output)
+	assert.Equal(t, "json", clone.Format, "unrelated fields must be copied verbatim")
+	assert.True(t, clone.ScanAll)
+
+	require.NoError(t, clone.ResolveClusterContextName())
+	assert.Equal(t, "context-selected", clone.GetClusterContextName(), "clone must resolve its own context, not inherit the parent's")
+	assert.Equal(t, "context-current", parent.GetClusterContextName(), "cloning must not mutate the parent's already-resolved context")
+
+	clone.Cleanup() // must not panic or invoke the parent's registered cleanup
+}
+
 func TestResolveClusterContextNameUsesDefaultLoadingRulesForOverride(t *testing.T) {
 	defaultPath := writeScanInfoMultiContextKubeconfig(t)
 	t.Setenv(clientcmd.RecommendedConfigPathEnvVar, defaultPath)


### PR DESCRIPTION

## Overview

This PR adds fleet mode (`--kube-contexts`) support for the `framework`, `control`, and `workload` scan commands. 

Before this, passing multiple contexts to these commands would silently scan only one context and ignore the rest. Now, they correctly loop over all given contexts and output the results for each one, just like the main `scan` command does.

To do this, I made `fleetScan` accept a generic callback and moved the core scanning code for each subcommand into separate functions so they can all reuse the fleet scanning logic.

## How to Test

1. Build the Kubescape CLI locally.
2. Setup at least two contexts in your kubeconfig (e.g., `kind-cluster-a` and `kind-cluster-b`).
3. Run the following commands and verify it outputs reports for both clusters:
   - `kubescape scan framework nsa --kube-contexts kind-cluster-a,kind-cluster-b --output report.json`
   - `kubescape scan control C-0058 --kube-contexts kind-cluster-a,kind-cluster-b --output report.json`
   - `kubescape scan workload Deployment/nginx --kube-contexts kind-cluster-a,kind-cluster-b --output report.json`

## Related issues/PRs:

* Resolved #3516

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-context Kubernetes scanning with the repeatable `--kube-contexts` option.
  * Scans now run across selected contexts, generating separate output files for each.
  * Results aggregate successes and failures while continuing when an individual context fails.

* **Bug Fixes**
  * Added validation for unsupported scan modes, missing contexts, missing output paths, and output-file collisions.
  * Preserved existing threshold, baseline, and timeout handling for single-context scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->