### PR TITLE
fix(opaprocessor): apply --skip-controls/--include-controls on the streaming path

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -232,15 +232,21 @@ func (opap *OPAProcessor) SetIncrementalCache(cache *scancache.Store) {
 	opap.incrementalCache = cache
 }
 
+// effectiveExcludedRules merges the session's rule exclusions with the
+// --skip-controls and --include-controls filters. Both the eager and the
+// streaming entry point build AllPolicies from it, so the same cluster is
+// scanned against the same control set whichever path a scan takes.
+func (opap *OPAProcessor) effectiveExcludedRules() map[string]bool {
+	if opap.SkipControls == "" && opap.IncludeControls == "" {
+		return opap.ExcludedRules
+	}
+	return buildControlExcludedRules(opap.ExcludedRules, opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
+}
+
 func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressListener IJobProgressNotificationClient) error {
 	scanningScope := cautils.GetScanningScope(opap.Metadata.ContextMetadata)
 
-	excludedRules := opap.ExcludedRules
-	if opap.SkipControls != "" || opap.IncludeControls != "" {
-		excludedRules = buildControlExcludedRules(excludedRules, opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
-	}
-
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, scanningScope)
+	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.effectiveExcludedRules(), scanningScope)
 
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 
@@ -294,7 +300,7 @@ func (opap *OPAProcessor) ProcessWithStreaming(ctx context.Context, batchChan <-
 	opap.loggerStartScanning()
 	defer opap.loggerDoneScanning()
 
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.ExcludedRules, cautils.GetScanningScope(opap.Metadata.ContextMetadata))
+	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.effectiveExcludedRules(), cautils.GetScanningScope(opap.Metadata.ContextMetadata))
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 
 	scopeControlIDs, wholeClusterControlIDs := splitWholeClusterControls(opap.AllPolicies, sortedControlIDs(opap.AllPolicies))

--- a/core/pkg/opaprocessor/streaming_control_filter_test.go
+++ b/core/pkg/opaprocessor/streaming_control_filter_test.go
@@ -1,0 +1,68 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// controlIDsInResults collects every control ID that reached the results map.
+func controlIDsInResults(opap *OPAProcessor) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, result := range opap.ResourcesResult {
+		for _, associated := range result.AssociatedControls {
+			ids[associated.GetID()] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// TestProcessWithStreaming_HonorsSkipControls runs the eager and streaming
+// pipelines over the same manifests with --skip-controls C-0013 and asserts
+// both drop the control. ProcessRulesListener applies the filter via
+// buildControlExcludedRules; ProcessWithStreaming must reach the same verdict,
+// otherwise the same cluster is scanned against a different control set once it
+// grows past the streaming threshold.
+func TestProcessWithStreaming_HonorsSkipControls(t *testing.T) {
+	t.Setenv("LARGE_CLUSTER_SIZE", "10000") // eager and streaming both evaluate as one scope
+
+	dir := t.TempDir()
+	writeFixtureManifests(t, dir)
+
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{dir}, SkipControls: "C-0013"}
+	handler := resourcehandler.NewFileResourceHandler()
+	frameworks := parityFrameworks(true)
+
+	eagerSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
+	eagerSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+	require.NoError(t, resourcehandler.CollectResources(context.Background(), handler, eagerSession, scanInfo))
+
+	eager := NewOPAProcessor(eagerSession, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	require.NoError(t, eager.ProcessRulesListener(context.Background(), cautils.NewProgressHandler("")))
+	require.NotEmpty(t, eager.ResourcesResult)
+
+	streamingSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
+	streamingSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+
+	batchChan, errChan, expectedBatches, err := handler.StreamResourcesBatches(context.Background(), streamingSession, scanInfo)
+	require.NoError(t, err)
+
+	streaming := NewOPAProcessor(streamingSession, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	streaming.SetInitialResourceCount(0) // file scans never estimate cluster size
+	require.NoError(t, streaming.ProcessWithStreaming(context.Background(), batchChan, errChan, cautils.NewProgressHandler(""), expectedBatches))
+
+	eagerControls := controlIDsInResults(eager)
+	streamingControls := controlIDsInResults(streaming)
+	t.Logf("eager controls: %v", eagerControls)
+	t.Logf("streaming controls: %v", streamingControls)
+
+	require.NotContains(t, eagerControls, "C-0013", "eager path must drop the skipped control")
+	assert.NotContains(t, streamingControls, "C-0013", "streaming path must drop the skipped control too")
+	assert.Equal(t, eagerControls, streamingControls, "both paths must scan the same control set")
+}


### PR DESCRIPTION
I found that --skip-controls and --include-controls stop working once a scan switches to the streaming path. This happens automatically for clusters above 2500 resources, or whenever someone passes --enable-streaming, so it is easy to hit without realizing it.

The eager path builds its policy set through buildControlExcludedRules, which applies these two flags. The streaming path builds its policy set straight from opap.ExcludedRules and never calls that function, so a control named in --skip-controls quietly comes back, and --include-controls stops narrowing anything. The scan still succeeds and looks normal, the control is just there in the results and in the score.

I pulled the filter logic into a small effectiveExcludedRules helper and had both entry points call it, so they always build their policy set from the same source.

I added a test that runs the eager and streaming pipelines over the same manifests with --skip-controls set and checks they report the same controls. It fails on current master (streaming still reports the skipped control) and passes with this change. I also confirmed it fails again when I revert the fix and passes once restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skip-control filters are now applied consistently during both standard and streaming processing.
  * Excluded controls no longer appear in results, regardless of the processing mode.

* **Tests**
  * Added coverage to verify matching control results across standard and streaming workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->