### PR TITLE
feat(scan): apply repository scan contracts

### DIFF
--- a/cmd/scan/apply_contract.go
+++ b/cmd/scan/apply_contract.go
@@ -40,10 +40,33 @@ func loadAndApplyScanContract(cmd *cobra.Command, scanInfo *cautils.ScanInfo, pa
 	if err := validateContractRunnerConflicts(selected, scanInfo); err != nil {
 		return nil, err
 	}
+	if err := validateExplicitRunnerGateFloors(cmd, scanInfo); err != nil {
+		return nil, err
+	}
 
 	applyContractOrdinarySettings(cmd, scanInfo, selected.Contract)
 	applyContractGateFloors(cmd, scanInfo, selected.Contract)
 	return selected, nil
+}
+
+// validateExplicitRunnerGateFloors preserves the existing CLI validation
+// boundary when a contract is present. Contract floors are allowed to tighten
+// valid runner values, but must not replace malformed values before the normal
+// scan validation gets a chance to reject them.
+func validateExplicitRunnerGateFloors(cmd *cobra.Command, scanInfo *cautils.ScanInfo) error {
+	if commandFlagChanged(cmd, "severity-threshold") && scanInfo.FailThresholdSeverity != "" {
+		if err := shared.ValidateSeverity(scanInfo.FailThresholdSeverity); err != nil {
+			return err
+		}
+	}
+
+	if commandFlagChanged(cmd, "compliance-threshold") || commandFlagChanged(cmd, "fail-coverage-below") {
+		if err := shared.ValidateThresholds(scanInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func validateContractRunnerConflicts(selected *contractv1alpha1.SelectedContract, scanInfo *cautils.ScanInfo) error {

--- a/cmd/scan/apply_contract.go
+++ b/cmd/scan/apply_contract.go
@@ -1,0 +1,201 @@
+package scan
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v4/cmd/shared"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/spf13/cobra"
+)
+
+// loadAndApplyScanContract is the single boundary between the repository-owned
+// contract and the existing CLI scan model. Contract values are applied first,
+// while flags Cobra marked as changed retain ordinary CLI precedence. Failure
+// gates are different: an explicit runner value is a floor that the contract
+// may tighten, but never weaken.
+func loadAndApplyScanContract(cmd *cobra.Command, scanInfo *cautils.ScanInfo, path, name string) (*contractv1alpha1.SelectedContract, error) {
+	if path == "" {
+		if name != "" {
+			return nil, fmt.Errorf("--contract requires --scan-contract")
+		}
+		return nil, nil
+	}
+
+	selected, err := contractv1alpha1.LoadFile(path, contractv1alpha1.LoadOptions{
+		ContractName:        name,
+		RunningVersion:      versioncheck.BuildNumber,
+		SupportedFormats:    shared.ScanFormats,
+		SupportedSeverities: reporthandlingapis.GetSupportedSeverities(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := validateContractRunnerConflicts(selected, scanInfo); err != nil {
+		return nil, err
+	}
+
+	applyContractOrdinarySettings(cmd, scanInfo, selected.Contract)
+	applyContractGateFloors(cmd, scanInfo, selected.Contract)
+	return selected, nil
+}
+
+func validateContractRunnerConflicts(selected *contractv1alpha1.SelectedContract, scanInfo *cautils.ScanInfo) error {
+	if selected == nil || selected.Contract.Policy == nil || selected.Contract.Policy.ControlsVersion == nil {
+		return nil
+	}
+
+	var conflicts []string
+	if scanInfo.AccountID != "" {
+		conflicts = append(conflicts, "--account")
+	}
+	if scanInfo.UseArtifactsFrom != "" {
+		conflicts = append(conflicts, "--use-artifacts-from")
+	}
+	if len(scanInfo.UseFrom) > 0 {
+		conflicts = append(conflicts, "--use-from")
+	}
+	if scanInfo.UseDefault {
+		conflicts = append(conflicts, "--use-default")
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("scan contract policy.controlsVersion cannot be used with %s because that mode bypasses the versioned policy download", strings.Join(conflicts, ", "))
+	}
+	return nil
+}
+
+func applyContractOrdinarySettings(cmd *cobra.Command, scanInfo *cautils.ScanInfo, contract contractv1alpha1.Contract) {
+	if contract.Policy != nil && contract.Policy.ControlsVersion != nil && !commandFlagChanged(cmd, "controls-version") {
+		scanInfo.ControlsVersion = *contract.Policy.ControlsVersion
+	}
+	if contract.Scope != nil {
+		includeChanged := commandFlagChanged(cmd, "include-namespaces")
+		excludeChanged := commandFlagChanged(cmd, "exclude-namespaces")
+		if contract.Scope.IncludeNamespaces != nil && !includeChanged && !excludeChanged {
+			scanInfo.IncludeNamespaces = strings.Join(*contract.Scope.IncludeNamespaces, ",")
+		}
+		if contract.Scope.ExcludeNamespaces != nil && !includeChanged && !excludeChanged {
+			scanInfo.ExcludedNamespaces = strings.Join(*contract.Scope.ExcludeNamespaces, ",")
+		}
+	}
+	if contract.Evaluation != nil {
+		if contract.Evaluation.ScanTimeout != nil && !commandFlagChanged(cmd, "scan-timeout") {
+			scanInfo.ScanTimeout = contract.Evaluation.ScanTimeout.Duration
+		}
+		if contract.Evaluation.ControlTimeout != nil && !commandFlagChanged(cmd, "control-timeout") {
+			scanInfo.ControlTimeout = contract.Evaluation.ControlTimeout.Duration
+		}
+	}
+	if contract.Output != nil {
+		if contract.Output.Formats != nil && !commandFlagChanged(cmd, "format") {
+			scanInfo.Format = strings.Join(*contract.Output.Formats, ",")
+		}
+		if contract.Output.OmitRawResources != nil && !commandFlagChanged(cmd, "omit-raw-resources") {
+			scanInfo.OmitRawResources = *contract.Output.OmitRawResources
+		}
+	}
+}
+
+func applyContractGateFloors(cmd *cobra.Command, scanInfo *cautils.ScanInfo, contract contractv1alpha1.Contract) {
+	if contract.Failure == nil {
+		return
+	}
+
+	if contract.Failure.SeverityAtLeast != nil {
+		contractValue := *contract.Failure.SeverityAtLeast
+		if commandFlagChanged(cmd, "severity-threshold") {
+			effective, floorWon := stricterSeverity(contractValue, scanInfo.FailThresholdSeverity)
+			scanInfo.FailThresholdSeverity = effective
+			logIgnoredWeakerGate("severityAtLeast", floorWon)
+		} else {
+			scanInfo.FailThresholdSeverity = contractValue
+		}
+	}
+	if contract.Failure.ComplianceBelow != nil {
+		contractValue := float32(*contract.Failure.ComplianceBelow)
+		floorWon := commandFlagChanged(cmd, "compliance-threshold") && scanInfo.ComplianceThreshold > contractValue
+		if contractValue > scanInfo.ComplianceThreshold {
+			scanInfo.ComplianceThreshold = contractValue
+		}
+		logIgnoredWeakerGate("complianceBelow", floorWon)
+	}
+	if contract.Failure.CoverageBelow != nil {
+		contractValue := float32(*contract.Failure.CoverageBelow)
+		floorWon := commandFlagChanged(cmd, "fail-coverage-below") && scanInfo.FailCoverageThreshold > contractValue
+		if contractValue > scanInfo.FailCoverageThreshold {
+			scanInfo.FailCoverageThreshold = contractValue
+		}
+		logIgnoredWeakerGate("coverageBelow", floorWon)
+	}
+	if contract.Failure.DegradedPolicyInput != nil {
+		contractFails := *contract.Failure.DegradedPolicyInput == contractv1alpha1.DegradedPolicyInputFail
+		floorWon := commandFlagChanged(cmd, "fail-on-degraded-config") && scanInfo.FailOnDegradedConfig && !contractFails
+		scanInfo.FailOnDegradedConfig = scanInfo.FailOnDegradedConfig || contractFails
+		logIgnoredWeakerGate("degradedPolicyInput", floorWon)
+	}
+}
+
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return flag.Changed
+	}
+	if flag := cmd.InheritedFlags().Lookup(name); flag != nil {
+		return flag.Changed
+	}
+	return false
+}
+
+func stricterSeverity(contractValue, runnerFloor string) (string, bool) {
+	if runnerFloor == "" {
+		return contractValue, false
+	}
+	if severityStrictness(runnerFloor) <= severityStrictness(contractValue) {
+		return runnerFloor, !strings.EqualFold(strings.TrimSpace(runnerFloor), strings.TrimSpace(contractValue))
+	}
+	return contractValue, false
+}
+
+// Lower severity boundaries are stricter because they fail on a wider set of
+// findings. Unknown is kept last for compatibility with the existing accepted
+// severity vocabulary; validation still owns whether it is executable.
+func severityStrictness(value string) int {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "low":
+		return 0
+	case "medium":
+		return 1
+	case "high":
+		return 2
+	case "critical":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func logIgnoredWeakerGate(field string, ignored bool) {
+	if ignored {
+		logger.L().Info("Scan contract gate cannot weaken the explicit CLI floor", helpers.String("field", field))
+	}
+}
+
+func contractPolicyIdentifiers(selected *contractv1alpha1.SelectedContract) []cautils.PolicyIdentifier {
+	if selected == nil || selected.Contract.Policy == nil {
+		return nil
+	}
+	policy := selected.Contract.Policy
+	var identifiers []cautils.PolicyIdentifier
+	if policy.Frameworks != nil {
+		identifiers = cautils.AppendPolicyIdentifiers(identifiers, *policy.Frameworks, apisv1.KindFramework)
+	}
+	if policy.Controls != nil {
+		identifiers = cautils.AppendPolicyIdentifiers(identifiers, *policy.Controls, apisv1.KindControl)
+	}
+	return identifiers
+}

--- a/cmd/scan/apply_contract_test.go
+++ b/cmd/scan/apply_contract_test.go
@@ -1,0 +1,354 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errContractScanReached = errors.New("contract scan reached")
+
+type contractCaptureKubescape struct {
+	mocks.MockIKubescape
+	captured *cautils.ScanInfo
+	policies []cautils.PolicyIdentifier
+}
+
+func (m *contractCaptureKubescape) Context() context.Context {
+	return context.Background()
+}
+
+func (m *contractCaptureKubescape) ScanContext(_ context.Context, scanInfo *cautils.ScanInfo, policies []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	copied := *scanInfo
+	m.captured = &copied
+	m.policies = append([]cautils.PolicyIdentifier(nil), policies...)
+	return nil, errContractScanReached
+}
+
+func writeScanContract(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubescape.yaml")
+	document := fmt.Sprintf(`apiVersion: config.kubescape.io/v1alpha1
+kind: ScanContract
+metadata:
+  name: application-test
+spec:
+  minimumKubescapeVersion: v0.0.1
+  defaultContract: ci
+  contracts:
+    ci:
+%s
+`, body)
+	require.NoError(t, os.WriteFile(path, []byte(document), 0o600))
+	return path
+}
+
+func executeCapturedScan(t *testing.T, contractBody string, args ...string) (*cautils.ScanInfo, []cautils.PolicyIdentifier, error) {
+	t.Helper()
+	path := writeScanContract(t, contractBody)
+	ks := &contractCaptureKubescape{}
+	cmd := GetScanCommand(ks)
+	root := &cobra.Command{Use: "kubescape", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(cmd)
+	root.SetArgs(append([]string{"scan"}, append(args, "--scan-contract", path)...))
+	err := root.Execute()
+	return ks.captured, ks.policies, err
+}
+
+func TestScanContractAppliesOrdinarySettings(t *testing.T) {
+	scanInfo, policies, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307
+      scope:
+        includeNamespaces: [payments, shared]
+      evaluation:
+        scanTimeout: 2m
+        controlTimeout: 30s
+      output:
+        formats: [json, sarif]
+        omitRawResources: true`, ".")
+
+	require.ErrorIs(t, err, errContractScanReached)
+	require.NotNil(t, scanInfo)
+	assert.Equal(t, "v2.0.307", scanInfo.ControlsVersion)
+	assert.Equal(t, "payments,shared", scanInfo.IncludeNamespaces)
+	assert.Equal(t, 2*time.Minute, scanInfo.ScanTimeout)
+	assert.Equal(t, 30*time.Second, scanInfo.ControlTimeout)
+	assert.Equal(t, "json,sarif", scanInfo.Format)
+	assert.True(t, scanInfo.OmitRawResources)
+	assert.Equal(t, cautils.ScanTypeRepo, scanInfo.ScanType)
+	require.Equal(t, []cautils.PolicyIdentifier{{Identifier: "nsa", Kind: apisv1.KindFramework}}, policies)
+}
+
+func TestExplicitCLIOverridesOrdinaryContractSettings(t *testing.T) {
+	scanInfo, _, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307
+      scope:
+        includeNamespaces: [contract-ns]
+      evaluation:
+        scanTimeout: 2m
+        controlTimeout: 30s
+      output:
+        formats: [json]
+        omitRawResources: true`,
+		".",
+		"--controls-version", "v2.0.400",
+		"--include-namespaces", "runner-ns",
+		"--scan-timeout", "5m",
+		"--control-timeout", "1m",
+		"--format", "yaml",
+		"--omit-raw-resources=false")
+
+	require.ErrorIs(t, err, errContractScanReached)
+	require.NotNil(t, scanInfo)
+	assert.Equal(t, "v2.0.400", scanInfo.ControlsVersion)
+	assert.Equal(t, "runner-ns", scanInfo.IncludeNamespaces)
+	assert.Equal(t, 5*time.Minute, scanInfo.ScanTimeout)
+	assert.Equal(t, time.Minute, scanInfo.ControlTimeout)
+	assert.Equal(t, "yaml", scanInfo.Format)
+	assert.False(t, scanInfo.OmitRawResources)
+}
+
+func TestExplicitNamespaceModeOverridesTheContractNamespaceMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		contractScope string
+		flags         []string
+		wantIncluded  string
+		wantExcluded  string
+	}{
+		{
+			name:          "runner include replaces contract exclude",
+			contractScope: "excludeNamespaces: [contract-excluded]",
+			flags:         []string{"--include-namespaces", "runner-included"},
+			wantIncluded:  "runner-included",
+		},
+		{
+			name:          "runner exclude replaces contract include",
+			contractScope: "includeNamespaces: [contract-included]",
+			flags:         []string{"--exclude-namespaces", "runner-excluded"},
+			wantExcluded:  "runner-excluded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`
+      policy:
+        frameworks: [nsa]
+      scope:
+        %s`, tt.contractScope)
+			args := append([]string{"."}, tt.flags...)
+			scanInfo, _, err := executeCapturedScan(t, body, args...)
+
+			require.ErrorIs(t, err, errContractScanReached)
+			require.NotNil(t, scanInfo)
+			assert.Equal(t, tt.wantIncluded, scanInfo.IncludeNamespaces)
+			assert.Equal(t, tt.wantExcluded, scanInfo.ExcludedNamespaces)
+		})
+	}
+}
+
+func TestContractAndCLIGateFloorsResolveMonotonically(t *testing.T) {
+	tests := []struct {
+		name                         string
+		failure                      string
+		flags                        []string
+		wantSeverity                 string
+		wantCompliance, wantCoverage float32
+		wantDegraded                 bool
+	}{
+		{
+			name: "contract supplies gates when runner has no floor",
+			failure: `severityAtLeast: medium
+        complianceBelow: 80
+        coverageBelow: 90
+        degradedPolicyInput: fail`,
+			wantSeverity: "medium", wantCompliance: 80, wantCoverage: 90, wantDegraded: true,
+		},
+		{
+			name: "contract tightens every runner floor",
+			failure: `severityAtLeast: low
+        complianceBelow: 95
+        coverageBelow: 98
+        degradedPolicyInput: fail`,
+			flags:        []string{"--severity-threshold", "high", "--compliance-threshold", "80", "--fail-coverage-below", "90", "--fail-on-degraded-config=false"},
+			wantSeverity: "low", wantCompliance: 95, wantCoverage: 98, wantDegraded: true,
+		},
+		{
+			name: "contract cannot weaken any runner floor",
+			failure: `severityAtLeast: critical
+        complianceBelow: 70
+        coverageBelow: 75
+        degradedPolicyInput: allow`,
+			flags:        []string{"--severity-threshold", "medium", "--compliance-threshold", "85", "--fail-coverage-below", "92", "--fail-on-degraded-config"},
+			wantSeverity: "medium", wantCompliance: 85, wantCoverage: 92, wantDegraded: true,
+		},
+		{
+			name: "equal gates remain equal",
+			failure: `severityAtLeast: high
+        complianceBelow: 80
+        coverageBelow: 90
+        degradedPolicyInput: allow`,
+			flags:        []string{"--severity-threshold", "high", "--compliance-threshold", "80", "--fail-coverage-below", "90", "--fail-on-degraded-config=false"},
+			wantSeverity: "high", wantCompliance: 80, wantCoverage: 90, wantDegraded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`
+      policy:
+        frameworks: [nsa]
+      failure:
+        %s`, tt.failure)
+			args := append([]string{"."}, tt.flags...)
+			scanInfo, _, err := executeCapturedScan(t, body, args...)
+
+			require.ErrorIs(t, err, errContractScanReached)
+			require.NotNil(t, scanInfo)
+			assert.Equal(t, tt.wantSeverity, scanInfo.FailThresholdSeverity)
+			assert.Equal(t, tt.wantCompliance, scanInfo.ComplianceThreshold)
+			assert.Equal(t, tt.wantCoverage, scanInfo.FailCoverageThreshold)
+			assert.Equal(t, tt.wantDegraded, scanInfo.FailOnDegradedConfig)
+		})
+	}
+}
+
+func TestContractPolicyCanMixFrameworksAndControls(t *testing.T) {
+	_, policies, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [nsa, mitre]
+        controls: [C-0013]`, ".")
+
+	require.ErrorIs(t, err, errContractScanReached)
+	assert.Equal(t, []cautils.PolicyIdentifier{
+		{Identifier: "nsa", Kind: apisv1.KindFramework},
+		{Identifier: "mitre", Kind: apisv1.KindFramework},
+		{Identifier: "C-0013", Kind: apisv1.KindControl},
+	}, policies)
+}
+
+func TestExplicitPolicySubcommandOverridesContractPolicySelection(t *testing.T) {
+	_, policies, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [mitre]
+        controls: [C-0013]`, "framework", "nsa", ".")
+
+	require.ErrorIs(t, err, errContractScanReached)
+	assert.Equal(t, []cautils.PolicyIdentifier{{Identifier: "nsa", Kind: apisv1.KindFramework}}, policies)
+}
+
+func TestContractControlsVersionRejectsBypassModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "account", args: []string{"--account", "runner-account"}, want: "--account"},
+		{name: "artifact directory", args: []string{"--use-artifacts-from", "artifacts"}, want: "--use-artifacts-from"},
+		{name: "local policy", args: []string{"--use-from", "framework.json"}, want: "--use-from"},
+		{name: "cached default", args: []string{"--use-default"}, want: "--use-default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"."}, tt.args...)
+			scanInfo, _, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307`, args...)
+
+			assert.Nil(t, scanInfo)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "policy.controlsVersion cannot be used")
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestContractNameRequiresContractFile(t *testing.T) {
+	cmd := GetScanCommand(&contractCaptureKubescape{})
+	root := &cobra.Command{Use: "kubescape", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(cmd)
+	root.SetArgs([]string{"scan", ".", "--contract", "ci"})
+
+	err := root.Execute()
+	require.EqualError(t, err, "--contract requires --scan-contract")
+}
+
+func TestScanContractIsRejectedForImageCommand(t *testing.T) {
+	path := writeScanContract(t, `
+      policy:
+        frameworks: [nsa]`)
+	cmd := GetScanCommand(&contractCaptureKubescape{})
+	root := &cobra.Command{Use: "kubescape", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(cmd)
+	root.SetArgs([]string{"scan", "image", "nginx:latest", "--scan-contract", path})
+
+	err := root.Execute()
+	require.EqualError(t, err, "--scan-contract is supported for posture scans, not image scans")
+}
+
+func TestContractDrivenAndFlagOnlySettingsAreEquivalent(t *testing.T) {
+	contractInfo, _, contractErr := executeCapturedScan(t, `
+      scope:
+        excludeNamespaces: [kube-system, monitoring]
+      evaluation:
+        scanTimeout: 3m
+        controlTimeout: 20s
+      output:
+        formats: [json]
+        omitRawResources: true
+      failure:
+        severityAtLeast: high
+        complianceBelow: 80
+        coverageBelow: 95
+        degradedPolicyInput: fail`, "framework", "nsa", ".")
+	require.ErrorIs(t, contractErr, errContractScanReached)
+
+	ks := &contractCaptureKubescape{}
+	cmd := GetScanCommand(ks)
+	root := &cobra.Command{Use: "kubescape", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(cmd)
+	root.SetArgs([]string{
+		"scan", "framework", "nsa", ".",
+		"--exclude-namespaces", "kube-system,monitoring",
+		"--scan-timeout", "3m",
+		"--control-timeout", "20s",
+		"--format", "json",
+		"--omit-raw-resources",
+		"--severity-threshold", "high",
+		"--compliance-threshold", "80",
+		"--fail-coverage-below", "95",
+		"--fail-on-degraded-config",
+	})
+	flagErr := root.Execute()
+	require.ErrorIs(t, flagErr, errContractScanReached)
+	require.NotNil(t, ks.captured)
+
+	assert.Equal(t, ks.captured.ExcludedNamespaces, contractInfo.ExcludedNamespaces)
+	assert.Equal(t, ks.captured.ScanTimeout, contractInfo.ScanTimeout)
+	assert.Equal(t, ks.captured.ControlTimeout, contractInfo.ControlTimeout)
+	assert.Equal(t, ks.captured.Format, contractInfo.Format)
+	assert.Equal(t, ks.captured.OmitRawResources, contractInfo.OmitRawResources)
+	assert.Equal(t, ks.captured.FailThresholdSeverity, contractInfo.FailThresholdSeverity)
+	assert.Equal(t, ks.captured.ComplianceThreshold, contractInfo.ComplianceThreshold)
+	assert.Equal(t, ks.captured.FailCoverageThreshold, contractInfo.FailCoverageThreshold)
+	assert.Equal(t, ks.captured.FailOnDegradedConfig, contractInfo.FailOnDegradedConfig)
+}

--- a/cmd/scan/apply_contract_test.go
+++ b/cmd/scan/apply_contract_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubescape/kubescape/v4/cmd/shared"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
@@ -226,6 +227,49 @@ func TestContractAndCLIGateFloorsResolveMonotonically(t *testing.T) {
 			assert.Equal(t, tt.wantCompliance, scanInfo.ComplianceThreshold)
 			assert.Equal(t, tt.wantCoverage, scanInfo.FailCoverageThreshold)
 			assert.Equal(t, tt.wantDegraded, scanInfo.FailOnDegradedConfig)
+		})
+	}
+}
+
+func TestContractDoesNotMaskInvalidExplicitCLIGates(t *testing.T) {
+	tests := []struct {
+		name    string
+		failure string
+		flags   []string
+		wantErr error
+	}{
+		{
+			name:    "invalid severity",
+			failure: "severityAtLeast: high",
+			flags:   []string{"--severity-threshold", "hihg"},
+			wantErr: shared.ErrUnknownSeverity,
+		},
+		{
+			name:    "invalid compliance threshold",
+			failure: "complianceBelow: 80",
+			flags:   []string{"--compliance-threshold", "-1"},
+			wantErr: shared.ErrBadThreshold,
+		},
+		{
+			name:    "invalid coverage threshold",
+			failure: "coverageBelow: 90",
+			flags:   []string{"--fail-coverage-below", "101"},
+			wantErr: shared.ErrBadThreshold,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`
+      policy:
+        frameworks: [nsa]
+      failure:
+        %s`, tt.failure)
+			args := append([]string{"."}, tt.flags...)
+			scanInfo, _, err := executeCapturedScan(t, body, args...)
+
+			assert.Nil(t, scanInfo)
+			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/meta"
 	"github.com/kubescape/kubescape/v4/core/pkg/reportcrypto"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
 	"github.com/kubescape/kubescape/v4/core/pkg/telemetry"
 	"github.com/kubescape/kubescape/v4/pkg/imagescan"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -68,6 +69,9 @@ var scanCmdExamples = fmt.Sprintf(`
 
 func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	var scanInfo cautils.ScanInfo
+	var scanContractPath string
+	var scanContractName string
+	var selectedContract *contractv1alpha1.SelectedContract
 
 	// scanCmd represents the scan command
 	scanCmd := &cobra.Command{
@@ -78,6 +82,14 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Name() == "validate-contract" {
 				return nil
+			}
+			if cmd.Name() == "image" && scanContractPath != "" {
+				return fmt.Errorf("--scan-contract is supported for posture scans, not image scans")
+			}
+			var err error
+			selectedContract, err = loadAndApplyScanContract(cmd, &scanInfo, scanContractPath, scanContractName)
+			if err != nil {
+				return err
 			}
 			// runs for the bare scan command and all subcommands (framework, control, workload, image)
 			if scanInfo.FormatVersion != "v1" && scanInfo.FormatVersion != "v2" {
@@ -127,6 +139,11 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 			scanInfo.View = requestedView
 
+			if policyIdentifiers := contractPolicyIdentifiers(selectedContract); len(policyIdentifiers) > 0 {
+				setContractScanTarget(args, &scanInfo)
+				return securityScan(scanInfo, ks, policyIdentifiers)
+			}
+
 			if scanInfo.View == string(cautils.SecurityViewType) {
 				policyIdentifiers := setSecurityViewScanInfo(args, &scanInfo)
 
@@ -158,6 +175,9 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	}
 
 	scanInfo.TriggeredByCLI = true
+
+	scanCmd.PersistentFlags().StringVar(&scanContractPath, "scan-contract", "", "Path to an explicit repository scan contract")
+	scanCmd.PersistentFlags().StringVar(&scanContractName, "contract", "", "Named contract to select; defaults to spec.defaultContract")
 
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
@@ -285,6 +305,15 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	installTelemetry(scanCmd, ks, &scanInfo)
 
 	return scanCmd
+}
+
+func setContractScanTarget(args []string, scanInfo *cautils.ScanInfo) {
+	if len(args) > 0 {
+		scanInfo.SetScanType(cautils.ScanTypeRepo)
+		scanInfo.InputPatterns = args
+		return
+	}
+	scanInfo.SetScanType(cautils.ScanTypeCluster)
 }
 
 func validateCombinedImageScanFlags(scanInfo *cautils.ScanInfo) error {


### PR DESCRIPTION
## Summary

This PR adds the first application layer for repository scan contracts introduced in [[designs-and-proposals#12](https://github.com/kubescape/designs-and-proposals/pull/12)](https://github.com/kubescape/designs-and-proposals/pull/12).

A repository can now provide a `v1alpha1` contract and run:

```bash
kubescape scan . --scan-contract .kubescape/scan-contract.yaml
```

The contract is loaded before the scan and supplies a shared baseline for policy selection, scan settings, namespace scope, output settings, and failure gates.

## What changed

* Added `--scan-contract` and `--contract` flags to posture scan commands.
* Applied contract policy selection when no explicit scan framework or scan control target is provided.
* Applied normal scan settings from the contract unless the same CLI flag was explicitly set.
* Kept CLI failure gates monotonic: a contract can make a user's requested threshold stricter, but cannot silently weaken it.
* Rejected incompatible combinations, including contract use with image scanning and contract-controlled framework versions with policy-bypass modes.
* Added focused tests for precedence, namespace handling, gate behavior, policy selection, and invalid invocation paths.

## Intent

The goal is to make a checked-in repository contract useful in day-to-day scans without taking control away from someone running Kubescape locally or in CI.

Explicit CLI choices remain authoritative for normal settings, while gates retain the stricter effective value.

This deliberately does not add provenance/reporting metadata yet. That belongs in the next phase once the application behavior is stable.

## Validation

```bash
go test ./cmd/scan ./core/pkg/scancontract/v1alpha1
go vet ./cmd/scan ./core/pkg/scancontract/v1alpha1
golangci-lint run ./cmd/scan/... ./core/pkg/scancontract/v1alpha1/...
go build ./...
```

All pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scan contract support for repository and posture scans.
  * Contract files can define scan settings, severity thresholds, failure gates, frameworks, and controls.
  * Added automatic target selection from posture scan arguments.
* **Validation**
  * Validates contract versions, formats, severity values, and threshold settings.
  * Prevents conflicting runner modes and unsupported contract usage with image scans.
* **Configuration**
  * Explicit command-line options take precedence over contract settings.
  * Contract failure gates cannot weaken stricter command-line thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->