### PR TITLE
fix(resourcehandler): a namespace filter naming no namespace silently skips every namespaced query

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -83,6 +83,11 @@ func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 
 }
 
+// GetNamespacesSelectors returns one field selector per query the collection has
+// to run for this resource. It never returns an empty slice: pullSingleResource
+// runs one query per entry, so no entry means the resource is never listed, and
+// a resource that is never listed leaves no failure behind either — the scan
+// reports it as collected and empty, and every control over it reads as clean.
 func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource, namespaced *bool) []string {
 	fieldSelectors := []string{}
 	for n := range strings.SplitSeq(is.namespace, FieldSelectorsSeparator) {
@@ -99,6 +104,11 @@ func (is *IncludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionR
 			return []string{""}
 		}
 		fieldSelectors = append(fieldSelectors, sel)
+	}
+	if len(fieldSelectors) == 0 {
+		// The value named no namespace, so it narrows nothing; fall back to the
+		// unfiltered query rather than dropping the resource.
+		return []string{""}
 	}
 	return fieldSelectors
 }

--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -13,6 +13,22 @@ const (
 	FieldSelectorsNotEqualsOperator = "!="
 )
 
+// splitNamespaces parses a comma-separated namespace list (as passed to
+// --include-namespaces / --exclude-namespaces) into a clean slice. Empty
+// entries and surrounding whitespace are dropped.
+func splitNamespaces(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for p := range strings.SplitSeq(s, ",") {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 type IFieldSelector interface {
 	GetNamespacesSelectors(*schema.GroupVersionResource, *bool) []string
 	GetClusterScope(*schema.GroupVersionResource) bool

--- a/core/pkg/resourcehandler/fieldselector_test.go
+++ b/core/pkg/resourcehandler/fieldselector_test.go
@@ -67,9 +67,11 @@ func TestIncludeNamespacesSelectors(t *testing.T) {
 	manyNs := NewIncludeSelector("a,b,c,d,e")
 	assert.Equal(t, []string{""}, manyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "clusterroles"}, nil))
 
-	// empty namespace string: no valid namespace to include, so result is empty
+	// A value naming no namespace narrows nothing, so it collapses to the single
+	// unfiltered query. An empty slice would make pullSingleResource run no query
+	// at all and drop the resource without recording a failure.
 	emptyNs := NewIncludeSelector("")
-	assert.Empty(t, emptyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"}, nil))
+	assert.Equal(t, []string{""}, emptyNs.GetNamespacesSelectors(&schema.GroupVersionResource{Resource: "pods"}, nil))
 
 	// malformed input with empty segments: empty segments are skipped
 	malformed := NewIncludeSelector("ns1,,ns3")

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -1169,22 +1169,6 @@ func (k8sHandler *K8sResourceHandler) countNamespaces(ctx context.Context, scanI
 	return count
 }
 
-// splitNamespaces parses a comma-separated namespace list (as passed to
-// --include-namespaces / --exclude-namespaces) into a clean slice. Empty
-// entries and surrounding whitespace are dropped.
-func splitNamespaces(s string) []string {
-	if s == "" {
-		return nil
-	}
-	var out []string
-	for p := range strings.SplitSeq(s, ",") {
-		if v := strings.TrimSpace(p); v != "" {
-			out = append(out, v)
-		}
-	}
-	return out
-}
-
 func (k8sHandler *K8sResourceHandler) pullWorkerNodesNumber(ctx context.Context) (int, error) {
 	schedulableCount := 0
 	err := getter.ListWithPagination(ctx, func(opts metav1.ListOptions) (string, error) {

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -99,6 +99,44 @@ func TestPullResources_PartialFailureSurface(t *testing.T) {
 	assert.ErrorContains(t, fq.err, "simulated API failure")
 }
 
+// A namespace filter naming no namespace must not silence collection. The
+// selector emitted no query for it, so pullSingleResource never listed the
+// resource and left no selectorFailure behind, which reads downstream as a GVR
+// that was collected and came back empty rather than one that was skipped.
+func TestPullResources_NamespaceFilterNamingNoNamespaceStillCollects(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	for _, value := range []string{" ", ",", ", ,"} {
+		t.Run(value, func(t *testing.T) {
+			var selectors []string
+			mockClient := &mockDynamicClient{
+				listFunc: func(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+					selectors = append(selectors, opts.FieldSelector)
+					return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{
+						Object: map[string]any{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata":   map[string]any{"name": "test-pod", "namespace": "default"},
+						},
+					}}}, nil
+				},
+			}
+
+			handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{DynamicClient: mockClient}}
+			queryableResources := QueryableResources{
+				"//v1/pods": QueryableResource{GroupVersionResourceTriplet: "//v1/pods"},
+			}
+
+			k8sResources, allResources, failedQueries := handler.pullResources(context.Background(), queryableResources, NewIncludeSelector(value), "")
+
+			assert.Equal(t, []string{""}, selectors, "expected one unfiltered LIST")
+			assert.Len(t, allResources, 1)
+			assert.Len(t, k8sResources["//v1/pods"], 1)
+			assert.Empty(t, failedQueries)
+		})
+	}
+}
+
 func TestGetResources_SurfacesMissingGVRFailuresInInfoMap(t *testing.T) {
 	k8sinterface.InitializeMapResourcesMock()
 	handler := getResourceHandlerMock()

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -174,11 +174,16 @@ func getGroupNVersion(apiVersion string) (string, string) {
 	return group, version
 }
 
+// getFieldSelectorFromScanInfo picks the namespace filter the collection queries
+// carry. A flag is honored only when its value actually names a namespace: a
+// value made of separators and whitespace ("," or " ") narrows nothing, which is
+// already how countNamespaces and the report metadata read it, and an include
+// selector built from one emits no query at all (see GetNamespacesSelectors).
 func getFieldSelectorFromScanInfo(scanInfo *cautils.ScanInfo) IFieldSelector {
-	if scanInfo.IncludeNamespaces != "" {
+	if len(splitNamespaces(scanInfo.IncludeNamespaces)) > 0 {
 		return NewIncludeSelector(scanInfo.IncludeNamespaces)
 	}
-	if scanInfo.ExcludedNamespaces != "" {
+	if len(splitNamespaces(scanInfo.ExcludedNamespaces)) > 0 {
 		return NewExcludeSelector(scanInfo.ExcludedNamespaces)
 	}
 

--- a/core/pkg/resourcehandler/k8sresourcesutils_test.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils_test.go
@@ -240,3 +240,40 @@ func TestInsertControls(t *testing.T) {
 		}
 	})
 }
+
+func TestGetFieldSelectorFromScanInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		include  string
+		exclude  string
+		expected IFieldSelector
+	}{
+		{name: "no filters", expected: &EmptySelector{}},
+		{name: "include narrows", include: "default", expected: &IncludeSelector{namespace: "default"}},
+		{name: "exclude narrows", exclude: "kube-system", expected: &ExcludeSelector{namespace: "kube-system"}},
+		{name: "include wins over exclude", include: "default", exclude: "kube-system", expected: &IncludeSelector{namespace: "default"}},
+		// A value built from separators and whitespace names no namespace, so it
+		// must not be honored: countNamespaces and the report metadata both read
+		// it as "no narrowing", and an include selector built from one used to
+		// leave every namespaced resource unqueried.
+		{name: "blank include", include: " ", expected: &EmptySelector{}},
+		{name: "separator-only include", include: ",", expected: &EmptySelector{}},
+		{name: "separator-only exclude", exclude: ", ,", expected: &EmptySelector{}},
+		{name: "blank include falls through to a real exclude", include: ",", exclude: "kube-system", expected: &ExcludeSelector{namespace: "kube-system"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{IncludeNamespaces: tt.include, ExcludedNamespaces: tt.exclude}
+			assert.Equal(t, tt.expected, getFieldSelectorFromScanInfo(scanInfo))
+		})
+	}
+}
+
+func TestSplitNamespaces(t *testing.T) {
+	assert.Nil(t, splitNamespaces(""))
+	assert.Nil(t, splitNamespaces(" "))
+	assert.Nil(t, splitNamespaces(",,"))
+	assert.Equal(t, []string{"default"}, splitNamespaces("default,"))
+	assert.Equal(t, []string{"default", "prod"}, splitNamespaces(" default , prod "))
+}


### PR DESCRIPTION
## Overview

`--include-namespaces` and `--exclude-namespaces` are comma separated lists, and everywhere except the collector a value that ends up naming no namespace is read as "no narrowing". `splitNamespaces` drops blank entries for the progress estimate, `splitNamespaceList` does the same for the report metadata, and `ExcludeSelector` collapses to one unfiltered query. The one place that disagrees is `getFieldSelectorFromScanInfo`, which only checks that the flag value is a non empty string.

So a value like `,` or a single space picks `IncludeSelector`, and `IncludeSelector.GetNamespacesSelectors` skips every blank entry and returns an empty slice. `pullSingleResource` runs one LIST per entry in that slice, so with zero entries it runs no LIST at all: it returns no items and no selector failure. Nothing downstream can tell that apart from a resource that was listed and came back empty. `recordFailedQueryStatuses` sees no failed query so it writes no skipped status into the InfoMap, coverage is not docked, and every control over a namespaced resource reports clean. Cluster scoped resources are unaffected because they hit the existing early return, which makes the failure mode worse rather than obvious: the scan collects nodes and cluster roles as usual and quietly drops all the workloads.

This is easy to hit from CI, where the flag is usually fed from a variable. `--include-namespaces "$NS_LIST"` with `NS_LIST=","` or a stray space produces a green scan over nothing.

## Fix

Two parts, one per side of the seam.

`getFieldSelectorFromScanInfo` now honours a flag only when its value actually names a namespace, reusing the `splitNamespaces` parser the progress count already used. A blank only include value therefore falls through to a real `--exclude-namespaces` if one was given, and to `EmptySelector` otherwise, which is what the rest of the scan already assumed. The parser moved from `k8sresources.go` to `fieldselector.go` in the first commit so it sits next to the selectors it feeds; that commit is a pure move.

`IncludeSelector.GetNamespacesSelectors` no longer returns an empty slice under any input. If no namespace resolved to a selector it falls back to the single unfiltered query it already returns for cluster scoped resources. The selector is exported, so this is the floor that keeps a future caller constructing it directly from silently dropping every query rather than relying on the caller above to have filtered first.

## Note

One existing assertion changed. `TestIncludeNamespacesSelectors` pinned `NewIncludeSelector("")` returning an empty slice, with a comment reading "no valid namespace to include, so result is empty". That was recording the output rather than a decision, and it is exactly the shape that makes `pullSingleResource` skip the resource, so it now expects the unfiltered query instead.

The detail most likely to regress is the cluster scoped early return inside the loop. It has to stay a `return`, not a `break`, or a multi namespace include would emit one query per namespace for a cluster scoped resource and append the same objects to `k8sResources[gvr]` once per namespace. The new floor is deliberately placed after the loop so it cannot change that path.

## Testing

`TestGetFieldSelectorFromScanInfo` covers the selector choice across both flags, including a blank include falling through to a real exclude. `TestPullResources_NamespaceFilterNamingNoNamespaceStillCollects` drives the collector for `" "`, `","` and `", ,"` and asserts one unfiltered LIST, the pod collected, and no failed query. `TestSplitNamespaces` covers the moved parser.

All four new assertions fail against `master` and pass with the change. `go build ./...`, `go vet`, `gofmt` and `go test ./core/...` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace filtering to ignore blank or separator-only values.
  * Resources are now collected with an unfiltered query when no valid namespace is specified, preventing them from being skipped.
  * Added consistent handling for whitespace and comma-separated namespace inputs.

* **Tests**
  * Expanded coverage for namespace parsing, selector precedence, and resource collection without a valid namespace filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->