### PR TITLE
fix(config): make config set keys case-insensitive and accept kebab-c…

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -50,6 +50,30 @@ func stringKeysToSlice(m map[string]func(*metav1.SetConfig, string)) []string {
 	return l
 }
 
+// normalizeConfigKey standardizes a key by stripping hyphens/underscores and converting to lowercase.
+func normalizeConfigKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, "_", "")
+	return key
+}
+
+func findConfigSetter(key string) (func(*metav1.SetConfig, string), bool) {
+	if setter, ok := supportConfigSet[key]; ok {
+		return setter, true
+	}
+	normalized := normalizeConfigKey(key)
+	if normalized == "account" {
+		normalized = "accountid"
+	}
+	for canonicalKey, setter := range supportConfigSet {
+		if normalizeConfigKey(canonicalKey) == normalized {
+			return setter, true
+		}
+	}
+	return nil, false
+}
+
 func parseSetArgs(args []string) (*metav1.SetConfig, error) {
 	supported := strings.Join(stringKeysToSlice(supportConfigSet), "/")
 
@@ -79,7 +103,7 @@ func parseSetArgs(args []string) (*metav1.SetConfig, error) {
 	}
 
 	setConfig := &metav1.SetConfig{}
-	if setConfigFunc, ok := supportConfigSet[key]; ok {
+	if setConfigFunc, ok := findConfigSetter(key); ok {
 		setConfigFunc(setConfig, value)
 		return setConfig, nil
 	}

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -92,6 +92,54 @@ func TestParseSetArgs_InvalidKey(t *testing.T) {
 	assert.EqualError(t, err, `key "invalidKey" unknown; supported: accessKey/accountID/cloudAPIURL/cloudReportURL`)
 }
 
+func TestParseSetArgs_CaseInsensitiveAndKebabCase(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantField string
+		wantVal   string
+	}{
+		{name: "accountId camelCase", args: []string{"accountId=val-acc"}, wantField: "account", wantVal: "val-acc"},
+		{name: "accountid lowercase", args: []string{"accountid=val-acc"}, wantField: "account", wantVal: "val-acc"},
+		{name: "account-id kebab-case", args: []string{"account-id=val-acc"}, wantField: "account", wantVal: "val-acc"},
+		{name: "account_id snake-case", args: []string{"account_id", "val-acc"}, wantField: "account", wantVal: "val-acc"},
+		{name: "account alias", args: []string{"account=val-acc"}, wantField: "account", wantVal: "val-acc"},
+		{name: "ACCOUNT_ID uppercase", args: []string{"ACCOUNT_ID=val-acc"}, wantField: "account", wantVal: "val-acc"},
+
+		{name: "accesskey lowercase", args: []string{"accesskey=val-key"}, wantField: "accessKey", wantVal: "val-key"},
+		{name: "access-key kebab-case", args: []string{"access-key=val-key"}, wantField: "accessKey", wantVal: "val-key"},
+		{name: "access_key snake-case", args: []string{"access_key", "val-key"}, wantField: "accessKey", wantVal: "val-key"},
+		{name: "ACCESS_KEY uppercase", args: []string{"ACCESS_KEY=val-key"}, wantField: "accessKey", wantVal: "val-key"},
+
+		{name: "cloudApiUrl mixedCase", args: []string{"cloudApiUrl=https://api.example.com"}, wantField: "cloudAPIURL", wantVal: "https://api.example.com"},
+		{name: "cloud-api-url kebab-case", args: []string{"cloud-api-url=https://api.example.com"}, wantField: "cloudAPIURL", wantVal: "https://api.example.com"},
+		{name: "cloud_api_url snake-case", args: []string{"cloud_api_url", "https://api.example.com"}, wantField: "cloudAPIURL", wantVal: "https://api.example.com"},
+
+		{name: "cloudReportUrl mixedCase", args: []string{"cloudReportUrl=https://report.example.com"}, wantField: "cloudReportURL", wantVal: "https://report.example.com"},
+		{name: "cloud-report-url kebab-case", args: []string{"cloud-report-url=https://report.example.com"}, wantField: "cloudReportURL", wantVal: "https://report.example.com"},
+		{name: "cloud_report_url snake-case", args: []string{"cloud_report_url", "https://report.example.com"}, wantField: "cloudReportURL", wantVal: "https://report.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setConfig, err := parseSetArgs(tt.args)
+			assert.NoError(t, err)
+			assert.NotNil(t, setConfig)
+
+			switch tt.wantField {
+			case "account":
+				assert.Equal(t, tt.wantVal, setConfig.Account)
+			case "accessKey":
+				assert.Equal(t, tt.wantVal, setConfig.AccessKey)
+			case "cloudAPIURL":
+				assert.Equal(t, tt.wantVal, setConfig.CloudAPIURL)
+			case "cloudReportURL":
+				assert.Equal(t, tt.wantVal, setConfig.CloudReportURL)
+			}
+		})
+	}
+}
+
 func TestParseSetArgs_TooManyArgs(t *testing.T) {
 	_, err := parseSetArgs([]string{"accountID", "v", "extra"})
 	assert.ErrorContains(t, err, "too many arguments")


### PR DESCRIPTION

## Overview
`kubescape config set` currently requires strict case-sensitive matching for keys (e.g. only `accountID`, `accessKey`, `cloudAPIURL`, and `cloudReportURL` are accepted). If a user inputs common variations like `accountId`, `account-id`, `access-key`, or `cloud-api-url`, it fails with an unknown key error.

This PR adds key normalization so that case-insensitive keys, kebab-case, and snake-case inputs are properly recognized and mapped to the corresponding configuration setters.

## How to Test
1. Run unit tests:
   ```bash
   go test -v ./cmd/config/...
   ```
2. Test CLI commands with various casing/kebab-case formats:
   ```bash
   kubescape config set accountId=test-account
   kubescape config set account-id=test-account
   kubescape config set access-key=test-key
   kubescape config set cloud-api-url=https://api.example.com
   ```

## Related issues/PRs:
* Resolved #3540

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration keys can now be entered without regard to capitalization.
  * Hyphens and underscores are ignored when matching configuration keys.
  * Added support for common naming styles, including camelCase, kebab-case, and snake_case.
  * The `account` alias can now be used when setting the account ID.
* **Bug Fixes**
  * Improved recognition of account, access key, Cloud API URL, and Cloud Report URL settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->