### PR TITLE
feat(version): add yaml output format support (#3542)

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubescape/backend/pkg/versioncheck"
 	"github.com/kubescape/kubescape/v4/core/meta"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 type versionInfo struct {
@@ -36,6 +37,18 @@ func GetVersionCmd(ks meta.IKubescape, version, commit, date string) *cobra.Comm
 				}
 				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(b))
 				return err
+			case "yaml":
+				info := versionInfo{
+					Version: version,
+					Commit:  commit,
+					Date:    date,
+				}
+				b, err := yaml.Marshal(info)
+				if err != nil {
+					return fmt.Errorf("failed to marshal version info: %w", err)
+				}
+				_, err = fmt.Fprint(cmd.OutOrStdout(), string(b))
+				return err
 			case "text":
 				v := versioncheck.NewIVersionCheckHandler(ks.Context())
 				_ = v.CheckLatestVersion(ks.Context(), versioncheck.NewVersionCheckRequest("", version, "", "", "version", nil))
@@ -49,12 +62,12 @@ func GetVersionCmd(ks meta.IKubescape, version, commit, date string) *cobra.Comm
 				_, err := fmt.Fprintf(cmd.OutOrStdout(), "Build date: %s\n", date)
 				return err
 			default:
-				return fmt.Errorf("unsupported format %q, supported: text, json", outputFormat)
+				return fmt.Errorf("unsupported format %q, supported: text, json, yaml", outputFormat)
 			}
 		},
 	}
 
-	versionCmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json"`)
+	versionCmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json", "yaml"`)
 
 	return versionCmd
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 type errorWriter struct {
@@ -113,6 +114,53 @@ func TestGetVersionCmd_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestGetVersionCmd_YAMLOutput(t *testing.T) {
+	t.Setenv("KS_SKIP_UPDATE_CHECK", "true")
+
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+		date    string
+	}{
+		{
+			name:    "all fields populated",
+			version: "v3.0.1",
+			commit:  "abc123",
+			date:    "2024-01-15",
+		},
+		{
+			name:    "empty commit and date",
+			version: "v3.2.0",
+			commit:  "",
+			date:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			versioncheck.BuildNumber = tt.version
+
+			ks := core.NewKubescape(context.Background())
+			cmd := GetVersionCmd(ks, tt.version, tt.commit, tt.date)
+			require.NotNil(t, cmd)
+
+			buf := bytes.NewBufferString("")
+			cmd.SetOut(buf)
+			cmd.SetArgs([]string{"--format", "yaml"})
+			require.NoError(t, cmd.Execute())
+
+			out, err := io.ReadAll(buf)
+			require.NoError(t, err)
+
+			var got versionInfo
+			require.NoError(t, yaml.Unmarshal(out, &got))
+			assert.Equal(t, tt.version, got.Version)
+			assert.Equal(t, tt.commit, got.Commit)
+			assert.Equal(t, tt.date, got.Date)
+		})
+	}
+}
+
 func TestGetVersionCmd_FormatFlagRegistered(t *testing.T) {
 	ks := core.NewKubescape(context.Background())
 	cmd := GetVersionCmd(ks, "v3.0.0", "", "")
@@ -130,11 +178,11 @@ func TestGetVersionCmd_InvalidFormat(t *testing.T) {
 	cmd := GetVersionCmd(ks, "v3.0.0", "", "")
 	require.NotNil(t, cmd)
 
-	cmd.SetArgs([]string{"--format", "yaml"})
+	cmd.SetArgs([]string{"--format", "xml"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "yaml")
+	assert.Contains(t, err.Error(), "xml")
 }
 
 func TestGetVersionCmd_TextWriterError(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -835,14 +835,14 @@ Display version information.
 ### Synopsis
 
 ```bash
-kubescape version [--format text|json]
+kubescape version [--format text|json|yaml]
 ```
 
 ### Flags
 
 | Flag | Short | Default | Description |
 |---|---|---|---|
-| `--format` | `-f` | `text` | Output format. Supported: `text`, `json` |
+| `--format` | `-f` | `text` | Output format. Supported: `text`, `json`, `yaml` |
 
 ### Examples
 
@@ -853,6 +853,12 @@ kubescape version
 # Machine-readable JSON output (safe to pipe to jq)
 kubescape version --format json
 # {"version":"v3.x.x","commit":"abc123","date":"2024-01-15"}
+
+# Machine-readable YAML output
+kubescape version --format yaml
+# commit: abc123
+# date: "2024-01-15"
+# version: v3.x.x
 ```
 
 ---


### PR DESCRIPTION

## Overview
Currently, `kubescape version` only supports `--format text` and `--format json`. Other subcommands in Kubescape (such as `list`, `scan`, `diff`, and `config view`) support YAML as a standard output format.

This PR adds `--format yaml` (and `-f yaml`) support to `kubescape version` to ensure CLI formatting flag consistency across the tool and make it easier to parse in automation pipelines.

## How to Test
1. Run unit tests:
   ```bash
   go test -v ./cmd/version/...
   ```
2. Test CLI commands:
   ```bash
   kubescape version --format yaml
   kubescape version -f yaml
   ```

## Related issues/PRs:
* Resolved #3542

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YAML output support to the version command.
  * Updated command help and format validation to include YAML.

* **Documentation**
  * Updated the CLI reference with YAML support details and an example.

* **Tests**
  * Added coverage for YAML output with populated and empty version metadata.
  * Updated invalid-format validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->