### PR TITLE
fix(junit): distinguish image scan platforms

### DIFF
--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -235,7 +235,7 @@ func imageTestsSuites(imageScanData []cautils.ImageScanData) *JUnitTestSuites {
 
 	suites := make([]JUnitTestSuite, 0, len(imageScanData))
 	for i := range imageScanData {
-		image := imageScanData[i].Image
+		image := imageScanData[i].Target()
 		cves := extractCVEs(imageScanData[i].Matches, image)
 		suite := JUnitTestSuite{
 			ID:        i,
@@ -246,7 +246,10 @@ func imageTestsSuites(imageScanData []cautils.ImageScanData) *JUnitTestSuites {
 			TestCases: imageTestCases(cves, imageScanData[i].Platform),
 		}
 		if imageScanData[i].Platform != "" {
-			suite.Properties = []JUnitProperty{{Name: "platform", Value: imageScanData[i].Platform}}
+			suite.Properties = []JUnitProperty{
+				{Name: "image", Value: imageScanData[i].Image},
+				{Name: "platform", Value: imageScanData[i].Platform},
+			}
 		}
 		suites = append(suites, suite)
 	}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -178,15 +178,16 @@ func TestJunitActionPrintCombinedScanIncludesPostureAndImages(t *testing.T) {
 	require.NoError(t, xml.Unmarshal(raw, &got))
 	require.Len(t, got.Suites, 3)
 	assert.Equal(t, "Kubescape Scanning", got.Name)
-	assert.Equal(t, []string{"kubescape", "combined:first", "combined:second"}, []string{
+	assert.Equal(t, []string{"kubescape", "combined:first", "combined:second [linux/arm64]"}, []string{
 		got.Suites[0].Name,
 		got.Suites[1].Name,
 		got.Suites[2].Name,
 	})
-	require.Len(t, got.Suites[2].Properties, 1)
-	assert.Equal(t, JUnitProperty{Name: "platform", Value: "linux/arm64"}, got.Suites[2].Properties[0])
+	require.Len(t, got.Suites[2].Properties, 2)
+	assert.Equal(t, JUnitProperty{Name: "image", Value: "combined:second"}, got.Suites[2].Properties[0])
+	assert.Equal(t, JUnitProperty{Name: "platform", Value: "linux/arm64"}, got.Suites[2].Properties[1])
 	require.Len(t, got.Suites[2].TestCases, 1)
-	assert.Equal(t, "combined:second", got.Suites[2].TestCases[0].Classname)
+	assert.Equal(t, "combined:second [linux/arm64]", got.Suites[2].TestCases[0].Classname)
 	require.NotNil(t, got.Suites[2].TestCases[0].Failure)
 	assert.Contains(t, got.Suites[2].TestCases[0].Failure.Contents, "Platform: linux/arm64")
 	assert.Equal(t, []int{0, 1, 2}, []int{got.Suites[0].ID, got.Suites[1].ID, got.Suites[2].ID})
@@ -198,6 +199,130 @@ func TestJunitActionPrintCombinedScanIncludesPostureAndImages(t *testing.T) {
 	assert.Contains(t, string(raw), "Combined posture control")
 	assert.Contains(t, string(raw), "CVE-COMBINED")
 	assert.Contains(t, string(raw), "CVE-COMBINED-SECOND")
+}
+
+func TestImageTestsSuitesUsesPlatformAwareTargets(t *testing.T) {
+	imageMatch := func(id, severity, packageName string) match.Match {
+		return match.Match{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{ID: id, Namespace: "nvd"},
+				Metadata:  &vulnerability.Metadata{ID: id, Severity: severity},
+				Fix: vulnerability.Fix{
+					Versions: []string{"2.0.0"},
+					State:    vulnerability.FixStateFixed,
+				},
+			},
+			Package: grypepkg.Package{
+				ID:      grypepkg.ID(packageName),
+				Name:    packageName,
+				Version: "1.0.0",
+			},
+		}
+	}
+
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:    "registry.example.com/app:v1",
+			Platform: "linux/amd64",
+			Matches:  match.NewMatches(imageMatch("CVE-PLATFORM-AMD64", "High", "openssl")),
+		},
+		{
+			Image:    "registry.example.com/app:v1",
+			Platform: "linux/arm64",
+			Matches:  match.NewMatches(imageMatch("CVE-PLATFORM-ARM64", "Critical", "glibc")),
+		},
+		{
+			Image:   "registry.example.com/sidecar:v1",
+			Matches: match.NewMatches(imageMatch("CVE-SIDECAR", "Low", "busybox")),
+		},
+	}
+
+	got := imageTestsSuites(imageScanData)
+
+	require.Len(t, got.Suites, 3)
+	assert.Equal(t, "Kubescape Image Scanning", got.Name)
+	assert.Equal(t, 3, got.Tests)
+	assert.Equal(t, 3, got.Failures)
+	assert.Zero(t, got.Errors)
+
+	assert.Equal(t, []string{
+		"registry.example.com/app:v1 [linux/amd64]",
+		"registry.example.com/app:v1 [linux/arm64]",
+		"registry.example.com/sidecar:v1",
+	}, []string{
+		got.Suites[0].Name,
+		got.Suites[1].Name,
+		got.Suites[2].Name,
+	})
+	assert.Equal(t, []int{0, 1, 2}, []int{got.Suites[0].ID, got.Suites[1].ID, got.Suites[2].ID})
+
+	require.Len(t, got.Suites[0].Properties, 2)
+	assert.Equal(t, JUnitProperty{Name: "image", Value: "registry.example.com/app:v1"}, got.Suites[0].Properties[0])
+	assert.Equal(t, JUnitProperty{Name: "platform", Value: "linux/amd64"}, got.Suites[0].Properties[1])
+	require.Len(t, got.Suites[1].Properties, 2)
+	assert.Equal(t, JUnitProperty{Name: "image", Value: "registry.example.com/app:v1"}, got.Suites[1].Properties[0])
+	assert.Equal(t, JUnitProperty{Name: "platform", Value: "linux/arm64"}, got.Suites[1].Properties[1])
+	assert.Empty(t, got.Suites[2].Properties)
+
+	for i, suite := range got.Suites {
+		require.Len(t, suite.TestCases, 1, "suite %d", i)
+		assert.Equal(t, suite.Name, suite.TestCases[0].Classname)
+		require.NotNil(t, suite.TestCases[0].Failure)
+	}
+	assert.Contains(t, got.Suites[0].TestCases[0].Failure.Contents, "Platform: linux/amd64")
+	assert.Contains(t, got.Suites[1].TestCases[0].Failure.Contents, "Platform: linux/arm64")
+	assert.NotContains(t, got.Suites[2].TestCases[0].Failure.Contents, "Platform:")
+}
+
+func TestJunitActionPrintImageScanKeepsMultiArchSuitesDistinct(t *testing.T) {
+	imageMatch := func(id, packageName string) match.Match {
+		return match.Match{
+			Vulnerability: vulnerability.Vulnerability{
+				Reference: vulnerability.Reference{ID: id, Namespace: "nvd"},
+				Metadata:  &vulnerability.Metadata{ID: id, Severity: "High"},
+			},
+			Package: grypepkg.Package{
+				ID:      grypepkg.ID(packageName),
+				Name:    packageName,
+				Version: "1.0.0",
+			},
+		}
+	}
+
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:    "registry.example.com/app:v1",
+			Platform: "linux/amd64",
+			Matches:  match.NewMatches(imageMatch("CVE-A", "openssl")),
+		},
+		{
+			Image:    "registry.example.com/app:v1",
+			Platform: "linux/arm64",
+			Matches:  match.NewMatches(imageMatch("CVE-B", "glibc")),
+		},
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "images.xml")
+	jp := NewJunitPrinter(false)
+	require.NoError(t, jp.SetWriter(context.Background(), outputPath))
+	require.NoError(t, jp.ActionPrint(context.Background(), nil, imageScanData))
+	require.NoError(t, jp.writer.Close())
+
+	raw, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var got JUnitTestSuites
+	require.NoError(t, xml.Unmarshal(raw, &got))
+	require.Len(t, got.Suites, 2)
+	assert.Equal(t, "Kubescape Image Scanning", got.Name)
+	assert.Equal(t, 2, got.Tests)
+	assert.Equal(t, 2, got.Failures)
+	assert.Equal(t, "registry.example.com/app:v1 [linux/amd64]", got.Suites[0].Name)
+	assert.Equal(t, "registry.example.com/app:v1 [linux/arm64]", got.Suites[1].Name)
+	assert.NotEqual(t, got.Suites[0].Name, got.Suites[1].Name)
+	assert.Contains(t, string(raw), `name="image" value="registry.example.com/app:v1"`)
+	assert.Contains(t, string(raw), `name="platform" value="linux/amd64"`)
+	assert.Contains(t, string(raw), `name="platform" value="linux/arm64"`)
 }
 
 func TestListTestSuites(t *testing.T) {


### PR DESCRIPTION
## Overview

JUnit image-scan output previously used only the raw image reference as the testsuite and testcase class name. For multi-architecture scans of the same image, that made separate platform results appear under the same JUnit identity even though `ImageScanData` already tracks the exact platform-aware target.

This change uses the platform-aware image target for JUnit suite and testcase identities, while preserving the original image reference in suite properties whenever a platform is present.

## Changes

- Use `ImageScanData.Target()` when building JUnit image scan suites.
- Add the raw `image` property alongside `platform` for platform-specific image suites.
- Cover image-only and combined posture/image scan output with multi-platform regression tests.

## Testing

- `go test ./core/pkg/resultshandling/printer/v2 -run 'TestJunit|TestImageTestsSuites|TestAggregateSuiteCounts|TestIso8601Timestamp'`\n- `go test ./core/pkg/resultshandling/printer/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JUnit reports for image scans by distinguishing results from different platforms.
  - Image scan suites now use the scan target as the suite name.
  - Reports include image and platform details when platform information is available.
  - Preserved existing output for images without platform data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->