### PR TITLE
fix(storage): recover missing workload posture controls

### DIFF
--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -69,6 +69,8 @@ func NewAPIServerStorage(clusterName string, namespace string, ksClient spdxv1be
 }
 
 func (a *APIServerStore) StorePostureReportResults(ctx context.Context, pr *v2.PostureReport) error {
+	recoveredResources := 0
+	recoveredControls := 0
 	for i := range pr.Results {
 		workloadScan, err := a.BuildWorkloadConfigurationScan(ctx, pr, &pr.Results[i])
 		if err != nil {
@@ -77,6 +79,10 @@ func (a *APIServerStore) StorePostureReportResults(ctx context.Context, pr *v2.P
 				continue
 			}
 			return err
+		}
+		if len(pr.Results[i].AssociatedControls) == 0 && len(workloadScan.Spec.Controls) > 0 {
+			recoveredResources++
+			recoveredControls += len(workloadScan.Spec.Controls)
 		}
 
 		if a.continuousPostureScan {
@@ -88,6 +94,10 @@ func (a *APIServerStore) StorePostureReportResults(ctx context.Context, pr *v2.P
 		if _, err := a.StoreWorkloadConfigurationScanResultSummary(ctx, workloadScan); err != nil {
 			return err
 		}
+	}
+	if recoveredResources > 0 {
+		logger.L().Ctx(ctx).Warning("recovered missing per-resource controls from aggregate posture summary",
+			helpers.Int("resources", recoveredResources), helpers.Int("controls", recoveredControls))
 	}
 	return nil
 }
@@ -107,6 +117,43 @@ func getControlsMapFromResult(ctx context.Context, result *resourcesresults.Resu
 			Rules:     parseScannedControlRules(&control),
 		}
 
+	}
+	if len(m) > 0 {
+		return m
+	}
+
+	// A posture report carries the resource/control relationship twice: in each
+	// Result.AssociatedControls entry and in ControlSummary.ResourceIDs. The
+	// former contains the richer rule-level evidence and remains the preferred
+	// source. When that entire per-resource list is missing, recover its
+	// relationships from the latter so an internally inconsistent report cannot
+	// be persisted as a false-clean WorkloadConfigurationScanSummary. The same
+	// summary resource lists drive the control table printed before in-cluster
+	// persistence. They retain
+	// only the per-resource status, so rule evidence, substatus, and status info
+	// remain empty for a recovered relationship.
+	for summaryKey, controlSummary := range controlSummaries {
+		status, associated := controlSummary.ResourceIDs.All()[result.ResourceID]
+		if !associated {
+			continue
+		}
+
+		controlID := controlSummary.GetID()
+		if controlID == "" {
+			controlID = summaryKey
+		}
+		if _, exists := m[controlID]; exists {
+			continue
+		}
+
+		m[controlID] = v1beta1.ScannedControl{
+			ControlID: controlID,
+			Name:      controlSummary.GetName(),
+			Severity:  parseControlSeverity(&controlSummary),
+			Status: v1beta1.ScannedControlStatus{
+				Status: string(status),
+			},
+		}
 	}
 	return m
 }

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -162,6 +162,74 @@ func TestGetControlsMapFromResult_MissingControl(t *testing.T) {
 	})
 }
 
+func TestGetControlsMapFromResult_RecoversMissingAssociationsFromSummary(t *testing.T) {
+	const resourceID = "v1/default/Pod/test-pod"
+
+	failedControl := reportsummary.ControlSummary{
+		ControlID:   "C-001",
+		Name:        "Control 1",
+		ScoreFactor: 7,
+	}
+	failedControl.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, resourceID)
+
+	otherControl := reportsummary.ControlSummary{
+		ControlID:   "C-002",
+		Name:        "Control 2",
+		ScoreFactor: 4,
+	}
+	otherControl.Append(&apis.StatusInfo{InnerStatus: apis.StatusPassed}, "v1/default/Pod/other-pod")
+
+	actual := getControlsMapFromResult(context.Background(), &resourcesresults.Result{
+		ResourceID: resourceID,
+	}, reportsummary.ControlSummaries{
+		"C-001": failedControl,
+		"C-002": otherControl,
+	})
+
+	if assert.Len(t, actual, 1) {
+		control := actual["C-001"]
+		assert.Equal(t, "C-001", control.ControlID)
+		assert.Equal(t, "Control 1", control.Name)
+		assert.Equal(t, string(apis.StatusFailed), control.Status.Status)
+		assert.Equal(t, "High", control.Severity.Severity)
+		assert.Equal(t, float32(7), control.Severity.ScoreFactor)
+		assert.Empty(t, control.Rules)
+	}
+}
+
+func TestGetControlsMapFromResult_PrefersDetailedAssociationOverSummaryFallback(t *testing.T) {
+	const resourceID = "v1/default/Pod/test-pod"
+
+	controlSummary := reportsummary.ControlSummary{
+		ControlID:   "C-001",
+		Name:        "Summary name",
+		ScoreFactor: 7,
+	}
+	controlSummary.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, resourceID)
+
+	actual := getControlsMapFromResult(context.Background(), &resourcesresults.Result{
+		ResourceID: resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{{
+			ControlID: "C-001",
+			Name:      "Detailed name",
+			Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{{
+				Name:   "detailed-rule",
+				Status: apis.StatusPassed,
+			}},
+		}},
+	}, reportsummary.ControlSummaries{"C-001": controlSummary})
+
+	if assert.Contains(t, actual, "C-001") {
+		control := actual["C-001"]
+		assert.Equal(t, "Detailed name", control.Name)
+		assert.Equal(t, string(apis.StatusPassed), control.Status.Status)
+		if assert.Len(t, control.Rules, 1) {
+			assert.Equal(t, "detailed-rule", control.Rules[0].Name)
+		}
+	}
+}
+
 type FakeMetadata struct {
 	workloadinterface.IMetadata
 
@@ -623,6 +691,86 @@ func TestStorePostureReportResults_NonRecoverableError(t *testing.T) {
 
 	err := store.StorePostureReportResults(ctx, pr)
 	assert.Error(t, err)
+}
+
+func TestStorePostureReportResults_PersistsControlsFromSummaryWhenAssociationsAreMissing(t *testing.T) {
+	const resourceID = "v1/default/Pod/test-pod"
+
+	controlSummary := reportsummary.ControlSummary{
+		ControlID:   "C-001",
+		Name:        "Control 1",
+		ScoreFactor: 7,
+	}
+	controlSummary.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, resourceID)
+
+	report := &v2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{"C-001": controlSummary},
+		},
+		Resources: []reporthandling.Resource{{
+			ResourceID: resourceID,
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      "test-pod",
+					"namespace": "default",
+				},
+			},
+		}},
+		// This is the inconsistent shape reported in #3494: the aggregate
+		// summary contains the failed resource, while the per-resource control
+		// slice consumed by in-cluster storage is empty.
+		Results: []resourcesresults.Result{{ResourceID: resourceID}},
+	}
+
+	tests := []struct {
+		name     string
+		existing []runtime.Object
+	}{
+		{name: "creates a populated summary"},
+		{
+			name: "replaces an existing false-clean summary",
+			existing: []runtime.Object{&v1beta1.WorkloadConfigurationScanSummary{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-test-pod", Namespace: "default"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.existing...)
+			store := &APIServerStore{
+				StorageClient: client.SpdxV1beta1(),
+				namespace:     "kubescape",
+			}
+			ctx := context.Background()
+			assert.NoError(t, store.StorePostureReportResults(ctx, report))
+
+			summaries, err := store.StorageClient.WorkloadConfigurationScanSummaries("default").List(ctx, metav1.ListOptions{})
+			if assert.NoError(t, err) && assert.Len(t, summaries.Items, 1) {
+				summary := summaries.Items[0]
+				if assert.Len(t, summary.Spec.Controls, 1) && assert.Contains(t, summary.Spec.Controls, "C-001") {
+					control := summary.Spec.Controls["C-001"]
+					assert.Equal(t, "C-001", control.ControlID)
+					assert.Equal(t, string(apis.StatusFailed), control.Status.Status)
+					assert.Equal(t, "High", control.Severity.Severity)
+					assert.Equal(t, float32(7), control.Severity.ScoreFactor)
+				}
+				assert.Equal(t, int64(1), summary.Spec.Severities.High)
+				assert.Zero(t, summary.Spec.Severities.Critical)
+				assert.Zero(t, summary.Spec.Severities.Medium)
+				assert.Zero(t, summary.Spec.Severities.Low)
+				assert.Zero(t, summary.Spec.Severities.Unknown)
+			}
+
+			// Detail objects remain opt-in through continuousPostureScan. Recovering
+			// summary payloads must not change that storage-volume contract.
+			details, err := store.StorageClient.WorkloadConfigurationScans("default").List(ctx, metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Empty(t, details.Items)
+		})
+	}
 }
 
 func TestMergeMaps(t *testing.T) {


### PR DESCRIPTION
## Overview

Posture reports carry the resource/control relationship in both the per-resource `Result.AssociatedControls` data and the aggregate `ControlSummary.ResourceIDs` index. In the inconsistent report shape from #3494, the aggregate summary still contains failed resources (and therefore the console table is correct), but the per-resource associations consumed by in-cluster storage are empty. This caused `WorkloadConfigurationScanSummary` objects to be persisted as false-clean.

This change hardens the persistence boundary by:

- keeping detailed associations authoritative whenever they are present, preserving rule evidence, substatus, and status info;
- recovering resource/control relationships and their primary status from the aggregate summary only when the detailed control map is entirely empty;
- emitting one aggregate warning when recovery is used;
- preserving the existing `continuousPostureScan` contract, so detail `WorkloadConfigurationScan` objects remain opt-in.

The fallback is intentionally limited: aggregate summaries can restore control status and severity, but cannot reconstruct rule-level evidence that was already missing.

## How to Test

```bash
cd httphandler
go test ./... -count=1
go test -race ./storage -run 'Test(GetControlsMapFromResult|StorePostureReportResults)' -count=1
```

Regression coverage includes fresh summary creation, replacement of an existing false-clean summary, detailed-association precedence, resource filtering, severity counts, and detail-object opt-in behavior.

## Related issues/PRs

Resolves #3494

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on the fallback and its information limits
- [x] I have performed a self-review of the code
- [x] I have added regression tests
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved posture report accuracy when per-resource control details are incomplete.
  - Missing control results can now be recovered from available summary information.
  - Detailed per-resource results continue to take precedence when available.
  - Corrected report summaries and severity totals for recovered results.
  - Prevented creation of misleading detail entries when only summary-level information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->