### PR TITLE
test(policy): validate all in-tree rule fixtures in CI

### DIFF
--- a/cmd/policy/test_test.go
+++ b/cmd/policy/test_test.go
@@ -23,6 +23,22 @@ func TestPolicyTestCmd_PassingRuleReturnsNoError(t *testing.T) {
 	assert.Contains(t, out.String(), "cases passed")
 }
 
+func TestPolicyTestCmd_AllInTreeRulesPass(t *testing.T) {
+	dir, err := filepath.Abs("../../rules")
+	require.NoError(t, err)
+
+	cmd := getPolicyTestCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{dir})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	require.NoError(t, err, out.String())
+	assert.Contains(t, out.String(), "cases passed")
+}
+
 func TestPolicyTestCmd_MissingPathReturnsError(t *testing.T) {
 	cmd := getPolicyTestCmd()
 	cmd.SetArgs([]string{"/nonexistent/path/for/policy/test"})

--- a/cmd/policy/test_test.go
+++ b/cmd/policy/test_test.go
@@ -36,7 +36,7 @@ func TestPolicyTestCmd_AllInTreeRulesPass(t *testing.T) {
 
 	err = cmd.Execute()
 	require.NoError(t, err, out.String())
-	assert.Contains(t, out.String(), "cases passed")
+	assert.Regexp(t, `\n[1-9][0-9]*/[1-9][0-9]* cases passed\n`, out.String())
 }
 
 func TestPolicyTestCmd_MissingPathReturnsError(t *testing.T) {

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,42 @@
+# In-tree policy rules
+
+This directory is a development and validation area for policy rules that are
+maintained alongside Kubescape. It is not a policy source for normal scans.
+Kubescape obtains the controls and frameworks used by default scans from the
+[regolibrary](https://github.com/kubescape/regolibrary), so merging a rule here
+does not publish it to users.
+
+## Test the fixtures
+
+Each rule directory contains `raw.rego`, `rule.metadata.json`, and test cases
+under `test/<case>/`. A test case has Kubernetes manifests in `input/` and the
+expected rule responses in `expected.json`.
+
+Run all in-tree fixtures with:
+
+```sh
+go run . policy test ./rules
+```
+
+To iterate on one rule, pass its directory instead:
+
+```sh
+go run . policy test ./rules/<rule-name>
+```
+
+The Go test suite runs the full-directory command, so a pull request fails CI
+when an in-tree rule no longer matches its fixtures.
+
+## Publish a rule
+
+To make an in-tree rule available to default scans:
+
+1. Keep its Rego, metadata, and fixtures passing in this repository.
+2. Add or update the corresponding `rules/<rule-name>` directory in
+   [kubescape/regolibrary](https://github.com/kubescape/regolibrary).
+3. In regolibrary, associate the rule with a control through the control's
+   `rulesNames` field and include that control in any intended frameworks.
+4. Run regolibrary's rule tests and follow its review and release process.
+
+The rule becomes part of Kubescape's default policy data only after the
+regolibrary change is merged and published.

--- a/rules/approve-csr-v1/test/clusterrole-approve-signer-wildcard-allowed/expected.json
+++ b/rules/approve-csr-v1/test/clusterrole-approve-signer-wildcard-allowed/expected.json
@@ -3,28 +3,34 @@
   "alertScore": 9,
   "packagename": "armo_builtins",
   "reviewPaths": [
-    "relatedObjects[0].rules[0].resources[0]",
-    "relatedObjects[0].rules[0].verbs[0]",
-    "relatedObjects[0].rules[0].apiGroups[0]",
-    "relatedObjects[0].rules[1].resources[0]",
-    "relatedObjects[0].rules[1].verbs[0]",
-    "relatedObjects[0].rules[1].apiGroups[0]",
-    "relatedObjects[0].rules[2].resources[0]",
-    "relatedObjects[0].rules[2].verbs[0]",
-    "relatedObjects[0].rules[2].apiGroups[0]",
+    "relatedObjects[1].rules[0].resources[0]",
+    "relatedObjects[1].rules[0].verbs[0]",
+    "relatedObjects[1].rules[0].verbs[1]",
+    "relatedObjects[1].rules[0].verbs[2]",
+    "relatedObjects[1].rules[0].verbs[3]",
+    "relatedObjects[1].rules[0].apiGroups[0]",
+    "relatedObjects[1].rules[1].resources[0]",
+    "relatedObjects[1].rules[1].verbs[0]",
+    "relatedObjects[1].rules[1].apiGroups[0]",
+    "relatedObjects[1].rules[2].resources[0]",
+    "relatedObjects[1].rules[2].verbs[0]",
+    "relatedObjects[1].rules[2].apiGroups[0]",
     "relatedObjects[0].roleRef.name",
     "relatedObjects[0].subjects[0]"
   ],
   "failedPaths": [
-    "relatedObjects[0].rules[0].resources[0]",
-    "relatedObjects[0].rules[0].verbs[0]",
-    "relatedObjects[0].rules[0].apiGroups[0]",
-    "relatedObjects[0].rules[1].resources[0]",
-    "relatedObjects[0].rules[1].verbs[0]",
-    "relatedObjects[0].rules[1].apiGroups[0]",
-    "relatedObjects[0].rules[2].resources[0]",
-    "relatedObjects[0].rules[2].verbs[0]",
-    "relatedObjects[0].rules[2].apiGroups[0]",
+    "relatedObjects[1].rules[0].resources[0]",
+    "relatedObjects[1].rules[0].verbs[0]",
+    "relatedObjects[1].rules[0].verbs[1]",
+    "relatedObjects[1].rules[0].verbs[2]",
+    "relatedObjects[1].rules[0].verbs[3]",
+    "relatedObjects[1].rules[0].apiGroups[0]",
+    "relatedObjects[1].rules[1].resources[0]",
+    "relatedObjects[1].rules[1].verbs[0]",
+    "relatedObjects[1].rules[1].apiGroups[0]",
+    "relatedObjects[1].rules[2].resources[0]",
+    "relatedObjects[1].rules[2].verbs[0]",
+    "relatedObjects[1].rules[2].apiGroups[0]",
     "relatedObjects[0].roleRef.name",
     "relatedObjects[0].subjects[0]"
   ],
@@ -34,8 +40,76 @@
     "externalObjects": {
       "kind": "User",
       "name": "test-user",
-      "namespace": "",
-      "apiGroup": "rbac.authorization.k8s.io"
+      "apiGroup": "rbac.authorization.k8s.io",
+      "relatedObjects": [
+        {
+          "apiVersion": "rbac.authorization.k8s.io/v1",
+          "kind": "ClusterRoleBinding",
+          "metadata": {
+            "name": "csr-approve-signer-wildcard-allowed-binding"
+          },
+          "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "csr-approve-signer-wildcard-allowed"
+          },
+          "subjects": [
+            {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "User",
+              "name": "test-user"
+            }
+          ]
+        },
+        {
+          "apiVersion": "rbac.authorization.k8s.io/v1",
+          "kind": "ClusterRole",
+          "metadata": {
+            "name": "csr-approve-signer-wildcard-allowed"
+          },
+          "rules": [
+            {
+              "apiGroups": [
+                "certificates.k8s.io"
+              ],
+              "resources": [
+                "certificatesigningrequests"
+              ],
+              "verbs": [
+                "create",
+                "get",
+                "list",
+                "watch"
+              ]
+            },
+            {
+              "apiGroups": [
+                "certificates.k8s.io"
+              ],
+              "resources": [
+                "certificatesigningrequests/approval"
+              ],
+              "verbs": [
+                "update"
+              ]
+            },
+            {
+              "apiGroups": [
+                "certificates.k8s.io"
+              ],
+              "resourceNames": [
+                "kubernetes.io/*"
+              ],
+              "resources": [
+                "signers"
+              ],
+              "verbs": [
+                "approve"
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }]

--- a/rules/approve-csr-v1/test/clusterrole-full-chain/expected.json
+++ b/rules/approve-csr-v1/test/clusterrole-full-chain/expected.json
@@ -100,7 +100,7 @@
                                     "certificates.k8s.io"
                                 ],
                                 "resourceNames": [
-                                    "*"
+                                    "kubernetes.io/kube-apiserver-client"
                                 ],
                                 "resources": [
                                     "signers"

--- a/rules/provider-iam-assumption-v1/test/eks-role-arn/expected.json
+++ b/rules/provider-iam-assumption-v1/test/eks-role-arn/expected.json
@@ -17,7 +17,11 @@
                     "apiVersion": "v1",
                     "kind": "ServiceAccount",
                     "metadata": {
-                        "name": "s3-reader"
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/s3-reader"
+                        },
+                        "name": "s3-reader",
+                        "namespace": "data"
                     }
                 }
             ]

--- a/rules/provider-iam-assumption-v1/test/gke-workload-identity/expected.json
+++ b/rules/provider-iam-assumption-v1/test/gke-workload-identity/expected.json
@@ -17,7 +17,11 @@
                     "apiVersion": "v1",
                     "kind": "ServiceAccount",
                     "metadata": {
-                        "name": "gcs-reader"
+                        "annotations": {
+                            "iam.gke.io/gcp-service-account": "gcs-reader@my-project.iam.gserviceaccount.com"
+                        },
+                        "name": "gcs-reader",
+                        "namespace": "data"
                     }
                 }
             ]


### PR DESCRIPTION
## Summary

- run the existing policy-test command against the complete `rules/` tree from the Go test suite, so the current `go test -race ./...` PR workflow catches fixture drift
- update four stale `expected.json` files to match their inputs and the real evaluator output
- document that in-tree rules are a development/validation area and describe the promotion path into `kubescape/regolibrary`

## Details

Before this change, `go run . policy test ./rules` reported **101/105** passing cases. The four failures were fixture drift rather than evaluator regressions:

- the CSR fixtures had stale related-object indexes/content and one signer value that no longer matched the input
- the EKS and GKE fixtures omitted the ServiceAccount namespace and provider annotation returned by the rule

After correcting those fixtures, the new full-tree test keeps all current and future rule cases covered by the existing CI job without adding another workflow or network-dependent test harness.

## Testing

- `go run . policy test ./rules` — 105/105 passed
- `go test ./cmd/policy ./core/pkg/policytest -count=1`
- `go test -race ./cmd/policy -run TestPolicyTestCmd_AllInTreeRulesPass -count=1`

Fixes #3385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage confirming all in-tree policy rules pass successfully and report passing results.

* **Documentation**
  * Added guidance for testing in-tree rules, fixture organization, CI behavior, and publishing workflows.

* **Bug Fixes**
  * Corrected policy test fixtures for CSR approval, signer permissions, and related object paths.
  * Improved cloud identity fixtures with required service-account annotations and namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->