### PR TITLE
chore(printer): clarify strings import dependency in policyreportprinter.go

### DIFF
--- a/core/pkg/resultshandling/printer/v2/policyreportprinter.go
+++ b/core/pkg/resultshandling/printer/v2/policyreportprinter.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
+	"strings" // required for sanitizeDNS1123Subdomain / sanitizeLabelValue (Builder, ToLower, TrimRight)
 	"time"
 
 	"github.com/kubescape/go-logger"


### PR DESCRIPTION
## Overview

This is a **comment-only follow-up** to the build break reported in #3549.

**Context:** `core/pkg/resultshandling/printer/v2/policyreportprinter.go` uses `strings.Builder / ToLower / TrimRight` in `sanitizeDNS1123Subdomain` and `sanitizeLabelValue` (added in #3470). #3492 refactored `SetWriter` to use `printer.ResolveOutputFile` and removed the `strings` import that was the only use it could see. The two PRs landed ~20s apart without a rebase, so the *semantic* conflict wasn't caught (see #3549 for full root cause). The break (`5x undefined: strings`) **was already fixed before this branch was cut** — #3503 and #3508 both restored the import prior to this PR's base (`76cf9a5f` on current `master`), so `master` already compiles and CI on this branch is green regardless of this diff.

**What this PR actually does:** adds an inline comment to the existing `strings` import so a future `SetWriter`-only cleanup doesn't drop it again:

```diff
-	"strings"
+	"strings" // required for sanitizeDNS1123Subdomain / sanitizeLabelValue (Builder, ToLower, TrimRight)
```

No behavior change.

## How to Test

```bash
go vet ./core/pkg/resultshandling/printer/v2/...
go build ./...
go test ./core/pkg/resultshandling/printer/v2 -run "TestPolicyReport|TestCloseWriter_PolicyReport" -count=1 -v
golangci-lint run ./core/pkg/resultshandling/printer/v2/...
```

Existing `policyreportprinter_test.go` already covers both sanitizers (ARN/URL/uppercase/TrimRight, truncation that lands on a separator, label `case preserved`).

## Related issues/PRs:

* Related to #3549 — that issue reproduces against `371f4aaf` which predates the fixes; it can be closed as superseded by #3503/#3508
* Follow-up to #3470 + #3492
* See also #3503, #3508 (the actual restores)

## Checklist before requesting a review

- [x] My code follows the style guidelines (`goimports` order, `gofmt -l` clean)
- [x] I have performed a self-review (comment-only, no behavior change)
- [x] New and existing unit tests pass locally (`go test ./core/pkg/resultshandling/printer/v2 -count=1`)
- [x] `go vet` / `go build` on clean checkout
