### PR TITLE
fix(opaprocessor): hard error when --include-controls matches no known control

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -236,9 +236,11 @@ func (opap *OPAProcessor) SetIncrementalCache(cache *scancache.Store) {
 // --skip-controls and --include-controls filters. Both the eager and the
 // streaming entry point build AllPolicies from it, so the same cluster is
 // scanned against the same control set whichever path a scan takes.
-func (opap *OPAProcessor) effectiveExcludedRules() map[string]bool {
+// It returns a hard error when the filter leaves nothing to scan, preventing
+// a 0-control, exit-0 result that would silently pass a CI gate.
+func (opap *OPAProcessor) effectiveExcludedRules() (map[string]bool, error) {
 	if opap.SkipControls == "" && opap.IncludeControls == "" {
-		return opap.ExcludedRules
+		return opap.ExcludedRules, nil
 	}
 	return buildControlExcludedRules(opap.ExcludedRules, opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
 }
@@ -246,7 +248,11 @@ func (opap *OPAProcessor) effectiveExcludedRules() map[string]bool {
 func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressListener IJobProgressNotificationClient) error {
 	scanningScope := cautils.GetScanningScope(opap.Metadata.ContextMetadata)
 
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.effectiveExcludedRules(), scanningScope)
+	excludedRules, err := opap.effectiveExcludedRules()
+	if err != nil {
+		return err
+	}
+	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, scanningScope)
 
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 
@@ -300,7 +306,11 @@ func (opap *OPAProcessor) ProcessWithStreaming(ctx context.Context, batchChan <-
 	opap.loggerStartScanning()
 	defer opap.loggerDoneScanning()
 
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, opap.effectiveExcludedRules(), cautils.GetScanningScope(opap.Metadata.ContextMetadata))
+	excludedRules, err := opap.effectiveExcludedRules()
+	if err != nil {
+		return err
+	}
+	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, cautils.GetScanningScope(opap.Metadata.ContextMetadata))
 	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
 
 	scopeControlIDs, wholeClusterControlIDs := splitWholeClusterControls(opap.AllPolicies, sortedControlIDs(opap.AllPolicies))

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -2,6 +2,7 @@ package opaprocessor
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -658,6 +659,18 @@ func ruleEnumeratorData(rule *reporthandling.PolicyRule) string {
 	return rule.ResourceEnumerator
 }
 
+// errIncludeControlsNoMatch is returned when --include-controls is set but
+// none of the requested IDs exist in the loaded frameworks. Returning a hard
+// error (instead of silently excluding every control and yielding 0 results
+// with exit 0) preserves CI-gate integrity: a typo like --include-controls
+// C-9999 must fail the scan, not pass it.
+var errIncludeControlsNoMatch = errors.New("--include-controls matched no known control")
+
+// errNoControlsAfterFilter is returned when --include-controls/--skip-controls
+// together filter out every control, mirroring policyhandler.excludeControls'
+// errAllControlsExcluded guard for --exclude-controls.
+var errNoControlsAfterFilter = errors.New("--include-controls/--skip-controls left no controls to scan")
+
 // buildControlExcludedRules merges the existing rule-exclusion map with any
 // --skip-controls or --include-controls filters. The resulting map marks
 // individual rule names with `true` so that convertFrameworksToPolicies drops
@@ -669,14 +682,14 @@ func ruleEnumeratorData(rule *reporthandling.PolicyRule) string {
 // --include-controls treats "not in the include set" as "exclude", a single
 // mistyped case produces a silently empty scan instead of the requested
 // control.
-func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling.Framework, skip, include []string) map[string]bool {
+func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling.Framework, skip, include []string) (map[string]bool, error) {
 	excludedRules := make(map[string]bool, len(base)+4)
 	for k, v := range base {
 		excludedRules[k] = v
 	}
 
 	if len(skip) == 0 && len(include) == 0 {
-		return excludedRules
+		return excludedRules, nil
 	}
 
 	skipSet := make(map[string]struct{}, len(skip))
@@ -707,13 +720,25 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 			logger.L().Warning("skip control not found in loaded policies", helpers.String("control", id))
 		}
 	}
-	for id := range includeSet {
-		if _, ok := knownIDs[id]; !ok {
-			logger.L().Warning("include control not found in loaded policies", helpers.String("control", id))
+	// include-controls is a whitelist: if the caller asked for specific
+	// controls but none of them exist, failing open with 0 controls and
+	// exit 0 breaks CI gates. Treat "no include matched" as a hard error,
+	// mirroring policyhandler.excludeControls' errAllControlsExcluded.
+	if len(includeSet) > 0 {
+		matchedInclude := 0
+		for id := range includeSet {
+			if _, ok := knownIDs[id]; ok {
+				matchedInclude++
+			} else {
+				logger.L().Warning("include control not found in loaded policies", helpers.String("control", id))
+			}
+		}
+		if matchedInclude == 0 {
+			return nil, errIncludeControlsNoMatch
 		}
 	}
 
-	if len(include) > 0 {
+	if len(includeSet) > 0 {
 		for _, fw := range frameworks {
 			for i := range fw.Controls {
 				if _, keep := includeSet[strings.ToLower(fw.Controls[i].ControlID)]; keep {
@@ -737,5 +762,31 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 		}
 	}
 
-	return excludedRules
+	// Guard against a filter that leaves nothing to scan. This can happen
+	// when --include-controls names only controls that are then removed by
+	// --skip-controls, or when --skip-controls alone excludes every loaded
+	// control. Mirroring excludeControls' remaining==0 check prevents a
+	// 0-control, 0-failure, exit-0 scan that silently passes a CI gate.
+	if countRemainingControls(frameworks, excludedRules) == 0 {
+		return nil, errNoControlsAfterFilter
+	}
+
+	return excludedRules, nil
+}
+
+// countRemainingControls returns the number of controls that still have at
+// least one rule not marked excluded.
+func countRemainingControls(frameworks []reporthandling.Framework, excludedRules map[string]bool) int {
+	count := 0
+	for _, fw := range frameworks {
+		for i := range fw.Controls {
+			for r := range fw.Controls[i].Rules {
+				if !excludedRules[fw.Controls[i].Rules[r].Name] {
+					count++
+					break
+				}
+			}
+		}
+	}
+	return count
 }

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1358,7 +1358,8 @@ func TestBuildControlExcludedRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildControlExcludedRules(tt.base, framework, tt.skip, tt.include)
+			got, err := buildControlExcludedRules(tt.base, framework, tt.skip, tt.include)
+			require.NoError(t, err)
 			for _, rule := range tt.excludedRules {
 				assert.True(t, got[rule], "expected rule %q to be excluded", rule)
 			}
@@ -1367,4 +1368,36 @@ func TestBuildControlExcludedRules(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildControlExcludedRules_IncludeNoMatchReturnsError(t *testing.T) {
+	framework := []reporthandling.Framework{{
+		Controls: []reporthandling.Control{
+			{ControlID: "C-0001", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
+			{ControlID: "C-0002", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-b"}}}},
+		},
+	}}
+
+	_, err := buildControlExcludedRules(nil, framework, nil, []string{"C-9999"})
+	require.ErrorIs(t, err, errIncludeControlsNoMatch)
+
+	_, err = buildControlExcludedRules(nil, framework, nil, []string{"c-9999"})
+	require.ErrorIs(t, err, errIncludeControlsNoMatch)
+
+	_, err = buildControlExcludedRules(nil, framework, nil, []string{"C-9999", "C-8888"})
+	require.ErrorIs(t, err, errIncludeControlsNoMatch)
+
+	// Mixed: one valid + one invalid should NOT error, invalid is warned but valid keeps scan alive
+	got, err := buildControlExcludedRules(nil, framework, nil, []string{"C-0001", "C-9999"})
+	require.NoError(t, err)
+	assert.True(t, got["rule-b"], "rule-b should be excluded (not included)")
+	assert.False(t, got["rule-a"], "rule-a should not be excluded")
+
+	// Include valid then skip same => leaves zero controls => noControlsAfterFilter
+	_, err = buildControlExcludedRules(nil, framework, []string{"C-0001"}, []string{"C-0001"})
+	require.ErrorIs(t, err, errNoControlsAfterFilter)
+
+	// Skip all controls via skip alone => leaves zero
+	_, err = buildControlExcludedRules(nil, framework, []string{"C-0001", "C-0002"}, nil)
+	require.ErrorIs(t, err, errNoControlsAfterFilter)
 }


### PR DESCRIPTION
## What happened

We use `--include-controls` to gate CI (`--severity-threshold low`). A small typo like `--include-controls C-9999` made a manifest that normally fails 11 controls look clean — `0 controls / 0 resources`, `100% compliance`, exit `0`. Only a `Warning` was logged, easy to miss in CI logs.

`--exclude-controls` already has a hard guard (`errAllControlsExcluded` in `core/pkg/policyhandler/controlfilter.go:11`) and fails the scan when the filter leaves nothing to scan. The `--include-controls` whitelist in `core/pkg/opaprocessor/processorhandlerutils.go:666-677` (`buildControlExcludedRules`) did not — it warned and then excluded every rule, so `convertFrameworksToPolicies` produced an empty policy set.

This also affects the streaming path — both `ProcessRulesListener` and `ProcessWithStreaming` build policies via `effectiveExcludedRules`, so the fix needs to land in one place for both to stay in parity.

Fixes #3551

## What this changes

* `processorhandlerutils.go`
  * `buildControlExcludedRules` now returns `(map[string]bool, error)` — same shape as `excludeControls`.
  * New errors: `errIncludeControlsNoMatch` ("`--include-controls matched no known control`") and `errNoControlsAfterFilter` ("`--include-controls/--skip-controls left no controls to scan`").
  * If `includeSet` is non-empty and `matchedInclude == 0` -> hard error (typo / stale ID).
  * After applying include (whitelist) + skip (blacklist, wins), if `countRemainingControls(...) == 0` -> hard error. This mirrors the `remaining == 0` check in `excludeControls` and covers `include C-0001` + `skip C-0001` or `skip` alone wiping everything.
  * Keeps per-ID `Warning` for each unknown ID, just doesn't let a zero-control scan succeed.
  * Added `countRemainingControls` helper.

* `processorhandler.go`
  * `effectiveExcludedRules() (map[string]bool, error)` — propagated to both `ProcessRulesListener` and `ProcessWithStreaming` so eager and streaming stay consistent. Error bubbles to `ScanContext` -> non-zero exit, no silent pass.

Matching stays case-insensitive (`strings.ToLower`) as already fixed for #3508.

## How I verified

Manual repro against `framework nsa`:
* Without filter: `kubescape scan framework nsa /path/to/manifests --severity-threshold low` -> exit `1` (11 failures)
* Before fix: `--include-controls C-9999 --severity-threshold low` -> `0/0 controls`, exit `0`
* After fix: same command -> `Error: --include-controls matched no known control` / `... left no controls to scan`, exit `1`

Tests:
* `go test ./core/pkg/opaprocessor -run TestBuildControlExcludedRules -v` — existing 7 cases still pass
* New `TestBuildControlExcludedRules_IncludeNoMatchReturnsError` — covers `C-9999`, `c-9999`, `C-9999,C-8888`, mixed `C-0001,C-9999` (warn but keep valid), `include C-0001` + `skip C-0001` and `skip all` -> `errNoControlsAfterFilter`
* `go test ./core/pkg/opaprocessor -count=1` — 15s PASS
* `go test ./core/pkg/policyhandler -count=1` — 9s PASS
* `go vet` clean

## Risk

Low. Only the filter path is touched. Valid include lists behave exactly as before; only the previously-silent zero-control cases now error. No printer / scoring / exception path changed.

## Additional context

This is the same class as the `excludeControls` guard — ideally a shared `validateControlFilterResult` helper could be added for all allowlist flags so it doesn't recur (follow-up from #3551 suggestion #5). Happy to do that in a follow-up if you prefer.

Workaround until merged: validate IDs with `kubescape list controls` before calling scan in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control scans now stop with a clear error when filters exclude all available controls.
  * Invalid include-control filters are reported instead of producing an empty scan.
  * Policy processing no longer continues when no controls remain after filtering.
  * Mixed valid and invalid include filters continue to work when at least one control matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->