### PR TITLE
fix(scan-coverage): surface skipped manifests in coverage and fail gate

### DIFF
--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -24,9 +24,15 @@ type ScanCoverage struct {
 	// exceptions) that could not be loaded from their configured source and
 	// were served from a fallback so the scan could proceed.
 	PolicyDegradations []PolicyDegradation `json:"policyDegradations,omitempty"`
+	// SkippedManifests records manifest files that were discovered but could
+	// not be loaded or parsed (invalid YAML/JSON, oversized, missing kind,
+	// unrendered Helm template, etc.). They are a coverage gap like
+	// PartialGVRPulls: the scan succeeded against incomplete input and the
+	// CI gate must be able to fail on it.
+	SkippedManifests []SkippedManifest `json:"skippedManifests,omitempty"`
 	// CoverageScore is an aggregate 0-100 measure of how complete the scan was:
-	// the ratio of evaluated controls, discounted for partial resource pulls
-	// and degraded policy inputs. It is computed once by ComputeCoverageScore.
+	// the ratio of evaluated controls, discounted for partial resource pulls,
+	// degraded policy inputs, and skipped manifests. It is computed once by ComputeCoverageScore.
 	CoverageScore float32 `json:"coverageScore"`
 	// EvaluatedControls is the number of controls that were actually evaluated.
 	EvaluatedControls int `json:"evaluatedControls"`
@@ -52,6 +58,7 @@ const (
 	failedGVRPullPenalty     float32 = 3
 	partialGVRPullPenalty    float32 = 2
 	policyDegradationPenalty float32 = 5
+	skippedManifestPenalty   float32 = 5
 )
 
 // ComputeCoverageScore derives CoverageScore from the controls actually
@@ -79,6 +86,7 @@ func (c *ScanCoverage) ComputeCoverageScore(totalControls int) {
 	score -= failedGVRPullPenalty * float32(c.SilentFailedGVRCount)
 	score -= partialGVRPullPenalty * float32(len(c.PartialGVRPulls))
 	score -= policyDegradationPenalty * float32(len(c.PolicyDegradations))
+	score -= skippedManifestPenalty * float32(len(c.SkippedManifests))
 
 	if score < 0 {
 		score = 0
@@ -89,7 +97,7 @@ func (c *ScanCoverage) ComputeCoverageScore(totalControls int) {
 
 	c.CoverageScore = score
 	c.Degraded = totalControls == 0 || len(c.FailedGVRPulls) > 0 || len(c.PartialGVRPulls) > 0 ||
-		len(c.PolicyDegradations) > 0 || len(c.NotEvaluatedControls) > 0
+		len(c.PolicyDegradations) > 0 || len(c.NotEvaluatedControls) > 0 || len(c.SkippedManifests) > 0
 }
 
 // PolicyDegradation records a policy input that could not be loaded from its
@@ -157,7 +165,11 @@ type NotEvaluatedControl struct {
 // policyDegradations carries policy inputs (control configurations,
 // exceptions) that were served from a fallback; they are included as-is in
 // ScanCoverage.PolicyDegradations.
-func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull, policyDegradations []PolicyDegradation) ScanCoverage {
+//
+// skippedManifests carries manifest files that were discovered but could not
+// be loaded or parsed; they are included as-is in ScanCoverage.SkippedManifests
+// and discounted from CoverageScore like PartialGVRPulls.
+func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap map[string][]string, timedOutControls map[string]string, partialPulls []PartialGVRPull, policyDegradations []PolicyDegradation, skippedManifests []SkippedManifest) ScanCoverage {
 	sortedPartialPulls := append([]PartialGVRPull(nil), partialPulls...)
 	sort.Slice(sortedPartialPulls, func(i, j int) bool {
 		if sortedPartialPulls[i].GVR != sortedPartialPulls[j].GVR {
@@ -168,9 +180,17 @@ func BuildScanCoverage(infoMap map[string]apis.StatusInfo, resourceToControlsMap
 		}
 		return sortedPartialPulls[i].Error < sortedPartialPulls[j].Error
 	})
+	sortedSkips := append([]SkippedManifest(nil), skippedManifests...)
+	sort.Slice(sortedSkips, func(i, j int) bool {
+		if sortedSkips[i].Path != sortedSkips[j].Path {
+			return sortedSkips[i].Path < sortedSkips[j].Path
+		}
+		return sortedSkips[i].Reason < sortedSkips[j].Reason
+	})
 	coverage := ScanCoverage{
 		PartialGVRPulls:    sortedPartialPulls,
 		PolicyDegradations: policyDegradations,
+		SkippedManifests:   sortedSkips,
 	}
 
 	notEvaluated := make(map[string]NotEvaluatedControl, len(timedOutControls))

--- a/core/cautils/scancoverage_test.go
+++ b/core/cautils/scancoverage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildScanCoverage_EmptyInfoMap(t *testing.T) {
-	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil, nil, nil)
+	coverage := BuildScanCoverage(nil, map[string][]string{"apps/v1/deployments": {"C-0001"}}, nil, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -19,7 +19,7 @@ func TestBuildScanCoverage_NoFailedGVRs(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusPassed},
 	}
-	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, map[string][]string{"networking.k8s.io/v1/networkpolicies": {"C-0001"}}, nil, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 }
@@ -32,7 +32,7 @@ func TestBuildScanCoverage_MappedDiscoveryFailureIsNotEvaluated(t *testing.T) {
 		nil,
 		[]PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
 		nil,
-	)
+		nil)
 	coverage.ComputeCoverageScore(1)
 
 	assert.Empty(t, coverage.FailedGVRPulls, "the discovery error is already present in PartialGVRPulls")
@@ -56,7 +56,7 @@ func TestBuildScanCoverage_DiscoveryFailureWithSuccessfulDependencyRemainsEvalua
 		nil,
 		[]PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
 		nil,
-	)
+		nil)
 
 	assert.Empty(t, coverage.NotEvaluatedControls)
 	assert.Empty(t, coverage.FailedGVRPulls)
@@ -69,7 +69,7 @@ func TestBuildScanCoverage_UnmappedDiscoveryFailureDoesNotInventControlDependenc
 		nil,
 		[]PartialGVRPull{{GVR: "discovery:example.com/v1", Selector: "discovery", Error: "forbidden"}},
 		nil,
-	)
+		nil)
 
 	assert.Empty(t, coverage.NotEvaluatedControls)
 	assert.Empty(t, coverage.FailedGVRPulls)
@@ -85,7 +85,7 @@ func TestBuildScanCoverage_FailedGVRPopulated(t *testing.T) {
 	resourceToControlsMap := map[string][]string{
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, "networking.k8s.io/v1/networkpolicies", coverage.FailedGVRPulls[0].GVR)
 	assert.Equal(t, "RBAC denied", coverage.FailedGVRPulls[0].Error)
@@ -97,7 +97,7 @@ func TestBuildScanCoverage_NoResourceMap(t *testing.T) {
 	infoMap := map[string]apis.StatusInfo{
 		"networking.k8s.io/v1/networkpolicies": {InnerStatus: apis.StatusSkipped},
 	}
-	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil, nil)
 	assert.Empty(t, coverage.FailedGVRPulls)
 }
 
@@ -110,7 +110,7 @@ func TestBuildScanCoverage_AllGVRsFailedControlNotEvaluated(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies":      {"C-0001", "C-0002"},
 		"rbac.authorization.k8s.io/v1/clusterroles": {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 2)
 
@@ -137,7 +137,7 @@ func TestBuildScanCoverage_IgnoresResourceLevelEvalSkips(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 
 	// Only the GVR-keyed entry should be in FailedGVRPulls
 	assert.Len(t, coverage.FailedGVRPulls, 1)
@@ -161,9 +161,9 @@ func TestBuildScanCoverage_DeterministicOrder(t *testing.T) {
 		"m/v1/mthings": {"C-0002"},
 	}
 
-	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	first := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 	for range 10 {
-		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+		next := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 		assert.Equal(t, first, next)
 	}
 
@@ -186,7 +186,7 @@ func TestBuildScanCoverage_PartialGVRFailureControlStillEvaluated(t *testing.T) 
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Empty(t, coverage.NotEvaluatedControls)
@@ -205,7 +205,7 @@ func TestBuildScanCoverage_FailedGVRPullIsNotPhantomNotEvaluatedControl(t *testi
 			InnerInfo:   "failed to list resources",
 		},
 	}
-	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, nil, nil, nil, nil, nil)
 
 	for _, ne := range coverage.NotEvaluatedControls {
 		assert.NotEqual(t, "networking.k8s.io/v1/networkpolicies", ne.ControlID)
@@ -307,7 +307,7 @@ func TestComputeCoverageScore_SilentFailedGVRReducesScore(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001"},
 		"apps/v1/deployments":                  {"C-0001"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Empty(t, coverage.NotEvaluatedControls)
 
@@ -329,7 +329,7 @@ func TestComputeCoverageScore_MixedDependencyFailedGVRIsCharged(t *testing.T) {
 		"networking.k8s.io/v1/networkpolicies": {"C-0001", "C-0002"},
 		"apps/v1/deployments":                  {"C-0002"},
 	}
-	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 
 	assert.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Len(t, coverage.NotEvaluatedControls, 1)
@@ -350,7 +350,7 @@ func TestBuildScanCoverage_PartialGVRPullsPassedThrough(t *testing.T) {
 		{GVR: "/v1/pods", Selector: "metadata.namespace==prod", Error: "RBAC denied for prod"},
 		{GVR: "core/v1/secrets", Selector: "metadata.name==prod-secret", Error: "forbidden"},
 	}
-	coverage := BuildScanCoverage(nil, nil, nil, partials, nil)
+	coverage := BuildScanCoverage(nil, nil, nil, partials, nil, nil)
 
 	assert.Len(t, coverage.PartialGVRPulls, 2)
 	assert.Equal(t, "/v1/pods", coverage.PartialGVRPulls[0].GVR)
@@ -369,7 +369,7 @@ func TestBuildScanCoverage_SortsPartialGVRPullsWithoutMutatingInput(t *testing.T
 	}
 	original := append([]PartialGVRPull(nil), partials...)
 
-	coverage := BuildScanCoverage(nil, nil, nil, partials, nil)
+	coverage := BuildScanCoverage(nil, nil, nil, partials, nil, nil)
 
 	assert.Equal(t, []PartialGVRPull{
 		{GVR: "/v1/pods", Selector: "metadata.namespace==z", Error: "denied"},

--- a/core/pkg/hostsensorutils/utils_test.go
+++ b/core/pkg/hostsensorutils/utils_test.go
@@ -141,7 +141,7 @@ func TestAddInfoToMap_BuildScanCoverageRecognizesHostSensorFailure(t *testing.T)
 		expectedKey: {"C-0001"},
 	}
 
-	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil)
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControlsMap, nil, nil, nil, nil)
 
 	require.Len(t, coverage.FailedGVRPulls, 1)
 	assert.Equal(t, expectedKey, coverage.FailedGVRPulls[0].GVR)

--- a/core/pkg/opaprocessor/partial_discovery_test.go
+++ b/core/pkg/opaprocessor/partial_discovery_test.go
@@ -46,6 +46,7 @@ func TestMarkNotEvaluatedControlsSkipped_LeavesPartiallyCollectedControlPassed(t
 		nil,
 		[]cautils.PartialGVRPull{{GVR: discoveryKey, Selector: "discovery", Error: "forbidden"}},
 		nil,
+		nil,
 	)
 
 	opap := NewOPAProcessor(session, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -259,7 +259,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	// rebuild ScanCoverage so controls that timed out during evaluation
 	// (recorded in TimedOutControls by markControlTimedOut) are reflected in
 	// NotEvaluatedControls alongside any collection-phase failures
-	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures, opap.PolicyDegradations)
+	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures, opap.PolicyDegradations, opap.SkippedManifests)
 	opap.ScanCoverage.ComputeCoverageScore(len(opap.Report.SummaryDetails.Controls))
 
 	// edit results
@@ -450,7 +450,7 @@ done:
 	}
 
 	// Rebuild scan coverage
-	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures, opap.PolicyDegradations)
+	opap.ScanCoverage = cautils.BuildScanCoverage(opap.InfoMap, opap.ResourceToControlsMap, opap.TimedOutControls, opap.PartialGVRFailures, opap.PolicyDegradations, opap.SkippedManifests)
 	opap.ScanCoverage.ComputeCoverageScore(len(opap.Report.SummaryDetails.Controls))
 
 	// Update results

--- a/core/pkg/opaprocessor/processorhandler_timeout_test.go
+++ b/core/pkg/opaprocessor/processorhandler_timeout_test.go
@@ -111,7 +111,7 @@ func TestProcess_ControlTimeout(t *testing.T) {
 	assert.Empty(t, opap.ResourcesResult, "timed-out control must not contribute resources to ResourcesResult")
 
 	// mirrors the rebuild step performed by ProcessRulesListener after Process returns
-	coverage := cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opap.TimedOutControls, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations)
+	coverage := cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, opap.TimedOutControls, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations, nil)
 	require.Len(t, coverage.NotEvaluatedControls, 1)
 	notEvaluated := coverage.NotEvaluatedControls[0]
 	assert.Equal(t, controlID, notEvaluated.ControlID)

--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -149,7 +149,7 @@ func TestDiscoveryResolverReportsPartialDiscoveryFailures(t *testing.T) {
 	require.Len(t, resolved, 1)
 	assert.Equal(t, "agents.x-k8s.io/v1alpha1/sandboxes", resolved[0].groupVersionResourceTriplet)
 
-	coverage := cautils.BuildScanCoverage(nil, nil, nil, failures, nil)
+	coverage := cautils.BuildScanCoverage(nil, nil, nil, failures, nil, nil)
 	coverage.ComputeCoverageScore(1)
 	assert.Len(t, coverage.PartialGVRPulls, 2)
 	assert.True(t, coverage.Degraded)

--- a/core/pkg/resourcehandler/handlerpullresources.go
+++ b/core/pkg/resourcehandler/handlerpullresources.go
@@ -30,7 +30,7 @@ func CollectResources(ctx context.Context, rsrcHandler IResourceHandler, opaSess
 	opaSessionObj.AllResources = allResources
 	opaSessionObj.ExternalResources = externalResources
 	opaSessionObj.ExcludedRules = excludedRulesMap
-	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, nil, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations)
+	opaSessionObj.ScanCoverage = cautils.BuildScanCoverage(opaSessionObj.InfoMap, opaSessionObj.ResourceToControlsMap, nil, opaSessionObj.PartialGVRFailures, opaSessionObj.PolicyDegradations, opaSessionObj.SkippedManifests)
 
 	if getErr != nil {
 		return getErr

--- a/core/pkg/resourcehandler/kindfilter_query_test.go
+++ b/core/pkg/resourcehandler/kindfilter_query_test.go
@@ -209,7 +209,7 @@ func TestKindFilteredQueryFailureStaysOutOfScanCoverage(t *testing.T) {
 	require.Empty(t, recordFailedQueryStatuses(failedQueries, k8sResources, infoMap))
 	assert.Empty(t, infoMap, "an excluded kind must not be reported as a failed dependency")
 
-	coverage := cautils.BuildScanCoverage(infoMap, resourceToControls, nil, nil, nil)
+	coverage := cautils.BuildScanCoverage(infoMap, resourceToControls, nil, nil, nil, nil)
 	coverage.ComputeCoverageScore(1)
 	assert.Empty(t, coverage.FailedGVRPulls)
 	assert.Empty(t, coverage.NotEvaluatedControls)

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -428,6 +428,6 @@ func TestGetResources_DiscoveryFailureReachesScanCoverage(t *testing.T) {
 	assert.Equal(t, "discovery", sessionObj.PartialGVRFailures[0].Selector)
 	assert.Contains(t, sessionObj.PartialGVRFailures[0].Error, "provider unavailable")
 
-	coverage := cautils.BuildScanCoverage(sessionObj.InfoMap, sessionObj.ResourceToControlsMap, nil, sessionObj.PartialGVRFailures, nil)
+	coverage := cautils.BuildScanCoverage(sessionObj.InfoMap, sessionObj.ResourceToControlsMap, nil, sessionObj.PartialGVRFailures, nil, nil)
 	assert.Len(t, coverage.PartialGVRPulls, 1)
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -359,7 +359,7 @@ func isPrintSeparatorType(scanType cautils.ScanTypes) bool {
 // failures caused controls to be skipped or partial data was collected.
 // Nothing is printed on a clean scan.
 func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
-	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 && len(coverage.PolicyDegradations) == 0 && len(coverage.VacuousFrameworks) == 0 {
+	if len(coverage.FailedGVRPulls) == 0 && len(coverage.NotEvaluatedControls) == 0 && len(coverage.PartialGVRPulls) == 0 && len(coverage.PolicyDegradations) == 0 && len(coverage.VacuousFrameworks) == 0 && len(coverage.SkippedManifests) == 0 {
 		return
 	}
 
@@ -408,6 +408,14 @@ func (pp *PrettyPrinter) printScanCoverage(coverage cautils.ScanCoverage) {
 		for _, f := range coverage.VacuousFrameworks {
 			fmt.Fprintf(pp.writer, "  • %s\n", f)
 		}
+	}
+
+	if len(coverage.SkippedManifests) > 0 {
+		fmt.Fprintf(pp.writer, "\nThe following manifest files could not be loaded and were not scanned:\n")
+		for _, s := range coverage.SkippedManifests {
+			fmt.Fprintf(pp.writer, "  • %s: %s\n", s.Path, s.Reason)
+		}
+		fmt.Fprintf(pp.writer, "\nControls were evaluated against incomplete input. Fix or exclude these files.\n")
 	}
 
 	if len(coverage.FailedGVRPulls) > 0 || len(coverage.PartialGVRPulls) > 0 {

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -179,7 +179,7 @@ func ConvertToPostureReportWithSeverityLabelsAndCoverage(report *reporthandlingv
 
 	// only attach coverage when there is something to show
 	var scanCoverage *cautils.ScanCoverage
-	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0 || len(coverage.VacuousFrameworks) > 0) {
+	if coverage != nil && (len(coverage.FailedGVRPulls) > 0 || len(coverage.NotEvaluatedControls) > 0 || len(coverage.PartialGVRPulls) > 0 || len(coverage.PolicyDegradations) > 0 || len(coverage.VacuousFrameworks) > 0 || len(coverage.SkippedManifests) > 0) {
 		scanCoverage = coverage
 	}
 


### PR DESCRIPTION
## Overview

When scanning a directory, files that can't be loaded — bad YAML, oversized files (`KUBESCAPE_MAX_FILE_SIZE`), missing `kind`, unrendered Helm templates — were only printed as a `logger.Warning` to stderr. The `ScanCoverage` that drives JSON/SARIF and `--fail-coverage-below` never saw them.

That means a CI run with `1 good + 2 broken` manifests looked identical to scanning just the good file: `1 resource`, same `complianceScore`, `scanCoverage: {}`, `exit 0` even with `--fail-coverage-below 100`. Bad files were silent.

This PR feeds the skipped files that `loadFiles()` already collects (`OPASessionObj.SkippedManifests` via `filesloader.go:56`) into the coverage path:

* `ScanCoverage` now carries `skippedManifests[]` (like `PartialGVRPulls`), sorted deterministically
* `CoverageScore` is discounted 5 points per skipped file, `Degraded=true` when any exist
* both `ProcessRulesListener` and `ProcessWithStreaming` pass `SkippedManifests` to `BuildScanCoverage`
* the v2 report and pretty-printer only attach/show coverage when skipped files exist
* pre-existing `* SkippedManifests` files (e.g. `results.json` left in the scan dir with a tiny `KUBESCAPE_MAX_FILE_SIZE`) are correctly surfaced — use `--output` outside the scan dir or exclude the pattern to keep the gate clean

**Behavioural change:** scans that previously passed with hidden skips will now show `coverageScore < 100` and may fail `--fail-coverage-below`. That's intentional — it's the integrity fix.

## How to Test

```bash
mkdir /tmp/repro
cat > /tmp/repro/good.yaml <<'YAML'
apiVersion: v1
kind: Pod
metadata: {name: good}
spec: {containers: [{name: c, image: nginx}]}
YAML
cat > /tmp/repro/bad.yaml <<'YAML'
apiVersion: v1
kind: Pod
metadata: [unterminated
YAML
export KUBESCAPE_MAX_FILE_SIZE=1024
python3 -c "print('x'*2048)" > /tmp/repro/huge.yaml

# before: exit 0, scanCoverage {}, same score as single file
# after:
kubescape scan /tmp/repro --format json --output /tmp/out.json
jq .scanCoverage /tmp/out.json
# -> {skippedManifests:[{path:bad.yaml,...},{path:huge.yaml,...}], coverageScore:90, degraded:true}

kubescape scan /tmp/repro --fail-coverage-below 100
# -> Scan Coverage Warning + Error: scan coverage is below permitted threshold: 90.00% (fail-coverage-below: 100.00%) + exit 1

kubescape scan /tmp/repro/good.yaml --fail-coverage-below 100
# -> exit 0, scanCoverage {} still 100% when nothing was skipped
```

Existing suites:

```bash
go test ./core/cautils -run TestBuildScanCoverage -count=1
go test ./core/pkg/opaprocessor ./core/pkg/resourcehandler ./core/pkg/resultshandling/printer/v2 -count=1
```

## Examples/Screenshots

Pretty-printer before/after for the 3-file dir:

Before:
```
Scan Coverage Warning — not shown
scanCoverage: {}
exit 0 with --fail-coverage-below 100
```

After:
```
Scan Coverage Warning
────────────────────────────────────────────────
Scan coverage score: 90% (129/129 controls evaluated)

The following manifest files could not be loaded and were not scanned:
  • /tmp/repro/bad.yaml: parse error: document 1: yaml: line 2: did not find expected ',' or ']'
  • /tmp/repro/huge.yaml: file too large: "...size 2049 exceeds limit 1024 bytes"

Controls were evaluated against incomplete input. Fix or exclude these files.
Error: scan coverage is below permitted threshold: 90.00% (fail-coverage-below: 100.00%)
exit 1
```

## Related issues/PRs:

* Fixes #3554

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scan coverage now reports manifest files that were discovered but skipped, including the file path and reason.
  - Skipped manifests are included in scan results and displayed in coverage warnings.
- **Bug Fixes**
  - Scan coverage now correctly reflects incomplete input when manifests cannot be loaded or parsed.
  - Coverage scores are reduced by 5 points per skipped manifest, and scans are marked as degraded when any are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->