### PR TITLE
fix(opaprocessor): quote inline exception designator attributes

### DIFF
--- a/core/pkg/opaprocessor/inlineexception_regex_test.go
+++ b/core/pkg/opaprocessor/inlineexception_regex_test.go
@@ -1,0 +1,61 @@
+package opaprocessor
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/stretchr/testify/require"
+)
+
+// inlineAnnotatedWorkload builds a manifest-sourced Deployment, optionally
+// carrying the kubescape.io/skip-controls annotation. sourcePath is shared by
+// every document in one file, mirroring a rendered multi-document manifest.
+func inlineAnnotatedWorkload(sourcePath, name string, skip bool) workloadinterface.IMetadata {
+	metadata := map[string]any{"name": name, "namespace": "prod"}
+	if skip {
+		metadata["annotations"] = map[string]any{skipControlsAnnotation: "C-0057"}
+	}
+	return localworkload.NewLocalWorkload(map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   metadata,
+		"sourcePath": sourcePath,
+	})
+}
+
+// TestInlineExceptionDoesNotLeakToSiblingResource pins that an inline exception
+// applies only to the resource that carries the annotation. The exceptions
+// processor matches designator attributes as anchored regular expressions, so
+// an unquoted name is a pattern: "web.api" would also match the sibling
+// "web-api" and silently suppress the annotated control on a workload nobody
+// asked to exempt.
+func TestInlineExceptionDoesNotLeakToSiblingResource(t *testing.T) {
+	const manifest = "/repo/rendered.yaml"
+
+	annotated := inlineAnnotatedWorkload(manifest, "web.api", true)
+	sibling := inlineAnnotatedWorkload(manifest, "web-api", false)
+
+	policies := inlineExceptionFromResource(annotated, "cluster")
+	require.Len(t, policies, 1)
+
+	processor := exceptions.NewProcessor()
+	require.Len(t, processor.GetResourceExceptions(policies, annotated, "cluster"), 1,
+		"the annotated resource must still be exempted")
+	require.Empty(t, processor.GetResourceExceptions(policies, sibling, "cluster"),
+		"a resource without the annotation must never be exempted by a sibling's inline exception")
+}
+
+// TestInlineExceptionMatchesDottedNameItself guards the other direction: quoting
+// the attributes must not stop an inline exception from matching the resource it
+// was authored on.
+func TestInlineExceptionMatchesDottedNameItself(t *testing.T) {
+	workload := inlineAnnotatedWorkload("/repo/rendered.yaml", "app.kubernetes.io", true)
+
+	policies := inlineExceptionFromResource(workload, "cluster")
+	require.Len(t, policies, 1)
+
+	processor := exceptions.NewProcessor()
+	require.Len(t, processor.GetResourceExceptions(policies, workload, "cluster"), 1)
+}

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -3,6 +3,7 @@ package opaprocessor
 import (
 	"context"
 	"errors"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -265,18 +266,24 @@ func inlineExceptionFromResource(obj workloadinterface.IMetadata, clusterName st
 		policies = append(policies, armotypes.PosturePolicy{ControlID: c})
 	}
 
+	// The exceptions processor matches designator attributes as anchored
+	// regular expressions. These values are the resource's own literal
+	// identity, so they must be quoted: a name containing a regex
+	// metacharacter (a dot is legal in an RFC 1123 subdomain) would otherwise
+	// also suppress the annotated control on sibling resources whose names
+	// differ only where that metacharacter sits.
 	attrs := map[string]string{}
 	if name := obj.GetName(); name != "" {
-		attrs["name"] = name
+		attrs["name"] = regexp.QuoteMeta(name)
 	}
 	if kind := obj.GetKind(); kind != "" {
-		attrs["kind"] = kind
+		attrs["kind"] = regexp.QuoteMeta(kind)
 	}
 	if ns := obj.GetNamespace(); ns != "" {
-		attrs["namespace"] = ns
+		attrs["namespace"] = regexp.QuoteMeta(ns)
 	}
 	if id := obj.GetID(); id != "" {
-		attrs["resourceID"] = id
+		attrs["resourceID"] = regexp.QuoteMeta(id)
 	}
 
 	var reasonPtr *string


### PR DESCRIPTION
## Overview

Inline exceptions are built from `kubescape.io/skip-controls` on a single resource, but the exceptions processor matches designator attributes (`name`, `kind`, `namespace`, `resourceID`) as regular expressions rather than literal strings. `inlineExceptionFromResource` was passing the resource's raw name, kind, namespace and ID straight into those designators, so any value containing a regex metacharacter became a pattern instead of an identity.

A dot is legal in an RFC 1123 subdomain, so this isn't an edge case: a resource named `web.api` produces the designator `name: "web.api"`, and `.` matches any character. That pattern also matches a sibling named `web-api`, so annotating one resource silently suppresses the control on another resource nobody asked to exempt.

## What's in here

`attrs` in `inlineExceptionFromResource` now quotes each value with `regexp.QuoteMeta` before it goes into the designator, so the match is against the resource's literal name, kind, namespace and ID.

`inlineexception_regex_test.go` covers both directions: `TestInlineExceptionDoesNotLeakToSiblingResource` pins that an annotated `web.api` no longer exempts an unannotated `web-api`, and `TestInlineExceptionMatchesDottedNameItself` guards that quoting doesn't stop the exception from matching the resource it was written for.

## Testing

```
go test ./core/pkg/opaprocessor/...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline exceptions so resource names containing regex characters match only the intended resource.
  * Prevented exceptions from unintentionally applying to similarly named sibling resources.
  * Improved matching for resources with dotted names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->