### PR TITLE
fix(opaprocessor): honor ResourceEnumerator output in scan path

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1149,7 +1149,7 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		opap.mu.Unlock()
 	}
 
-	ruleResponses, celOut, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData, controlID)
+	ruleResponses, celOut, err := opap.runOPAOnSingleRule(ctx, rule, enumeratedData, ruleData, ruleRegoDependenciesData, controlID)
 	if err != nil {
 		opap.markResourcesSkipped(resources, rule, ruleRegoDependenciesData, inputResources, err)
 		return resources, fmt.Errorf("rego eval failed for namespace %q: %w", scope.name, err)

--- a/core/pkg/opaprocessor/processorhandler_enumerator_test.go
+++ b/core/pkg/opaprocessor/processorhandler_enumerator_test.go
@@ -1,0 +1,230 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helpers to build minimal pods
+func podWithLabels(name, appLabel string, hostNetwork bool) workloadinterface.IMetadata {
+	m := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+			"labels":    map[string]any{"app": appLabel},
+		},
+		"spec": map[string]any{
+			"hostNetwork": hostNetwork,
+			"containers":  []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	}
+	return workloadinterface.NewWorkloadObj(m)
+}
+
+func newTestProcessor(pods []workloadinterface.IMetadata) (*OPAProcessor, *cautils.OPASessionObj) {
+	opaSessionObj := cautils.NewOPASessionObjMock()
+	opaSessionObj.AllResources = map[string]workloadinterface.IMetadata{}
+	opaSessionObj.K8SResources = cautils.K8SResources{}
+	opaSessionObj.ResourceToControlsMap = map[string][]string{"/v1/Pod": {"C-TEST"}}
+	opaSessionObj.Report = &reporthandlingv2.PostureReport{}
+	opaSessionObj.Report.SummaryDetails.Controls = map[string]reportsummary.ControlSummary{}
+	opaSessionObj.InfoMap = map[string]apis.StatusInfo{}
+	opaSessionObj.Report.ClusterCloudProvider = ""
+	// populate
+	var ids []string
+	for _, p := range pods {
+		id := p.GetID()
+		opaSessionObj.AllResources[id] = p
+		ids = append(ids, id)
+	}
+	opaSessionObj.K8SResources["/v1/Pod"] = ids
+	return NewOPAProcessor(opaSessionObj, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil), opaSessionObj
+}
+
+// TestResourceEnumeratorHonored is the regression test for
+// processorhandler.go:1140 — ensure enumeratedData is evaluated, not inputRawResources.
+// Without the fix 113 rule instances evaluate against un-narrowed input.
+func TestResourceEnumeratorHonored(t *testing.T) {
+	tests := []struct {
+		name          string
+		enumerator    string
+		mainRule      string
+		pods          []workloadinterface.IMetadata
+		expectFailed  []string // pod names expected to be failed
+		expectPassed  []string
+		expectAbsent  []string // not in ResourcesResult at all (filtered away)
+		expectSkipped []string
+	}{
+		{
+			name: "enumerator filters to app=keep — only keep is evaluated",
+			enumerator: `package armo_builtins
+deny[msg]{ obj:=input[_]; obj.metadata.labels.app=="keep"; msg:={"alertObject":{"k8sApiObjects":[obj]}}}`,
+			mainRule: `package armo_builtins
+import rego.v1
+deny contains msga if { obj:=input[_]; obj.spec.hostNetwork==true; msga:={"alertMessage":"hostNetwork","alertObject":{"k8sApiObjects":[obj]}} }`,
+			pods: []workloadinterface.IMetadata{
+				podWithLabels("keep-pod", "keep", true),
+				podWithLabels("drop-pod", "drop", true),
+			},
+			expectFailed: []string{"keep-pod"},
+			expectAbsent: []string{"drop-pod"},
+		},
+		{
+			name:       "empty enumerator — all pods evaluated",
+			enumerator: "",
+			mainRule: `package armo_builtins
+import rego.v1
+deny contains msga if { obj:=input[_]; obj.spec.hostNetwork==true; msga:={"alertMessage":"x","alertObject":{"k8sApiObjects":[obj]}} }`,
+			pods: []workloadinterface.IMetadata{
+				podWithLabels("keep-pod", "keep", true),
+				podWithLabels("drop-pod", "drop", true),
+			},
+			expectFailed: []string{"keep-pod", "drop-pod"},
+		},
+		{
+			name: "enumerator selects none — no evaluation, no results",
+			enumerator: `package armo_builtins
+deny[msg]{ obj:=input[_]; obj.metadata.labels.app=="nonexistent"; msg:={"alertObject":{"k8sApiObjects":[obj]}}}`,
+			mainRule: `package armo_builtins
+import rego.v1
+deny contains msga if { obj:=input[_]; obj.spec.hostNetwork==true; msga:={"alertMessage":"x","alertObject":{"k8sApiObjects":[obj]}} }`,
+			pods: []workloadinterface.IMetadata{
+				podWithLabels("keep-pod", "keep", true),
+				podWithLabels("drop-pod", "drop", true),
+			},
+			expectAbsent: []string{"keep-pod", "drop-pod"},
+		},
+		{
+			name: "enumerator filters then main rule passes — pass reported only for enumerated",
+			enumerator: `package armo_builtins
+deny[msg]{ obj:=input[_]; obj.metadata.labels.app=="keep"; msg:={"alertObject":{"k8sApiObjects":[obj]}}}`,
+			mainRule: `package armo_builtins
+import rego.v1
+deny contains msga if { obj:=input[_]; obj.spec.hostNetwork==true; obj.metadata.name=="impossible"; msga:={"alertMessage":"x","alertObject":{"k8sApiObjects":[obj]}} }`,
+			pods: []workloadinterface.IMetadata{
+				podWithLabels("keep-pod", "keep", false),
+				podWithLabels("drop-pod", "drop", false),
+			},
+			expectPassed: []string{"keep-pod"},
+			expectAbsent: []string{"drop-pod"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := &reporthandling.PolicyRule{
+				PortalBase:         armotypes.PortalBase{Name: "test-rule"},
+				Rule:               tc.mainRule,
+				ResourceEnumerator: tc.enumerator,
+				Match:              []reporthandling.RuleMatchObjects{{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}}},
+				RuleLanguage:       reporthandling.RegoLanguage,
+			}
+			control := &reporthandling.Control{ControlID: "C-TEST", Rules: []reporthandling.PolicyRule{*rule}}
+			policies := &cautils.Policies{Controls: map[string]reporthandling.Control{"C-TEST": *control}}
+			// session setup per case
+			opap, sess := newTestProcessor(tc.pods)
+			sess.Policies = []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "fw"}, Controls: []reporthandling.Control{*control}}}
+			opap.AllPolicies = policies
+			ConvertFrameworksToSummaryDetails(&sess.Report.SummaryDetails, sess.Policies, policies)
+
+			err := opap.Process(context.Background(), policies, nil)
+			require.NoError(t, err, "Process should not error for valid enumerator")
+
+			for _, name := range tc.expectFailed {
+				found := false
+				for _, r := range sess.ResourcesResult {
+					for _, ac := range r.AssociatedControls {
+						for _, rr := range ac.ResourceAssociatedRules {
+							if rr.Name == "test-rule" && rr.Status == apis.StatusFailed {
+								// need to locate by name in AllResources
+								for _, p := range tc.pods {
+									if p.GetName() == name && r.ResourceID == p.GetID() {
+										found = true
+									}
+								}
+							}
+						}
+					}
+				}
+				assert.True(t, found, "expected %s to be failed", name)
+			}
+			for _, name := range tc.expectAbsent {
+				for _, p := range tc.pods {
+					if p.GetName() == name {
+						_, ok := sess.ResourcesResult[p.GetID()]
+						assert.False(t, ok, "expected %s to be absent (filtered by enumerator), but found in ResourcesResult", name)
+					}
+				}
+			}
+			for _, name := range tc.expectPassed {
+				found := false
+				for _, r := range sess.ResourcesResult {
+					for _, ac := range r.AssociatedControls {
+						for _, rr := range ac.ResourceAssociatedRules {
+							if rr.Name == "test-rule" && rr.Status == apis.StatusPassed {
+								for _, p := range tc.pods {
+									if p.GetName() == name && r.ResourceID == p.GetID() {
+										found = true
+									}
+								}
+							}
+						}
+					}
+				}
+				assert.True(t, found, "expected %s to be passed", name)
+			}
+		})
+	}
+}
+
+func TestEnumerateData_UsesEnumeratedNotRaw(t *testing.T) {
+	// Direct unit test for the bug: processRuleOnScope must not evaluate inputRawResources after enumeration.
+	// We use EvaluateRule (correct reference) vs Process (fixed path) and assert they agree.
+	podKeep := podWithLabels("keep-pod", "keep", true)
+	podDrop := podWithLabels("drop-pod", "drop", true)
+	enumerator := `package armo_builtins
+deny[msg]{ obj:=input[_]; obj.metadata.labels.app=="keep"; msg:={"alertObject":{"k8sApiObjects":[obj]}}}`
+	mainRule := `package armo_builtins
+import rego.v1
+deny contains msga if { obj:=input[_]; obj.kind=="Pod"; obj.spec.hostNetwork==true; msga:={"alertMessage":"x","alertObject":{"k8sApiObjects":[obj]}} }`
+	rule := &reporthandling.PolicyRule{
+		PortalBase: armotypes.PortalBase{Name: "test-rule"}, Rule: mainRule, ResourceEnumerator: enumerator,
+		Match:        []reporthandling.RuleMatchObjects{{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}}},
+		RuleLanguage: reporthandling.RegoLanguage,
+	}
+	// Correct path via EvaluateRule
+	sess := cautils.NewOPASessionObjMock()
+	opapRef := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	refRes, err := opapRef.EvaluateRule(context.Background(), rule, []workloadinterface.IMetadata{podKeep, podDrop}, "C-TEST")
+	require.NoError(t, err)
+	require.Len(t, refRes, 1, "enumerated path should only fail keep-pod")
+	assert.Equal(t, "keep-pod", refRes[0].GetFailedResources()[0]["metadata"].(map[string]any)["name"])
+
+	// Production path via Process
+	rule2 := *rule
+	control := &reporthandling.Control{ControlID: "C-TEST", Rules: []reporthandling.PolicyRule{rule2}}
+	policies := &cautils.Policies{Controls: map[string]reporthandling.Control{"C-TEST": *control}}
+	opap, sess2 := newTestProcessor([]workloadinterface.IMetadata{podKeep, podDrop})
+	sess2.Policies = []reporthandling.Framework{{PortalBase: armotypes.PortalBase{Name: "fw"}, Controls: []reporthandling.Control{*control}}}
+	opap.AllPolicies = policies
+	ConvertFrameworksToSummaryDetails(&sess2.Report.SummaryDetails, sess2.Policies, policies)
+	require.NoError(t, opap.Process(context.Background(), policies, nil))
+	// drop-pod must be absent — if bug present, it would be failed too
+	_, hasDrop := sess2.ResourcesResult[podDrop.GetID()]
+	assert.False(t, hasDrop, "drop-pod must be filtered by enumerator; buggy code would report it as failed")
+	_, hasKeep := sess2.ResourcesResult[podKeep.GetID()]
+	assert.True(t, hasKeep, "keep-pod must be present")
+}


### PR DESCRIPTION
## Overview

Hey team — small but high-impact fix in the scan path.

`processRuleOnScope` already narrows the input via `ResourceEnumerator`, but the narrowed result was never actually evaluated. We compute `enumeratedData` at `processorhandler.go:1112`, correctly update `AllResources` and the pass-inference set, then call `runOPAOnSingleRule` with the **original un-narrowed** `inputRawResources` at `1140`. So 113 shipped rule instances ( `C-0079`, `C-0090`, `C-0261`, pod-security-admission, etc.) were seeing objects they were explicitly scoped away from. If the rule errored on that stray shape, `markResourcesSkipped` wiped the whole rule.

Fix is one line — pass `enumeratedData` to `runOPAOnSingleRule`, matching the correct helper in `evaluate.go:33` used by `kubescape policy test`. Both `Process` and `ProcessWithStreaming` go through `processRuleOnScope`, so both are fixed.

**Before:** `keep-pod` (app=keep) and `drop-pod` (app=drop) both failed even though enumerator kept only `keep`.
**After:** only `keep-pod` is evaluated.

Resolves #3557

## Additional Information

The enumerator path had zero table-driven coverage (`grep -r ResourceEnumerator --include="*_test.go"` was empty), which is why this slipped through. This PR adds `processorhandler_enumerator_test.go` to lock it.

Blast radius is limited to rules with a `resourceEnumerator`, but for those it's a correctness fix — no new deps, no API change, `AllResources` write-back stays with the narrowed set as before.

## How to Test

```bash
go test ./core/pkg/opaprocessor -run TestResourceEnumeratorHonored -v
# 4 cases: filter to keep, empty enumerator, select-none, filtered+pass
go test ./core/pkg/opaprocessor -run TestEnumerateData_UsesEnumeratedNotRaw -v
go test ./core/pkg/opaprocessor -count=1   # full suite ~16s
go vet ./core/pkg/opaprocessor
```

Manual repro (also in issue):
- 2 Pods: `keep-pod` (labels.app=keep, hostNetwork=true) vs `drop-pod` (labels.app=drop, hostNetwork=true)
- Rule enumerator keeps only `app=keep`, main rule denies `hostNetwork=true`
- Buggy: `ResourcesResult size:2` (both failed)
- Fixed: `ResourcesResult size:1` (keep only) — also verified by reverting the line and seeing the test fail.

## Related issues/PRs:

* Resolves #3557

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rule evaluation now uses the filtered and enumerated resource set, improving result accuracy and ensuring excluded resources are not evaluated.

- **Tests**
  - Added coverage for resource filtering, empty and unmatched enumerators, successful and failed evaluations, and production processing with enumerated resources.
  - Added validation that processing results correctly reflect evaluations performed on the enumerated resource set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->