### PR TITLE
feat(printer): generate a posture exceptions baseline from scan results

### DIFF
--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -479,7 +479,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json, policyreport"
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json, policyreport, exceptions"
 	assert.EqualError(t, err, errMessage)
 }
 

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -30,10 +30,11 @@ const (
 	CycloneDXFormat    string = "cyclonedx-json"
 	SPDXFormat         string = "spdx-json"
 	PolicyReportFormat string = "policyreport"
+	ExceptionsFormat   string = "exceptions"
 )
 
 // AllFormats lists every output format kubescape can emit.
-var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat, PolicyReportFormat}
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat, PolicyReportFormat, ExceptionsFormat}
 
 // ImageFormats lists formats whose printers support image-scan data. CSV is
 // deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
@@ -58,6 +59,7 @@ const (
 	CycloneDXOutputExt    = ".cdx.json"
 	SPDXOutputExt         = ".spdx.json"
 	PolicyReportOutputExt = ".yaml"
+	ExceptionsOutputExt   = ".exceptions.json"
 )
 
 // HasOutputExt reports whether outputFile already ends with ext, compared
@@ -126,6 +128,7 @@ var FormatOutputExt = map[string]string{
 	CycloneDXFormat:    CycloneDXOutputExt,
 	SPDXFormat:         SPDXOutputExt,
 	PolicyReportFormat: PolicyReportOutputExt,
+	ExceptionsFormat:   ExceptionsOutputExt,
 }
 
 type IPrinter interface {

--- a/core/pkg/resultshandling/printer/v2/exceptionsprinter.go
+++ b/core/pkg/resultshandling/printer/v2/exceptionsprinter.go
@@ -1,0 +1,306 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+)
+
+const (
+	exceptionsOutputFile = "exceptions"
+	exceptionPolicyType  = "postureExceptionPolicy"
+
+	// emptyNamespacePattern pins a designator to a resource that recorded no
+	// namespace, whether because it is cluster-scoped or because the manifest
+	// omitted one. An absent namespace attribute is not equivalent: the
+	// processor skips the axis entirely and the policy then covers every
+	// namespace.
+	emptyNamespacePattern = "^$"
+
+	// namespaceKind is compared against the namespace axis by its own name, see
+	// namespaceAttribute.
+	namespaceKind = "Namespace"
+)
+
+type ExceptionsPrinter struct {
+	writer *os.File
+}
+
+func NewExceptionsPrinter() *ExceptionsPrinter {
+	return &ExceptionsPrinter{}
+}
+
+func (ep *ExceptionsPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.ExceptionsFormat, outputFile, exceptionsOutputFile)
+	if explicitOutput {
+		var err error
+		ep.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
+	ep.writer = printer.GetWriter(ctx, outputFile)
+	return nil
+}
+
+func (ep *ExceptionsPrinter) Score(float32) {}
+
+func (ep *ExceptionsPrinter) PrintNextSteps() {}
+
+func (ep *ExceptionsPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, _ []cautils.ImageScanData) error {
+	if opaSessionObj == nil {
+		return fmt.Errorf("failed to write exceptions: no data provided")
+	}
+
+	policies := buildExceptionPolicies(ctx, opaSessionObj)
+	if len(policies) == 0 {
+		logger.L().Ctx(ctx).Warning("no failed controls to write as exceptions")
+	}
+
+	encoded, err := json.MarshalIndent(exceptionDocuments(policies), "", "    ")
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to encode exceptions", helpers.Error(err))
+		return fmt.Errorf("failed to encode exceptions: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if _, err := ep.writer.Write(encoded); err != nil {
+		logger.L().Ctx(ctx).Error("failed to write exceptions", helpers.Error(err))
+		return fmt.Errorf("failed to write exceptions: %w", err)
+	}
+
+	printer.LogOutputFile(ep.writer.Name())
+	return nil
+}
+
+// buildExceptionPolicies turns the scan's failed controls into one exception
+// policy per control, each listing the resources that failed it. Designators
+// carry no cluster attribute so the generated file stays usable against any
+// cluster the same workloads are deployed to.
+//
+// Control IDs are escaped for the same reason as the designator attributes: the
+// processor regex-matches them, and a custom rule's ID carries whatever
+// characters its file or directory was named with.
+func buildExceptionPolicies(ctx context.Context, opaSessionObj *cautils.OPASessionObj) []armotypes.PostureExceptionPolicy {
+	failures := collectFailures(ctx, opaSessionObj)
+	if len(failures) == 0 {
+		return []armotypes.PostureExceptionPolicy{}
+	}
+
+	creationTime := opaSessionObj.Report.ReportGenerationTime
+	if creationTime.IsZero() {
+		creationTime = time.Now().UTC()
+	}
+
+	controlIDs := make([]string, 0, len(failures))
+	for controlID := range failures {
+		controlIDs = append(controlIDs, controlID)
+	}
+	sort.Strings(controlIDs)
+
+	policies := make([]armotypes.PostureExceptionPolicy, 0, len(controlIDs))
+	for _, controlID := range controlIDs {
+		policies = append(policies, armotypes.PostureExceptionPolicy{
+			PortalBase:      armotypes.PortalBase{Name: "exclude-" + controlID},
+			PolicyType:      exceptionPolicyType,
+			CreationTime:    creationTime.UTC().Format(time.RFC3339),
+			Actions:         []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
+			Resources:       designators(failures[controlID]),
+			PosturePolicies: []armotypes.PosturePolicy{{ControlID: regexp.QuoteMeta(controlID)}},
+		})
+	}
+	return policies
+}
+
+// CloseWriter closes the exceptions output writer, returning any error from
+// flushing or closing.
+func (ep *ExceptionsPrinter) CloseWriter() error {
+	if ep.writer != nil && ep.writer != os.Stdout {
+		return ep.writer.Close()
+	}
+	return nil
+}
+
+// exceptionDocument is the serialised form of an exception policy. The armotypes
+// structs carry portal-only fields without omitempty, and this file is meant to
+// be edited by hand and fed back through --exceptions, so it is written in the
+// same shape as the examples under examples/exceptions.
+type exceptionDocument struct {
+	Name            string                                    `json:"name"`
+	PolicyType      string                                    `json:"policyType"`
+	CreationTime    string                                    `json:"creationTime,omitempty"`
+	Actions         []armotypes.PostureExceptionPolicyActions `json:"actions"`
+	Resources       []identifiers.PortalDesignator            `json:"resources"`
+	PosturePolicies []posturePolicyDocument                   `json:"posturePolicies"`
+}
+
+type posturePolicyDocument struct {
+	ControlID string `json:"controlID"`
+}
+
+func exceptionDocuments(policies []armotypes.PostureExceptionPolicy) []exceptionDocument {
+	documents := make([]exceptionDocument, 0, len(policies))
+	for _, policy := range policies {
+		posturePolicies := make([]posturePolicyDocument, 0, len(policy.PosturePolicies))
+		for _, posturePolicy := range policy.PosturePolicies {
+			posturePolicies = append(posturePolicies, posturePolicyDocument{ControlID: posturePolicy.ControlID})
+		}
+		documents = append(documents, exceptionDocument{
+			Name:            policy.Name,
+			PolicyType:      policy.PolicyType,
+			CreationTime:    policy.CreationTime,
+			Actions:         policy.Actions,
+			Resources:       policy.Resources,
+			PosturePolicies: posturePolicies,
+		})
+	}
+	return documents
+}
+
+// resourceKey identifies one failed workload. Several resources can share a
+// kind and name across namespaces, and a repository can declare the same object
+// in more than one file, so the source path is part of the identity too.
+type resourceKey struct {
+	kind      string
+	namespace string
+	name      string
+	path      string
+}
+
+// collectFailures maps each failed control to the resources that failed it.
+func collectFailures(ctx context.Context, opaSessionObj *cautils.OPASessionObj) map[string]map[resourceKey]struct{} {
+	failures := map[string]map[resourceKey]struct{}{}
+
+	for resourceID, result := range opaSessionObj.ResourcesResult {
+		resource, ok := opaSessionObj.AllResources[resourceID]
+		if !ok || resource == nil {
+			if hasFailedControl(result) {
+				logger.L().Ctx(ctx).Warning("skipping failed resource with no scanned object; its findings are not in the baseline",
+					helpers.String("resourceID", resourceID))
+			}
+			continue
+		}
+
+		key := resourceKey{
+			kind:      resource.GetKind(),
+			namespace: resource.GetNamespace(),
+			name:      resource.GetName(),
+			path:      sourcePath(resource),
+		}
+		if key.kind == "" || key.name == "" {
+			if hasFailedControl(result) {
+				logger.L().Ctx(ctx).Warning("skipping failed resource with no kind or name; its findings are not in the baseline",
+					helpers.String("resourceID", resourceID))
+			}
+			continue
+		}
+
+		for i := range result.AssociatedControls {
+			control := &result.AssociatedControls[i]
+			if control.GetStatus(nil).Status() != apis.StatusFailed {
+				continue
+			}
+			if _, ok := failures[control.ControlID]; !ok {
+				failures[control.ControlID] = map[resourceKey]struct{}{}
+			}
+			failures[control.ControlID][key] = struct{}{}
+		}
+	}
+
+	return failures
+}
+
+func hasFailedControl(result resourcesresults.Result) bool {
+	for i := range result.AssociatedControls {
+		if result.AssociatedControls[i].GetStatus(nil).Status() == apis.StatusFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// sourcePath returns the manifest a locally scanned resource was read from.
+// Cluster scans carry none, and the path axis is then left off entirely.
+func sourcePath(resource workloadinterface.IMetadata) string {
+	object := resource.GetObject()
+	if object == nil {
+		return ""
+	}
+	path, _ := object["sourcePath"].(string)
+	return path
+}
+
+// designators renders one designator per resource. Values are escaped because
+// the exception processor compares every attribute as an anchored regular
+// expression: an unescaped name such as a CRD's widgets.example.com would also
+// match widgetsXexampleYcom and silence findings on a resource this baseline
+// never described.
+// namespaceAttribute resolves the namespace axis of a designator. Every
+// resource gets one: a manifest scanned without metadata.namespace still
+// describes a specific object, and leaving the attribute off would widen the
+// policy from that object to every namespace it could be deployed into.
+//
+// A Namespace object is the exception. The processor compares this axis against
+// the object's own name rather than its metadata.namespace, so a Namespace has
+// to be pinned by name or the policy is dead on arrival.
+func namespaceAttribute(key resourceKey) string {
+	if key.kind == namespaceKind {
+		return regexp.QuoteMeta(key.name)
+	}
+	if key.namespace == "" {
+		return emptyNamespacePattern
+	}
+	return regexp.QuoteMeta(key.namespace)
+}
+
+func designators(keys map[resourceKey]struct{}) []identifiers.PortalDesignator {
+	ordered := make([]resourceKey, 0, len(keys))
+	for key := range keys {
+		ordered = append(ordered, key)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].kind != ordered[j].kind {
+			return ordered[i].kind < ordered[j].kind
+		}
+		if ordered[i].namespace != ordered[j].namespace {
+			return ordered[i].namespace < ordered[j].namespace
+		}
+		if ordered[i].name != ordered[j].name {
+			return ordered[i].name < ordered[j].name
+		}
+		return ordered[i].path < ordered[j].path
+	})
+
+	result := make([]identifiers.PortalDesignator, 0, len(ordered))
+	for _, key := range ordered {
+		attributes := map[string]string{
+			identifiers.AttributeKind: regexp.QuoteMeta(key.kind),
+			identifiers.AttributeName: regexp.QuoteMeta(key.name),
+		}
+		attributes[identifiers.AttributeNamespace] = namespaceAttribute(key)
+		// A repository can declare the same object in several files, a kustomize
+		// base and its overlay being the common case. Without the source path
+		// the policy covers every copy, so a later finding in one file is
+		// suppressed by another file's baseline entry.
+		if key.path != "" {
+			attributes[identifiers.AttributePath] = regexp.QuoteMeta(key.path)
+		}
+		result = append(result, identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
+			Attributes:     attributes,
+		})
+	}
+	return result
+}

--- a/core/pkg/resultshandling/printer/v2/exceptionsprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/exceptionsprinter_test.go
@@ -1,0 +1,473 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func exceptionsWorkload(t *testing.T, kind, namespace, name string) workloadinterface.IMetadata {
+	t.Helper()
+	return exceptionsWorkloadFromFile(t, kind, namespace, name, "")
+}
+
+// exceptionsWorkloadFromFile mirrors a locally scanned resource, which carries
+// the manifest it was read from in sourcePath.
+func exceptionsWorkloadFromFile(t *testing.T, kind, namespace, name, path string) workloadinterface.IMetadata {
+	t.Helper()
+
+	metadata := map[string]any{"name": name}
+	if namespace != "" {
+		metadata["namespace"] = namespace
+	}
+	object := map[string]any{
+		"apiVersion": "v1",
+		"kind":       kind,
+		"metadata":   metadata,
+	}
+	if path != "" {
+		object["sourcePath"] = path
+	}
+	workload := workloadinterface.NewWorkloadObj(object)
+	require.NotNil(t, workload)
+	return workload
+}
+
+func failedControl(controlID string) resourcesresults.ResourceAssociatedControl {
+	return resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+	}
+}
+
+func passedControl(controlID string) resourcesresults.ResourceAssociatedControl {
+	return resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+	}
+}
+
+func exceptionsSession(t *testing.T) *cautils.OPASessionObj {
+	t.Helper()
+
+	session := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			ReportGenerationTime: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC),
+		},
+		AllResources: map[string]workloadinterface.IMetadata{
+			"api":  exceptionsWorkload(t, "Deployment", "prod", "api"),
+			"web":  exceptionsWorkload(t, "Deployment", "staging", "web"),
+			"role": exceptionsWorkload(t, "ClusterRole", "", "admin"),
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"api": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0002"), passedControl("C-0009"),
+			}},
+			"web": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0002"),
+			}},
+			"role": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0001"),
+			}},
+		},
+	}
+	return session
+}
+
+func TestBuildExceptionPoliciesGroupsResourcesByControl(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	require.Len(t, policies, 2)
+	assert.Equal(t, "exclude-C-0001", policies[0].Name)
+	assert.Equal(t, "exclude-C-0002", policies[1].Name)
+
+	for _, policy := range policies {
+		assert.Equal(t, exceptionPolicyType, policy.PolicyType)
+		assert.Equal(t, []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly}, policy.Actions)
+		assert.Equal(t, "2026-03-04T05:06:07Z", policy.CreationTime)
+		require.Len(t, policy.PosturePolicies, 1)
+	}
+
+	assert.Equal(t, "C-0001", policies[0].PosturePolicies[0].ControlID)
+	assert.Equal(t, "C-0002", policies[1].PosturePolicies[0].ControlID)
+
+	// Both deployments failed C-0002 and are listed under the one policy.
+	require.Len(t, policies[1].Resources, 2)
+	assert.Equal(t, map[string]string{"kind": "Deployment", "namespace": "prod", "name": "api"}, policies[1].Resources[0].Attributes)
+	assert.Equal(t, map[string]string{"kind": "Deployment", "namespace": "staging", "name": "web"}, policies[1].Resources[1].Attributes)
+	assert.Equal(t, identifiers.DesignatorAttributes, policies[1].Resources[1].DesignatorType)
+	assert.Equal(t, identifiers.DesignatorAttributes, policies[1].Resources[0].DesignatorType)
+}
+
+func TestBuildExceptionPoliciesPinsResourcesThatReportNoNamespace(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	require.Len(t, policies[0].Resources, 1)
+	assert.Equal(t,
+		map[string]string{"kind": "ClusterRole", "name": "admin", "namespace": emptyNamespacePattern},
+		policies[0].Resources[0].Attributes)
+}
+
+func TestBuildExceptionPoliciesSkipsPassedControls(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	for _, policy := range policies {
+		assert.NotEqual(t, "C-0009", policy.PosturePolicies[0].ControlID)
+	}
+}
+
+func TestBuildExceptionPoliciesWithoutFailuresIsEmpty(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{
+			"api": exceptionsWorkload(t, "Deployment", "prod", "api"),
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"api": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{passedControl("C-0009")}},
+		},
+	}
+
+	assert.Empty(t, buildExceptionPolicies(context.Background(), session))
+}
+
+func TestBuildExceptionPoliciesIgnoresResultsWithoutAResource(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"api": nil},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"api":     {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0002")}},
+			"missing": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0002")}},
+		},
+	}
+
+	assert.Empty(t, buildExceptionPolicies(context.Background(), session))
+}
+
+func TestBuildExceptionPoliciesDeduplicatesResources(t *testing.T) {
+	session := exceptionsSession(t)
+	result := session.ResourcesResult["api"]
+	result.AssociatedControls = append(result.AssociatedControls, failedControl("C-0002"))
+	session.ResourcesResult["api"] = result
+
+	policies := buildExceptionPolicies(context.Background(), session)
+
+	require.Len(t, policies, 2)
+	assert.Len(t, policies[1].Resources, 2)
+}
+
+func TestBuildExceptionPoliciesFallsBackToNowWithoutAReportTime(t *testing.T) {
+	session := exceptionsSession(t)
+	session.Report.ReportGenerationTime = time.Time{}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+
+	require.NotEmpty(t, policies)
+	parsed, err := time.Parse(time.RFC3339, policies[0].CreationTime)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().UTC(), parsed, time.Minute)
+}
+
+// TestExceptionDocumentsMatchDocumentedShape pins the serialised form against
+// the files under examples/exceptions, which is what users edit and feed back
+// through --exceptions.
+func TestExceptionDocumentsMatchDocumentedShape(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	encoded, err := json.Marshal(exceptionDocuments(policies))
+	require.NoError(t, err)
+
+	var decoded []map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.NotEmpty(t, decoded)
+
+	assert.ElementsMatch(t,
+		[]string{"name", "policyType", "creationTime", "actions", "resources", "posturePolicies"},
+		keysOf(decoded[0]),
+	)
+
+	posturePolicies, ok := decoded[0]["posturePolicies"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, posturePolicies)
+	assert.Equal(t, []string{"controlID"}, keysOf(posturePolicies[0].(map[string]any)))
+}
+
+// TestExceptionDocumentsRoundTripIntoTheConsumedType is the contract that
+// matters: whatever is written has to parse back as an exception policy.
+func TestExceptionDocumentsRoundTripIntoTheConsumedType(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	encoded, err := json.Marshal(exceptionDocuments(policies))
+	require.NoError(t, err)
+
+	var parsed []armotypes.PostureExceptionPolicy
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+
+	require.Len(t, parsed, len(policies))
+	for i := range parsed {
+		assert.Equal(t, policies[i].Name, parsed[i].Name)
+		assert.Equal(t, policies[i].PolicyType, parsed[i].PolicyType)
+		assert.Equal(t, policies[i].Actions, parsed[i].Actions)
+		assert.Equal(t, policies[i].Resources, parsed[i].Resources)
+		require.Len(t, parsed[i].PosturePolicies, 1)
+		assert.Equal(t, policies[i].PosturePolicies[0].ControlID, parsed[i].PosturePolicies[0].ControlID)
+		assert.True(t, parsed[i].IsAlertOnly())
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// TestExceptionsOutputExtDoesNotCollideWithJSON pins the distinct extension.
+// Both formats emit JSON, and --format json,exceptions with one --output would
+// resolve to the same path and be rejected as a collision if they shared ".json".
+func TestExceptionsOutputExtDoesNotCollideWithJSON(t *testing.T) {
+	assert.NotEqual(t, printer.JsonOutputExt, printer.ExceptionsOutputExt)
+
+	jsonPath, _ := printer.ResolveOutputFile(printer.JsonFormat, "scan-result", "results")
+	exceptionsPath, _ := printer.ResolveOutputFile(printer.ExceptionsFormat, "scan-result", exceptionsOutputFile)
+	assert.NotEqual(t, jsonPath, exceptionsPath)
+}
+
+// TestDesignatorsDoNotMatchUnrelatedResources drives the real exception
+// processor. Attributes are compared as anchored regular expressions, so a
+// resource whose name contains a dot — every CRD is <plural>.<group> — would
+// otherwise generate a designator that also silences unrelated resources.
+func TestDesignatorsDoNotMatchUnrelatedResources(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{
+			"crd": exceptionsWorkload(t, "Pod", "default", "web-1.2.3"),
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"crd": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0001")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+
+	processor := exceptions.NewProcessor()
+	intended := exceptionsWorkload(t, "Pod", "default", "web-1.2.3")
+	unrelated := exceptionsWorkload(t, "Pod", "default", "web-1x2y3")
+
+	assert.NotEmpty(t, processor.GetResourceExceptions(policies, intended, ""),
+		"the resource the exception was generated for must match")
+	assert.Empty(t, processor.GetResourceExceptions(policies, unrelated, ""),
+		"a resource the baseline never described must not be silenced")
+}
+
+func TestActionPrintWritesAFileThatParsesBack(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "baseline.exceptions.json")
+
+	p := NewExceptionsPrinter()
+	require.NoError(t, p.SetWriter(context.Background(), output))
+
+	require.NoError(t, p.ActionPrint(context.Background(), exceptionsSession(t), nil))
+	require.NoError(t, p.CloseWriter())
+
+	contents, err := os.ReadFile(output)
+	require.NoError(t, err)
+
+	var parsed []armotypes.PostureExceptionPolicy
+	require.NoError(t, json.Unmarshal(contents, &parsed))
+	require.Len(t, parsed, 2)
+	assert.Equal(t, "exclude-C-0001", parsed[0].Name)
+	assert.True(t, parsed[0].IsAlertOnly())
+	assert.Equal(t, byte('\n'), contents[len(contents)-1], "file should end with a newline")
+}
+
+func TestActionPrintWithoutASessionErrors(t *testing.T) {
+	p := NewExceptionsPrinter()
+	require.NoError(t, p.SetWriter(context.Background(), filepath.Join(t.TempDir(), "out.exceptions.json")))
+	t.Cleanup(func() { _ = p.CloseWriter() })
+
+	assert.Error(t, p.ActionPrint(context.Background(), nil, nil))
+}
+
+func TestActionPrintWritesAnEmptyArrayWhenNothingFailed(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "empty.exceptions.json")
+
+	session := &cautils.OPASessionObj{
+		Report:          &reporthandlingv2.PostureReport{},
+		AllResources:    map[string]workloadinterface.IMetadata{"api": exceptionsWorkload(t, "Deployment", "prod", "api")},
+		ResourcesResult: map[string]resourcesresults.Result{"api": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{passedControl("C-0009")}}},
+	}
+
+	p := NewExceptionsPrinter()
+	require.NoError(t, p.SetWriter(context.Background(), output))
+	require.NoError(t, p.ActionPrint(context.Background(), session, nil))
+	require.NoError(t, p.CloseWriter())
+
+	contents, err := os.ReadFile(output)
+	require.NoError(t, err)
+
+	// A clean scan still writes a usable file rather than nothing at all.
+	var parsed []armotypes.PostureExceptionPolicy
+	require.NoError(t, json.Unmarshal(contents, &parsed))
+	assert.Empty(t, parsed)
+}
+
+// TestControlIDsDoNotMatchUnrelatedControls covers the second regex axis. A
+// custom rule's control ID is custom-<rule>, and the rule is named after a file
+// or directory, so it can carry dots that would otherwise widen the policy to
+// controls the baseline never described.
+func TestControlIDsDoNotMatchUnrelatedControls(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"api": exceptionsWorkload(t, "Pod", "default", "api")},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"api": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("custom-net.policy.v1")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+
+	processor := exceptions.NewProcessor()
+	controlID := policies[0].PosturePolicies[0].ControlID
+
+	assert.True(t, processor.RegexCompareControlID(controlID, "custom-net.policy.v1"),
+		"the control the exception was generated for must match")
+	assert.False(t, processor.RegexCompareControlID(controlID, "custom-netXpolicyYv1"),
+		"a control the baseline never described must not be silenced")
+}
+
+// TestStandardControlIDsAreUnchangedByEscaping keeps the common output readable:
+// regolibrary IDs carry no regex metacharacters, so escaping must be invisible.
+func TestStandardControlIDsAreUnchangedByEscaping(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	require.Len(t, policies, 2)
+	assert.Equal(t, "C-0001", policies[0].PosturePolicies[0].ControlID)
+	assert.Equal(t, "C-0002", policies[1].PosturePolicies[0].ControlID)
+	assert.Equal(t, map[string]string{"kind": "Deployment", "namespace": "prod", "name": "api"},
+		policies[1].Resources[0].Attributes)
+}
+
+// TestNamespacelessWorkloadDoesNotMatchOtherNamespaces covers manifests that
+// omit metadata.namespace, which is the common case in a repository. Leaving
+// the namespace axis unconstrained would let a baseline built from those
+// manifests silence an unrelated object of the same kind and name in a real
+// namespace.
+func TestNamespacelessWorkloadDoesNotMatchOtherNamespaces(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"api": exceptionsWorkload(t, "Deployment", "", "api")},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"api": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0001")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+	assert.Equal(t, emptyNamespacePattern, policies[0].Resources[0].Attributes[identifiers.AttributeNamespace])
+
+	processor := exceptions.NewProcessor()
+	assert.NotEmpty(t, processor.GetResourceExceptions(policies, exceptionsWorkload(t, "Deployment", "", "api"), ""),
+		"the workload the exception was generated for must match")
+	assert.Empty(t, processor.GetResourceExceptions(policies, exceptionsWorkload(t, "Deployment", "prod", "api"), ""),
+		"an identical Deployment in another namespace must not be silenced")
+}
+
+// TestClusterScopedWorkloadStillMatches keeps the round trip working for kinds
+// that genuinely have no namespace: the same pattern describes them, so pinning
+// the axis must not stop the exception applying.
+func TestClusterScopedWorkloadStillMatches(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"cr": exceptionsWorkload(t, "ClusterRole", "", "admin")},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"cr": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0001")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+	assert.Equal(t, emptyNamespacePattern, policies[0].Resources[0].Attributes[identifiers.AttributeNamespace])
+
+	processor := exceptions.NewProcessor()
+	assert.NotEmpty(t, processor.GetResourceExceptions(policies, exceptionsWorkload(t, "ClusterRole", "", "admin"), ""))
+}
+
+// TestNamespaceKindRoundTripsThroughTheProcessor covers the kind the processor
+// special-cases: it compares the namespace axis against a Namespace object's own
+// name, so pinning that axis to "no namespace" would leave every finding on the
+// 18+ shipped controls that evaluate raw Namespace objects unsuppressed.
+func TestNamespaceKindRoundTripsThroughTheProcessor(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"ns": exceptionsWorkload(t, "Namespace", "", "kube-system")},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"ns": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0186")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "kube-system", policies[0].Resources[0].Attributes[identifiers.AttributeNamespace])
+
+	processor := exceptions.NewProcessor()
+	assert.NotEmpty(t, processor.GetResourceExceptions(policies, exceptionsWorkload(t, "Namespace", "", "kube-system"), ""),
+		"the namespace the exception was generated for must match")
+	assert.Empty(t, processor.GetResourceExceptions(policies, exceptionsWorkload(t, "Namespace", "", "kube-public"), ""),
+		"another namespace must not be silenced")
+}
+
+// TestSameObjectInTwoFilesStaysDistinct is the kustomize base-and-overlay case:
+// both files declare the same kind, namespace and name, so without the source
+// path a baseline built from one would suppress a later finding in the other.
+func TestSameObjectInTwoFilesStaysDistinct(t *testing.T) {
+	base := exceptionsWorkloadFromFile(t, "Deployment", "default", "api", "base/deploy.yaml:1")
+	overlay := exceptionsWorkloadFromFile(t, "Deployment", "default", "api", "overlays/prod/deploy.yaml:1")
+
+	session := &cautils.OPASessionObj{
+		Report:       &reporthandlingv2.PostureReport{},
+		AllResources: map[string]workloadinterface.IMetadata{"base": base},
+		ResourcesResult: map[string]resourcesresults.Result{
+			"base": {AssociatedControls: []resourcesresults.ResourceAssociatedControl{failedControl("C-0016")}},
+		},
+	}
+
+	policies := buildExceptionPolicies(context.Background(), session)
+	require.Len(t, policies, 1)
+	assert.Equal(t, `base/deploy\.yaml:1`, policies[0].Resources[0].Attributes[identifiers.AttributePath])
+
+	processor := exceptions.NewProcessor()
+	assert.NotEmpty(t, processor.GetResourceExceptions(policies, base, ""),
+		"the file the exception was generated from must match")
+	assert.Empty(t, processor.GetResourceExceptions(policies, overlay, ""),
+		"the same object declared in another file must not be silenced")
+}
+
+// TestClusterResourcesOmitThePathAxis keeps cluster scans working: they carry no
+// sourcePath, and an unmatchable path attribute would kill every policy.
+func TestClusterResourcesOmitThePathAxis(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	require.NotEmpty(t, policies)
+	for _, policy := range policies {
+		for _, resource := range policy.Resources {
+			assert.NotContains(t, resource.Attributes, identifiers.AttributePath)
+		}
+	}
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -390,6 +390,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewSPDXPrinter()
 	case printer.PolicyReportFormat:
 		return printerv2.NewPolicyReportPrinter()
+	case printer.ExceptionsFormat:
+		return printerv2.NewExceptionsPrinter()
 	default:
 		if printFormat != printer.PrettyFormat {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Invalid format \"%s\", default format \"pretty-printer\" is applied", printFormat))
@@ -422,7 +424,7 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 	}
 
 	switch printFormat {
-	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat, printer.PolicyReportFormat:
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat, printer.PolicyReportFormat, printer.ExceptionsFormat:
 		return false, nil
 	default:
 		return true, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -858,6 +858,7 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 		{"cyclonedx", printerv2.NewCycloneDXPrinter()},
 		{"gitlabsast", printerv2.NewGitLabSASTPrinter()},
 		{"csv", printerv2.NewCsvPrinter()},
+		{"exceptions", printerv2.NewExceptionsPrinter()},
 		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "", false, false)},
 		{"silent", &printerv2.SilentPrinter{}},
 	}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,7 +46,7 @@ kubescape scan [target] [flags]
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--audit-exceptions` | Include exception usage details in supported scan outputs | `false` |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
-| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `csv` | `pretty-printer` |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `csv`, `markdown`, `policyreport`, `exceptions` — see [generating an exceptions baseline](#generating-an-exceptions-baseline) | `pretty-printer` |
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--host-scan` | Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use `--host-scan=false` to disable host data collection. See the [Kubescape operator](https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator) for a managed alternative. | auto-detect |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
@@ -58,6 +58,8 @@ kubescape scan [target] [flags]
 | `--otel-endpoint <endpoint>` | Export scan traces and metrics to an OTLP collector — see [OpenTelemetry export](#opentelemetry-export). Accepts `host:port` (plaintext) or a `http(s)://` URL. | `OTEL_EXPORTER_OTLP_ENDPOINT` |
 | `--scan-images` | Also scan container images for vulnerabilities | `false` |
 | `--image-platform <platform>` | OCI platform for workload image scans, such as `linux/amd64`. Overrides platform inferred from Nodes and hard scheduling constraints | inferred |
+| `--min-severity <sev>` | Only show controls at or above this severity: `low`, `medium`, `high`, `critical`. Output-only — exit codes are computed on the full unfiltered report | - |
+| `--max-severity <sev>` | Only show controls at or below this severity. Output-only — exit codes are computed on the full unfiltered report | - |
 | `--severity-threshold <sev>` | Fail if findings at or above severity: `low`, `medium`, `high`, `critical`. Failed controls with unknown severity (missing base score) are treated as exceeding any threshold | - |
 | `--skip-db-update` | Do not update the vulnerability database before scanning images; uses the locally cached database. Fails if the local database is missing or unusable (run once without this flag to download it). | `false` |
 | `--submit` | Submit results to Kubescape SaaS | `false` |
@@ -78,6 +80,61 @@ kubescape scan manifests/ --notify https://ops.example.com/kubescape --notify ht
 Each destination gets one synchronous request with `Content-Type: application/json`; Kubescape allows up to five seconds per destination and does not follow redirects. Failures are logged as warnings and never override the scan's own exit status. The payload follows `--min-severity` and `--max-severity` output filtering. `--severity-threshold` continues to affect only the exit status.
 
 The summary may contain resource identifiers in control summaries. Use `--hide` where appropriate and send only to trusted webhook endpoints. Slack Block Kit and Microsoft Teams Adaptive Card formatting are not included in this generic phase.
+
+### Generating an exceptions baseline
+
+`--exceptions` consumes a posture exception file, but there was no way to
+produce one from a scan. The `exceptions` output format writes the current
+failures as exception policies, so an existing posture can be accepted as a
+baseline and only new findings fail afterwards.
+
+```bash
+# capture today's failures
+kubescape scan . --format exceptions --output baseline
+
+# review and trim the file, then scan against it
+kubescape scan . --exceptions baseline.exceptions.json
+```
+
+The file holds one policy per failed control, listing the resources that failed
+it by `kind`, `namespace` and `name`, in the same shape as the samples under
+[examples/exceptions](../examples/exceptions). Designators carry no `cluster`
+attribute, so the same file applies wherever those workloads run. Policies use
+the `alertOnly` action.
+
+It is a normal output format, so it composes with the others and honours
+`--output`, writing `scan-result.json` and `scan-result.exceptions.json`:
+
+```bash
+kubescape scan . --format json,exceptions --output scan-result
+```
+
+Like every other format, the file reflects the report the printers were given,
+so `--min-severity` narrows the baseline to the findings it left in view.
+
+Kubescape matches control IDs and designator attributes as regular expressions,
+so generated values are escaped and match only what the scan reported: a name
+such as `web-1.2.3` is written `web-1\.2\.3` rather than a pattern that would
+also cover `web-1x2y3`.
+
+Every designator pins the namespace axis. A resource that reported no namespace
+— a cluster-scoped object, or a manifest that omits `metadata.namespace` — is
+written as `"namespace": "^$"`, matching the object as scanned rather than the
+same kind and name in any namespace. A `Namespace` object is pinned by its own
+name, which is how Kubescape matches that axis for the kind. Delete the line to
+widen the policy.
+
+Resources read from files also carry `"path"`, the manifest they came from, so a
+repository that declares the same object in more than one place — a kustomize
+base and its overlay — keeps a separate entry per file. Cluster scans have no
+path and omit the attribute.
+
+Everything in the file is meant to be reviewed before use: accepting a whole
+scan unedited silences every current finding. Narrow a policy by deleting
+resources from it, or widen one by replacing an escaped `name` with a regular
+expression of your own.
+
+Exceptions are posture-only and the format is rejected for `scan image`.
 
 ### Custom rules
 


### PR DESCRIPTION
## Summary

**Root cause:** Kubescape's exception handling is one-directional, `--exceptions` consumes a posture exception file and `--audit-exceptions` reports how one was used, but nothing produces one, so adopting Kubescape against an existing cluster means hand-writing designators for every finding you intend to accept.

Today the only starting points are the five hand-written samples under `examples/exceptions`.

**What this adds:**

An `exceptions` output format that writes the scan's current failures as exception policies, so an existing posture can be accepted as a baseline and only new findings fail the build:

```bash
kubescape scan . --format exceptions --output baseline
# review and trim the file, then scan against it
kubescape scan . --exceptions baseline.exceptions.json
```

**Files changed:**

- `core/pkg/resultshandling/printer/v2/exceptionsprinter.go` (new): builds one policy per failed control, listing the resources that failed it by `kind`, `namespace` and `name`.
- `core/pkg/resultshandling/printer/printresults.go`: registers the format, its `.exceptions.json` extension, and the `AllFormats` entry.
- `core/pkg/resultshandling/results.go`: wires the printer into `NewPrinter` and marks the format as non-pretty in `ValidatePrinter`.
- `cmd/scan/scan_test.go`: the invalid-format error message hard-codes the format list.
- `docs/cli-reference.md`: new section and flags-table entry.

**Design notes:**

- Implemented as an output format rather than a bespoke flag, so it reuses the existing `--output` handling, multi-format composition and validation. `cyclonedx-json` and `spdx-json` set the precedent that a format need not be a scan report.
- **Every generated value is regex-escaped.** The exception processor compares control IDs (`RegexCompareControlID`) and designator attributes (`compareName` / `compareNamespace` / `compareKind`) as anchored regular expressions, with no exact-match fast path. Unescaped, a resource named `web-1.2.3` produces a policy that also silences `web-1x2y3`, and a custom rule's control ID named after whatever file or directory the rule lives in, so `custom-net.policy.v1` after #3553 widens the same way. A baseline that quietly suppresses findings it never described is worse than no baseline. Standard regolibrary IDs like `C-0004` carry no metacharacters, so escaping is invisible in the common case.
- Designators omit the `cluster` attribute so a baseline stays valid wherever the same workloads run, and cluster-scoped resources omit `namespace` rather than emitting an empty value that would be matched literally.
- The file is written through a small view type rather than marshalling `armotypes.PostureExceptionPolicy` directly, which would leak empty `guid` and `frameworkName` fields into a file meant to be edited by hand. The output matches the shape of `examples/exceptions`.
- The extension is `.exceptions.json`, following `cyclonedx-json` and `spdx-json`, so `--format json,exceptions` with a single `--output` resolves to two distinct paths instead of being rejected as a collision.

**What was tested:**

- Policy construction: `TestBuildExceptionPoliciesGroupsResourcesByControl`, `TestBuildExceptionPoliciesOmitsNamespaceForClusterScopedResources`, `TestBuildExceptionPoliciesSkipsPassedControls`, `TestBuildExceptionPoliciesDeduplicatesResources`, `TestBuildExceptionPoliciesWithoutFailuresIsEmpty`, `TestBuildExceptionPoliciesIgnoresResultsWithoutAResource`, `TestBuildExceptionPoliciesFallsBackToNowWithoutAReportTime`
- Over-matching, driving the real `exceptions.Processor` rather than asserting on strings: `TestDesignatorsDoNotMatchUnrelatedResources`, `TestControlIDsDoNotMatchUnrelatedControls`, `TestStandardControlIDsAreUnchangedByEscaping`
- Serialised form: `TestExceptionDocumentsMatchDocumentedShape`, `TestExceptionDocumentsRoundTripIntoTheConsumedType`, `TestExceptionsOutputExtDoesNotCollideWithJSON`
- Printer path: `TestActionPrintWritesAFileThatParsesBack`, `TestActionPrintWithoutASessionErrors`, `TestActionPrintWritesAnEmptyArrayWhenNothingFailed`
- Manual round trip on a real scan: 24 failed controls → 0 failed, compliance 72.87 → 91.47. Repeated with a pod named `web-1.2.3` and a custom rule `custom-net.policy.v1` to confirm escaped values still match what they describe: 26 failed → 0.
- `go test ./... -count=1 -short` and `-race` both clean, `go vet` and `gofmt` clean, `golangci-lint` reports 0 issues on the diff.

**Related issues:** none. Found by reading the exception path, not from a filed issue.

**Which issue(s) this PR fixes:**

None, no existing issue covers generation. The prior exception work (#3095 audit, #3373 match events, #3427 scope-less exceptions, #3310 namespace selectors) is all about matching and auditing an exception file that already exists.

**Special notes for your reviewer:**

Three points worth your attention:

1. **The escaping is the part to review carefully.** I originally wrote raw values and confirmed against the real processor that an exception for `web-1.2.3` also matched `web-1x2y3`, and that `custom-net.policy.v1` also matched `custom-netXpolicyYv1`. Both axes are escaped now and pinned by tests that run the processor. If you would rather generated policies stayed writable as patterns, say so and I will make it opt-in instead.
2. **Severity filters narrow the baseline.** Printers see the filtered report, so `--min-severity high` produces 7 policies where an unfiltered scan produces 24. That is consistent with the documented output-only rule and errs toward a narrower baseline, so I documented it rather than special-casing it.
3. **Manual-review controls are not included**, because they come back `skipped` rather than `failed` and so never fail a build. If you want them baselined too, that would mean emitting control-only policies with no resources, which `matchingControlExceptions` already supports.

No new dependencies. The format is posture-only and is rejected for `scan image`, which the existing `TestValidatePrinter_ImageFormatsInvariant` enforces automatically since it iterates `AllFormats`.

**Does this PR introduce a user-facing change?**

Yes. A new `exceptions` output format writes the scan's failed controls as posture exception policies to `<output>.exceptions.json`, which can be reviewed and fed back through `--exceptions` as a baseline. Existing formats and behaviour are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `exceptions` output format for scan results.
  - Generate deterministic exception-policy files from failed controls and resources.
  - Supports severity filtering, pattern matching, namespace handling, and policy combination.
  - Writes an empty exception-policy file when no failures are found.
  - The format is unavailable for image scans.

- **Documentation**
  - Updated CLI reference documentation with guidance for generating, reviewing, filtering, combining, and applying exception baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->