### PR TITLE
fix(hostsensorutils): record a status when reported CRD items cannot be read

### DIFF
--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -29,6 +29,35 @@ func (c crdCollection) dropped() int {
 	return c.listed - c.converted
 }
 
+// reportCollectionGaps records what one resource's collection lost.
+//
+// A resource whose reported items were all unreadable is recorded on the scan
+// like an empty one: it reached the scan with no data, and without an entry the
+// controls that read it are inferred as passing off data that never arrived.
+// A partial loss only warns, because the resource keeps what it did read and
+// marking it skipped would discard real results.
+//
+// The zero-item case is deliberately not judged here. Whether it is a problem
+// depends on what the caller expected: for a per-node resource it means the
+// node-agent has not reported for its nodes, while for CloudProviderInfo it is
+// the normal answer on an on-prem cluster.
+func reportCollectionGaps(ctx context.Context, resource k8shostsensor.HostSensorResource, collected crdCollection, infoMap map[string]apis.StatusInfo) {
+	switch {
+	case collected.listed == 0:
+	case collected.converted == 0:
+		err := fmt.Errorf("node-agent reported %d %s but none of them could be read", collected.listed, resource.String())
+		addInfoToMap(resource, infoMap, err)
+		logger.L().Ctx(ctx).Warning("No readable CRD items",
+			helpers.String("resource", resource.String()),
+			helpers.Error(err))
+	case collected.dropped() > 0:
+		logger.L().Ctx(ctx).Warning("Some CRD items could not be read",
+			helpers.String("resource", resource.String()),
+			helpers.Int("read", collected.converted),
+			helpers.Int("reported", collected.listed))
+	}
+}
+
 // getCRDResources retrieves resources from CRDs and converts them to HostSensorDataEnvelope format
 func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType k8shostsensor.HostSensorResource) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	pluralName := k8shostsensor.MapResourceToPlural(resourceType)
@@ -293,25 +322,8 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 			logger.L().Ctx(ctx).Warning("Zero CRD items found",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
-		case collected.converted == 0 && collected.listed > 0:
-			// The node-agent did report, but nothing survived conversion (a CRD
-			// whose spec is missing or not a map). Without this the resource is
-			// the one case that leaves no trace: the "didn't report any" arm
-			// above never fires, so the controls that read it are inferred as
-			// passing off data the scan never got.
-			err = fmt.Errorf("node-agent reported %d %s but none of them could be read", collected.listed, k8sInfo.Resource.String())
-			addInfoToMap(k8sInfo.Resource, infoMap, err)
-			logger.L().Ctx(ctx).Warning("No readable CRD items",
-				helpers.String("resource", k8sInfo.Resource.String()),
-				helpers.Error(err))
-		case collected.dropped() > 0:
-			// Some nodes came through and some did not. The resource keeps the
-			// data it has, so it is not skipped, but the scan now covers fewer
-			// nodes than the cluster has and only the per-item warnings say so.
-			logger.L().Ctx(ctx).Warning("Some CRD items could not be read",
-				helpers.String("resource", k8sInfo.Resource.String()),
-				helpers.Int("read", collected.converted),
-				helpers.Int("reported", collected.listed))
+		default:
+			reportCollectionGaps(ctx, k8sInfo.Resource, collected, infoMap)
 		}
 
 		if len(kcData) > 0 {

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -248,11 +248,17 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 
 	var hasCloudProvider bool
 	// We first query CloudProviderInfo to determine if we should skip ControlPlaneInfo
-	cloudProviderData, _, err := hsh.getCloudProviderInfo(ctx)
+	cloudProviderData, collected, err := hsh.getCloudProviderInfo(ctx)
 	if err != nil {
 		addInfoToMap(k8shostsensor.CloudProviderInfo, infoMap, err)
 		logger.L().Ctx(ctx).Warning("Failed to get CloudProviderInfo from CRD", helpers.Error(err))
 	} else {
+		// This query runs ahead of the loop below, so it needs its own call:
+		// without one, CloudProviderInfo is the resource that can lose every
+		// item it reported and still leave no status behind. It also decides
+		// whether ControlPlaneInfo is collected at all, and an unreadable
+		// answer reads the same as "no cloud provider".
+		reportCollectionGaps(ctx, k8shostsensor.CloudProviderInfo, collected, infoMap)
 		hasCloudProvider = hasCloudProviderInfo(cloudProviderData)
 		if len(cloudProviderData) > 0 {
 			res = append(res, cloudProviderData...)

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -304,6 +304,14 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 			logger.L().Ctx(ctx).Warning("No readable CRD items",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
+		case collected.dropped() > 0:
+			// Some nodes came through and some did not. The resource keeps the
+			// data it has, so it is not skipped, but the scan now covers fewer
+			// nodes than the cluster has and only the per-item warnings say so.
+			logger.L().Ctx(ctx).Warning("Some CRD items could not be read",
+				helpers.String("resource", k8sInfo.Resource.String()),
+				helpers.Int("read", collected.converted),
+				helpers.Int("reported", collected.listed))
 		}
 
 		if len(kcData) > 0 {

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -281,15 +281,27 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 		}
 
 		kcData, collected, err := k8sInfo.Query(ctx)
-		if err != nil {
+		switch {
+		case err != nil:
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Failed to get resource from CRD",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
-		} else if collected.listed == 0 && hsh.nodeCount > 0 {
+		case collected.listed == 0 && hsh.nodeCount > 0:
 			err = fmt.Errorf("node-agent didn't report any %s for %d nodes", k8sInfo.Resource.String(), hsh.nodeCount)
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Zero CRD items found",
+				helpers.String("resource", k8sInfo.Resource.String()),
+				helpers.Error(err))
+		case collected.converted == 0 && collected.listed > 0:
+			// The node-agent did report, but nothing survived conversion (a CRD
+			// whose spec is missing or not a map). Without this the resource is
+			// the one case that leaves no trace: the "didn't report any" arm
+			// above never fires, so the controls that read it are inferred as
+			// passing off data the scan never got.
+			err = fmt.Errorf("node-agent reported %d %s but none of them could be read", collected.listed, k8sInfo.Resource.String())
+			addInfoToMap(k8sInfo.Resource, infoMap, err)
+			logger.L().Ctx(ctx).Warning("No readable CRD items",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
 		}

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds.go
@@ -15,26 +15,41 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// crdCollection is what one resource's CRD listing yielded: the items the API
+// server returned and the ones that became envelopes. Both counts are kept
+// because they answer different questions - listed says whether the node-agent
+// reported anything at all, converted says whether any of it reached the scan.
+type crdCollection struct {
+	listed    int
+	converted int
+}
+
+// dropped is the number of reported items the scan could not read.
+func (c crdCollection) dropped() int {
+	return c.listed - c.converted
+}
+
 // getCRDResources retrieves resources from CRDs and converts them to HostSensorDataEnvelope format
-func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType k8shostsensor.HostSensorResource) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType k8shostsensor.HostSensorResource) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	pluralName := k8shostsensor.MapResourceToPlural(resourceType)
 	if pluralName == "" {
-		return nil, 0, fmt.Errorf("unsupported resource type: %s", resourceType)
+		return nil, crdCollection{}, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
 
 	clusterName := k8sinterface.GetContextName()
 	// Try loading from cache first
 	if cachedEnvelopes, err := loadFromCache(clusterName, resourceType.String()); err == nil {
-		return cachedEnvelopes, len(cachedEnvelopes), nil
+		// The cache only ever holds envelopes that converted, so nothing was dropped.
+		return cachedEnvelopes, crdCollection{listed: len(cachedEnvelopes), converted: len(cachedEnvelopes)}, nil
 	} else if !os.IsNotExist(err) {
 		logger.L().Warning("Failed to load cache, proceeding to fetch", helpers.Error(err))
 	}
 
 	// List CRD resources and process them page by page
 	result := make([]hostsensor.HostSensorDataEnvelope, 0)
-	totalItems := 0
+	collected := crdCollection{}
 	err := hsh.listCRDResources(ctx, pluralName, resourceType.String(), func(items []unstructured.Unstructured) error {
-		totalItems += len(items)
+		collected.listed += len(items)
 		for _, item := range items {
 			envelope, err := hsh.convertCRDToEnvelope(item, resourceType)
 			if err != nil {
@@ -54,9 +69,10 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 			helpers.String("kind", resourceType.String()),
 			helpers.String("plural", pluralName),
 			helpers.Error(err))
-		return nil, 0, err
+		return nil, crdCollection{}, err
 	}
 
+	collected.converted = len(result)
 	logger.L().Ctx(ctx).Info("Retrieved resources from CRDs",
 		helpers.String("kind", resourceType.String()),
 		helpers.Int("count", len(result)))
@@ -66,7 +82,7 @@ func (hsh *HostSensorHandler) getCRDResources(ctx context.Context, resourceType 
 		logger.L().Warning("Failed to save to cache", helpers.Error(err))
 	}
 
-	return result, totalItems, nil
+	return result, collected, nil
 }
 
 // convertCRDToEnvelope converts a CRD unstructured object to HostSensorDataEnvelope
@@ -126,52 +142,52 @@ func (hsh *HostSensorHandler) convertCRDToEnvelope(item unstructured.Unstructure
 }
 
 // getOsReleaseFile returns the list of osRelease metadata from CRDs.
-func (hsh *HostSensorHandler) getOsReleaseFile(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getOsReleaseFile(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.OsReleaseFile)
 }
 
 // getKernelVersion returns the list of kernelVersion metadata from CRDs.
-func (hsh *HostSensorHandler) getKernelVersion(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getKernelVersion(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KernelVersion)
 }
 
 // getLinuxSecurityHardeningStatus returns the list of LinuxSecurityHardeningStatus metadata from CRDs.
-func (hsh *HostSensorHandler) getLinuxSecurityHardeningStatus(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getLinuxSecurityHardeningStatus(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.LinuxSecurityHardeningStatus)
 }
 
 // getOpenPortsList returns the list of open ports from CRDs.
-func (hsh *HostSensorHandler) getOpenPortsList(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getOpenPortsList(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.OpenPortsList)
 }
 
 // getKernelVariables returns the list of Linux Kernel variables from CRDs.
-func (hsh *HostSensorHandler) getKernelVariables(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getKernelVariables(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.LinuxKernelVariables)
 }
 
 // getKubeletInfo returns the list of kubelet metadata from CRDs.
-func (hsh *HostSensorHandler) getKubeletInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getKubeletInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KubeletInfo)
 }
 
 // getKubeProxyInfo returns the list of kubeProxy metadata from CRDs.
-func (hsh *HostSensorHandler) getKubeProxyInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getKubeProxyInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.KubeProxyInfo)
 }
 
 // getControlPlaneInfo returns the list of controlPlaneInfo metadata from CRDs.
-func (hsh *HostSensorHandler) getControlPlaneInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getControlPlaneInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.ControlPlaneInfo)
 }
 
 // getCloudProviderInfo returns the list of cloudProviderInfo metadata from CRDs.
-func (hsh *HostSensorHandler) getCloudProviderInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getCloudProviderInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.CloudProviderInfo)
 }
 
 // getCNIInfo returns the list of CNI metadata from CRDs.
-func (hsh *HostSensorHandler) getCNIInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error) {
+func (hsh *HostSensorHandler) getCNIInfo(ctx context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error) {
 	return hsh.getCRDResources(ctx, k8shostsensor.CNIInfo)
 }
 
@@ -216,7 +232,7 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 
 	for _, toPin := range []struct {
 		Resource k8shostsensor.HostSensorResource
-		Query    func(context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error)
+		Query    func(context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error)
 	}{
 		// queries to CRDs
 		{
@@ -264,13 +280,13 @@ func (hsh *HostSensorHandler) CollectResources(ctx context.Context) ([]hostsenso
 			continue
 		}
 
-		kcData, rawCount, err := k8sInfo.Query(ctx)
+		kcData, collected, err := k8sInfo.Query(ctx)
 		if err != nil {
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Failed to get resource from CRD",
 				helpers.String("resource", k8sInfo.Resource.String()),
 				helpers.Error(err))
-		} else if rawCount == 0 && hsh.nodeCount > 0 {
+		} else if collected.listed == 0 && hsh.nodeCount > 0 {
 			err = fmt.Errorf("node-agent didn't report any %s for %d nodes", k8sInfo.Resource.String(), hsh.nodeCount)
 			addInfoToMap(k8sInfo.Resource, infoMap, err)
 			logger.L().Ctx(ctx).Warning("Zero CRD items found",

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -113,7 +113,7 @@ func TestCRDResourceGetters(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		query func(context.Context) ([]hostsensor.HostSensorDataEnvelope, int, error)
+		query func(context.Context) ([]hostsensor.HostSensorDataEnvelope, crdCollection, error)
 	}{
 		{"OsReleaseFile", hsh.getOsReleaseFile},
 		{"KernelVersion", hsh.getKernelVersion},
@@ -147,18 +147,18 @@ func TestGetCRDResources_RecoversAfterEmptyCollection(t *testing.T) {
 	withK8sHost(t, "https://cluster-a.example.com")
 
 	hsh := &HostSensorHandler{dynamicClient: newCRDDynamicClient(t)}
-	got, rawCount, err := hsh.getKubeletInfo(context.Background())
+	got, collected, err := hsh.getKubeletInfo(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, got)
-	require.Zero(t, rawCount)
+	require.Zero(t, collected.listed)
 
 	item := newCRDItem("KubeletInfo", "node-1", map[string]any{"KubeletInfo": map[string]any{"version": "v1.30.0"}})
 	hsh.dynamicClient = newCRDDynamicClient(t, item)
 
-	got, rawCount, err = hsh.getKubeletInfo(context.Background())
+	got, collected, err = hsh.getKubeletInfo(context.Background())
 	require.NoError(t, err)
 	require.Len(t, got, 1)
-	assert.Equal(t, 1, rawCount)
+	assert.Equal(t, 1, collected.listed)
 	assert.Equal(t, "node-1", got[0].GetName())
 }
 

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -9,6 +9,7 @@ import (
 	k8shostsensor "github.com/kubescape/k8s-interface/hostsensor"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -256,4 +257,90 @@ func hasKind(envelopes []hostsensor.HostSensorDataEnvelope, kind k8shostsensor.H
 		}
 	}
 	return false
+}
+
+// newCRDShell is a CRD item the node-agent created but never filled in, which
+// convertCRDToEnvelope cannot read.
+func newCRDShell(kind, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": hostDataGroup + "/" + hostDataVersion,
+			"kind":       kind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+}
+
+// A resource the node-agent reported but the scan could not read must land in
+// infoMap like a resource it never reported. Without it the resource whose data
+// actually failed is the only one carrying no status, while the resources that
+// are merely absent are all flagged.
+func TestCollectResources_RecordsUnreadableItems(t *testing.T) {
+	hsh := &HostSensorHandler{
+		dynamicClient: newCRDDynamicClient(t, newCRDShell("KubeletInfo", "node-1")),
+		nodeCount:     1,
+	}
+
+	res, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	assert.False(t, hasKind(res, k8shostsensor.KubeletInfo))
+	assertInfoMapContains(t, infoMap, k8shostsensor.KubeletInfo,
+		"node-agent reported 1 KubeletInfo but none of them could be read")
+}
+
+// The unreadable-items status must not depend on the node count: the items are
+// there, so "didn't report any" was never the right answer either way.
+func TestCollectResources_RecordsUnreadableItemsWithoutNodeCount(t *testing.T) {
+	hsh := &HostSensorHandler{
+		dynamicClient: newCRDDynamicClient(t, newCRDShell("CNIInfo", "node-1")),
+	}
+
+	res, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, res)
+	assertInfoMapContains(t, infoMap, k8shostsensor.CNIInfo,
+		"node-agent reported 1 CNIInfo but none of them could be read")
+}
+
+// A resource that lost only some of its items keeps the ones it read, so it
+// must not be marked skipped over the nodes it is missing.
+func TestCollectResources_KeepsPartiallyReadableItems(t *testing.T) {
+	items := []*unstructured.Unstructured{
+		newCRDItem("KubeProxyInfo", "node-1", map[string]any{"mode": "iptables"}),
+		newCRDShell("KubeProxyInfo", "node-2"),
+	}
+	hsh := &HostSensorHandler{
+		dynamicClient: newCRDDynamicClient(t, items...),
+		nodeCount:     2,
+	}
+
+	res, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, hasKind(res, k8shostsensor.KubeProxyInfo))
+	group, version := k8sinterface.SplitApiVersion(k8shostsensor.MapHostSensorResourceToApiGroup(k8shostsensor.KubeProxyInfo))
+	for _, r := range k8sinterface.ResourceGroupToString(group, version, k8shostsensor.KubeProxyInfo.String()) {
+		assert.NotContains(t, infoMap, r)
+	}
+}
+
+func TestCrdCollectionDropped(t *testing.T) {
+	assert.Equal(t, 2, crdCollection{listed: 3, converted: 1}.dropped())
+	assert.Zero(t, crdCollection{listed: 3, converted: 3}.dropped())
+	assert.Zero(t, crdCollection{}.dropped())
+}
+
+func assertInfoMapContains(t *testing.T, infoMap map[string]apis.StatusInfo, resource k8shostsensor.HostSensorResource, want string) {
+	t.Helper()
+
+	group, version := k8sinterface.SplitApiVersion(k8shostsensor.MapHostSensorResourceToApiGroup(resource))
+	for _, r := range k8sinterface.ResourceGroupToString(group, version, resource.String()) {
+		require.Contains(t, infoMap, r)
+		assert.Equal(t, want, infoMap[r].InnerInfo)
+		assert.Equal(t, apis.StatusSkipped, infoMap[r].InnerStatus)
+	}
 }

--- a/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
+++ b/core/pkg/hostsensorutils/hostsensorcollectcrds_test.go
@@ -328,12 +328,17 @@ func TestCollectResources_KeepsPartiallyReadableItems(t *testing.T) {
 	}
 }
 
+// dropped is what tells a partial loss from a total one, so it is pinned
+// rather than left to the callers that branch on it.
 func TestCrdCollectionDropped(t *testing.T) {
 	assert.Equal(t, 2, crdCollection{listed: 3, converted: 1}.dropped())
 	assert.Zero(t, crdCollection{listed: 3, converted: 3}.dropped())
 	assert.Zero(t, crdCollection{}.dropped())
 }
 
+// assertInfoMapContains checks that a resource was recorded as skipped under
+// every key ResourceGroupToString spells it with, since that is what the scan
+// looks it up by.
 func assertInfoMapContains(t *testing.T, infoMap map[string]apis.StatusInfo, resource k8shostsensor.HostSensorResource, want string) {
 	t.Helper()
 
@@ -342,5 +347,38 @@ func assertInfoMapContains(t *testing.T, infoMap map[string]apis.StatusInfo, res
 		require.Contains(t, infoMap, r)
 		assert.Equal(t, want, infoMap[r].InnerInfo)
 		assert.Equal(t, apis.StatusSkipped, infoMap[r].InnerStatus)
+	}
+}
+
+// CloudProviderInfo is queried ahead of the loop, so it needs its own coverage:
+// it was the one resource that could lose every item it reported and still
+// carry no status.
+func TestCollectResources_RecordsUnreadableCloudProviderItems(t *testing.T) {
+	hsh := &HostSensorHandler{
+		dynamicClient: newCRDDynamicClient(t, newCRDShell("CloudProviderInfo", "node-1")),
+		nodeCount:     1,
+	}
+
+	res, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	assert.False(t, hasKind(res, k8shostsensor.CloudProviderInfo))
+	assertInfoMapContains(t, infoMap, k8shostsensor.CloudProviderInfo,
+		"node-agent reported 1 CloudProviderInfo but none of them could be read")
+}
+
+// A cluster that simply has no CloudProviderInfo is the normal on-prem case, so
+// the zero-item arm the per-node resources get must stay off this query.
+func TestCollectResources_IgnoresAbsentCloudProviderInfo(t *testing.T) {
+	hsh := &HostSensorHandler{
+		dynamicClient: newCRDDynamicClient(t, newCRDItem("OsReleaseFile", "node-1", map[string]any{"pretty": "Ubuntu"})),
+	}
+
+	_, infoMap, err := hsh.CollectResources(context.Background())
+
+	require.NoError(t, err)
+	group, version := k8sinterface.SplitApiVersion(k8shostsensor.MapHostSensorResourceToApiGroup(k8shostsensor.CloudProviderInfo))
+	for _, r := range k8sinterface.ResourceGroupToString(group, version, k8shostsensor.CloudProviderInfo.String()) {
+		assert.NotContains(t, infoMap, r)
 	}
 }


### PR DESCRIPTION
While reading the host sensor CRD collection path I noticed that a resource can disappear from a scan without leaving any trace behind.

`CollectResources` records a skipped status in two cases: the query failed, or the node-agent reported zero items for a cluster that has nodes. There is a third case it does not cover. `getCRDResources` counts the items the API server returned, but each one still has to go through `convertCRDToEnvelope`, which fails when the CRD carries no `spec` or a `spec` that is not a map. A dropped item is logged and skipped. If every item is dropped, the raw count is still non zero, so the "didn't report any" branch never fires, and the resource ends up with no envelopes and no entry in `InfoMap`.

That is the wrong way round. A resource nobody reported gets flagged, while the resource whose data actually failed to read looks fine, and the controls that depend on it are then inferred as passing off data the scan never received. The case is easy to hit in practice: the node-agent creates the CR and fills its spec afterwards, so a scan landing in that window sees a shell.

The fix adds the missing arm. When items were reported but none could be read, the resource lands in `InfoMap` the same way an empty listing does, with a message that says how many items came back. Partial loss is handled separately: those resources keep the data they did read, so marking them skipped would throw away real results, and they get a warning naming the read and reported counts instead of only the per item warnings that were already there.

Getting there needed the count plumbing to carry a bit more. The listing used to return a single item count, which cannot tell "nothing was reported" apart from "nothing was readable". It now returns a small struct with both the listed and the converted count, which is also what makes the partial case expressible at all.

The detail most likely to regress is the ordering of the switch in `CollectResources`. The zero items arm has to stay ahead of the unreadable arm, since a listing that returned nothing has a converted count of zero too and would otherwise be reported with the wrong message. The tests pin both arms, including the unreadable case on a handler with no node count, where the zero items arm is inactive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource collection reporting when items cannot be read or converted.
  - Records errors when reported items produce no usable results, including CloudProviderInfo items.
  - Preserves successfully processed items when only some items fail.
  - Adds warnings when items are partially dropped during collection.
  - Ignores absent CloudProviderInfo data without reporting a false issue.
- **Tests**
  - Added coverage for unreadable, partially readable, empty, and CloudProviderInfo collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->