### PR TITLE
fix(opaprocessor): guard InfoMap read against concurrent writes in hasUnreachableDependency

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1261,8 +1261,12 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 //
 // This runs once per rule-scope evaluation (not once per resource), so its
 // O(len(ResourceToControlsMap)) cost is paid a small, bounded number of times
-// per scan rather than once per resource.
+// per scan rather than once per resource. It runs on processScope's worker
+// goroutines concurrently with markResourcesSkipped/seedCELSkips, which write
+// InfoMap under mu, so the read must hold mu as well.
 func (opap *OPAProcessor) hasUnreachableDependency(controlID string) bool {
+	opap.mu.Lock()
+	defer opap.mu.Unlock()
 	for gvr, controlIDs := range opap.ResourceToControlsMap {
 		if !slices.Contains(controlIDs, controlID) {
 			continue

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"reflect"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/opa-utils/resources"
@@ -1100,4 +1103,92 @@ func TestCELNamespaceObjectFor(t *testing.T) {
 		assert.Nil(t, (&OPAProcessor{}).celNamespaceObjectFor(podIn("prod")))
 		assert.Nil(t, NewOPAProcessor(nil, nil, "", "", "", false, nil).celNamespaceObjectFor(podIn("prod")))
 	})
+}
+
+// TestHasUnreachableDependency_GVRPullFailureGuard pins the mixed-purpose
+// InfoMap guard: only a whole-GVR pull failure (keyed by GVR string AND
+// listed in the control's dependency set) counts as an unreachable
+// dependency; per-resource eval skips keyed by resource ID must not match.
+func TestHasUnreachableDependency_GVRPullFailureGuard(t *testing.T) {
+	opap := NewOPAProcessor(&cautils.OPASessionObj{
+		InfoMap: map[string]apis.StatusInfo{
+			"apps/v1/deployments": {InnerStatus: apis.StatusSkipped},
+			"/v1/pods":            {InnerStatus: apis.StatusSkipped},
+		},
+		ResourceToControlsMap: map[string][]string{
+			"apps/v1/deployments": {"C-0001"},
+			"/v1/secrets":         {"C-0002"},
+		},
+	}, nil, "test", "", "", false, nil)
+
+	assert.True(t, opap.hasUnreachableDependency("C-0001"),
+		"control depending on a skipped GVR must report an unreachable dependency")
+	assert.False(t, opap.hasUnreachableDependency("C-0002"),
+		"a per-resource skip keyed by resource ID must not be mistaken for a GVR pull failure")
+	assert.False(t, opap.hasUnreachableDependency("C-9999"),
+		"control with no dependencies must report no unreachable dependency")
+}
+
+// TestHasUnreachableDependency_ConcurrentWithSkipWrites is a -race regression
+// test for #3562: hasUnreachableDependency used to read opap.InfoMap without
+// holding opap.mu while concurrent processScope workers wrote that same map
+// through markResourcesSkipped/seedCELSkips on the rule-error path, aborting
+// scans with "fatal error: concurrent map read and map write". The test
+// hammers exactly that read/write pair concurrently — wide write windows
+// (many resources per markResourcesSkipped call) and frequent reads — so a
+// run under -race trips quickly if the read ever loses its guard again.
+func TestHasUnreachableDependency_ConcurrentWithSkipWrites(t *testing.T) {
+	opap := NewOPAProcessor(&cautils.OPASessionObj{
+		InfoMap:               make(map[string]apis.StatusInfo),
+		ResourceToControlsMap: make(map[string][]string),
+	}, nil, "test", "", "", false, nil)
+
+	// Seed several dependency mappings so every reader iteration does real
+	// map work rather than falling out of the loop immediately.
+	for i := 0; i < 8; i++ {
+		gvr := fmt.Sprintf("apps/v1/deployments-set%d", i)
+		opap.ResourceToControlsMap[gvr] = []string{"C-0001", "C-0002"}
+	}
+
+	// Many input resources per call widens the write window: each
+	// markResourcesSkipped call takes and releases mu once per resource.
+	const resourcesPerWrite = 200
+	inputResources := make([]workloadinterface.IMetadata, 0, resourcesPerWrite)
+	for i := 0; i < resourcesPerWrite; i++ {
+		inputResources = append(inputResources, workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      fmt.Sprintf("pod-%d", i),
+				"namespace": "default",
+			},
+		}))
+	}
+	erroringRule := &reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{Name: "simulated-erroring-rule"}}
+
+	var wg sync.WaitGroup
+	const writers = 4
+	const readers = 4
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out := make(map[string]*resourcesresults.ResourceAssociatedRule)
+			for i := 0; i < 25; i++ {
+				opap.markResourcesSkipped(out, erroringRule, resources.RegoDependenciesData{}, inputResources, errors.New("simulated evaluation failure"))
+			}
+		}()
+	}
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				opap.hasUnreachableDependency("C-0001")
+				opap.hasUnreachableDependency("C-0002")
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Closes #3562.

## Overview

**Current behavior:** `hasUnreachableDependency` reads `opap.InfoMap` without holding the processor mutex, while concurrent `processScope` worker goroutines write that same map under the lock via `markResourcesSkipped` and `seedCELSkips` — which fire whenever a rule evaluation errors or a CEL check skips a resource. On a multi-core cluster scan where one control's rule fails while others are evaluating, Go aborts the entire process with `fatal error: concurrent map read and map write` — mid-scan, no results file, no clean error.

**Future behavior:** the read now holds `opap.mu` (the same mutex that already guards the writes), so all concurrent `InfoMap` accesses are synchronized and the failure-tolerance paths (`markResourcesSkipped`) can no longer turn a single failing rule into a hard process crash. A single rule failure is tolerated as designed: skipped findings for that control, scan completes.

Maintainer-confirmed on Slack ("yup we're missing some mutex locks").

## Changes

- `core/pkg/opaprocessor/processorhandler.go`: guard the `InfoMap` read in `hasUnreachableDependency` with `opap.mu`, and document why the guard is required.
- `core/pkg/opaprocessor/processorhandler_test.go`: two new tests:
  - `TestHasUnreachableDependency_GVRPullFailureGuard` — pins the mixed-purpose InfoMap semantics (whole-GVR pull failures count; per-resource skips keyed by resource ID do not).
  - `TestHasUnreachableDependency_ConcurrentWithSkipWrites` — ``-race`` regression test hammering the exact read/write pair concurrently (4 writers × 25 iterations × 200 resources per write call; 4 readers × 1000 guarded reads).

## Verification

- Red/green proven: reverting the fix and running the new test under `go test -race` reproduces the exact `concurrent map read and map write` crash in `hasUnreachableDependency`; with the fix it passes.
- `go test -race -count=2 ./core/pkg/opaprocessor/` → 510 passed.
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./cmd/scan/ ./cmd/shared/ ./core/cautils/` → 1296 passed.

## Follow-up (intentionally out of scope)

Embedding a `sync.RWMutex` in `OPASessionObj` to make it more broadly shareable was discussed with the maintainer and deferred: the struct has copy-by-value call sites (`go vet copylocks`) and JSON-marshaling paths that need separate review.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking dependencies while resource processing is ongoing.
  * Correctly distinguishes failed resource retrievals from individual resource skips.
  * Prevented potential concurrency-related errors during simultaneous dependency checks and skip updates.

* **Tests**
  * Added coverage for dependency checks involving retrieval failures.
  * Added concurrency tests to verify safe behavior during concurrent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->