### PR TITLE
fix(imagescan): bound GCP GetImagesScanStatus pagination loop

### DIFF
--- a/pkg/imagescan/gcp_adaptor.go
+++ b/pkg/imagescan/gcp_adaptor.go
@@ -168,7 +168,14 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 			}
 
 			it := a.client.ListOccurrences(ctx, req)
+			const maxScanStatusOccurrences = 1000
+			seen := 0
 			for {
+				if seen >= maxScanStatusOccurrences {
+					logger.L().Warning("truncated scan status occurrences", helpers.String("repository", imageID.Repository), helpers.Int("limit", maxScanStatusOccurrences))
+					break
+				}
+
 				occurrence, err := it.Next()
 				if err == iterator.Done {
 					break
@@ -176,6 +183,7 @@ func (a *GCPAdaptor) GetImagesScanStatus(ctx context.Context, imageIDs []Contain
 				if err != nil {
 					return status, fmt.Errorf("failed to query scan status for repository %s: %w", imageID.Repository, err)
 				}
+				seen++
 
 				if occurrence != nil && occurrence.GetDiscovery() != nil {
 					discovery := occurrence.GetDiscovery()

--- a/pkg/imagescan/gcp_adaptor_test.go
+++ b/pkg/imagescan/gcp_adaptor_test.go
@@ -18,18 +18,21 @@ import (
 )
 
 type mockGCPClient struct {
-	occurrences []*grafeaspb.Occurrence
-	mockErr     error
-	lastReq     *grafeaspb.ListOccurrencesRequest
+	occurrences  []*grafeaspb.Occurrence
+	mockErr      error
+	lastReq      *grafeaspb.ListOccurrencesRequest
+	lastIterator *mockGrafeasIterator
 }
 
 func (m *mockGCPClient) ListOccurrences(ctx context.Context, req *grafeaspb.ListOccurrencesRequest, opts ...interface{}) GrafeasIterator {
 	m.lastReq = req
-	return &mockGrafeasIterator{
+	it := &mockGrafeasIterator{
 		occurrences: m.occurrences,
 		err:         m.mockErr,
 		index:       0,
 	}
+	m.lastIterator = it
+	return it
 }
 
 type mockGrafeasIterator struct {
@@ -122,6 +125,43 @@ func TestGCPAdaptor_GetImagesScanStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGCPAdaptor_GetImagesScanStatus_Bounded guards against an unbounded
+// ListOccurrences loop: a registry that keeps returning non-terminal (e.g.
+// PENDING) discovery occurrences must not make GetImagesScanStatus walk the
+// entire response. Mirrors the maxVulns cap GetImagesVulnerabilities already
+// enforces in this file.
+func TestGCPAdaptor_GetImagesScanStatus_Bounded(t *testing.T) {
+	mockOccurrences := make([]*grafeaspb.Occurrence, 0, 5000)
+	for i := 0; i < 5000; i++ {
+		mockOccurrences = append(mockOccurrences, &grafeaspb.Occurrence{
+			Details: &grafeaspb.Occurrence_Discovery{
+				Discovery: &grafeaspb.DiscoveryOccurrence{
+					AnalysisStatus: grafeaspb.DiscoveryOccurrence_PENDING, // never terminal
+				},
+			},
+		})
+	}
+
+	client := &mockGCPClient{occurrences: mockOccurrences}
+	adaptor := NewGCPAdaptor()
+	adaptor.client = client
+
+	images := []ContainerImageIdentifier{
+		{Registry: "us-docker.pkg.dev", Repository: "my-project/my-repo/my-image", Hash: "sha256:1234"},
+	}
+
+	statuses, err := adaptor.GetImagesScanStatus(context.Background(), images)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	assert.False(t, statuses[0].IsScanAvailable)
+
+	// The mock only reports iterator.Done once every occurrence is consumed,
+	// so an index short of len(mockOccurrences) proves the loop stopped on
+	// its own cap rather than draining the whole (simulated) response.
+	require.NotNil(t, client.lastIterator)
+	assert.Less(t, client.lastIterator.index, len(mockOccurrences), "GetImagesScanStatus consumed the entire unbounded response instead of stopping at a cap")
 }
 
 func TestGCPAdaptor_GetImagesVulnerabilities(t *testing.T) {


### PR DESCRIPTION
## Summary

`GCPAdaptor.GetImagesScanStatus` had no bound on its `ListOccurrences` pagination loop, unlike its sibling `GetImagesVulnerabilities` in the same file (capped at `maxVulns = 1000`) and unlike the bound `#3473` added to the GitLab/Harbor adaptors for the same class of issue.

Fixes #3565

## Root cause

`pkg/imagescan/gcp_adaptor.go:171`'s loop only exits on `iterator.Done`, an error, or a `FINISHED_SUCCESS` discovery occurrence. A registry returning many non-terminal occurrences makes it walk the entire response with no cap.

## Fix

Added a `maxScanStatusOccurrences = 1000` cap, logging a truncation warning (matching `GetImagesVulnerabilities`' existing pattern) and stopping once reached.

## Test plan

New test `TestGCPAdaptor_GetImagesScanStatus_Bounded` feeds a mock iterator 5000 never-terminal (`PENDING`) occurrences and asserts the loop stopped short of consuming all of them. Confirmed this test fails without the fix (consumes all 5000) and passes with it:

```
=== RUN   TestGCPAdaptor_GetImagesScanStatus_Bounded
[warning] truncated scan status occurrences. repository: my-project/my-repo/my-image; limit: 1000
--- PASS: TestGCPAdaptor_GetImagesScanStatus_Bounded (0.00s)
```

Full suite:
- `go build ./...`, `go vet ./...` — clean
- `go test -race ./pkg/imagescan/...` — clean
- `go test ./...` (full repo) — clean
- `golangci-lint run --new-from-rev=upstream/master ./pkg/imagescan/...` — 0 issues
- `gofmt -l` on changed files — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited image scan status processing to 1,000 occurrences per image.
  * Prevented prolonged processing when scans contain large numbers of pending results.
  * Preserved the existing unavailable status and error handling behavior when the limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->