### PR TITLE
feat(mcpserver): add apply_remediation tool for deterministic AI auto-patching

### DIFF
--- a/cmd/mcpserver/iac_scan_controls.go
+++ b/cmd/mcpserver/iac_scan_controls.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
 	printerv2 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
 // iacControlPolicyIdentifiers validates the tool arguments and builds the
@@ -45,27 +46,64 @@ func (ksServer *KubescapeMcpserver) runIaCScanControls(ctx context.Context, path
 	return runScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Control", false, fileHandler, []string{path}, nil)
 }
 
+// iacScanOutcome carries the PostureReport together with the scan's coverage
+// signal. printerv2.FinalizeResults does not copy ScanCoverage into the report,
+// so a caller holding only the report JSON cannot tell a control that genuinely
+// passed from one the scan never evaluated. The summarized scanResponse exposes
+// this as its `degraded` flag; the report path has to carry it explicitly.
+type iacScanOutcome struct {
+	ReportJSON []byte
+	// Degraded mirrors runScan's signal: the scan did not fully complete,
+	// either because coverage was incomplete or because rule processing
+	// partially failed.
+	Degraded bool
+	// NotEvaluatedControls lists controls the scan could not evaluate, with the
+	// reason, so callers can surface them instead of reporting "nothing to fix".
+	NotEvaluatedControls []cautils.NotEvaluatedControl
+}
+
 // runIaCScanControlsReport runs the same scan as runIaCScanControls but returns
 // the full v2 PostureReport JSON — the document `kubescape scan --format json`
 // writes, and the only format fixhandler.NewFixHandler accepts. The scan tools
 // return a summarized scanResponse instead, which the fixhandler rejects.
 //
-// A non-fatal rule-processing error is tolerated, matching runScan: controls
-// that did evaluate still yield valid fixes.
-func (ksServer *KubescapeMcpserver) runIaCScanControlsReport(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+// A non-fatal rule-processing error does not fail the scan (controls that did
+// evaluate still yield valid fixes) but it is reported through the outcome's
+// Degraded flag rather than discarded: a partially-failed run can drop a
+// requested control before it is ever evaluated, and the caller has to be able
+// to see that.
+func (ksServer *KubescapeMcpserver) runIaCScanControlsReport(ctx context.Context, path string, controlIDs []string) (*iacScanOutcome, error) {
 	policyIdentifiers, err := iacControlPolicyIdentifiers(path, controlIDs)
 	if err != nil {
 		return nil, err
 	}
 	fileHandler := resourcehandler.NewFileResourceHandler()
-	scanData, _, err := executeScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Remediation", false, fileHandler, []string{path}, nil)
+	scanData, processErr, err := executeScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Remediation", false, fileHandler, []string{path}, nil)
 	if err != nil {
 		return nil, err
 	}
 	report := printerv2.FinalizeResults(scanData)
-	reportJSON, err := json.Marshal(report)
+
+	// FinalizeResults does not copy ScanCoverage, but the document
+	// `kubescape scan --format json` writes does carry it: ResultsHandler.ToJson
+	// embeds the PostureReport and adds a top-level scanCoverage key. Mirror that
+	// shape so the coverage gaps travel with the report rather than being
+	// dropped. NewFixHandler unmarshals into reporthandlingv2.PostureReport,
+	// which ignores the extra key.
+	output := struct {
+		*reporthandlingv2.PostureReport
+		ScanCoverage *cautils.ScanCoverage `json:"scanCoverage,omitempty"`
+	}{
+		PostureReport: report,
+		ScanCoverage:  &scanData.ScanCoverage,
+	}
+	reportJSON, err := json.Marshal(&output)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal posture report: %w", err)
 	}
-	return reportJSON, nil
+	return &iacScanOutcome{
+		ReportJSON:           reportJSON,
+		Degraded:             scanData.ScanCoverage.Degraded || processErr != nil,
+		NotEvaluatedControls: scanData.ScanCoverage.NotEvaluatedControls,
+	}, nil
 }

--- a/cmd/mcpserver/iac_scan_controls.go
+++ b/cmd/mcpserver/iac_scan_controls.go
@@ -2,15 +2,19 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
+	printerv2 "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 )
 
-func (ksServer *KubescapeMcpserver) runIaCScanControls(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+// iacControlPolicyIdentifiers validates the tool arguments and builds the
+// policy identifiers shared by the IaC control scan and the remediation tool.
+func iacControlPolicyIdentifiers(path string, controlIDs []string) ([]cautils.PolicyIdentifier, error) {
 	filtered := make([]string, 0, len(controlIDs))
 	for _, id := range controlIDs {
 		if id = strings.TrimSpace(id); id != "" {
@@ -27,6 +31,41 @@ func (ksServer *KubescapeMcpserver) runIaCScanControls(ctx context.Context, path
 	for i, id := range filtered {
 		policyIdentifiers[i] = cautils.PolicyIdentifier{Kind: apisv1.KindControl, Identifier: id}
 	}
+	return policyIdentifiers, nil
+}
+
+// runIaCScanControls scans local IaC at path against the given control IDs and
+// returns the summarized scanResponse JSON used by the MCP scan tools.
+func (ksServer *KubescapeMcpserver) runIaCScanControls(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+	policyIdentifiers, err := iacControlPolicyIdentifiers(path, controlIDs)
+	if err != nil {
+		return nil, err
+	}
 	fileHandler := resourcehandler.NewFileResourceHandler()
 	return runScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Control", false, fileHandler, []string{path}, nil)
+}
+
+// runIaCScanControlsReport runs the same scan as runIaCScanControls but returns
+// the full v2 PostureReport JSON — the document `kubescape scan --format json`
+// writes, and the only format fixhandler.NewFixHandler accepts. The scan tools
+// return a summarized scanResponse instead, which the fixhandler rejects.
+//
+// A non-fatal rule-processing error is tolerated, matching runScan: controls
+// that did evaluate still yield valid fixes.
+func (ksServer *KubescapeMcpserver) runIaCScanControlsReport(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+	policyIdentifiers, err := iacControlPolicyIdentifiers(path, controlIDs)
+	if err != nil {
+		return nil, err
+	}
+	fileHandler := resourcehandler.NewFileResourceHandler()
+	scanData, _, err := executeScan(ctx, ksServer, "", policyIdentifiers, "Local IaC Remediation", false, fileHandler, []string{path}, nil)
+	if err != nil {
+		return nil, err
+	}
+	report := printerv2.FinalizeResults(scanData)
+	reportJSON, err := json.Marshal(report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal posture report: %w", err)
+	}
+	return reportJSON, nil
 }

--- a/cmd/mcpserver/iac_scan_controls_test.go
+++ b/cmd/mcpserver/iac_scan_controls_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
@@ -106,13 +107,13 @@ func TestIaCScanControlsReport_ReturnsPostureReport(t *testing.T) {
 		t.Fatalf("failed to write fixture: %v", err)
 	}
 
-	reportBytes, err := ksServer.runIaCScanControlsReport(context.Background(), fixture, []string{"C-0017"})
+	outcome, err := ksServer.runIaCScanControlsReport(context.Background(), fixture, []string{"C-0017"})
 	if err != nil {
 		t.Fatalf("unexpected error scanning fixture: %v", err)
 	}
 
 	var report reporthandlingv2.PostureReport
-	if err := json.Unmarshal(reportBytes, &report); err != nil {
+	if err := json.Unmarshal(outcome.ReportJSON, &report); err != nil {
 		t.Fatalf("failed to unmarshal posture report: %v", err)
 	}
 
@@ -137,5 +138,18 @@ func TestIaCScanControlsReport_ReturnsPostureReport(t *testing.T) {
 	// the report useless to it even though it parses.
 	if len(report.Resources) == 0 {
 		t.Error("expected the report to carry raw resources")
+	}
+
+	// ResultsHandler.ToJson adds scanCoverage alongside the PostureReport;
+	// mirror it here so coverage gaps (degraded runs, controls that were never
+	// evaluated) travel with the report instead of being dropped.
+	var envelope struct {
+		ScanCoverage *cautils.ScanCoverage `json:"scanCoverage"`
+	}
+	if err := json.Unmarshal(outcome.ReportJSON, &envelope); err != nil {
+		t.Fatalf("failed to unmarshal report envelope: %v", err)
+	}
+	if envelope.ScanCoverage == nil {
+		t.Error("expected the report JSON to carry scanCoverage")
 	}
 }

--- a/cmd/mcpserver/iac_scan_controls_test.go
+++ b/cmd/mcpserver/iac_scan_controls_test.go
@@ -2,11 +2,30 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
+
+// privilegedPodManifest mirrors testdata/privileged-pod.yaml. The report test
+// writes its own copy into t.TempDir() so it can assert the absolute FilePath
+// the scan records without depending on where the package is checked out.
+const privilegedPodManifest = `apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged-pod
+spec:
+  containers:
+  - name: myapp
+    image: nginx
+    securityContext:
+      privileged: true
+`
 
 func TestIaCScanControls_EmptyPath(t *testing.T) {
 	srv := &KubescapeMcpserver{}
@@ -69,5 +88,54 @@ func TestIaCScanControls_ValidPath(t *testing.T) {
 	respStr := string(respBytes)
 	if !strings.Contains(respStr, `"total_failed":`) {
 		t.Errorf("expected scan response to include total_failed, got: %s", respStr)
+	}
+}
+
+// TestIaCScanControlsReport_ReturnsPostureReport asserts the report variant
+// emits the v2 PostureReport rather than the summarized scanResponse, carrying
+// the three things fixhandler.NewFixHandler validates: a File scanning target,
+// the absolute path of the scanned file, and the raw resources.
+func TestIaCScanControlsReport_ReturnsPostureReport(t *testing.T) {
+	ksServer := &KubescapeMcpserver{
+		policyGetter: getter.NewDownloadReleasedPolicy(),
+	}
+	_, _ = ksServer.policyGetter.SetRegoObjectsWithFallback()
+
+	fixture := filepath.Join(t.TempDir(), "privileged-pod.yaml")
+	if err := os.WriteFile(fixture, []byte(privilegedPodManifest), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	reportBytes, err := ksServer.runIaCScanControlsReport(context.Background(), fixture, []string{"C-0017"})
+	if err != nil {
+		t.Fatalf("unexpected error scanning fixture: %v", err)
+	}
+
+	var report reporthandlingv2.PostureReport
+	if err := json.Unmarshal(reportBytes, &report); err != nil {
+		t.Fatalf("failed to unmarshal posture report: %v", err)
+	}
+
+	if report.Metadata.ScanMetadata.ScanningTarget != reporthandlingv2.File {
+		t.Errorf("expected ScanningTarget %d (File), got %d", reporthandlingv2.File, report.Metadata.ScanMetadata.ScanningTarget)
+	}
+
+	fileCtx := report.Metadata.ContextMetadata.FileContextMetadata
+	if fileCtx == nil {
+		t.Fatal("expected FileContextMetadata to be set for a file-target scan")
+	}
+	wantPath, err := filepath.Abs(fixture)
+	if err != nil {
+		t.Fatalf("failed to resolve fixture path: %v", err)
+	}
+	if fileCtx.FilePath != wantPath {
+		t.Errorf("expected FilePath %q, got %q", wantPath, fileCtx.FilePath)
+	}
+
+	// The fixhandler resolves each result back to a raw resource to find the
+	// file and document index to patch, so an empty Resources list would make
+	// the report useless to it even though it parses.
+	if len(report.Resources) == 0 {
+		t.Error("expected the report to carry raw resources")
 	}
 }

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -677,6 +677,31 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return mcp.NewToolResultError(fmt.Sprintf("failed to run IaC control scan: %v", err)), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
+	case "apply_remediation":
+		path := ""
+		if p, ok := arguments["path"]; ok {
+			pStr, ok := p.(string)
+			if !ok {
+				return mcp.NewToolResultError("path argument must be a string"), nil
+			}
+			path = strings.TrimSpace(pStr)
+		}
+		if path == "" {
+			return mcp.NewToolResultError("path argument is required and cannot be empty"), nil
+		}
+		rawControlIDs, hasControlIDs := arguments["control_ids"]
+		controlIDs, toolErr := parseControlIDs(rawControlIDs, hasControlIDs)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		key := fmt.Sprintf("apply_remediation:%s:%s", url.QueryEscape(path), url.QueryEscape(strings.Join(controlIDs, ",")))
+		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
+			return ksServer.runApplyRemediation(scanCtx, path, controlIDs)
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to compute remediation: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "run_network_security_scan":
 		namespace, err := mcpScanNamespace(arguments)
 		if err != nil {
@@ -1250,6 +1275,7 @@ func mcpServerEntrypoint() error {
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)
+	createRemediationTools(ksServer)
 	createControlScanningTools(ksServer)
 	createPolicyListingTools(ksServer)
 

--- a/cmd/mcpserver/remediation.go
+++ b/cmd/mcpserver/remediation.go
@@ -1,0 +1,146 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	ksmetav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v4/core/pkg/fixhandler"
+)
+
+// iacScanReportFn produces the PostureReport the remediation flow feeds to the
+// fixhandler. Package-level so tests can supply a canned report instead of
+// running a real scan.
+var iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+	return s.runIaCScanControlsReport(ctx, path, controlIDs)
+}
+
+// remediationFileResult is the patched content for one file. Multiple entries
+// appear when path is a directory whose resources span several files.
+type remediationFileResult struct {
+	FilePath           string   `json:"file_path"`
+	PatchedYAML        string   `json:"patched_yaml"`
+	AppliedExpressions []string `json:"applied_expressions"`
+}
+
+type remediationResponse struct {
+	Files []remediationFileResult `json:"files"`
+	// FixedControlInstances counts (resource, control) tuples that produced at
+	// least one edit.
+	FixedControlInstances int `json:"fixed_control_instances"`
+	// UnfixedControls tells the caller which controls have no deterministic
+	// fix — the signal that stops an agent inventing one.
+	UnfixedControls []fixhandler.UnfixedControl `json:"unfixed_controls,omitempty"`
+}
+
+func createRemediationTools(ksServer *KubescapeMcpserver) {
+	applyRemediationTool := mcp.NewTool(
+		"apply_remediation",
+		mcp.WithDescription("Compute the exact, deterministic YAML patch for failed controls in local IaC. Scans the given path for the given controls, derives Kubescape's official yq-based fixes, and returns the fully patched YAML as a string. DOES NOT modify any file on disk — the caller decides whether to write the returned content. Controls with no automatic fix are listed in unfixed_controls and must not be fixed by guesswork. Use list_controls to discover valid IDs."),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Absolute or relative path to the local YAML file or directory to remediate (e.g., /path/to/manifest.yaml)"),
+		),
+		withControlIDsProperty("Control IDs to remediate: a comma-separated string (e.g. \"C-0013,C-0017\") or an array of strings (e.g. [\"C-0013\"]). At least one ID is required."),
+	)
+	ksServer.s.AddTool(applyRemediationTool, ksServer.toolHandler(applyRemediationTool.Name))
+}
+
+func (ksServer *KubescapeMcpserver) runApplyRemediation(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+	// 1. Scan in memory.
+	reportBytes, err := iacScanReportFn(ksServer, ctx, path, controlIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. NewFixHandler only accepts a report on disk, so stage one. Write and
+	//    close before handing it over — NewFixHandler opens and reads it
+	//    synchronously in the constructor (fixhandler.go:42-47), so removal is
+	//    safe on every path after that.
+	tempFile, err := os.CreateTemp("", "kubescape-mcp-remediation-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp report file: %w", err)
+	}
+	tempName := tempFile.Name()
+	defer os.Remove(tempName)
+	if _, err := tempFile.Write(reportBytes); err != nil {
+		tempFile.Close()
+		return nil, fmt.Errorf("failed to write temp report file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temp report file: %w", err)
+	}
+
+	// 3. Instantiate the fixer in a dry-run configuration.
+	handler, err := fixhandler.NewFixHandler(&ksmetav1.FixInfo{
+		ReportFile: tempName,
+		DryRun:     true, // documents intent; ApplyChanges is never called
+		NoConfirm:  true,
+		// SkipUserValues stays false: fixes whose value is a YOUR_* placeholder
+		// are still returned, because the calling agent is exactly the party
+		// that can substitute a real value.
+		// BasePath stays empty: the report was generated in-process from the
+		// caller's own path, so this is not the untrusted-report case BasePath
+		// guards against.
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize fix handler: %w", err)
+	}
+
+	// 4. Plan the fixes. This writes nothing.
+	resourcesToFix := handler.PrepareResourcesToFix(ctx)
+
+	// 5. Group expressions per file and apply them in memory. Mirrors
+	//    getFileYamlExpressions/reduceYamlExpressions (fixhandler.go:818, :989)
+	//    without their disk write. Each key is already scoped with
+	//    select(di==N), so multi-document files compose under one " | " pipeline.
+	fileExprs := make(map[string][]string)
+	for _, rfi := range resourcesToFix {
+		exprs := make([]string, 0, len(rfi.YamlExpressions))
+		for expr := range rfi.YamlExpressions {
+			exprs = append(exprs, expr)
+		}
+		sort.Strings(exprs) // map iteration order is random; output must be stable
+		fileExprs[rfi.FilePath] = append(fileExprs[rfi.FilePath], exprs...)
+	}
+
+	filePaths := make([]string, 0, len(fileExprs))
+	for fp := range fileExprs {
+		filePaths = append(filePaths, fp)
+	}
+	sort.Strings(filePaths)
+
+	files := make([]remediationFileResult, 0, len(filePaths))
+	for _, fp := range filePaths {
+		joined := strings.Join(fileExprs[fp], " | ")
+		fileAsString, err := fixhandler.GetFileString(fp)
+		if err != nil {
+			return nil, err
+		}
+		patched, err := fixhandler.ApplyFixToContent(ctx, fileAsString, joined)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute fix for %s: %w", fp, err)
+		}
+		files = append(files, remediationFileResult{
+			FilePath:           fp,
+			PatchedYAML:        patched,
+			AppliedExpressions: fileExprs[fp],
+		})
+	}
+
+	// 6. Always return the envelope, even with zero files: unfixed_controls
+	//    then explains why nothing was fixable, which is more useful to an
+	//    agent than an error.
+	resp := remediationResponse{
+		Files:                 files,
+		FixedControlInstances: handler.FixedControlsCount(),
+		UnfixedControls:       handler.UnfixedControls(),
+	}
+	return json.MarshalIndent(resp, "", "  ")
+}

--- a/cmd/mcpserver/remediation.go
+++ b/cmd/mcpserver/remediation.go
@@ -10,14 +10,16 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	ksmetav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v4/core/pkg/fixhandler"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
 // iacScanReportFn produces the PostureReport the remediation flow feeds to the
 // fixhandler. Package-level so tests can supply a canned report instead of
 // running a real scan.
-var iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, controlIDs []string) ([]byte, error) {
+var iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, controlIDs []string) (*iacScanOutcome, error) {
 	return s.runIaCScanControlsReport(ctx, path, controlIDs)
 }
 
@@ -34,9 +36,86 @@ type remediationResponse struct {
 	// FixedControlInstances counts (resource, control) tuples that produced at
 	// least one edit.
 	FixedControlInstances int `json:"fixed_control_instances"`
+	// Degraded reports that the scan behind this remediation did not fully
+	// complete, mirroring scanResponse.Degraded. An agent must not read an
+	// empty files list on a degraded run as "everything is compliant".
+	Degraded bool `json:"degraded"`
 	// UnfixedControls tells the caller which controls have no deterministic
-	// fix — the signal that stops an agent inventing one.
+	// fix — the signal that stops an agent inventing one. It also carries any
+	// requested control the scan never evaluated, so a control can never
+	// silently vanish from the response.
 	UnfixedControls []fixhandler.UnfixedControl `json:"unfixed_controls,omitempty"`
+}
+
+// normalizeControlID makes control IDs comparable regardless of how the caller
+// spelled them: parseControlIDs only trims, so "c-0013" must still match the
+// report's "C-0013".
+func normalizeControlID(id string) string {
+	return strings.ToUpper(strings.TrimSpace(id))
+}
+
+// reportedControlIDs collects every control the scan actually accounted for,
+// from both the summary and the per-resource results.
+func reportedControlIDs(reportJSON []byte) (map[string]bool, error) {
+	var report reporthandlingv2.PostureReport
+	if err := json.Unmarshal(reportJSON, &report); err != nil {
+		return nil, fmt.Errorf("failed to parse posture report: %w", err)
+	}
+	seen := make(map[string]bool)
+	for id := range report.SummaryDetails.Controls {
+		seen[normalizeControlID(id)] = true
+	}
+	for _, result := range report.Results {
+		for _, control := range result.AssociatedControls {
+			seen[normalizeControlID(control.ControlID)] = true
+		}
+	}
+	return seen, nil
+}
+
+// unaddressedControls returns an UnfixedControl for every requested control the
+// scan never accounted for.
+//
+// A degraded run can drop a control before it is ever evaluated. Such a control
+// appears in neither files (nothing was fixed for it) nor the fixhandler's own
+// unfixed list (which only covers controls the report marked failed), so
+// omitting it would leave the caller unable to tell "this control passed" from
+// "this control was skipped" — exactly the ambiguity apply_remediation exists to
+// remove. A control that is present in the report and simply produced no fix
+// genuinely passed, and is not reported here.
+func unaddressedControls(requested []string, reported map[string]bool, unfixed []fixhandler.UnfixedControl, notEvaluated []cautils.NotEvaluatedControl) []fixhandler.UnfixedControl {
+	covered := make(map[string]bool, len(unfixed))
+	for _, uc := range unfixed {
+		covered[normalizeControlID(uc.ControlID)] = true
+	}
+
+	reasons := make(map[string]string, len(notEvaluated))
+	for _, ne := range notEvaluated {
+		reason := ne.Reason
+		if reason == "" {
+			reason = "not evaluated: the scan could not evaluate this control"
+		}
+		if len(ne.MissingGVRs) > 0 {
+			reason = fmt.Sprintf("%s (missing resource types: %s)", reason, strings.Join(ne.MissingGVRs, ", "))
+		}
+		reasons[normalizeControlID(ne.ControlID)] = reason
+	}
+
+	out := make([]fixhandler.UnfixedControl, 0)
+	emitted := make(map[string]bool)
+	for _, id := range requested {
+		key := normalizeControlID(id)
+		if key == "" || covered[key] || emitted[key] || reported[key] {
+			continue
+		}
+		reason, ok := reasons[key]
+		if !ok {
+			reason = "not evaluated: control did not appear in the scan report"
+		}
+		emitted[key] = true
+		out = append(out, fixhandler.UnfixedControl{ControlID: id, Reason: reason})
+	}
+	return out
 }
 
 func createRemediationTools(ksServer *KubescapeMcpserver) {
@@ -54,10 +133,11 @@ func createRemediationTools(ksServer *KubescapeMcpserver) {
 
 func (ksServer *KubescapeMcpserver) runApplyRemediation(ctx context.Context, path string, controlIDs []string) ([]byte, error) {
 	// 1. Scan in memory.
-	reportBytes, err := iacScanReportFn(ksServer, ctx, path, controlIDs)
+	outcome, err := iacScanReportFn(ksServer, ctx, path, controlIDs)
 	if err != nil {
 		return nil, err
 	}
+	reportBytes := outcome.ReportJSON
 
 	// 2. NewFixHandler only accepts a report on disk, so stage one. Write and
 	//    close before handing it over — NewFixHandler opens and reads it
@@ -134,13 +214,23 @@ func (ksServer *KubescapeMcpserver) runApplyRemediation(ctx context.Context, pat
 		})
 	}
 
-	// 6. Always return the envelope, even with zero files: unfixed_controls
+	// 6. Reconcile what was asked for against what the scan actually covered, so
+	//    a control dropped by a degraded run surfaces instead of vanishing.
+	unfixed := handler.UnfixedControls()
+	reported, err := reportedControlIDs(reportBytes)
+	if err != nil {
+		return nil, err
+	}
+	unfixed = append(unfixed, unaddressedControls(controlIDs, reported, unfixed, outcome.NotEvaluatedControls)...)
+
+	// 7. Always return the envelope, even with zero files: unfixed_controls
 	//    then explains why nothing was fixable, which is more useful to an
 	//    agent than an error.
 	resp := remediationResponse{
 		Files:                 files,
 		FixedControlInstances: handler.FixedControlsCount(),
-		UnfixedControls:       handler.UnfixedControls(),
+		Degraded:              outcome.Degraded,
+		UnfixedControls:       unfixed,
 	}
 	return json.MarshalIndent(resp, "", "  ")
 }

--- a/cmd/mcpserver/remediation_test.go
+++ b/cmd/mcpserver/remediation_test.go
@@ -11,9 +11,12 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/fixhandler"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -107,15 +110,23 @@ func remediationReport(baseDir string, res *reporthandling.Resource, controls ..
 	}
 }
 
-// stubScanReport replaces the scan seam with a canned report so the test runs
+// stubScanOutcome replaces the scan seam with a canned outcome so the test runs
 // fully offline, and restores it afterwards.
-func stubScanReport(t *testing.T, report *reporthandlingv2.PostureReport) {
+func stubScanOutcome(t *testing.T, outcome *iacScanOutcome) {
 	t.Helper()
 	orig := iacScanReportFn
 	t.Cleanup(func() { iacScanReportFn = orig })
-	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) ([]byte, error) {
-		return json.Marshal(report)
+	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) (*iacScanOutcome, error) {
+		return outcome, nil
 	}
+}
+
+// stubScanReport is the common case: a healthy, non-degraded scan.
+func stubScanReport(t *testing.T, report *reporthandlingv2.PostureReport) {
+	t.Helper()
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+	stubScanOutcome(t, &iacScanOutcome{ReportJSON: raw})
 }
 
 // countTempReports counts the staged report files the remediation flow creates,
@@ -217,7 +228,7 @@ func TestApplyRemediation_ArgumentValidation(t *testing.T) {
 func TestApplyRemediation_ScanFailurePropagates(t *testing.T) {
 	orig := iacScanReportFn
 	t.Cleanup(func() { iacScanReportFn = orig })
-	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) ([]byte, error) {
+	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) (*iacScanOutcome, error) {
 		return nil, fmt.Errorf("policy download exploded")
 	}
 
@@ -260,6 +271,135 @@ func TestApplyRemediation_NoFixableControlsReportsUnfixed(t *testing.T) {
 	require.NotEmpty(t, resp.UnfixedControls, "the agent must be told which controls it may not guess at")
 	assert.Equal(t, "C-0041", resp.UnfixedControls[0].ControlID)
 	assert.NotEmpty(t, resp.UnfixedControls[0].Reason)
+}
+
+// --- 4b. degraded scan must not silently drop a requested control ---------
+
+// TestApplyRemediation_DegradedScanSurfacesSkippedControl covers the review
+// finding: when rule processing partially fails, a requested control can be
+// dropped before it is ever evaluated. It then appears in neither files nor the
+// fixhandler's unfixed list, leaving the caller unable to distinguish "passed"
+// from "silently skipped".
+func TestApplyRemediation_DegradedScanSurfacesSkippedControl(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	// The report only accounts for C-0013. C-0041 was requested but never
+	// evaluated, so it appears nowhere in the report.
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	report := remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	)
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+	stubScanOutcome(t, &iacScanOutcome{
+		ReportJSON: raw,
+		Degraded:   true,
+		NotEvaluatedControls: []cautils.NotEvaluatedControl{
+			{ControlID: "C-0041", Reason: "control evaluation timed out"},
+		},
+	})
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0013,C-0041",
+	})
+	require.False(t, result.IsError, "a degraded scan is still a usable result: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+
+	assert.True(t, resp.Degraded, "a degraded scan must be visible to the caller")
+
+	// C-0013 was evaluated and fixed.
+	require.Len(t, resp.Files, 1)
+	assert.Contains(t, resp.Files[0].PatchedYAML, "runAsNonRoot: true")
+
+	// C-0041 must not vanish.
+	var found *fixhandler.UnfixedControl
+	for i := range resp.UnfixedControls {
+		if resp.UnfixedControls[i].ControlID == "C-0041" {
+			found = &resp.UnfixedControls[i]
+		}
+	}
+	require.NotNil(t, found, "an unevaluated control must surface in unfixed_controls, not vanish")
+	assert.Contains(t, found.Reason, "timed out", "the caller should be told why it was skipped")
+
+	// A control the scan did evaluate must not be reported as skipped.
+	for _, uc := range resp.UnfixedControls {
+		assert.NotEqual(t, "C-0013", uc.ControlID, "an evaluated control must not be flagged unaddressed")
+	}
+}
+
+// TestApplyRemediation_EvaluatedPassingControlIsNotFlagged guards the opposite
+// error: a control present in the report that simply produced no fix genuinely
+// passed, and must not be reported as skipped.
+func TestApplyRemediation_EvaluatedPassingControlIsNotFlagged(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	report := remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	)
+	// C-0999 was requested and evaluated; it passed, so it has no result entry
+	// but does appear in the summary.
+	report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-0999": reportsummary.ControlSummary{ControlID: "C-0999"},
+	}
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+	stubScanOutcome(t, &iacScanOutcome{ReportJSON: raw})
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0013,C-0999",
+	})
+	require.False(t, result.IsError, "unexpected tool error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+
+	assert.False(t, resp.Degraded)
+	for _, uc := range resp.UnfixedControls {
+		assert.NotEqual(t, "C-0999", uc.ControlID,
+			"a control the scan evaluated and passed must not be reported as skipped")
+	}
+}
+
+// TestApplyRemediation_ControlIDMatchingIsCaseInsensitive guards the diff
+// against a false "skipped" verdict when the caller lowercases the ID, since
+// parseControlIDs only trims.
+func TestApplyRemediation_ControlIDMatchingIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	stubScanReport(t, remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	))
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "c-0013",
+	})
+	require.False(t, result.IsError, "unexpected tool error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+	assert.Empty(t, resp.UnfixedControls, "lowercase c-0013 must match the report's C-0013")
 }
 
 // --- 5. multi-document file ----------------------------------------------

--- a/cmd/mcpserver/remediation_test.go
+++ b/cmd/mcpserver/remediation_test.go
@@ -1,0 +1,366 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fixture helpers ------------------------------------------------------
+//
+// Ported from core/pkg/fixhandler/unfixed_test.go, whose equivalents are
+// unexported and therefore cannot be imported.
+
+func remediationFailedRuleWithFix(path, value string) resourcesresults.ResourceAssociatedRule {
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-" + path,
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{FixPath: armotypes.FixPath{Path: path, Value: value}},
+		},
+	}
+}
+
+// remediationFailedRuleNoFix is a failed rule carrying a FailedPath but no
+// FixPath — the shape that has no deterministic fix and must surface in
+// unfixed_controls rather than being silently dropped.
+func remediationFailedRuleNoFix() resourcesresults.ResourceAssociatedRule {
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   "rule-no-fix",
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{FailedPath: "spec.hostNetwork"},
+		},
+	}
+}
+
+func remediationFailedControl(id, name string, rules ...resourcesresults.ResourceAssociatedRule) resourcesresults.ResourceAssociatedControl {
+	return resourcesresults.ResourceAssociatedControl{
+		ControlID:               id,
+		Name:                    name,
+		Status:                  apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: rules,
+	}
+}
+
+// remediationResource builds a reporthandling.Resource backed by the local YAML
+// file <baseDir>/<filename>. documentIndex is encoded into sourcePath because
+// that is how the fixhandler locates the document to patch.
+func remediationResource(baseDir, filename, kind, name string, documentIndex int) *reporthandling.Resource {
+	obj := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]any{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath(filename + ":" + strconv.Itoa(documentIndex))
+
+	return &reporthandling.Resource{
+		ResourceID: lw.GetID(),
+		Object:     lw.GetObject(),
+		Source:     &reporthandling.Source{FileType: reporthandling.SourceTypeYaml, Path: baseDir},
+	}
+}
+
+// remediationReport wraps resources and controls into the Directory-target
+// PostureReport shape NewFixHandler accepts.
+func remediationReport(baseDir string, res *reporthandling.Resource, controls ...resourcesresults.ResourceAssociatedControl) *reporthandlingv2.PostureReport {
+	return &reporthandlingv2.PostureReport{
+		Metadata: reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reporthandlingv2.Directory,
+			},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+					BasePath: baseDir,
+				},
+			},
+		},
+		Results: []resourcesresults.Result{
+			{
+				ResourceID:         res.GetID(),
+				RawResource:        res,
+				AssociatedControls: controls,
+			},
+		},
+		Resources: []reporthandling.Resource{*res},
+	}
+}
+
+// stubScanReport replaces the scan seam with a canned report so the test runs
+// fully offline, and restores it afterwards.
+func stubScanReport(t *testing.T, report *reporthandlingv2.PostureReport) {
+	t.Helper()
+	orig := iacScanReportFn
+	t.Cleanup(func() { iacScanReportFn = orig })
+	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) ([]byte, error) {
+		return json.Marshal(report)
+	}
+}
+
+// countTempReports counts the staged report files the remediation flow creates,
+// so a test can prove none were left behind.
+func countTempReports(t *testing.T) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "kubescape-mcp-remediation-*.json"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+func callApplyRemediation(t *testing.T, ksServer *KubescapeMcpserver, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	res, err := ksServer.CallTool(context.Background(), "apply_remediation", args)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	return res
+}
+
+const deploymentNoSecurityContext = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx
+`
+
+// --- 1. happy path --------------------------------------------------------
+
+func TestApplyRemediation_SingleFilePatchesWithoutTouchingDisk(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	stubScanReport(t, remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	))
+
+	before := countTempReports(t)
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0013",
+	})
+	require.False(t, result.IsError, "unexpected tool error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+
+	require.Len(t, resp.Files, 1)
+	assert.Equal(t, fixture, resp.Files[0].FilePath)
+	assert.Contains(t, resp.Files[0].PatchedYAML, "runAsNonRoot: true")
+	assert.NotEmpty(t, resp.Files[0].AppliedExpressions)
+	assert.Equal(t, 1, resp.FixedControlInstances)
+
+	// The dry-run guarantee: the file on disk is byte-identical to before.
+	after, err := os.ReadFile(fixture)
+	require.NoError(t, err)
+	assert.Equal(t, deploymentNoSecurityContext, string(after),
+		"apply_remediation must never modify the file on disk")
+
+	assert.Equal(t, before, countTempReports(t), "staged report file was leaked")
+}
+
+// --- 2. argument validation ----------------------------------------------
+
+func TestApplyRemediation_ArgumentValidation(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+
+	t.Run("missing path", func(t *testing.T) {
+		result := callApplyRemediation(t, ksServer, map[string]any{"control_ids": "C-0013"})
+		assert.True(t, result.IsError)
+		assert.Contains(t, toolResultText(t, result), "path argument is required")
+	})
+
+	t.Run("blank path", func(t *testing.T) {
+		result := callApplyRemediation(t, ksServer, map[string]any{"path": "   ", "control_ids": "C-0013"})
+		assert.True(t, result.IsError)
+		assert.Contains(t, toolResultText(t, result), "path argument is required")
+	})
+
+	t.Run("missing control_ids", func(t *testing.T) {
+		result := callApplyRemediation(t, ksServer, map[string]any{"path": "/some/path"})
+		assert.True(t, result.IsError)
+		assert.Contains(t, toolResultText(t, result), "control_ids")
+	})
+}
+
+// --- 3. scan failure propagates ------------------------------------------
+
+func TestApplyRemediation_ScanFailurePropagates(t *testing.T) {
+	orig := iacScanReportFn
+	t.Cleanup(func() { iacScanReportFn = orig })
+	iacScanReportFn = func(s *KubescapeMcpserver, ctx context.Context, path string, ids []string) ([]byte, error) {
+		return nil, fmt.Errorf("policy download exploded")
+	}
+
+	before := countTempReports(t)
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        "/some/path",
+		"control_ids": "C-0013",
+	})
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, toolResultText(t, result), "policy download exploded")
+	assert.Equal(t, before, countTempReports(t), "staged report file was leaked on the error path")
+}
+
+// --- 4. nothing fixable ---------------------------------------------------
+
+func TestApplyRemediation_NoFixableControlsReportsUnfixed(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	stubScanReport(t, remediationReport(dir, res,
+		remediationFailedControl("C-0041", "HostNetwork access", remediationFailedRuleNoFix()),
+	))
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0041",
+	})
+	require.False(t, result.IsError, "a control with no auto-fix must not be an error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+
+	assert.Empty(t, resp.Files, "nothing was fixable, so no patched files")
+	assert.Equal(t, 0, resp.FixedControlInstances)
+	require.NotEmpty(t, resp.UnfixedControls, "the agent must be told which controls it may not guess at")
+	assert.Equal(t, "C-0041", resp.UnfixedControls[0].ControlID)
+	assert.NotEmpty(t, resp.UnfixedControls[0].Reason)
+}
+
+// --- 5. multi-document file ----------------------------------------------
+
+const twoDocumentDeployments = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: first
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx
+`
+
+func TestApplyRemediation_MultiDocumentPatchesOnlyTargetDocument(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployments.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(twoDocumentDeployments), 0o600))
+
+	// documentIndex 1 -> the fix expression is scoped with select(di==1).
+	res := remediationResource(dir, "deployments.yaml", "Deployment", "second", 1)
+	stubScanReport(t, remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	))
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0013",
+	})
+	require.False(t, result.IsError, "unexpected tool error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+	require.Len(t, resp.Files, 1)
+
+	patched := resp.Files[0].PatchedYAML
+	assert.Equal(t, 1, strings.Count(patched, "runAsNonRoot: true"),
+		"exactly one document may be patched")
+
+	docs := strings.Split(patched, "\n---")
+	require.Len(t, docs, 2, "both documents must survive the patch")
+	assert.NotContains(t, docs[0], "runAsNonRoot", "document 0 must be untouched")
+	assert.Contains(t, docs[1], "runAsNonRoot: true", "document 1 is the target")
+}
+
+// --- 6. tool registration -------------------------------------------------
+
+func TestCreateRemediationTools_RegistersApplyRemediation(t *testing.T) {
+	ksServer := &KubescapeMcpserver{s: server.NewMCPServer("kubescape-test", "test")}
+	require.NotPanics(t, func() { createRemediationTools(ksServer) })
+
+	message, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	})
+	require.NoError(t, err)
+	raw, err := json.Marshal(ksServer.s.HandleMessage(context.Background(), message))
+	require.NoError(t, err)
+
+	var listed struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				InputSchema struct {
+					Properties map[string]any `json:"properties"`
+					Required   []string       `json:"required"`
+				} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &listed))
+
+	var found bool
+	for _, tool := range listed.Result.Tools {
+		if tool.Name != "apply_remediation" {
+			continue
+		}
+		found = true
+		assert.Contains(t, tool.InputSchema.Properties, "path")
+		assert.Contains(t, tool.InputSchema.Properties, "control_ids")
+		assert.Contains(t, tool.InputSchema.Required, "path")
+		assert.Contains(t, tool.InputSchema.Required, "control_ids")
+	}
+	assert.True(t, found, "apply_remediation was not registered")
+}

--- a/cmd/mcpserver/scan_helper.go
+++ b/cmd/mcpserver/scan_helper.go
@@ -41,7 +41,16 @@ func runControlScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace
 	return runScan(ctx, ksServer, namespace, policyIdentifiers, label, false, nil, nil, nil)
 }
 
-func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string, policyIdentifiers []cautils.PolicyIdentifier, label string, wantComplianceScore bool, rsrcHandler resourcehandler.IResourceHandler, inputPatterns []string, customGetters *cautils.Getters) ([]byte, error) {
+// executeScan runs the collect-policies → collect-resources → OPA pipeline and
+// returns the raw session object. It is the shared core of runScan (which
+// summarizes the session for scan tools) and runIaCScanControlsReport (which
+// serializes it as a full PostureReport for the remediation tool).
+//
+// The second return value is the non-fatal rule-processing error: rules that
+// failed to evaluate still leave usable partial results, so callers fold it
+// into a "degraded" signal rather than treating it as a failure. The third is a
+// genuine failure, where scanData is nil.
+func executeScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string, policyIdentifiers []cautils.PolicyIdentifier, label string, wantComplianceScore bool, rsrcHandler resourcehandler.IResourceHandler, inputPatterns []string, customGetters *cautils.Getters) (*cautils.OPASessionObj, error, error) {
 	logger.L().Ctx(ctx).Info(fmt.Sprintf("Initiating on-demand MCP %s security scan", label), helpers.String("namespace", namespace))
 
 	var client *k8sinterface.KubernetesApi
@@ -49,7 +58,7 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 		var err error
 		client, err = ksServer.getK8sClient()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -73,14 +82,14 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 	defer policyHandler.Close()
 	scanData, err := policyHandler.CollectPolicies(scanCtx, policyIdentifiers, scanInfo, &getters)
 	if err != nil {
-		return nil, fmt.Errorf("failed to collect %s policies: %w", label, err)
+		return nil, nil, fmt.Errorf("failed to collect %s policies: %w", label, err)
 	}
 
 	if rsrcHandler == nil {
 		rsrcHandler = resourcehandler.NewK8sResourceHandler(scanCtx, client, nil, nil, "")
 	}
 	if err := resourcehandler.CollectResources(scanCtx, rsrcHandler, scanData, scanInfo); err != nil {
-		return nil, fmt.Errorf("failed to collect %s resources: %w", label, err)
+		return nil, nil, fmt.Errorf("failed to collect %s resources: %w", label, err)
 	}
 
 	k8sConfig := k8sinterface.GetK8sConfig()
@@ -93,9 +102,18 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 		opap.ControlTimeout = scanInfo.ScanTimeout / 4
 	}
 
-	err = opap.ProcessRulesListener(scanCtx, cautils.NewProgressHandler(""))
+	processErr := opap.ProcessRulesListener(scanCtx, cautils.NewProgressHandler(""))
+	if processErr != nil {
+		logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to fully process %s rules (partial results will be returned)", label), helpers.Error(processErr))
+	}
+
+	return scanData, processErr, nil
+}
+
+func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string, policyIdentifiers []cautils.PolicyIdentifier, label string, wantComplianceScore bool, rsrcHandler resourcehandler.IResourceHandler, inputPatterns []string, customGetters *cautils.Getters) ([]byte, error) {
+	scanData, processErr, err := executeScan(ctx, ksServer, namespace, policyIdentifiers, label, wantComplianceScore, rsrcHandler, inputPatterns, customGetters)
 	if err != nil {
-		logger.L().Ctx(ctx).Warning(fmt.Sprintf("failed to fully process %s rules (partial results will be returned)", label), helpers.Error(err))
+		return nil, err
 	}
 
 	var complianceScore *float32
@@ -105,7 +123,7 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, namespace string
 	totalControls := 0
 
 	if scanData.Report != nil {
-		degraded = scanData.ScanCoverage.Degraded || err != nil
+		degraded = scanData.ScanCoverage.Degraded || processErr != nil
 		notEvaluated = len(scanData.ScanCoverage.NotEvaluatedControls)
 		totalControls = len(scanData.Report.SummaryDetails.Controls)
 


### PR DESCRIPTION
## Overview
**Current behavior:** Our Model Context Protocol (MCP) server allows AI agents to scan local IaC and identify failed controls. However, if an agent attempts to fix the YAML itself, it often hallucinates incorrect field paths, wrong indentation, or invalid data types. 

**Future behavior:** This PR introduces the `apply_remediation` MCP tool. Instead of hallucinating, the AI agent can now call this tool with a file path and a list of `control_ids`. The tool hooks directly into Kubescape's internal `core/pkg/fixhandler` to generate and return the mathematically perfect `yqlib` YAML patch string back to the AI. The AI can then confidently apply the exact patch to the user's workspace.

## Additional Information
To make this work seamlessly with our existing architecture, this PR includes:
1. **`executeScan` Refactor:** Split `runScan` in `scan_helper.go` to expose the raw `*cautils.OPASessionObj` without altering existing behavior.
2. **`runIaCScanControlsReport`:** A new helper that leverages `printerv2.FinalizeResults` to serialize the session into a full v2 `PostureReport` JSON (the exact format `fixhandler` strictly requires).
3. **Strict Dry-Run Execution:** The tool uses `os.CreateTemp` to feed the report to `NewFixHandler`, computes the `YamlExpressions`, and calls `ApplyFixToContent` in memory. It *never* calls `ApplyChanges`, guaranteeing zero unexpected disk writes.
4. **Anti-Hallucination payload:** The tool returns a structured envelope containing `patched_yaml` and `unfixed_controls`. If a control cannot be auto-fixed, it is returned in `unfixed_controls` so the AI explicitly knows *not* to invent a fix.

## How to Test
1. Compile the MCP server and configure Claude Desktop or Cursor to connect to it.
2. Create a `deployment.yaml` with a known vulnerability (e.g., missing `securityContext.runAsNonRoot`).
3. Prompt the AI: `"Please scan my deployment.yaml and fix the runAsNonRoot vulnerability."`
4. The AI will call `scan_local_iac`, identify the control ID, and then call `apply_remediation` to fetch the exact patch.
5. Verify that the AI receives the perfect patch and that the original file on disk was not modified behind the scenes (dry-run).

## Related issues/PRs:
* Resolved #3564 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `apply_remediation` tool for generating IaC fixes for selected controls.
  * Remediations are returned as patched YAML without modifying source files.
  * Reports identify fixed, unfixed, and skipped controls with explanations.
  * IaC reports now include scan coverage and file-scanning metadata.

* **Bug Fixes**
  * Improved scan reliability by distinguishing recoverable processing issues from critical failures.
  * Scans now clearly indicate degraded results when coverage or rule processing is incomplete.
  * Control matching now handles differences in capitalization and surrounding whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->