### PR TITLE
feat(vapreconcile): add per-resource VAPBinding scope coverage

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/vapreconcile"
 	"github.com/kubescape/opa-utils/reporthandling"
 	apis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
@@ -122,6 +123,15 @@ type OPASessionObj struct {
 	IncludeControls       string                      // Comma-separated control IDs to include (all others skipped)
 	VAPPolicies           []unstructured.Unstructured // ValidatingAdmissionPolicy resources collected from the cluster
 	VAPBindings           []unstructured.Unstructured // ValidatingAdmissionPolicyBinding resources collected from the cluster
+
+	// VAPCoverage refines VAPPolicies/VAPBindings' coarse "is any binding
+	// present" signal (see reportsummary.ControlSummary.VAPEnforcement) with
+	// per-resource binding-scope matching: a control's VAP can be Bound
+	// while its binding's namespaceSelector/objectSelector does not actually
+	// cover some or all of the resources that failed it. Populated by
+	// resultshandling after VAPPolicies/VAPBindings are enriched into the
+	// report, keyed by control ID.
+	VAPCoverage map[string]*vapreconcile.ControlCoverage
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -265,6 +265,13 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 	if rh.ScanData != nil && len(rh.ScanData.VAPPolicies) > 0 {
 		index := vapreconcile.BuildIndex(rh.ScanData.VAPPolicies, rh.ScanData.VAPBindings)
 		vapreconcile.EnrichSummary(rh.ScanData.Report.SummaryDetails.Controls, index)
+
+		// Refine that coarse per-control Bound signal with per-resource
+		// binding-scope matching, before ApplySeverityFilters below narrows
+		// which resources/controls are considered.
+		failing := vapreconcile.CollectFailingResourcesByControl(rh.ScanData.ResourcesResult, rh.ScanData.AllResources)
+		namespaceLabels := vapreconcile.CollectNamespaceLabels(rh.ScanData.AllResources)
+		rh.ScanData.VAPCoverage = vapreconcile.BuildCoverage(rh.ScanData.VAPPolicies, rh.ScanData.VAPBindings, failing, namespaceLabels)
 	}
 
 	// Snapshot Report.SummaryDetails.Controls, every

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -28,6 +28,7 @@ import (
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type DummyReporter struct{}
@@ -974,6 +975,92 @@ func TestHandleResults_RestoresReportAfterSeverityFilter(t *testing.T) {
 	// any caller reading rh.ScanData after HandleResults sees a consistent report.
 	assert.Len(t, rh.ScanData.Report.SummaryDetails.Controls, 3, "Controls must be unfiltered after HandleResults")
 	assert.Len(t, rh.ScanData.ResourcesResult["resource-1"].AssociatedControls, 2, "AssociatedControls must be unfiltered after HandleResults")
+}
+
+// TestHandleResults_ComputesVAPCoverage verifies the vapreconcile.BuildCoverage
+// wiring added alongside the existing BuildIndex/EnrichSummary call: a
+// control bound to a policy whose only binding is scoped to a namespace the
+// failing resource is not in must come out Bound but not FullyCovered.
+func TestHandleResults_ComputesVAPCoverage(t *testing.T) {
+	vap := unstructured.Unstructured{}
+	vap.SetName("policy-a")
+	vap.SetLabels(map[string]string{"controlId": "C-scoped"})
+
+	binding := unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"policyName": "policy-a",
+				"matchResources": map[string]any{
+					"namespaceSelector": map[string]any{
+						"matchLabels": map[string]any{"env": "prod"},
+					},
+				},
+			},
+		},
+	}
+	binding.SetName("binding-a")
+
+	failingResource := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "app",
+			"namespace": "dev",
+		},
+	})
+	devNamespace := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "dev",
+			"labels": map[string]any{"env": "dev"},
+		},
+	})
+	resourceID := failingResource.GetID()
+
+	sessionObj := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: map[string]reportsummary.ControlSummary{
+					"C-scoped": {ControlID: "C-scoped", ScoreFactor: 7},
+				},
+			},
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			resourceID: {
+				ResourceID: resourceID,
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{ControlID: "C-scoped", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+				},
+			},
+		},
+		AllResources: map[string]workloadinterface.IMetadata{
+			resourceID:           failingResource,
+			devNamespace.GetID(): devNamespace,
+		},
+		VAPPolicies: []unstructured.Unstructured{vap},
+		VAPBindings: []unstructured.Unstructured{binding},
+	}
+
+	rh := &ResultsHandler{
+		ScanData:  sessionObj,
+		UiPrinter: &SpyPrinter{},
+	}
+
+	err := rh.HandleResults(context.Background(), &cautils.ScanInfo{})
+	require.NoError(t, err)
+
+	require.Contains(t, rh.ScanData.VAPCoverage, "C-scoped")
+	coverage := rh.ScanData.VAPCoverage["C-scoped"]
+	assert.True(t, coverage.Bound, "the binding names the control's policy, so it must be Bound")
+	assert.False(t, coverage.FullyCovered(), "the binding's namespaceSelector only matches env=prod, so the dev-namespace failure must not be covered")
+	require.Len(t, coverage.Resources, 1)
+	assert.False(t, coverage.Resources[0].Covered)
+	assert.Contains(t, coverage.Resources[0].Reason, "namespaceSelector")
+
+	// The existing coarse signal must still be populated exactly as before.
+	require.NotNil(t, rh.ScanData.Report.SummaryDetails.Controls["C-scoped"].VAPEnforcement)
+	assert.True(t, rh.ScanData.Report.SummaryDetails.Controls["C-scoped"].VAPEnforcement.Bound)
 }
 
 func makeFilteredSession() *cautils.OPASessionObj {

--- a/core/pkg/vapreconcile/coverage.go
+++ b/core/pkg/vapreconcile/coverage.go
@@ -1,0 +1,371 @@
+package vapreconcile
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ResourceInfo is the minimal identity a coverage check needs for one
+// scanned resource: which namespace it lives in (empty for cluster-scoped)
+// and its own labels, for objectSelector matching.
+type ResourceInfo struct {
+	ResourceID string
+	Namespace  string
+	Labels     map[string]string
+}
+
+// ResourceCoverage reports whether one specific resource that failed a
+// control actually falls within the scope of a live, bound VAPBinding for
+// that control's policy -- as opposed to merely having *some* binding exist
+// somewhere in the cluster, which BuildIndex/EnrichSummary already report
+// via VAPEnforcementStatus.Bound.
+type ResourceCoverage struct {
+	ResourceID string
+	Covered    bool
+	// Reason explains why Covered is false. Empty when Covered is true.
+	Reason string
+}
+
+// ControlCoverage summarizes, for one control, how much of its failing
+// resource set a live VAPBinding actually enforces against -- versus how
+// much BuildIndex/EnrichSummary's coarser, all-or-nothing Bound signal
+// implies. A control can be Bound (some binding exists) while none of its
+// failing resources are actually covered by that binding's scope, e.g. a
+// namespaceSelector that only matches kube-system while every failure is
+// elsewhere.
+type ControlCoverage struct {
+	ControlID  string
+	PolicyName string
+	// Bound mirrors VAPEnforcementStatus.Bound: true when at least one
+	// binding names this control's policy, regardless of its scope.
+	Bound     bool
+	Resources []ResourceCoverage
+}
+
+// TotalFailing returns how many of the control's failing resources were
+// evaluated for coverage.
+func (c *ControlCoverage) TotalFailing() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.Resources)
+}
+
+// CoveredCount returns how many of the control's failing resources are
+// within scope of a live, bound binding.
+func (c *ControlCoverage) CoveredCount() int {
+	if c == nil {
+		return 0
+	}
+	n := 0
+	for _, r := range c.Resources {
+		if r.Covered {
+			n++
+		}
+	}
+	return n
+}
+
+// FullyCovered reports whether every one of the control's failing resources
+// is within scope of a live, bound binding: the case where the coarse
+// Bound=true signal is actually trustworthy end to end.
+func (c *ControlCoverage) FullyCovered() bool {
+	if c == nil || !c.Bound || len(c.Resources) == 0 {
+		return false
+	}
+	return c.CoveredCount() == len(c.Resources)
+}
+
+// PartiallyCovered reports whether the binding is bound and enforces against
+// some, but not all, of the control's failing resources -- the case where
+// Bound=true actively misleads about the control's actual live-enforcement
+// reach.
+func (c *ControlCoverage) PartiallyCovered() bool {
+	if c == nil || !c.Bound {
+		return false
+	}
+	covered := c.CoveredCount()
+	return covered > 0 && covered < len(c.Resources)
+}
+
+// bindingScope is the parsed matchResources.namespaceSelector/objectSelector
+// of one binding, compiled once per BuildCoverage call rather than once per
+// resource it is checked against.
+type bindingScope struct {
+	namespaceSelector labels.Selector
+	objectSelector    labels.Selector
+}
+
+// matches reports whether a resource falls within this binding's scope.
+// namespaceLabelsKnown is false when the resource's Namespace object was not
+// collected by the scan (out of scope, or the scan predates namespace
+// collection): a namespaceSelector then cannot be evaluated, so the binding
+// is treated as not matching rather than optimistically matching --
+// silently over-crediting a binding's coverage would defeat the point of
+// this check.
+func (s *bindingScope) matches(resourceNamespace string, resourceLabels, namespaceLabels map[string]string, namespaceLabelsKnown bool) (bool, string) {
+	if !s.objectSelector.Empty() && !s.objectSelector.Matches(labels.Set(resourceLabels)) {
+		return false, "objectSelector does not match the resource's labels"
+	}
+	if !s.namespaceSelector.Empty() {
+		if resourceNamespace == "" {
+			return false, "namespaceSelector is set but the resource is cluster-scoped"
+		}
+		if !namespaceLabelsKnown {
+			return false, "namespaceSelector is set but the resource's Namespace object was not collected by the scan"
+		}
+		if !s.namespaceSelector.Matches(labels.Set(namespaceLabels)) {
+			return false, "namespaceSelector does not match the resource's namespace"
+		}
+	}
+	return true, ""
+}
+
+// parseSelector converts a raw, unstructured LabelSelector (as decoded from
+// JSON into map[string]any) into a labels.Selector. A missing or empty
+// selector (nil, or a map with neither matchLabels nor matchExpressions)
+// selects everything, matching the Kubernetes API's own semantics for an
+// absent selector field.
+func parseSelector(raw any) (labels.Selector, error) {
+	if raw == nil {
+		return labels.Everything(), nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok || len(m) == 0 {
+		return labels.Everything(), nil
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var typed metav1.LabelSelector
+	if err := json.Unmarshal(b, &typed); err != nil {
+		return nil, err
+	}
+	return metav1.LabelSelectorAsSelector(&typed)
+}
+
+// resolveBindingScope extracts and compiles one binding's
+// matchResources.namespaceSelector/objectSelector. A binding with no
+// matchResources at all (or no spec, which should not happen for a real
+// object but is handled rather than assumed) has no additional scoping
+// beyond its policy's own matchConstraints, so it resolves to a scope that
+// matches everything.
+func resolveBindingScope(binding unstructured.Unstructured) (*bindingScope, error) {
+	spec, _ := binding.Object["spec"].(map[string]any)
+	matchResources, _ := spec["matchResources"].(map[string]any)
+
+	var nsRaw, objRaw any
+	if matchResources != nil {
+		nsRaw = matchResources["namespaceSelector"]
+		objRaw = matchResources["objectSelector"]
+	}
+
+	nsSel, err := parseSelector(nsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("binding %q: invalid namespaceSelector: %w", binding.GetName(), err)
+	}
+	objSel, err := parseSelector(objRaw)
+	if err != nil {
+		return nil, fmt.Errorf("binding %q: invalid objectSelector: %w", binding.GetName(), err)
+	}
+	return &bindingScope{namespaceSelector: nsSel, objectSelector: objSel}, nil
+}
+
+// indexPoliciesByControl mirrors BuildIndex's own policy/control join, kept
+// separate (rather than shared) so BuildCoverage cannot be destabilized by a
+// future change to BuildIndex's semantics, and vice versa.
+func indexPoliciesByControl(policies []unstructured.Unstructured) (controlByPolicy map[string]string, policiesByControl map[string][]string) {
+	controlByPolicy = make(map[string]string, len(policies))
+	policiesByControl = make(map[string][]string, len(policies))
+	for i := range policies {
+		name := policies[i].GetName()
+		controlID := policies[i].GetLabels()[controlIDLabel]
+		if name == "" || controlID == "" {
+			continue
+		}
+		if _, seen := controlByPolicy[name]; seen {
+			continue // a repeated name is the same policy listed twice
+		}
+		controlByPolicy[name] = controlID
+		policiesByControl[controlID] = append(policiesByControl[controlID], name)
+	}
+	return controlByPolicy, policiesByControl
+}
+
+// indexBindingsByPolicy groups bindings by the policy name they name in
+// spec.policyName, keeping the raw binding objects (unlike BuildIndex's
+// actionsByPolicy, which only needs their validationActions) so
+// BuildCoverage can inspect each one's own matchResources scope.
+func indexBindingsByPolicy(bindings []unstructured.Unstructured, controlByPolicy map[string]string) map[string][]unstructured.Unstructured {
+	byPolicy := make(map[string][]unstructured.Unstructured, len(bindings))
+	for i := range bindings {
+		spec, ok := bindings[i].Object["spec"].(map[string]any)
+		if !ok {
+			continue
+		}
+		policyName, _ := spec["policyName"].(string)
+		if _, known := controlByPolicy[policyName]; !known {
+			continue
+		}
+		byPolicy[policyName] = append(byPolicy[policyName], bindings[i])
+	}
+	return byPolicy
+}
+
+// BuildCoverage computes, per control, whether each of its failing
+// resources actually falls within the scope of a live, bound VAPBinding --
+// refining BuildIndex's coarser "is any binding present" signal with the
+// namespaceSelector/objectSelector scoping the Kubernetes API server itself
+// applies at admission time. A control absent from the returned map has no
+// VAP at all (BuildIndex would not have indexed it either); a control
+// present with Bound=false has a policy but no binding names it -- both
+// match BuildIndex's own reporting for the same inputs.
+//
+// resourceRules, excludeResourceRules and matchPolicy on the binding are not
+// evaluated: a binding's scope is assumed to cover every GVR/operation its
+// policy's matchConstraints admits. This can overstate coverage for a
+// binding that further narrows the GVRs/operations from what its policy
+// covers, but never understates it, and namespaceSelector/objectSelector are
+// by far the more commonly used per-binding scoping mechanism.
+func BuildCoverage(
+	policies, bindings []unstructured.Unstructured,
+	failingByControl map[string][]ResourceInfo,
+	namespaceLabels map[string]map[string]string,
+) map[string]*ControlCoverage {
+	controlByPolicy, policiesByControl := indexPoliciesByControl(policies)
+	bindingsByPolicy := indexBindingsByPolicy(bindings, controlByPolicy)
+
+	coverage := make(map[string]*ControlCoverage, len(failingByControl))
+	for controlID, resources := range failingByControl {
+		policyNames := policiesByControl[controlID]
+		if len(policyNames) == 0 {
+			continue // no VAP for this control: nothing to report
+		}
+		slices.Sort(policyNames)
+
+		result := &ControlCoverage{ControlID: controlID, PolicyName: policyNames[0]}
+
+		scopesByPolicy := make(map[string][]*bindingScope)
+		for _, name := range policyNames {
+			rawBindings := bindingsByPolicy[name]
+			if len(rawBindings) == 0 {
+				continue
+			}
+			if !result.Bound {
+				result.Bound = true
+				result.PolicyName = name
+			}
+			for _, b := range rawBindings {
+				scope, err := resolveBindingScope(b)
+				if err != nil {
+					// A binding this malformed cannot be evaluated for scope;
+					// treat it as covering nothing rather than guessing.
+					continue
+				}
+				scopesByPolicy[name] = append(scopesByPolicy[name], scope)
+			}
+		}
+
+		for _, res := range resources {
+			nsLabels, known := namespaceLabels[res.Namespace]
+			covered := false
+			reason := "no bound binding names this control's policy"
+			if result.Bound {
+				reason = "no binding's scope covers this resource"
+			policyLoop:
+				for _, scopes := range scopesByPolicy {
+					for _, scope := range scopes {
+						ok, whyNot := scope.matches(res.Namespace, res.Labels, nsLabels, known)
+						if ok {
+							covered = true
+							break policyLoop
+						}
+						// Keep the most recent scope's reason: with a single
+						// binding (the common case) it is the only reason
+						// there is, and with several it is still a concrete,
+						// truthful example of why none of them matched.
+						reason = whyNot
+					}
+				}
+			}
+			rc := ResourceCoverage{ResourceID: res.ResourceID, Covered: covered}
+			if !covered {
+				rc.Reason = reason
+			}
+			result.Resources = append(result.Resources, rc)
+		}
+
+		coverage[controlID] = result
+	}
+
+	return coverage
+}
+
+// CollectFailingResourcesByControl derives, for every control, the identity
+// (ID, namespace, labels) of each resource that failed it -- the input
+// BuildCoverage needs to check per-resource binding scope, since neither
+// ResourcesResult nor the OPA session tracks that on its own.
+func CollectFailingResourcesByControl(
+	resourcesResult map[string]resourcesresults.Result,
+	allResources map[string]workloadinterface.IMetadata,
+) map[string][]ResourceInfo {
+	byControl := make(map[string][]ResourceInfo)
+	for resourceID, result := range resourcesResult {
+		resource, ok := allResources[resourceID]
+		if !ok || resource == nil {
+			continue
+		}
+		info := ResourceInfo{
+			ResourceID: resourceID,
+			Namespace:  resource.GetNamespace(),
+			Labels:     resourceLabels(resource),
+		}
+		for _, ac := range result.AssociatedControls {
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+			byControl[ac.ControlID] = append(byControl[ac.ControlID], info)
+		}
+	}
+	return byControl
+}
+
+// CollectNamespaceLabels indexes every scanned Namespace object's labels by
+// name, for BuildCoverage's namespaceSelector evaluation. A namespace absent
+// from this map was not collected by the scan (out of scope, or the scan
+// predates namespace collection), and BuildCoverage treats that as "cannot
+// determine" rather than "matches everything".
+func CollectNamespaceLabels(allResources map[string]workloadinterface.IMetadata) map[string]map[string]string {
+	nsLabels := make(map[string]map[string]string)
+	for _, resource := range allResources {
+		if resource == nil || resource.GetApiVersion() != "v1" || resource.GetKind() != "Namespace" {
+			continue
+		}
+		name := resource.GetName()
+		if name == "" {
+			continue
+		}
+		nsLabels[name] = resourceLabels(resource)
+	}
+	return nsLabels
+}
+
+// resourceLabels extracts a resource's labels. IMetadata does not carry
+// labels; IBasicWorkload does, so this casts rather than widening every
+// caller's parameter type to it.
+func resourceLabels(resource workloadinterface.IMetadata) map[string]string {
+	basicWorkload, ok := resource.(workloadinterface.IBasicWorkload)
+	if !ok {
+		return nil
+	}
+	return basicWorkload.GetLabels()
+}

--- a/core/pkg/vapreconcile/coverage_test.go
+++ b/core/pkg/vapreconcile/coverage_test.go
@@ -1,0 +1,379 @@
+package vapreconcile
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeVAPBScoped extends makeVAPB with a matchResources.namespaceSelector
+// and/or matchResources.objectSelector. A nil selector omits that key
+// entirely, matching how a real binding without that field decodes.
+func makeVAPBScoped(name, policyName string, namespaceSelector, objectSelector map[string]any) unstructured.Unstructured {
+	matchResources := map[string]any{}
+	if namespaceSelector != nil {
+		matchResources["namespaceSelector"] = namespaceSelector
+	}
+	if objectSelector != nil {
+		matchResources["objectSelector"] = objectSelector
+	}
+
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"policyName":     policyName,
+				"matchResources": matchResources,
+			},
+		},
+	}
+	u.SetName(name)
+	return u
+}
+
+func matchLabels(kv ...string) map[string]any {
+	m := map[string]any{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		m[kv[i]] = kv[i+1]
+	}
+	return map[string]any{"matchLabels": m}
+}
+
+func TestBuildCoverage_FullyCoveredWhenNoSelectors(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{makeVAPB("binding-a", "policy-a", []string{"Deny"})}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "default"}},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.Bound)
+	assert.True(t, c.FullyCovered())
+	assert.False(t, c.PartiallyCovered())
+	require.Len(t, c.Resources, 1)
+	assert.True(t, c.Resources[0].Covered)
+	assert.Empty(t, c.Resources[0].Reason)
+}
+
+func TestBuildCoverage_NamespaceSelectorExcludesResource(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "dev"}},
+	}
+	nsLabels := map[string]map[string]string{
+		"dev": {"env": "dev"},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nsLabels)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.Bound)
+	assert.False(t, c.FullyCovered())
+	require.Len(t, c.Resources, 1)
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "namespaceSelector")
+}
+
+func TestBuildCoverage_NamespaceSelectorIncludesResource(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "prod"}},
+	}
+	nsLabels := map[string]map[string]string{
+		"prod": {"env": "prod"},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nsLabels)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.FullyCovered())
+}
+
+func TestBuildCoverage_ObjectSelectorExcludesResource(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", nil, matchLabels("tier", "critical")),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "default", Labels: map[string]string{"tier": "internal"}}},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.FullyCovered())
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "objectSelector")
+}
+
+func TestBuildCoverage_ObjectSelectorIncludesResource(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", nil, matchLabels("tier", "critical")),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "default", Labels: map[string]string{"tier": "critical"}}},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.FullyCovered())
+}
+
+func TestBuildCoverage_UnknownNamespaceTreatedAsNotCovered(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "prod"}},
+	}
+
+	// namespaceLabels does not contain "prod" at all -- the scan never
+	// collected the Namespace object, so coverage cannot be determined and
+	// must not be assumed.
+	coverage := BuildCoverage(policies, bindings, failing, map[string]map[string]string{})
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "not collected")
+}
+
+func TestBuildCoverage_ClusterScopedResourceWithNamespaceSelectorNotCovered(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: ""}}, // cluster-scoped
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "cluster-scoped")
+}
+
+func TestBuildCoverage_MultipleBindingsOrSemantics(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-narrow", "policy-a", matchLabels("env", "prod"), nil),
+		makeVAPBScoped("binding-broad", "policy-a", nil, nil), // matches everything
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "dev"}},
+	}
+	nsLabels := map[string]map[string]string{"dev": {"env": "dev"}}
+
+	coverage := BuildCoverage(policies, bindings, failing, nsLabels)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	// The narrow binding excludes it, but the broad one covers it -- any
+	// one bound binding enforcing is enough for the resource to be covered.
+	assert.True(t, c.FullyCovered())
+}
+
+func TestBuildCoverage_NotBoundReturnsAllUncovered(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "default"}},
+	}
+
+	coverage := BuildCoverage(policies, nil, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.Bound)
+	assert.False(t, c.FullyCovered())
+	assert.False(t, c.PartiallyCovered())
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "no bound binding")
+}
+
+func TestBuildCoverage_NoVAPForControlOmittedFromMap(t *testing.T) {
+	failing := map[string][]ResourceInfo{
+		"C-9999": {{ResourceID: "res-1", Namespace: "default"}},
+	}
+
+	coverage := BuildCoverage(nil, nil, failing, nil)
+
+	_, ok := coverage["C-9999"]
+	assert.False(t, ok)
+}
+
+func TestBuildCoverage_MalformedSelectorDoesNotCrashAndCoversNothing(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	// "In" requires a Values list; omitting it makes the selector invalid.
+	badSelector := map[string]any{
+		"matchExpressions": []any{
+			map[string]any{"key": "env", "operator": "In"},
+		},
+	}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", badSelector, nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{ResourceID: "res-1", Namespace: "default"}},
+	}
+
+	require.NotPanics(t, func() {
+		coverage := BuildCoverage(policies, bindings, failing, map[string]map[string]string{"default": {}})
+		c := coverage["C-0001"]
+		require.NotNil(t, c)
+		assert.True(t, c.Bound) // the binding still binds the policy
+		assert.False(t, c.Resources[0].Covered)
+	})
+}
+
+func TestBuildCoverage_PartiallyCoveredAcrossMultipleResources(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {
+			{ResourceID: "res-prod", Namespace: "prod"},
+			{ResourceID: "res-dev", Namespace: "dev"},
+		},
+	}
+	nsLabels := map[string]map[string]string{
+		"prod": {"env": "prod"},
+		"dev":  {"env": "dev"},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nsLabels)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.PartiallyCovered())
+	assert.False(t, c.FullyCovered())
+	assert.Equal(t, 1, c.CoveredCount())
+	assert.Equal(t, 2, c.TotalFailing())
+}
+
+func TestControlCoverage_NilReceiverIsSafe(t *testing.T) {
+	var c *ControlCoverage
+	assert.Equal(t, 0, c.TotalFailing())
+	assert.Equal(t, 0, c.CoveredCount())
+	assert.False(t, c.FullyCovered())
+	assert.False(t, c.PartiallyCovered())
+}
+
+func TestControlCoverage_FullyCoveredRequiresAtLeastOneResource(t *testing.T) {
+	c := &ControlCoverage{ControlID: "C-0001", Bound: true}
+	assert.False(t, c.FullyCovered(), "a bound control with zero failing resources has nothing to be 'fully covered' about")
+}
+
+func TestCollectFailingResourcesByControl_OnlyIncludesFailedControls(t *testing.T) {
+	wl := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "app",
+			"namespace": "default",
+			"labels":    map[string]any{"tier": "critical"},
+		},
+	})
+	resourceID := wl.GetID()
+
+	resourcesResult := map[string]resourcesresults.Result{
+		resourceID: {
+			ResourceID: resourceID,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-0001", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+				{ControlID: "C-0002", Status: apis.StatusInfo{InnerStatus: apis.StatusPassed}},
+			},
+		},
+		"missing-from-allresources": {
+			ResourceID: "missing-from-allresources",
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-0003", Status: apis.StatusInfo{InnerStatus: apis.StatusFailed}},
+			},
+		},
+	}
+	allResources := map[string]workloadinterface.IMetadata{resourceID: wl}
+
+	byControl := CollectFailingResourcesByControl(resourcesResult, allResources)
+
+	require.Contains(t, byControl, "C-0001")
+	require.Len(t, byControl["C-0001"], 1)
+	assert.Equal(t, resourceID, byControl["C-0001"][0].ResourceID)
+	assert.Equal(t, "default", byControl["C-0001"][0].Namespace)
+	assert.Equal(t, map[string]string{"tier": "critical"}, byControl["C-0001"][0].Labels)
+
+	assert.NotContains(t, byControl, "C-0002", "passed controls must not be reported as failing")
+	assert.NotContains(t, byControl, "C-0003", "a resource missing from allResources must be skipped, not panic")
+}
+
+func TestCollectNamespaceLabels_OnlyNamespaceKind(t *testing.T) {
+	ns := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "prod",
+			"labels": map[string]any{"env": "prod"},
+		},
+	})
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "app",
+			"namespace": "prod",
+		},
+	})
+
+	allResources := map[string]workloadinterface.IMetadata{
+		ns.GetID():  ns,
+		pod.GetID(): pod,
+	}
+
+	nsLabels := CollectNamespaceLabels(allResources)
+
+	require.Contains(t, nsLabels, "prod")
+	assert.Equal(t, map[string]string{"env": "prod"}, nsLabels["prod"])
+	assert.Len(t, nsLabels, 1, "only the Namespace object should contribute, not the Pod")
+}
+
+func TestParseSelector_AbsentSelectorMatchesEverything(t *testing.T) {
+	sel, err := parseSelector(nil)
+	require.NoError(t, err)
+	assert.True(t, sel.Empty())
+}
+
+func TestParseSelector_EmptySelectorMatchesEverything(t *testing.T) {
+	sel, err := parseSelector(map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, sel.Empty())
+}
+
+func TestParseSelector_InvalidSelectorReturnsError(t *testing.T) {
+	_, err := parseSelector(map[string]any{
+		"matchExpressions": []any{
+			map[string]any{"key": "env", "operator": "NotARealOperator"},
+		},
+	})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds `vapreconcile.BuildCoverage`: per-resource, binding-scope-aware refinement of the existing `VAPEnforcementStatus.Bound` signal, which currently reports a control as live-enforced based purely on whether *any* binding names its policy, ignoring the binding's `namespaceSelector`/`objectSelector`.

Fixes #3569

## What changed

- **`core/pkg/vapreconcile/coverage.go`** (new): `BuildCoverage(policies, bindings, failingByControl, namespaceLabels)` computes, per control, which of its failing resources actually fall within the scope of a live, bound binding — using the same label-selector semantics the apiserver applies at admission (`metav1.LabelSelectorAsSelector`). Multiple bindings for the same policy are OR'd. A `namespaceSelector` that can't be evaluated (the scan didn't collect the `Namespace` object) is treated as **not covering**, not as matching everything — silently over-crediting coverage would defeat the point. Also adds `CollectFailingResourcesByControl` and `CollectNamespaceLabels`, the two inputs `BuildCoverage` needs from an `OPASessionObj`.
- **`core/cautils/datastructures.go`**: new `OPASessionObj.VAPCoverage map[string]*vapreconcile.ControlCoverage` field, alongside the existing `VAPPolicies`/`VAPBindings`.
- **`core/pkg/resultshandling/results.go`**: computes `VAPCoverage` right after the existing `BuildIndex`/`EnrichSummary` call, before severity filtering narrows the result set.

Kept entirely on the kubescape side rather than extending opa-utils' `VAPEnforcementStatus` struct, to avoid a cross-repo dependency bump for this.

## Scope

`matchResources.resourceRules`/`excludeResourceRules`/`matchPolicy` are **not** evaluated — a binding's scope is assumed to cover every GVR/operation its policy's `matchConstraints` admits. This can overstate coverage for a binding that further narrows GVRs/operations, but never understates it, and `namespaceSelector`/`objectSelector` are by far the more commonly used per-binding scoping mechanism. Documented in `BuildCoverage`'s doc comment.

## Test plan

**Unit tests** (`core/pkg/vapreconcile/coverage_test.go`, 19 new tests): namespace/object selector matching (inclusion and exclusion), absent/empty/invalid selectors, multi-binding OR semantics, cluster-scoped resources, unknown-namespace handling (not silently treated as a match), and the `ControlCoverage` summary methods (`FullyCovered`/`PartiallyCovered`/nil-receiver safety).

**Wiring test** (`core/pkg/resultshandling/results_test.go`): `TestHandleResults_ComputesVAPCoverage` runs the real `HandleResults` path end to end with a namespace-scoped binding and confirms `VAPCoverage` comes out correctly while the existing `VAPEnforcement` signal is untouched.

**Real cluster verification** (not just mocks) — `kind`, Kubernetes 1.30, real VAP v1 API:
- Two namespaces, `prod` (`env=prod`) / `dev` (`env=dev`), each with a privileged pod failing `C-0057`.
- A real `ValidatingAdmissionPolicy` + `ValidatingAdmissionPolicyBinding` (`namespaceSelector: {matchLabels: {env: prod}}`).
- `kubescape scan framework nsa --include-namespaces prod,dev --include-controls C-0057 --kube-context kind-kind` produced:
```
C-0057 (Bound: true)
  /v1/dev/Pod/bad-pod  -> Covered: false (namespaceSelector does not match the resource's namespace)
  /v1/prod/Pod/bad-pod -> Covered: true
```
Exactly the gap this PR fixes: the existing coarse `Bound: true` signal would have implied full enforcement; `VAPCoverage` correctly flags the `dev` failure as unenforced.

Full suite:
- `go build ./...`, `go vet ./...` — clean
- `go test -race ./core/pkg/vapreconcile/... ./core/pkg/resultshandling ./core/cautils/...` — clean
- `go test ./...` (full repo) — clean
- `golangci-lint run --new-from-rev=upstream/master ./core/pkg/vapreconcile/... ./core/pkg/resultshandling/... ./core/cautils/...` — 0 issues
- `gofmt -l` on changed files — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more precise reporting for policy coverage at the individual resource level.
  * Coverage now accounts for namespace and object selectors, multiple bindings, and partial enforcement.
  * Controls can be identified as fully covered, partially covered, or not covered based on failing resources.

* **Bug Fixes**
  * Improved accuracy when determining whether failing resources fall within an enforced policy scope.
  * Invalid selectors and missing namespace data are handled conservatively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->