### PR TITLE
feat(scan): add Slack webhook notifications

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -228,7 +228,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
-	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.NotifyURLs, "notify", nil, "POST the scan summary as JSON to this webhook URL; repeat for multiple destinations")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.NotifyURLs, "notify", nil, "POST the scan summary to this webhook URL; Slack incoming webhooks use Block Kit; repeat for multiple destinations")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ShowEvidence, "show-evidence", "E", false, "Show evidence paths with current field values for each failed control (pretty-printer only)")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.ShowSecrets, "show-secrets", false, "Show secret field values in evidence output. By default secret values are redacted. Only effective with --show-evidence")

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -130,7 +130,7 @@ type ScanInfo struct {
 	View                      string                       //
 	Format                    string                       // Format results (table, json, junit ...)
 	Output                    string                       // Store results in an output file, Output file name
-	NotifyURLs                []string                     // Generic webhook destinations that receive the posture summary JSON
+	NotifyURLs                []string                     // Webhook destinations that receive a formatted posture summary
 	FormatVersion             string                       // Output object can be different between versions, this is for testing and backward compatibility
 	CustomClusterName         string                       // Set the custom name of the cluster
 	ExcludedNamespaces        string                       // used for host scanner namespace

--- a/core/pkg/resultshandling/notification/notification.go
+++ b/core/pkg/resultshandling/notification/notification.go
@@ -1,4 +1,4 @@
-// Package notification delivers generic scan summary webhooks.
+// Package notification delivers scan summaries to supported webhook targets.
 package notification
 
 import (

--- a/core/pkg/resultshandling/notification/payload.go
+++ b/core/pkg/resultshandling/notification/payload.go
@@ -1,0 +1,159 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+const maxSlackFailingControls = 10
+
+type slackPayload struct {
+	Text   string       `json:"text"`
+	Blocks []slackBlock `json:"blocks"`
+}
+
+type slackBlock struct {
+	Type   string      `json:"type"`
+	Text   *slackText  `json:"text,omitempty"`
+	Fields []slackText `json:"fields,omitempty"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// IsSlackEndpoint reports whether endpoint is an official Slack or GovSlack
+// incoming webhook URL. Matching the exact hostname avoids treating lookalike
+// domains as Slack destinations.
+func IsSlackEndpoint(endpoint string) bool {
+	u, err := validateEndpoint(endpoint)
+	if err != nil || !strings.EqualFold(u.Scheme, "https") {
+		return false
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "hooks.slack.com", "hooks.slack-gov.com":
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalPayload formats summary for endpoint. Slack incoming webhooks receive
+// a compact Block Kit message; every other endpoint receives the existing
+// generic SummaryDetails JSON object.
+func MarshalPayload(endpoint string, summary *reportsummary.SummaryDetails) ([]byte, error) {
+	if summary == nil {
+		return nil, fmt.Errorf("marshal notification payload: summary is nil")
+	}
+	if IsSlackEndpoint(endpoint) {
+		return json.Marshal(newSlackPayload(summary))
+	}
+	return json.Marshal(summary)
+}
+
+func newSlackPayload(summary *reportsummary.SummaryDetails) slackPayload {
+	controls := summarizeControls(summary.Controls)
+	fallback := fmt.Sprintf(
+		"Kubescape scan completed: %.1f%% compliance; %d of %d controls failed.",
+		summary.ComplianceScore,
+		controls.failed,
+		controls.total,
+	)
+
+	payload := slackPayload{
+		Text: fallback,
+		Blocks: []slackBlock{
+			{
+				Type: "header",
+				Text: &slackText{Type: "plain_text", Text: "Kubescape scan results"},
+			},
+			{
+				Type: "section",
+				Fields: []slackText{
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Controls*\n%d failed / %d total\n%d passed · %d skipped", controls.failed, controls.total, controls.passed, controls.skipped)},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Compliance score*\n%.1f%%", summary.ComplianceScore)},
+				},
+			},
+		},
+	}
+	if len(controls.topFailing) > 0 {
+		lines := make([]string, 0, len(controls.topFailing)+1)
+		lines = append(lines, "*Top failing controls*")
+		for _, control := range controls.topFailing {
+			id := control.ControlID
+			if id == "" {
+				id = "unknown"
+			}
+			name := control.Name
+			if name == "" {
+				name = "Unnamed control"
+			}
+			lines = append(lines, fmt.Sprintf(
+				"• *%s* · `%s` — %s",
+				escapeSlackText(apis.ControlSeverityToString(control.ScoreFactor)),
+				escapeSlackText(id),
+				escapeSlackText(name),
+			))
+		}
+		payload.Blocks = append(payload.Blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{Type: "mrkdwn", Text: strings.Join(lines, "\n")},
+		})
+	}
+	return payload
+}
+
+type controlSummary struct {
+	total      int
+	failed     int
+	passed     int
+	skipped    int
+	topFailing []reportsummary.ControlSummary
+}
+
+func summarizeControls(controls reportsummary.ControlSummaries) controlSummary {
+	result := controlSummary{total: len(controls)}
+	for key, control := range controls {
+		if control.ControlID == "" {
+			control.ControlID = key
+		}
+		switch control.GetStatus().Status() {
+		case apis.StatusFailed:
+			result.failed++
+			result.topFailing = append(result.topFailing, control)
+		case apis.StatusPassed:
+			result.passed++
+		case apis.StatusSkipped:
+			result.skipped++
+		}
+	}
+	sort.Slice(result.topFailing, func(i, j int) bool {
+		left, right := result.topFailing[i], result.topFailing[j]
+		leftSeverity := apis.ControlSeverityToInt(left.ScoreFactor)
+		rightSeverity := apis.ControlSeverityToInt(right.ScoreFactor)
+		if leftSeverity != rightSeverity {
+			return leftSeverity > rightSeverity
+		}
+		if left.StatusCounters.FailedResources != right.StatusCounters.FailedResources {
+			return left.StatusCounters.FailedResources > right.StatusCounters.FailedResources
+		}
+		if left.ControlID != right.ControlID {
+			return left.ControlID < right.ControlID
+		}
+		return left.Name < right.Name
+	})
+	if len(result.topFailing) > maxSlackFailingControls {
+		result.topFailing = result.topFailing[:maxSlackFailingControls]
+	}
+	return result
+}
+
+func escapeSlackText(value string) string {
+	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
+}

--- a/core/pkg/resultshandling/notification/payload.go
+++ b/core/pkg/resultshandling/notification/payload.go
@@ -5,12 +5,20 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
-const maxSlackFailingControls = 10
+const (
+	maxSlackFailingControls     = 10
+	maxSlackSectionTextLength   = 3000
+	maxSlackControlIDTextLength = 80
+	slackTopControlsHeading     = "*Top failing controls*"
+)
+
+var slackTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
 
 type slackPayload struct {
 	Text   string       `json:"text"`
@@ -24,8 +32,9 @@ type slackBlock struct {
 }
 
 type slackText struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Verbatim bool   `json:"verbatim,omitempty"`
 }
 
 // IsSlackEndpoint reports whether endpoint is an official Slack or GovSlack
@@ -76,34 +85,21 @@ func newSlackPayload(summary *reportsummary.SummaryDetails) slackPayload {
 			{
 				Type: "section",
 				Fields: []slackText{
-					{Type: "mrkdwn", Text: fmt.Sprintf("*Controls*\n%d failed / %d total\n%d passed · %d skipped", controls.failed, controls.total, controls.passed, controls.skipped)},
-					{Type: "mrkdwn", Text: fmt.Sprintf("*Compliance score*\n%.1f%%", summary.ComplianceScore)},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Controls*\n%d failed / %d total\n%d passed · %d skipped", controls.failed, controls.total, controls.passed, controls.skipped), Verbatim: true},
+					{Type: "mrkdwn", Text: fmt.Sprintf("*Compliance score*\n%.1f%%", summary.ComplianceScore), Verbatim: true},
 				},
 			},
 		},
 	}
 	if len(controls.topFailing) > 0 {
 		lines := make([]string, 0, len(controls.topFailing)+1)
-		lines = append(lines, "*Top failing controls*")
+		lines = append(lines, slackTopControlsHeading)
 		for _, control := range controls.topFailing {
-			id := control.ControlID
-			if id == "" {
-				id = "unknown"
-			}
-			name := control.Name
-			if name == "" {
-				name = "Unnamed control"
-			}
-			lines = append(lines, fmt.Sprintf(
-				"• *%s* · `%s` — %s",
-				escapeSlackText(apis.ControlSeverityToString(control.ScoreFactor)),
-				escapeSlackText(id),
-				escapeSlackText(name),
-			))
+			lines = append(lines, slackControlLine(control))
 		}
 		payload.Blocks = append(payload.Blocks, slackBlock{
 			Type: "section",
-			Text: &slackText{Type: "mrkdwn", Text: strings.Join(lines, "\n")},
+			Text: &slackText{Type: "mrkdwn", Text: strings.Join(lines, "\n"), Verbatim: true},
 		})
 	}
 	return payload
@@ -155,5 +151,60 @@ func summarizeControls(controls reportsummary.ControlSummaries) controlSummary {
 }
 
 func escapeSlackText(value string) string {
-	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
+	return slackTextEscaper.Replace(value)
+}
+
+func slackControlLine(control reportsummary.ControlSummary) string {
+	id := control.ControlID
+	if id == "" {
+		id = "unknown"
+	}
+	name := control.Name
+	if name == "" {
+		name = "Unnamed control"
+	}
+
+	severity := escapeSlackText(apis.ControlSeverityToString(control.ScoreFactor))
+	prefix := fmt.Sprintf("• *%s* · `", severity)
+	separator := "` — "
+	lineLength := maxSlackControlLineLength()
+	idBudget := min(maxSlackControlIDTextLength, lineLength-utf8.RuneCountInString(prefix+separator)-1)
+	renderedID := escapeAndTruncateSlackText(id, idBudget)
+	nameBudget := lineLength - utf8.RuneCountInString(prefix+renderedID+separator)
+	renderedName := escapeAndTruncateSlackText(name, nameBudget)
+	return prefix + renderedID + separator + renderedName
+}
+
+func maxSlackControlLineLength() int {
+	// Reserve one newline for each possible entry. Bounding every line to the
+	// remaining equal share guarantees the complete section stays within Slack's
+	// 3,000-character section text limit even when all ten entries are present.
+	return (maxSlackSectionTextLength - utf8.RuneCountInString(slackTopControlsHeading) - maxSlackFailingControls) / maxSlackFailingControls
+}
+
+func escapeAndTruncateSlackText(value string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	escaped := escapeSlackText(value)
+	if utf8.RuneCountInString(escaped) <= maxLength {
+		return escaped
+	}
+	if maxLength == 1 {
+		return "…"
+	}
+
+	var result strings.Builder
+	used := 0
+	for _, r := range value {
+		piece := escapeSlackText(string(r))
+		pieceLength := utf8.RuneCountInString(piece)
+		if used+pieceLength > maxLength-1 {
+			break
+		}
+		result.WriteString(piece)
+		used += pieceLength
+	}
+	result.WriteRune('…')
+	return result.String()
 }

--- a/core/pkg/resultshandling/notification/payload_test.go
+++ b/core/pkg/resultshandling/notification/payload_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -54,7 +55,7 @@ func TestMarshalPayloadBuildsDeterministicSlackBlockKit(t *testing.T) {
 		Controls: reportsummary.ControlSummaries{
 			"C-CRITICAL": failedControl("C-CRITICAL", "Critical <control>", 9.5, 1),
 			"C-HIGH-C":   failedControl("C-HIGH-C", "High with most failures", 8, 4),
-			"C-HIGH-B":   failedControl("C-HIGH-B", "High & beta", 8, 2),
+			"C-HIGH-B":   failedControl("C-HIGH-B", "High @channel & beta", 8, 2),
 			"C-HIGH-A":   failedControl("C-HIGH-A", "High alpha", 7, 2),
 			"C-MEDIUM":   failedControl("C-MEDIUM", "Medium", 5, 10),
 			"C-LOW":      failedControl("C-LOW", "Low control", 2, 20),
@@ -84,16 +85,17 @@ func TestMarshalPayloadBuildsDeterministicSlackBlockKit(t *testing.T) {
 		Text: &slackText{Type: "plain_text", Text: "Kubescape scan results"},
 	}, got.Blocks[0])
 	assert.Equal(t, []slackText{
-		{Type: "mrkdwn", Text: "*Controls*\n7 failed / 9 total\n1 passed · 1 skipped"},
-		{Type: "mrkdwn", Text: "*Compliance score*\n73.2%"},
+		{Type: "mrkdwn", Text: "*Controls*\n7 failed / 9 total\n1 passed · 1 skipped", Verbatim: true},
+		{Type: "mrkdwn", Text: "*Compliance score*\n73.2%", Verbatim: true},
 	}, got.Blocks[1].Fields)
 	require.NotNil(t, got.Blocks[2].Text)
 	assert.Equal(t, "mrkdwn", got.Blocks[2].Text.Type)
+	assert.True(t, got.Blocks[2].Text.Verbatim)
 	assert.Equal(t, "*Top failing controls*\n"+
 		"• *Critical* · `C-CRITICAL` — Critical &lt;control&gt;\n"+
 		"• *High* · `C-HIGH-C` — High with most failures\n"+
 		"• *High* · `C-HIGH-A` — High alpha\n"+
-		"• *High* · `C-HIGH-B` — High &amp; beta\n"+
+		"• *High* · `C-HIGH-B` — High @channel &amp; beta\n"+
 		"• *Medium* · `C-MEDIUM` — Medium\n"+
 		"• *Low* · `C-LOW` — Low control\n"+
 		"• *Unknown* · `C-UNKNOWN` — Unknown control", got.Blocks[2].Text.Text)
@@ -115,6 +117,32 @@ func TestMarshalPayloadLimitsSlackMessageToTopTenFailingControls(t *testing.T) {
 	assert.Equal(t, maxSlackFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
 	assert.Contains(t, got.Blocks[2].Text.Text, "C-09")
 	assert.NotContains(t, got.Blocks[2].Text.Text, "C-10")
+}
+
+func TestMarshalPayloadBoundsLongSlackControlNames(t *testing.T) {
+	controls := make(reportsummary.ControlSummaries, maxSlackFailingControls)
+	for i := 0; i < maxSlackFailingControls; i++ {
+		id := fmt.Sprintf("C-%02d-%s", i, strings.Repeat("<", 500))
+		controls[id] = failedControl(id, strings.Repeat("@channel <&>", 500), 7, 1)
+	}
+
+	raw, err := MarshalPayload("https://hooks.slack.com/services/T000/B000/secret", &reportsummary.SummaryDetails{Controls: controls})
+	require.NoError(t, err)
+	var got slackPayload
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Len(t, got.Blocks, 3)
+	require.NotNil(t, got.Blocks[2].Text)
+	assert.True(t, got.Blocks[2].Text.Verbatim)
+	assert.LessOrEqual(t, utf8.RuneCountInString(got.Blocks[2].Text.Text), maxSlackSectionTextLength)
+	assert.Equal(t, maxSlackFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
+	assert.Contains(t, got.Blocks[2].Text.Text, "@channel")
+	assert.NotContains(t, got.Blocks[2].Text.Text, "&am…")
+	assert.NotContains(t, got.Blocks[2].Text.Text, "&l…")
+}
+
+func TestEscapeAndTruncateSlackTextKeepsEntitiesIntact(t *testing.T) {
+	assert.Equal(t, "&amp;…", escapeAndTruncateSlackText("&&", 6))
+	assert.Equal(t, "&lt;…", escapeAndTruncateSlackText("<<", 5))
 }
 
 func TestMarshalPayloadSlackOmitsFailingSectionWhenAllControlsPass(t *testing.T) {

--- a/core/pkg/resultshandling/notification/payload_test.go
+++ b/core/pkg/resultshandling/notification/payload_test.go
@@ -1,0 +1,151 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSlackEndpoint(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://hooks.slack.com/services/T000/B000/secret",
+		"https://hooks.slack-gov.com/services/T000/B000/secret",
+		"https://HOOKS.SLACK.COM/services/T000/B000/secret",
+	} {
+		assert.True(t, IsSlackEndpoint(endpoint), endpoint)
+	}
+
+	for _, endpoint := range []string{
+		"http://hooks.slack.com/services/T000/B000/secret",
+		"https://user:secret@hooks.slack.com/services/T000/B000/secret",
+		"https://hooks.slack.com/services/T000/B000/secret#fragment",
+		"https://hooks.slack.com.example.com/services/T000/B000/secret",
+		"https://example.com/hooks.slack.com",
+		"not a URL",
+	} {
+		assert.False(t, IsSlackEndpoint(endpoint), endpoint)
+	}
+}
+
+func TestMarshalPayloadKeepsGenericSummaryJSON(t *testing.T) {
+	summary := &reportsummary.SummaryDetails{
+		ComplianceScore: 82.5,
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": {ControlID: "C-0001", Name: "Generic webhook control"},
+		},
+	}
+
+	got, err := MarshalPayload("https://example.com/webhook", summary)
+	require.NoError(t, err)
+	want, err := json.Marshal(summary)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(want), string(got))
+}
+
+func TestMarshalPayloadBuildsDeterministicSlackBlockKit(t *testing.T) {
+	summary := &reportsummary.SummaryDetails{
+		ComplianceScore: 73.25,
+		Controls: reportsummary.ControlSummaries{
+			"C-CRITICAL": failedControl("C-CRITICAL", "Critical <control>", 9.5, 1),
+			"C-HIGH-C":   failedControl("C-HIGH-C", "High with most failures", 8, 4),
+			"C-HIGH-B":   failedControl("C-HIGH-B", "High & beta", 8, 2),
+			"C-HIGH-A":   failedControl("C-HIGH-A", "High alpha", 7, 2),
+			"C-MEDIUM":   failedControl("C-MEDIUM", "Medium", 5, 10),
+			"C-LOW":      failedControl("C-LOW", "Low control", 2, 20),
+			"C-UNKNOWN":  failedControl("C-UNKNOWN", "Unknown control", 0, 30),
+			"C-PASSED": {
+				ControlID: "C-PASSED",
+				Name:      "Passed",
+				Status:    apis.StatusPassed,
+			},
+			"C-SKIPPED": {
+				ControlID: "C-SKIPPED",
+				Name:      "Skipped",
+				Status:    apis.StatusSkipped,
+			},
+		},
+	}
+
+	raw, err := MarshalPayload("https://hooks.slack.com/services/T000/B000/secret", summary)
+	require.NoError(t, err)
+
+	var got slackPayload
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, "Kubescape scan completed: 73.2% compliance; 7 of 9 controls failed.", got.Text)
+	require.Len(t, got.Blocks, 3)
+	assert.Equal(t, slackBlock{
+		Type: "header",
+		Text: &slackText{Type: "plain_text", Text: "Kubescape scan results"},
+	}, got.Blocks[0])
+	assert.Equal(t, []slackText{
+		{Type: "mrkdwn", Text: "*Controls*\n7 failed / 9 total\n1 passed · 1 skipped"},
+		{Type: "mrkdwn", Text: "*Compliance score*\n73.2%"},
+	}, got.Blocks[1].Fields)
+	require.NotNil(t, got.Blocks[2].Text)
+	assert.Equal(t, "mrkdwn", got.Blocks[2].Text.Type)
+	assert.Equal(t, "*Top failing controls*\n"+
+		"• *Critical* · `C-CRITICAL` — Critical &lt;control&gt;\n"+
+		"• *High* · `C-HIGH-C` — High with most failures\n"+
+		"• *High* · `C-HIGH-A` — High alpha\n"+
+		"• *High* · `C-HIGH-B` — High &amp; beta\n"+
+		"• *Medium* · `C-MEDIUM` — Medium\n"+
+		"• *Low* · `C-LOW` — Low control\n"+
+		"• *Unknown* · `C-UNKNOWN` — Unknown control", got.Blocks[2].Text.Text)
+}
+
+func TestMarshalPayloadLimitsSlackMessageToTopTenFailingControls(t *testing.T) {
+	controls := make(reportsummary.ControlSummaries, maxSlackFailingControls+1)
+	for i := 0; i <= maxSlackFailingControls; i++ {
+		id := fmt.Sprintf("C-%02d", i)
+		controls[id] = failedControl(id, "Failed control", 7, 1)
+	}
+
+	raw, err := MarshalPayload("https://hooks.slack.com/services/T000/B000/secret", &reportsummary.SummaryDetails{Controls: controls})
+	require.NoError(t, err)
+	var got slackPayload
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Len(t, got.Blocks, 3)
+	require.NotNil(t, got.Blocks[2].Text)
+	assert.Equal(t, maxSlackFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
+	assert.Contains(t, got.Blocks[2].Text.Text, "C-09")
+	assert.NotContains(t, got.Blocks[2].Text.Text, "C-10")
+}
+
+func TestMarshalPayloadSlackOmitsFailingSectionWhenAllControlsPass(t *testing.T) {
+	summary := &reportsummary.SummaryDetails{
+		ComplianceScore: 100,
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": {ControlID: "C-0001", Status: apis.StatusPassed},
+		},
+	}
+
+	raw, err := MarshalPayload("https://hooks.slack-gov.com/services/T000/B000/secret", summary)
+	require.NoError(t, err)
+	var got slackPayload
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Len(t, got.Blocks, 2)
+	assert.Contains(t, got.Text, "0 of 1 controls failed")
+}
+
+func TestMarshalPayloadRejectsNilSummary(t *testing.T) {
+	_, err := MarshalPayload("https://example.com/webhook", nil)
+	require.EqualError(t, err, "marshal notification payload: summary is nil")
+}
+
+func failedControl(id, name string, score float32, failedResources int) reportsummary.ControlSummary {
+	return reportsummary.ControlSummary{
+		ControlID:   id,
+		Name:        name,
+		Status:      apis.StatusFailed,
+		ScoreFactor: score,
+		StatusCounters: reportsummary.StatusCounters{
+			FailedResources: failedResources,
+		},
+	}
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -319,18 +319,18 @@ func (rh *ResultsHandler) HandleResults(ctx context.Context, scanInfo *cautils.S
 	// best-effort: a notification endpoint must never alter scan results or exit
 	// status.
 	if len(scanInfo.NotifyURLs) > 0 && rh.ScanData != nil && rh.ScanData.Report != nil {
-		payload, err := json.Marshal(rh.ScanData.Report.SummaryDetails)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("Failed to marshal scan summary for notification", helpers.Error(err))
-		} else {
-			client := notification.NewClient(notification.DefaultTimeout)
-			for _, endpoint := range scanInfo.NotifyURLs {
-				requestCtx, cancel := context.WithTimeout(ctx, notification.DefaultTimeout)
-				err := notification.Send(requestCtx, client, endpoint, payload)
-				cancel()
-				if err != nil {
-					logger.L().Ctx(ctx).Warning("Failed to deliver scan notification", helpers.String("target", notification.SafeTarget(endpoint)), helpers.Error(err))
-				}
+		client := notification.NewClient(notification.DefaultTimeout)
+		for _, endpoint := range scanInfo.NotifyURLs {
+			payload, err := notification.MarshalPayload(endpoint, &rh.ScanData.Report.SummaryDetails)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("Failed to marshal scan summary for notification", helpers.String("target", notification.SafeTarget(endpoint)), helpers.Error(err))
+				continue
+			}
+			requestCtx, cancel := context.WithTimeout(ctx, notification.DefaultTimeout)
+			sendErr := notification.Send(requestCtx, client, endpoint, payload)
+			cancel()
+			if sendErr != nil {
+				logger.L().Ctx(ctx).Warning("Failed to deliver scan notification", helpers.String("target", notification.SafeTarget(endpoint)), helpers.Error(sendErr))
 			}
 		}
 	}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,7 +52,7 @@ kubescape scan [target] [flags]
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
 | `--label-selector <selector>` | Filter collected resources by Kubernetes label selector. Accepts any expression `kubectl -l` supports, e.g. `app=nginx,env!=dev` or `env in (prod,staging)`. Syntax is validated before scanning begins; filtering is applied during live cluster collection and ignored when scanning local files. | - |
 | `--keep-local` | Don't report results to backend | `false` |
-| `--notify <url>` | POST the posture scan's JSON summary to a trusted generic webhook URL. Repeat the flag for multiple endpoints. Delivery is best-effort and does not affect scan exit status. Not supported by `scan image`. | - |
+| `--notify <url>` | POST the posture scan summary to a webhook URL. Slack incoming webhooks receive Block Kit; other destinations receive generic JSON. Repeat for multiple endpoints. Delivery is best-effort and does not affect scan exit status. Not supported by `scan image`. | - |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
 | `--otel-endpoint <endpoint>` | Export scan traces and metrics to an OTLP collector — see [OpenTelemetry export](#opentelemetry-export). Accepts `host:port` (plaintext) or a `http(s)://` URL. | `OTEL_EXPORTER_OTLP_ENDPOINT` |
@@ -66,18 +66,48 @@ kubescape scan [target] [flags]
 | `-v, --verbose` | Display all resources, not just failed ones | `false` |
 | `--view <type>` | View type: `security`, `control`, `resource` | `security` |
 
-### Generic webhook notifications
+### Webhook notifications
 
-Use `--notify` to POST the existing JSON `summaryDetails` object after a posture scan:
+Use `--notify` to send a compact summary after a posture scan. Official Slack and GovSlack incoming webhook URLs receive a Block Kit message; every other URL receives the existing JSON `summaryDetails` object:
 
 ```bash
+export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/T00000000/B00000000/SECRET'
+kubescape scan manifests/ --notify "$SLACK_WEBHOOK_URL"
 kubescape scan manifests/ --notify https://hooks.example.com/kubescape
 kubescape scan manifests/ --notify https://ops.example.com/kubescape --notify https://audit.example.com/kubescape
 ```
 
 Each destination gets one synchronous request with `Content-Type: application/json`; Kubescape allows up to five seconds per destination and does not follow redirects. Failures are logged as warnings and never override the scan's own exit status. The payload follows `--min-severity` and `--max-severity` output filtering. `--severity-threshold` continues to affect only the exit status.
 
-The summary may contain resource identifiers in control summaries. Use `--hide` where appropriate and send only to trusted webhook endpoints. Slack Block Kit and Microsoft Teams Adaptive Card formatting are not included in this generic phase.
+Slack messages contain the compliance score, passed/failed/skipped control counts, and up to ten failing controls ordered by severity, failed resource count, and control ID. The top-level `text` field provides a notification and accessibility fallback. For example:
+
+```json
+{
+  "text": "Kubescape scan completed: 73.2% compliance; 2 of 8 controls failed.",
+  "blocks": [
+    {"type": "header", "text": {"type": "plain_text", "text": "Kubescape scan results"}},
+    {"type": "section", "fields": [
+      {"type": "mrkdwn", "text": "*Controls*\n2 failed / 8 total\n5 passed · 1 skipped"},
+      {"type": "mrkdwn", "text": "*Compliance score*\n73.2%"}
+    ]},
+    {"type": "section", "text": {"type": "mrkdwn", "text": "*Top failing controls*\n• *Critical* · `C-0001` — Privileged container"}}
+  ]
+}
+```
+
+Generic destinations continue to receive only the scan summary. An abridged example is:
+
+```json
+{
+  "status": "failed",
+  "frameworks": [],
+  "ResourceCounters": {"passedResources": 5, "failedResources": 2, "skippedResources": 1, "excludedResources": 0},
+  "score": 73.2,
+  "complianceScore": 73.2
+}
+```
+
+The summary and Slack control names may contain identifiers from the scan. Use `--hide` where appropriate and send only to trusted webhook endpoints. A Slack webhook URL is itself a secret; keep it out of source control and prefer passing it through an environment variable. Microsoft Teams Adaptive Card formatting is not currently included.
 
 ### Custom rules
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,10 +87,10 @@ Slack messages contain the compliance score, passed/failed/skipped control count
   "blocks": [
     {"type": "header", "text": {"type": "plain_text", "text": "Kubescape scan results"}},
     {"type": "section", "fields": [
-      {"type": "mrkdwn", "text": "*Controls*\n2 failed / 8 total\n5 passed · 1 skipped"},
-      {"type": "mrkdwn", "text": "*Compliance score*\n73.2%"}
+      {"type": "mrkdwn", "text": "*Controls*\n2 failed / 8 total\n5 passed · 1 skipped", "verbatim": true},
+      {"type": "mrkdwn", "text": "*Compliance score*\n73.2%", "verbatim": true}
     ]},
-    {"type": "section", "text": {"type": "mrkdwn", "text": "*Top failing controls*\n• *Critical* · `C-0001` — Privileged container"}}
+    {"type": "section", "text": {"type": "mrkdwn", "text": "*Top failing controls*\n• *Critical* · `C-0001` — Privileged container", "verbatim": true}}
   ]
 }
 ```


### PR DESCRIPTION
## Summary

- detect official Slack and GovSlack incoming webhook URLs and format scan summaries with Block Kit
- show control counts before compliance score and include the top 10 failing controls
- rank failing controls by severity, failed resource count, then control ID
- preserve the existing full `SummaryDetails` JSON payload for generic webhook destinations
- document Slack setup, payload shape, secret handling, and generic fallback

This is phase 2 of #3401. Microsoft Teams formatting is intentionally out of scope.

## Security and reliability

- require HTTPS and exact Slack/GovSlack hostnames to avoid lookalike-domain detection
- reuse the existing five-second timeout, no-redirect client, bounded response reads, and no retries
- redact webhook path/query secrets from errors and logs
- keep notification delivery best-effort so failures never change the scan exit code

## Testing

- `go test ./core/pkg/resultshandling/... ./cmd/scan/...`
- `go vet ./core/pkg/resultshandling/notification ./core/pkg/resultshandling ./cmd/scan`
- `go test -race ./core/pkg/resultshandling/notification`
- manual end-to-end scan against a Slack incoming webhook; Block Kit rendered successfully and the scan exited 0

Refs #3401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack and GovSlack notifications now use readable Block Kit summaries with compliance scores, control counts, and top failing controls.
  * Other webhook destinations continue receiving summary JSON payloads.
  * Notification formatting is handled per destination, allowing other notifications to proceed if one payload cannot be generated.

* **Documentation**
  * Expanded notification documentation with payload formats, delivery behavior, filtering, ordering, timeouts, and failure handling.
  * Clarified Slack webhook formatting in command help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->