### PR TITLE
feat(markdown): support image scan reports

### DIFF
--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -119,7 +119,7 @@ func TestGetImageCmd_RunE_FormatFlagInvalid(t *testing.T) {
 	assert.NoError(t, parent.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"nginx"})
-	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, cyclonedx-json, spdx-json`)
+	assert.EqualError(t, err, `invalid format "xml", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, markdown, cyclonedx-json, spdx-json`)
 }
 
 func TestGetImageCmd_RunE_Success(t *testing.T) {

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -42,7 +42,7 @@ var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, Prometheu
 //
 // CycloneDXFormat and SPDXFormat are the inverse: they encode the SBOM that
 // only exists on image scans, so they are image-scan-only (see ValidatePrinter).
-var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CycloneDXFormat, SPDXFormat}
+var ImageFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat}
 
 const (
 	JsonOutputExt         = ".json"

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -7,11 +7,15 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
+	v5 "github.com/anchore/grype/grype/db/v5"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	tableutils "github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
@@ -51,6 +55,14 @@ func (mp *MarkdownPrinter) Score(score float32) {
 }
 
 func (mp *MarkdownPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	if opaSessionObj == nil && len(imageScanData) > 0 {
+		if err := mdWriteImageScanReport(mp.writer, imageScanData); err != nil {
+			return err
+		}
+		printer.LogOutputFile(mp.writer.Name())
+		return nil
+	}
+
 	if opaSessionObj == nil || opaSessionObj.Report == nil {
 		logger.L().Ctx(ctx).Error("no data provided for markdown output")
 		return nil
@@ -211,6 +223,201 @@ func mdWriteFailedSection(ctx context.Context, w io.Writer, controls []reportsum
 	return ew.err
 }
 
+func mdWriteImageScanReport(w io.Writer, imageScanData []cautils.ImageScanData) error {
+	summary := buildImageScanSummary(imageScanData)
+	ew := &mdErrWriter{w: w}
+
+	ew.printf("# Kubescape Image Scan Report\n\n")
+	if len(summary.Images) == 1 {
+		ew.printf("**Image:** `%s`\n\n", mdEscapeInline(summary.Images[0]))
+	} else {
+		ew.printf("**Images:** %d\n\n", len(summary.Images))
+	}
+	if summary.VulnDBBuilt != nil {
+		ew.printf("**Vulnerability DB Built:** %s\n\n", summary.VulnDBBuilt.UTC().Format(time.RFC3339))
+	}
+	if ew.err != nil {
+		return ew.err
+	}
+
+	if err := mdWriteImageTargets(w, summary.Images); err != nil {
+		return err
+	}
+	if err := mdWriteImageSeveritySummary(w, summary.MapsSeverityToSummary); err != nil {
+		return err
+	}
+	if err := mdWriteImagePackageSummary(w, summary.PackageScores); err != nil {
+		return err
+	}
+	return mdWriteImageVulnerabilities(w, summary.CVEs)
+}
+
+func mdWriteImageTargets(w io.Writer, images []string) error {
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Images\n\n")
+	if len(images) == 0 {
+		ew.printf("No image targets were scanned.\n\n")
+		return ew.err
+	}
+
+	ew.printf("| Image |\n")
+	ew.printf("|---|\n")
+	for _, image := range images {
+		ew.printf("| `%s` |\n", mdEscapeCell(image))
+	}
+	ew.printf("\n")
+	return ew.err
+}
+
+func mdWriteImageSeveritySummary(w io.Writer, severities map[string]*imageprinter.SeveritySummary) error {
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Vulnerability Summary\n\n")
+	ew.printf("| Severity | CVEs | Fixable |\n")
+	ew.printf("|---|---:|---:|\n")
+
+	totalCVEs := 0
+	totalFixable := 0
+	for _, severity := range mdImageSeverityOrder(severities) {
+		summary := severities[severity]
+		totalCVEs += summary.NumberOfCVEs
+		totalFixable += summary.NumberOfFixableCVEs
+		ew.printf("| %s | %d | %d |\n", mdEscapeCell(severity), summary.NumberOfCVEs, summary.NumberOfFixableCVEs)
+	}
+	ew.printf("| **Total** | **%d** | **%d** |\n\n", totalCVEs, totalFixable)
+	return ew.err
+}
+
+func mdWriteImagePackageSummary(w io.Writer, packages map[string]*imageprinter.PackageScore) error {
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Affected Packages\n\n")
+	if len(packages) == 0 {
+		ew.printf("No affected packages were found.\n\n")
+		return ew.err
+	}
+
+	ew.printf("| Package | Version | Score | Critical | High | Medium | Low | Unknown |\n")
+	ew.printf("|---|---|---:|---:|---:|---:|---:|---:|\n")
+	for _, pkg := range mdSortedImagePackages(packages) {
+		ew.printf("| %s | %s | %d | %d | %d | %d | %d | %d |\n",
+			mdEscapeCell(pkg.Name),
+			mdEscapeCell(pkg.Version),
+			pkg.Score,
+			pkg.MapSeverityToCVEsNumber["Critical"],
+			pkg.MapSeverityToCVEsNumber["High"],
+			pkg.MapSeverityToCVEsNumber["Medium"],
+			pkg.MapSeverityToCVEsNumber["Low"],
+			mdUnknownSeverityCount(pkg.MapSeverityToCVEsNumber),
+		)
+	}
+	ew.printf("\n")
+	return ew.err
+}
+
+func mdWriteImageVulnerabilities(w io.Writer, cves []imageprinter.CVE) error {
+	ew := &mdErrWriter{w: w}
+	ew.printf("## Vulnerabilities\n\n")
+	if len(cves) == 0 {
+		ew.printf("No vulnerabilities were found.\n")
+		return ew.err
+	}
+
+	ew.printf("| Severity | Vulnerability | Package | Version | Fixed In | Image |\n")
+	ew.printf("|---|---|---|---|---|---|\n")
+	for _, cve := range mdSortedImageCVEs(cves) {
+		ew.printf("| %s | %s | %s | %s | %s | `%s` |\n",
+			mdEscapeCell(cve.Severity),
+			mdEscapeCell(cve.ID),
+			mdEscapeCell(cve.Package),
+			mdEscapeCell(cve.Version),
+			mdEscapeCell(mdFixedIn(cve)),
+			mdEscapeCell(cve.Image),
+		)
+	}
+	return ew.err
+}
+
+func mdImageSeverityOrder(severities map[string]*imageprinter.SeveritySummary) []string {
+	out := make([]string, 0, len(severities))
+	for severity := range severities {
+		out = append(out, severity)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri := tableutils.ImageSeverityToInt(out[i])
+		rj := tableutils.ImageSeverityToInt(out[j])
+		if ri != rj {
+			return ri > rj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+func mdSortedImagePackages(packages map[string]*imageprinter.PackageScore) []*imageprinter.PackageScore {
+	out := make([]*imageprinter.PackageScore, 0, len(packages))
+	for _, pkg := range packages {
+		out = append(out, pkg)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Version < out[j].Version
+	})
+	return out
+}
+
+func mdSortedImageCVEs(cves []imageprinter.CVE) []imageprinter.CVE {
+	out := append([]imageprinter.CVE(nil), cves...)
+	sort.SliceStable(out, func(i, j int) bool {
+		ri := tableutils.ImageSeverityToInt(out[i].Severity)
+		rj := tableutils.ImageSeverityToInt(out[j].Severity)
+		if ri != rj {
+			return ri > rj
+		}
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		if out[i].Package != out[j].Package {
+			return out[i].Package < out[j].Package
+		}
+		return out[i].Image < out[j].Image
+	})
+	return out
+}
+
+func mdUnknownSeverityCount(counts map[string]int) int {
+	known := map[string]struct{}{
+		"Critical": {},
+		"High":     {},
+		"Medium":   {},
+		"Low":      {},
+	}
+	total := 0
+	for severity, count := range counts {
+		if _, ok := known[severity]; !ok {
+			total += count
+		}
+	}
+	return total
+}
+
+func mdFixedIn(cve imageprinter.CVE) string {
+	switch cve.FixedState {
+	case string(v5.FixedState):
+		if len(cve.FixVersions) == 0 {
+			return "fixed"
+		}
+		return strings.Join(cve.FixVersions, ", ")
+	case string(v5.WontFixState):
+		return cve.FixedState
+	default:
+		return ""
+	}
+}
+
 func mdStatusLabel(status apis.IStatus) string {
 	if status == nil {
 		return "Unknown"
@@ -229,4 +436,8 @@ func mdStatusLabel(status apis.IStatus) string {
 
 func mdEscapeCell(s string) string {
 	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+func mdEscapeInline(s string) string {
+	return strings.ReplaceAll(s, "`", "\\`")
 }

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -6,8 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/anchore/grype/grype/match"
+	grypepkg "github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -98,6 +103,41 @@ func mdRunActionPrint(t *testing.T, session *cautils.OPASessionObj) string {
 	mp := NewMarkdownPrinter()
 	mp.writer = tmp
 	err = mp.ActionPrint(context.TODO(), session, nil)
+	require.NoError(t, err)
+	mp.CloseWriter()
+
+	content, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return string(content)
+}
+
+func mdImageMatch(id, severity, packageName, version string, fixState vulnerability.FixState, fixVersions ...string) match.Match {
+	return match.Match{
+		Vulnerability: vulnerability.Vulnerability{
+			Reference: vulnerability.Reference{ID: id, Namespace: "nvd"},
+			Metadata:  &vulnerability.Metadata{ID: id, Severity: severity},
+			Fix: vulnerability.Fix{
+				Versions: fixVersions,
+				State:    fixState,
+			},
+		},
+		Package: grypepkg.Package{
+			ID:      grypepkg.ID(packageName + "@" + version),
+			Name:    packageName,
+			Version: version,
+		},
+	}
+}
+
+func mdRunImageActionPrint(t *testing.T, imageScanData []cautils.ImageScanData) string {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "kubescape-image-md-*.md")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(tmp.Name()) })
+
+	mp := NewMarkdownPrinter()
+	mp.writer = tmp
+	err = mp.ActionPrint(context.TODO(), nil, imageScanData)
 	require.NoError(t, err)
 	mp.CloseWriter()
 
@@ -438,4 +478,194 @@ func TestMarkdownPrinter_ActionPrint_ResourceNameWithPipe(t *testing.T) {
 	out := mdRunActionPrint(t, session)
 
 	assert.Contains(t, out, "my\\|deployment", "pipe in resource name must be escaped")
+}
+
+func TestMarkdownPrinter_ActionPrint_ImageScanReport(t *testing.T) {
+	imageScanData := mdImageScanDataFixture()
+
+	out := mdRunImageActionPrint(t, imageScanData)
+
+	assert.True(t, strings.HasPrefix(out, "# Kubescape Image Scan Report"))
+	assert.Contains(t, out, "**Images:** 2")
+	assert.Contains(t, out, "**Vulnerability DB Built:** 2026-08-25T10:30:00Z")
+	assert.Contains(t, out, "## Images")
+	assert.Contains(t, out, "`registry.example.com/app:v1 [linux/amd64]`")
+	assert.Contains(t, out, "`registry.example.com/app:v1 [linux/arm64]`")
+
+	assert.Contains(t, out, "## Vulnerability Summary")
+	assert.Contains(t, out, "| Critical | 1 | 1 |")
+	assert.Contains(t, out, "| High | 1 | 0 |")
+	assert.Contains(t, out, "| Medium | 1 | 0 |")
+	assert.Contains(t, out, "| **Total** | **3** | **1** |")
+
+	assert.Contains(t, out, "## Affected Packages")
+	assert.Contains(t, out, "| openssl | 1.0.0 |")
+	assert.Contains(t, out, "| glibc | 2.39 |")
+	assert.Contains(t, out, "| busybox | 1.36.0 |")
+
+	assert.Contains(t, out, "## Vulnerabilities")
+	assert.Contains(t, out, "| Critical | CVE-2026-0001 | openssl | 1.0.0 | 1.0.1, 1.0.2 | `registry.example.com/app:v1 [linux/amd64]` |")
+	assert.Contains(t, out, "| High | CVE-2026-0003 | glibc | 2.39 | wont-fix | `registry.example.com/app:v1 [linux/arm64]` |")
+	assert.Contains(t, out, "| Medium | CVE-2026-0002 | busybox | 1.36.0 |  | `registry.example.com/app:v1 [linux/amd64]` |")
+}
+
+func TestMarkdownPrinter_ActionPrint_ImageScanGolden(t *testing.T) {
+	out := mdRunImageActionPrint(t, mdImageScanDataFixture())
+	want, err := os.ReadFile(filepath.Join("testdata", "markdown_image_scan.md"))
+	require.NoError(t, err)
+	assert.Equal(t, string(want), out)
+}
+
+func mdImageScanDataFixture() []cautils.ImageScanData {
+	dbBuilt := time.Date(2026, 8, 25, 10, 30, 0, 0, time.UTC)
+	return []cautils.ImageScanData{
+		{
+			Image:       "registry.example.com/app:v1",
+			Platform:    "linux/amd64",
+			VulnDBBuilt: &dbBuilt,
+			Matches: match.NewMatches(
+				mdImageMatch("CVE-2026-0001", "Critical", "openssl", "1.0.0", vulnerability.FixStateFixed, "1.0.1", "1.0.2"),
+				mdImageMatch("CVE-2026-0002", "Medium", "busybox", "1.36.0", vulnerability.FixStateNotFixed),
+			),
+		},
+		{
+			Image:    "registry.example.com/app:v1",
+			Platform: "linux/arm64",
+			Matches: match.NewMatches(
+				mdImageMatch("CVE-2026-0003", "High", "glibc", "2.39", vulnerability.FixStateWontFix),
+			),
+		},
+	}
+}
+
+func TestMarkdownPrinter_ActionPrint_ImageScanNoVulnerabilities(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:   "registry.example.com/clean:v1",
+			Matches: match.NewMatches(),
+		},
+	}
+
+	out := mdRunImageActionPrint(t, imageScanData)
+
+	assert.Contains(t, out, "# Kubescape Image Scan Report")
+	assert.Contains(t, out, "**Image:** `registry.example.com/clean:v1`")
+	assert.Contains(t, out, "| `registry.example.com/clean:v1` |")
+	assert.Contains(t, out, "| **Total** | **0** | **0** |")
+	assert.Contains(t, out, "No affected packages were found.")
+	assert.Contains(t, out, "No vulnerabilities were found.")
+}
+
+func TestMarkdownPrinter_ActionPrint_ImageScanEscapesTableCells(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:    "registry.example.com/app|with-pipe:v1",
+			Platform: "linux/amd64",
+			Matches: match.NewMatches(
+				mdImageMatch("CVE-2026-PIPE", "High", "pkg|name", "1|2", vulnerability.FixStateFixed, "3|4"),
+			),
+		},
+	}
+
+	out := mdRunImageActionPrint(t, imageScanData)
+
+	assert.Contains(t, out, "`registry.example.com/app\\|with-pipe:v1 [linux/amd64]`")
+	assert.Contains(t, out, "| High | CVE-2026-PIPE | pkg\\|name | 1\\|2 | 3\\|4 | `registry.example.com/app\\|with-pipe:v1 [linux/amd64]` |")
+}
+
+func TestMdWriteImageSeveritySummarySortsBySeverity(t *testing.T) {
+	var out strings.Builder
+	err := mdWriteImageSeveritySummary(&out, map[string]*imageprinter.SeveritySummary{
+		"Low":      {NumberOfCVEs: 1},
+		"Critical": {NumberOfCVEs: 2, NumberOfFixableCVEs: 1},
+		"Medium":   {NumberOfCVEs: 3},
+		"High":     {NumberOfCVEs: 4},
+	})
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.Less(t, strings.Index(text, "Critical"), strings.Index(text, "High"))
+	assert.Less(t, strings.Index(text, "High"), strings.Index(text, "Medium"))
+	assert.Less(t, strings.Index(text, "Medium"), strings.Index(text, "Low"))
+	assert.Contains(t, text, "| **Total** | **10** | **1** |")
+}
+
+func TestMdSortedImagePackages(t *testing.T) {
+	packages := map[string]*imageprinter.PackageScore{
+		"b": {Name: "b", Version: "1", Score: 2},
+		"a": {Name: "a", Version: "2", Score: 5},
+		"c": {Name: "a", Version: "1", Score: 5},
+	}
+
+	got := mdSortedImagePackages(packages)
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", got[0].Name)
+	assert.Equal(t, "1", got[0].Version)
+	assert.Equal(t, "a", got[1].Name)
+	assert.Equal(t, "2", got[1].Version)
+	assert.Equal(t, "b", got[2].Name)
+}
+
+func TestMdSortedImageCVEs(t *testing.T) {
+	cves := []imageprinter.CVE{
+		{ID: "CVE-Z", Severity: "Low", Package: "pkg", Image: "image"},
+		{ID: "CVE-B", Severity: "Critical", Package: "pkg", Image: "image"},
+		{ID: "CVE-A", Severity: "Critical", Package: "pkg", Image: "image"},
+		{ID: "CVE-M", Severity: "High", Package: "pkg", Image: "image"},
+	}
+
+	got := mdSortedImageCVEs(cves)
+
+	require.Len(t, got, 4)
+	assert.Equal(t, "CVE-A", got[0].ID)
+	assert.Equal(t, "CVE-B", got[1].ID)
+	assert.Equal(t, "CVE-M", got[2].ID)
+	assert.Equal(t, "CVE-Z", got[3].ID)
+}
+
+func TestMdUnknownSeverityCount(t *testing.T) {
+	got := mdUnknownSeverityCount(map[string]int{
+		"Critical":   1,
+		"High":       2,
+		"Negligible": 3,
+		"Unknown":    4,
+	})
+
+	assert.Equal(t, 7, got)
+}
+
+func TestMdFixedIn(t *testing.T) {
+	cases := []struct {
+		name string
+		cve  imageprinter.CVE
+		want string
+	}{
+		{
+			name: "fixed with versions",
+			cve:  imageprinter.CVE{FixedState: "fixed", FixVersions: []string{"1.0.1", "1.0.2"}},
+			want: "1.0.1, 1.0.2",
+		},
+		{
+			name: "fixed without versions",
+			cve:  imageprinter.CVE{FixedState: "fixed"},
+			want: "fixed",
+		},
+		{
+			name: "wont fix",
+			cve:  imageprinter.CVE{FixedState: "wont-fix"},
+			want: "wont-fix",
+		},
+		{
+			name: "not fixed",
+			cve:  imageprinter.CVE{FixedState: "not-fixed"},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mdFixedIn(tc.cve))
+		})
+	}
 }

--- a/core/pkg/resultshandling/printer/v2/testdata/markdown_image_scan.md
+++ b/core/pkg/resultshandling/printer/v2/testdata/markdown_image_scan.md
@@ -1,0 +1,37 @@
+# Kubescape Image Scan Report
+
+**Images:** 2
+
+**Vulnerability DB Built:** 2026-08-25T10:30:00Z
+
+## Images
+
+| Image |
+|---|
+| `registry.example.com/app:v1 [linux/amd64]` |
+| `registry.example.com/app:v1 [linux/arm64]` |
+
+## Vulnerability Summary
+
+| Severity | CVEs | Fixable |
+|---|---:|---:|
+| Critical | 1 | 1 |
+| High | 1 | 0 |
+| Medium | 1 | 0 |
+| **Total** | **3** | **1** |
+
+## Affected Packages
+
+| Package | Version | Score | Critical | High | Medium | Low | Unknown |
+|---|---|---:|---:|---:|---:|---:|---:|
+| openssl | 1.0.0 | 5 | 1 | 0 | 0 | 0 | 0 |
+| glibc | 2.39 | 4 | 0 | 1 | 0 | 0 | 0 |
+| busybox | 1.36.0 | 3 | 0 | 0 | 1 | 0 | 0 |
+
+## Vulnerabilities
+
+| Severity | Vulnerability | Package | Version | Fixed In | Image |
+|---|---|---|---|---|---|
+| Critical | CVE-2026-0001 | openssl | 1.0.0 | 1.0.1, 1.0.2 | `registry.example.com/app:v1 [linux/amd64]` |
+| High | CVE-2026-0003 | glibc | 2.39 | wont-fix | `registry.example.com/app:v1 [linux/arm64]` |
+| Medium | CVE-2026-0002 | busybox | 1.36.0 |  | `registry.example.com/app:v1 [linux/amd64]` |

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -439,10 +439,10 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "markdown format for image scan should return error",
+			name:      "markdown format for image scan should not return error",
 			scanType:  cautils.ScanTypeImage,
 			format:    printer.MarkdownFormat,
-			expectErr: errors.New("format \"markdown\" is not supported for image scanning"),
+			expectErr: nil,
 		},
 	}
 


### PR DESCRIPTION
## Overview

Closes #3572.

Kubescape already supports Markdown output for posture scans, but image scans reject `--format markdown` even though users often need a portable human-readable vulnerability report for CI artifacts and pull request summaries.

This PR adds Markdown rendering for image scan results without changing the existing posture Markdown path.

## Changes

- Allow `markdown` as an image scan output format.
- Render image scan reports with image targets, vulnerability DB build time, severity totals, affected packages, and vulnerability details.
- Preserve platform-aware image targets for multi-architecture scans.
- Add regression tests for validation, rendering, sorting, escaping, fixed-version display, and a golden Markdown report.

## Testing

- `go test ./core/pkg/resultshandling ./core/pkg/resultshandling/printer ./core/pkg/resultshandling/printer/v2`
- `go test ./cmd/shared ./cmd/scan ./cmd/patch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown report support for image scans.
  * Image reports now include scan targets, vulnerability database details, severity summaries, affected packages, vulnerabilities, and available fix versions.
  * Reports handle scans without vulnerabilities and safely format special characters.

* **Bug Fixes**
  * Corrected supported-format validation so image scans are accepted for Markdown output and not incorrectly listed as CSV-compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->