### PR TITLE
fix(mcpserver): prefer ScanCoverage over the seeded summary when flagging unevaluated controls

### DIFF
--- a/cmd/mcpserver/remediation.go
+++ b/cmd/mcpserver/remediation.go
@@ -105,11 +105,22 @@ func unaddressedControls(requested []string, reported map[string]bool, unfixed [
 	emitted := make(map[string]bool)
 	for _, id := range requested {
 		key := normalizeControlID(id)
-		if key == "" || covered[key] || emitted[key] || reported[key] {
+		if key == "" || covered[key] || emitted[key] {
 			continue
 		}
-		reason, ok := reasons[key]
-		if !ok {
+		// ScanCoverage is authoritative about what was not evaluated and must be
+		// consulted before the report. ConvertFrameworksToSummaryDetails seeds
+		// SummaryDetails.Controls with every in-scope control *before* evaluation,
+		// so a control can appear there — possibly with a skipped status — and
+		// still never have been evaluated. Testing the report first would drop the
+		// control-specific reason, and for a seeded summary would drop the entry
+		// entirely, reintroducing the vanishing-control bug this function exists
+		// to prevent.
+		reason, notEvaluated := reasons[key]
+		if !notEvaluated {
+			if reported[key] {
+				continue // evaluated; the absence of a fix means it passed
+			}
 			reason = "not evaluated: control did not appear in the scan report"
 		}
 		emitted[key] = true

--- a/cmd/mcpserver/remediation_test.go
+++ b/cmd/mcpserver/remediation_test.go
@@ -375,6 +375,65 @@ func TestApplyRemediation_EvaluatedPassingControlIsNotFlagged(t *testing.T) {
 	}
 }
 
+// TestApplyRemediation_NotEvaluatedWinsOverSeededSummary covers the overlap
+// case: ConvertFrameworksToSummaryDetails seeds SummaryDetails.Controls with
+// every in-scope control before evaluation, so a control can be present in the
+// report (here with a skipped status) *and* be listed in ScanCoverage as never
+// evaluated. ScanCoverage must win, and its specific reason must survive —
+// otherwise the control silently disappears from the response.
+func TestApplyRemediation_NotEvaluatedWinsOverSeededSummary(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(fixture, []byte(deploymentNoSecurityContext), 0o600))
+
+	res := remediationResource(dir, "deployment.yaml", "Deployment", "demo", 0)
+	report := remediationReport(dir, res,
+		remediationFailedControl("C-0013", "Non-root containers",
+			remediationFailedRuleWithFix("spec.template.spec.securityContext.runAsNonRoot", "true"),
+		),
+	)
+	// C-0041 is seeded into the summary with a skipped status, exactly as a real
+	// scan would, while ScanCoverage reports it was never evaluated.
+	report.SummaryDetails.Controls = reportsummary.ControlSummaries{
+		"C-0041": reportsummary.ControlSummary{
+			ControlID:  "C-0041",
+			StatusInfo: apis.StatusInfo{InnerStatus: apis.StatusSkipped},
+		},
+	}
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+	stubScanOutcome(t, &iacScanOutcome{
+		ReportJSON: raw,
+		Degraded:   true,
+		NotEvaluatedControls: []cautils.NotEvaluatedControl{
+			{ControlID: "C-0041", Reason: "control evaluation timed out", MissingGVRs: []string{"apps/v1/deployments"}},
+		},
+	})
+
+	ksServer := &KubescapeMcpserver{}
+	result := callApplyRemediation(t, ksServer, map[string]any{
+		"path":        fixture,
+		"control_ids": "C-0013,C-0041",
+	})
+	require.False(t, result.IsError, "unexpected tool error: %s", toolResultText(t, result))
+
+	var resp remediationResponse
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &resp))
+
+	var found *fixhandler.UnfixedControl
+	for i := range resp.UnfixedControls {
+		if resp.UnfixedControls[i].ControlID == "C-0041" {
+			found = &resp.UnfixedControls[i]
+		}
+	}
+	require.NotNil(t, found,
+		"a control present in the seeded summary but listed as not-evaluated must still surface")
+	assert.Contains(t, found.Reason, "timed out",
+		"the control-specific coverage reason must be preserved, not replaced by the generic one")
+	assert.Contains(t, found.Reason, "apps/v1/deployments",
+		"missing resource types should be carried through to the caller")
+}
+
 // TestApplyRemediation_ControlIDMatchingIsCaseInsensitive guards the diff
 // against a false "skipped" verdict when the caller lowercases the ID, since
 // parseControlIDs only trims.


### PR DESCRIPTION
## Overview

Follow-up to #3568, addressing the CodeRabbit review comment left on it.

**Current behavior:** `unaddressedControls` tests `reported[key]` before `reasons[key]`. Because `ConvertFrameworksToSummaryDetails` seeds `SummaryDetails.Controls` with every in-scope control *before* evaluation, `reported[key]` is true for essentially every requested control so the coverage diff short-circuits and returns nothing. A control that was never evaluated still vanishes from the response, and an agent reads an empty `files` list as "compliant".

**Future behavior:** `ScanCoverage` is consulted first as the authoritative "not evaluated" signal. The report is only a fallback, meaning "evaluated, so the absence of a fix means it passed". The control-specific reason and `MissingGVRs` are preserved instead of being replaced by the generic message.

## Additional Information

This makes the fix in #3568 actually take effect as merged, `unaddressedControls` is close to dead code, so the `degraded` flag works while the per-control signal is missing.

## How to Test

`TestApplyRemediation_NotEvaluatedWinsOverSeededSummary` is a genuine regression guard it fails against current `master`. It seeds `C-0041` into the summary with a skipped status *and* lists it in `NotEvaluatedControls`, then asserts it still surfaces with its "timed out" reason.

## Related issues/PRs:

* Follow-up to #3568

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected remediation results for controls marked as not evaluated.
  * Preserved specific skip reasons, such as timeouts, even when controls also appear in scan reports.
  * Ensured missing resource types are included in unfixed control details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->