### PR TITLE
fix(cel): resolve a cluster-scoped paramRef, and refuse one that selects params

### DIFF
--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -376,12 +376,20 @@ func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, re
 
 // paramLookupNamespaces returns the namespaces to look the param object up in,
 // in order. An explicit namespace on the ref is the only candidate; without one
-// the paramKind's scope decides where the object lives.
+// the paramKind's scope decides where the object lives and offline there is no
+// discovery to read that scope from, so both candidates are tried: the scanned
+// resource's namespace for a namespaced kind, then the empty namespace the index
+// keys a cluster-scoped one by. A kind is registered at exactly one scope, so the
+// order cannot pick the wrong object. Trying only the resource's namespace missed
+// the bundled ControlConfiguration (scope: Cluster) for every namespaced resource.
 func paramLookupNamespaces(paramRef *admissionregistrationv1.ParamRef, resourceNamespace string) []string {
 	if paramRef.Namespace != "" {
 		return []string{paramRef.Namespace}
 	}
-	return []string{resourceNamespace}
+	if resourceNamespace == "" {
+		return []string{""}
+	}
+	return []string{resourceNamespace, ""}
 }
 
 // resolveParams returns the value bound to the evaluator's "params" variable. A

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -80,6 +80,12 @@ func (v *VAP) failOnError() bool {
 	return v.failurePolicy != admissionregistrationv1.Ignore
 }
 
+// TakesParams reports whether the policy declares a spec.paramKind, i.e. whether
+// a binding's paramRef is something the apiserver resolves rather than ignores.
+func (v *VAP) TakesParams() bool {
+	return v.paramKind != nil
+}
+
 // requireSupported reports whether the offline engine can honor this policy with
 // scan/admission parity. A refusal maps to the same errored/skipped status a
 // Rego eval error takes, never a silent pass or a false violation. Removing a

--- a/core/pkg/opaprocessor/cel/loader.go
+++ b/core/pkg/opaprocessor/cel/loader.go
@@ -366,15 +366,22 @@ func ResolveParamObject(vap *VAP, paramRef *admissionregistrationv1.ParamRef, re
 	if paramRef == nil || paramRef.Name == "" {
 		return resolveParams(vap)
 	}
-	ns := paramRef.Namespace
-	if ns == "" {
-		ns = resourceNamespace
+	for _, ns := range paramLookupNamespaces(paramRef, resourceNamespace) {
+		if obj, ok := findParam(vap.paramKind.APIVersion, vap.paramKind.Kind, ns, paramRef.Name); ok {
+			return obj, nil
+		}
 	}
-	obj, ok := findParam(vap.paramKind.APIVersion, vap.paramKind.Kind, ns, paramRef.Name)
-	if !ok {
-		return nil, ErrParamNotFound
+	return nil, ErrParamNotFound
+}
+
+// paramLookupNamespaces returns the namespaces to look the param object up in,
+// in order. An explicit namespace on the ref is the only candidate; without one
+// the paramKind's scope decides where the object lives.
+func paramLookupNamespaces(paramRef *admissionregistrationv1.ParamRef, resourceNamespace string) []string {
+	if paramRef.Namespace != "" {
+		return []string{paramRef.Namespace}
 	}
-	return obj, nil
+	return []string{resourceNamespace}
 }
 
 // resolveParams returns the value bound to the evaluator's "params" variable. A

--- a/core/pkg/opaprocessor/cel/loader_test.go
+++ b/core/pkg/opaprocessor/cel/loader_test.go
@@ -478,3 +478,63 @@ func TestResolveParamObjectBinding(t *testing.T) {
 	_, err = ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "missing"}, "default", findParam)
 	require.ErrorIs(t, err, ErrParamNotFound)
 }
+
+// TestResolveParamObjectClusterScoped resolves a paramRef naming a cluster-scoped
+// param object while the scanned resource is namespaced. The bundled
+// ControlConfiguration is scope: Cluster, so this is the shape every binding that
+// names it takes.
+func TestResolveParamObjectClusterScoped(t *testing.T) {
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+
+	clusterScoped := map[string]any{
+		"apiVersion": vap.paramKind.APIVersion,
+		"kind":       vap.paramKind.Kind,
+		"metadata":   map[string]any{"name": "custom"},
+		"settings":   map[string]any{"insecureCapabilities": []any{"ADD"}},
+	}
+	findParam := func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
+		if apiVersion == vap.paramKind.APIVersion && kind == vap.paramKind.Kind && namespace == "" && name == "custom" {
+			return clusterScoped, true
+		}
+		return nil, false
+	}
+
+	params, err := ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "custom"}, "prod", findParam)
+	require.NoError(t, err)
+	assert.Equal(t, clusterScoped, params)
+
+	// A cluster-scoped resource already looked the object up under "".
+	params, err = ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "custom"}, "", findParam)
+	require.NoError(t, err)
+	assert.Equal(t, clusterScoped, params)
+
+	// A namespace on the ref stays the only candidate: the apiserver rejects one
+	// against a cluster-scoped paramKind rather than falling back to it.
+	_, err = ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "custom", Namespace: "prod"}, "prod", findParam)
+	require.ErrorIs(t, err, ErrParamNotFound)
+}
+
+// TestResolveParamObjectPrefersResourceNamespace keeps a namespaced param object
+// ahead of the cluster-scoped candidate, so the fallback cannot take over a
+// lookup the resource's own namespace already answers.
+func TestResolveParamObjectPrefersResourceNamespace(t *testing.T) {
+	vap, err := loadVAP("C-0046")
+	require.NoError(t, err)
+
+	namespaced := map[string]any{"metadata": map[string]any{"name": "custom", "namespace": "prod"}}
+	clusterScoped := map[string]any{"metadata": map[string]any{"name": "custom"}}
+	findParam := func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
+		switch namespace {
+		case "prod":
+			return namespaced, true
+		case "":
+			return clusterScoped, true
+		}
+		return nil, false
+	}
+
+	params, err := ResolveParamObject(vap, &admissionregistrationv1.ParamRef{Name: "custom"}, "prod", findParam)
+	require.NoError(t, err)
+	assert.Equal(t, namespaced, params)
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1497,6 +1497,9 @@ func (opap *OPAProcessor) runCELOnK8s(ctx context.Context, rule *reporthandling.
 		if celBindingHasMatchResources(bindings[0]) {
 			return nil, celOutcome{}, fmt.Errorf("rule: '%s', binding for policy %q declares spec.matchResources, which the offline engine does not evaluate yet; refusing it to preserve scan/admission parity", rule.Name, vap.PolicyName)
 		}
+		if vap.TakesParams() && celBindingSelectsParams(bindings[0]) {
+			return nil, celOutcome{}, fmt.Errorf("rule: '%s', binding for policy %q selects its params with spec.paramRef.selector, which the offline engine does not resolve yet; refusing it to preserve scan/admission parity", rule.Name, vap.PolicyName)
+		}
 		paramRef = celParamRefForBinding(bindings[0])
 	default:
 		return nil, celOutcome{}, fmt.Errorf("rule: '%s', policy %q is matched by %d live bindings; the offline engine does not yet select per-binding paramRefs, so refusing it to preserve scan/admission parity", rule.Name, vap.PolicyName, len(bindings))
@@ -1793,6 +1796,20 @@ func celBindingHasMatchResources(binding metav1unstructured.Unstructured) bool {
 	}
 	mr, ok := spec["matchResources"].(map[string]any)
 	return ok && len(mr) > 0
+}
+
+// celBindingSelectsParams reports whether the binding picks its params with
+// spec.paramRef.selector rather than naming one. celParamRefForBinding reads
+// only the name, so such a binding used to arrive as no paramRef at all and the
+// policy was evaluated against the bundled defaults instead of the objects the
+// binding selects. An empty selector is still a selection (it matches every
+// object of the paramKind), so presence is what counts, not length.
+func celBindingSelectsParams(binding metav1unstructured.Unstructured) bool {
+	if binding.Object == nil {
+		return false
+	}
+	_, found, err := metav1unstructured.NestedMap(binding.Object, "spec", "paramRef", "selector")
+	return err == nil && found
 }
 
 // celParamRefForBinding extracts the binding's spec.paramRef, if any. Missing

--- a/core/pkg/opaprocessor/processorhandler_paramref_test.go
+++ b/core/pkg/opaprocessor/processorhandler_paramref_test.go
@@ -1,0 +1,121 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// paramRefBindingFor builds a live binding for the control's policy carrying the
+// given spec.paramRef.
+func paramRefBindingFor(t *testing.T, controlID string, paramRef map[string]any) metav1unstructured.Unstructured {
+	t.Helper()
+	policyName, err := cel.PolicyNameForControl(controlID)
+	require.NoError(t, err)
+	return metav1unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1",
+		"kind":       "ValidatingAdmissionPolicyBinding",
+		"metadata":   map[string]any{"name": "binding"},
+		"spec": map[string]any{
+			"policyName": policyName,
+			"paramRef":   paramRef,
+		},
+	}}
+}
+
+func paramRefProcessor(bindings ...metav1unstructured.Unstructured) *OPAProcessor {
+	return &OPAProcessor{OPASessionObj: &cautils.OPASessionObj{VAPBindings: bindings}}
+}
+
+// TestRunCELOnK8sParamRef covers how a live binding hands the offline engine its
+// params. A selector picks params the engine cannot resolve, and reading only
+// the absent name left the policy on the bundled defaults instead. A name points
+// at a cluster-scoped object, which the pod's own namespace never holds.
+func TestRunCELOnK8sParamRef(t *testing.T) {
+	pod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "mutable", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	}
+	// privilegedPod adds a capability the bundled configuration calls insecure,
+	// so only the binding's own params can clear it.
+	privilegedPod := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "privileged", "namespace": "default"},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{
+				"name":  "c",
+				"image": "nginx",
+				"securityContext": map[string]any{
+					"capabilities": map[string]any{"add": []any{"SETPCAP"}},
+				},
+			}},
+		},
+	}
+	rule := &reporthandling.PolicyRule{
+		PortalBase:   armotypes.PortalBase{Name: "cel-paramref"},
+		RuleLanguage: reporthandling.CELLanguage,
+	}
+
+	t.Run("a params-bearing control refuses the whole rule", func(t *testing.T) {
+		selector := map[string]any{"selector": map[string]any{
+			"matchLabels": map[string]any{"tier": "strict"},
+		}}
+		opap := paramRefProcessor(paramRefBindingFor(t, "C-0046", selector))
+
+		_, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{pod}, nil, "C-0046")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.paramRef.selector")
+	})
+
+	t.Run("an empty selector still selects, so it is refused too", func(t *testing.T) {
+		opap := paramRefProcessor(paramRefBindingFor(t, "C-0046", map[string]any{"selector": map[string]any{}}))
+
+		_, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{pod}, nil, "C-0046")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.paramRef.selector")
+	})
+
+	t.Run("a named paramRef resolves the cluster-scoped param object", func(t *testing.T) {
+		// The bundled ControlConfiguration is scope: Cluster, so a named paramRef
+		// carries no namespace and the object lives outside the pod's.
+		config := objectsenvelopes.NewObject(map[string]any{
+			"apiVersion": "kubescape.io/v1",
+			"kind":       "ControlConfiguration",
+			"metadata":   map[string]any{"name": "permissive-config"},
+			"settings":   map[string]any{"insecureCapabilities": []any{}},
+		})
+		require.NotNil(t, config)
+
+		opap := paramRefProcessor(paramRefBindingFor(t, "C-0046", map[string]any{"name": "permissive-config"}))
+		opap.AllResources = map[string]workloadinterface.IMetadata{config.GetID(): config}
+
+		responses, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{privilegedPod}, nil, "C-0046")
+		require.NoError(t, err)
+		assert.Empty(t, responses, "the binding's params allow every capability, so the pod passes")
+	})
+
+	t.Run("a paramless control ignores the selector, as the apiserver does", func(t *testing.T) {
+		selector := map[string]any{"selector": map[string]any{
+			"matchLabels": map[string]any{"tier": "strict"},
+		}}
+		opap := paramRefProcessor(paramRefBindingFor(t, "C-0017", selector))
+
+		responses, _, err := opap.runCELOnK8s(context.Background(), rule, []map[string]any{pod}, nil, "C-0017")
+		require.NoError(t, err)
+		assert.Len(t, responses, 1, "C-0017 still flags the pod's mutable root filesystem")
+	})
+}


### PR DESCRIPTION
The offline CEL engine resolves a binding's `spec.paramRef` before it evaluates a policy, and it was getting that wrong in two different ways.

The first one bites the bundled configuration itself. `ResolveParamObject` looks the param object up under `paramRef.namespace`, and when the ref carries none it substitutes the scanned resource's namespace. But the ControlConfiguration the library ships is `scope: Cluster` (see `policy-configuration-definition.yaml`), so a namespaced paramRef is exactly what it must not have, and the object is indexed under the empty namespace. The result was that any binding naming it by `paramRef.name` resolved to nothing for every namespaced resource: `ErrParamNotFound`, and since `parameterNotFoundAction` defaults to Deny, each Pod, Deployment and Job came back as a param-not-found failure the cluster never produced. Cluster-scoped resources happened to work, because their namespace is already empty.

Offline there is no discovery to read a paramKind's scope from, so the lookup now tries both candidates: the scanned resource's namespace first, then the empty namespace a cluster-scoped object is keyed by. A kind is registered at exactly one scope, so the order cannot pick up the wrong object, and an explicit `paramRef.namespace` is still the only candidate when one is given. That second detail is the part most likely to regress: the apiserver treats a namespace against a cluster-scoped paramKind as a configuration error rather than a hint, so widening that case would be wrong. There is a test pinning it.

The second one is a binding that selects its params with `paramRef.selector` instead of naming one. `celParamRefForBinding` reads only `name`, so such a binding arrived at the engine as no paramRef at all and the policy was quietly evaluated against the library defaults, which is a different verdict from the one the selected objects would produce. The engine already refuses a binding whose `matchResources` it cannot evaluate, so this now takes the same route and refuses the rule with a message naming the field. An empty selector counts as a selection, since it matches every object of the paramKind, and a policy that declares no paramKind is left alone because the apiserver ignores its paramRef anyway.

Verified both directions by restoring the pre-fix files and confirming the new tests fail as assertions, then restoring the fix. `go vet`, `gofmt` and the opaprocessor, cel, resourcehandler and cmd/vap suites are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for resolving parameter objects from either the resource namespace or cluster scope when no namespace is specified.
  - Added policy parameter-awareness reporting.

- **Bug Fixes**
  - CEL evaluation now rejects unsupported selector-based parameter references.
  - Explicit namespace references remain restricted to that namespace.
  - Parameterless policies continue evaluation without parameter selection.

- **Tests**
  - Added coverage for namespace precedence, cluster-scoped parameters, selector handling, and parameterless policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->