### PR TITLE
fix(imagescan): correct gofmt indentation in NewDefaultDBConfig

### DIFF
--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -75,10 +75,10 @@ func NewDefaultDBConfig(grypeURL string, skipDBUpdate bool) (distribution.Config
 	shouldUpdate := !skipDBUpdate
 
 	return distribution.Config{
-			LatestURL: finalURL,
-		}, installation.Config{
-			DBRootDir: dir,
-		}, shouldUpdate, nil
+		LatestURL: finalURL,
+	}, installation.Config{
+		DBRootDir: dir,
+	}, shouldUpdate, nil
 }
 
 func getMatchers(useDefaultMatchers bool) []match.Matcher {


### PR DESCRIPTION
## Summary
`NewDefaultDBConfig`'s multi-value return indents the `distribution.Config{}` / `installation.Config{}` field lists one level deeper than gofmt's canonical formatting:

```go
return distribution.Config{
        LatestURL: finalURL,
    }, installation.Config{
        DBRootDir: dir,
    }, shouldUpdate, nil
```

A full, non-incremental `golangci-lint run ./pkg/imagescan/...` flags this (`gofmt` formatter). This repo's `pr-scanner` CI workflow lints only each PR's own new/changed lines (`golangci-lint run --new-from-patch=...`), so a pre-existing formatting defect elsewhere in an untouched line range never surfaces in an unrelated PR's check — which is how this went unnoticed since at least #3387.

## Fix
Reformatted to gofmt's canonical indentation:

```go
return distribution.Config{
    LatestURL: finalURL,
}, installation.Config{
    DBRootDir: dir,
}, shouldUpdate, nil
```

No behavior change — purely whitespace.

## Test plan
- [x] `golangci-lint run ./pkg/imagescan/...` — 0 issues (was 1 gofmt issue before).
- [x] `golangci-lint fmt --diff pkg/imagescan/imagescan.go` — empty diff after the fix.
- [x] `go build ./...` and `go vet ./...` pass.
- [x] `go test ./...` passes (full repo, both Go modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected indentation in vulnerability database configuration code.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->