### PR TITLE
fix(anonymizer): restore reference-backed env var name anonymization

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -133,14 +133,22 @@ type OPASessionObj struct {
 	// report, keyed by control ID.
 	VAPCoverage map[string]*vapreconcile.ControlCoverage
 
-	// EnvVarSecretRefs records, per resource ID, which container env var
-	// names had a ValueFrom reference (SecretKeyRef/ConfigMapKeyRef/FieldRef/
-	// ResourceFieldRef) before updateResults's removeData step clears
-	// ValueFrom and overwrites Value. It deliberately holds only the env var
-	// name, never the reference target or value, so the anonymizer can still
-	// recognize which env var names to anonymize under --hide/--encrypt
-	// after the scrub, without the scrub itself retaining anything sensitive.
-	EnvVarSecretRefs map[string]map[string]struct{}
+	// EnvVarSecretRefs records, per resource ID and then per container name,
+	// which container env var names had a ValueFrom reference
+	// (SecretKeyRef/ConfigMapKeyRef/FieldRef/ResourceFieldRef) before
+	// updateResults's removeData step clears ValueFrom and overwrites Value.
+	// It deliberately holds only the env var name, never the reference
+	// target or value, so the anonymizer can still recognize which env var
+	// names to anonymize under --hide/--encrypt after the scrub, without the
+	// scrub itself retaining anything sensitive.
+	//
+	// Keyed by container name (unique across containers/initContainers/
+	// ephemeralContainers within one pod, enforced by the API server) rather
+	// than merged into one per-resource set: two containers in the same pod
+	// can have an env var with the same name where only one is
+	// reference-backed, and only that container's env var may be
+	// anonymized.
+	EnvVarSecretRefs map[string]map[string]map[string]struct{}
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -132,6 +132,15 @@ type OPASessionObj struct {
 	// resultshandling after VAPPolicies/VAPBindings are enriched into the
 	// report, keyed by control ID.
 	VAPCoverage map[string]*vapreconcile.ControlCoverage
+
+	// EnvVarSecretRefs records, per resource ID, which container env var
+	// names had a ValueFrom reference (SecretKeyRef/ConfigMapKeyRef/FieldRef/
+	// ResourceFieldRef) before updateResults's removeData step clears
+	// ValueFrom and overwrites Value. It deliberately holds only the env var
+	// name, never the reference target or value, so the anonymizer can still
+	// recognize which env var names to anonymize under --hide/--encrypt
+	// after the scrub, without the scrub itself retaining anything sensitive.
+	EnvVarSecretRefs map[string]map[string]struct{}
 }
 
 func NewOPASessionObj(ctx context.Context, frameworks []reporthandling.Framework, k8sResources K8SResources, scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *OPASessionObj {

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -15,7 +15,7 @@ import (
 // reversible encryption, or decryption using different Transformer
 // implementations.
 
-func transformContainerMetadata(resource workloadinterface.IMetadata, transformer Transformer) error {
+func transformContainerMetadata(resource workloadinterface.IMetadata, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	if resource == nil {
 		return nil
@@ -26,7 +26,7 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 		return nil
 	}
 
-	if err := transformPodSpecs(obj, transformer); err != nil {
+	if err := transformPodSpecs(obj, knownRefNames, transformer); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, transforme
 	return nil
 }
 
-func transformTypedContainerList(containers []corev1.Container, transformer Transformer) error {
+func transformTypedContainerList(containers []corev1.Container, knownRefNames map[string]struct{}, transformer Transformer) error {
 	var err error
 
 	for i := range containers {
@@ -53,7 +53,7 @@ func transformTypedContainerList(containers []corev1.Container, transformer Tran
 			}
 		}
 
-		if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+		if err := transformTypedEnv(containers[i].Env, knownRefNames, transformer); err != nil {
 			return err
 		}
 
@@ -65,7 +65,7 @@ func transformTypedContainerList(containers []corev1.Container, transformer Tran
 	return nil
 }
 
-func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer, transformer Transformer) error {
+func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer, knownRefNames map[string]struct{}, transformer Transformer) error {
 	var err error
 
 	for i := range containers {
@@ -83,7 +83,7 @@ func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer
 			}
 		}
 
-		if err := transformTypedEnv(containers[i].Env, transformer); err != nil {
+		if err := transformTypedEnv(containers[i].Env, knownRefNames, transformer); err != nil {
 			return err
 		}
 
@@ -102,13 +102,14 @@ func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer
 // into generic maps or as fully unstructured manifests depending on the scan
 // source, so traversal stays representation-agnostic and delegates
 // shape-specific transformations to dedicated helpers.
-func transformPodSpecs(node any, transformer Transformer) error {
+func transformPodSpecs(node any, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	switch v := node.(type) {
 	case map[string]any:
 		if err := transformContainerList(
 			v,
 			"containers",
+			knownRefNames,
 			transformer,
 		); err != nil {
 			return err
@@ -117,6 +118,7 @@ func transformPodSpecs(node any, transformer Transformer) error {
 		if err := transformContainerList(
 			v,
 			"initContainers",
+			knownRefNames,
 			transformer,
 		); err != nil {
 			return err
@@ -125,6 +127,7 @@ func transformPodSpecs(node any, transformer Transformer) error {
 		if err := transformEphemeralContainerList(
 			v,
 			"ephemeralContainers",
+			knownRefNames,
 			transformer,
 		); err != nil {
 			return err
@@ -147,6 +150,7 @@ func transformPodSpecs(node any, transformer Transformer) error {
 		for _, child := range v {
 			if err := transformPodSpecs(
 				child,
+				knownRefNames,
 				transformer,
 			); err != nil {
 				return err
@@ -157,6 +161,7 @@ func transformPodSpecs(node any, transformer Transformer) error {
 		for _, item := range v {
 			if err := transformPodSpecs(
 				item,
+				knownRefNames,
 				transformer,
 			); err != nil {
 				return err
@@ -177,7 +182,7 @@ func transformPodSpecs(node any, transformer Transformer) error {
 // Different Transformer implementations can provide pseudonymization,
 // encryption, or decryption while sharing the same traversal logic.
 
-func transformContainerFields(container map[string]any, transformer Transformer) error {
+func transformContainerFields(container map[string]any, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	var err error
 
@@ -199,7 +204,7 @@ func transformContainerFields(container map[string]any, transformer Transformer)
 		container["image"] = image
 	}
 
-	if err := transformUnstructuredEnv(container, transformer); err != nil {
+	if err := transformUnstructuredEnv(container, knownRefNames, transformer); err != nil {
 		return err
 	}
 
@@ -217,7 +222,7 @@ func transformContainerFields(container map[string]any, transformer Transformer)
 // referenced Kubernetes resources are transformed while preserving the
 // original workload structure.
 
-func transformContainerList(obj map[string]any, key string, transformer Transformer) error {
+func transformContainerList(obj map[string]any, key string, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
@@ -232,14 +237,14 @@ func transformContainerList(obj map[string]any, key string, transformer Transfor
 				continue
 			}
 
-			if err := transformContainerFields(container, transformer); err != nil {
+			if err := transformContainerFields(container, knownRefNames, transformer); err != nil {
 				return err
 			}
 		}
 
 		obj[key] = containers
 	case []corev1.Container:
-		if err := transformTypedContainerList(containers, transformer); err != nil {
+		if err := transformTypedContainerList(containers, knownRefNames, transformer); err != nil {
 			return err
 		}
 	}
@@ -254,7 +259,7 @@ func transformContainerList(obj map[string]any, key string, transformer Transfor
 // Container identifiers, image references, environment variables, and
 // referenced Kubernetes resources are transformed while preserving the
 // original workload structure.
-func transformEphemeralContainerList(obj map[string]any, key string, transformer Transformer) error {
+func transformEphemeralContainerList(obj map[string]any, key string, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
@@ -269,14 +274,14 @@ func transformEphemeralContainerList(obj map[string]any, key string, transformer
 				continue
 			}
 
-			if err := transformContainerFields(container, transformer); err != nil {
+			if err := transformContainerFields(container, knownRefNames, transformer); err != nil {
 				return err
 			}
 		}
 
 		obj[key] = containers
 	case []corev1.EphemeralContainer:
-		if err := transformTypedEphemeralContainerList(containers, transformer); err != nil {
+		if err := transformTypedEphemeralContainerList(containers, knownRefNames, transformer); err != nil {
 			return err
 		}
 	}
@@ -290,7 +295,16 @@ func transformEphemeralContainerList(obj map[string]any, key string, transformer
 // Literal environment values are transformed only when they appear
 // sensitive, while Secret and ConfigMap references are always
 // transformed when present.
-func transformTypedEnv(envVars []corev1.EnvVar, transformer Transformer) error {
+//
+// knownRefNames carries the env var names that a caller earlier upstream
+// (processorhandlerutils.removeData) already found to have a ValueFrom
+// reference, before that reference was cleared. It exists because this
+// function normally runs after that clearing, so envVar.ValueFrom is nil by
+// the time it gets here for every reference-backed env var, and there is no
+// longer anything on envVar itself to detect that from. When ValueFrom is
+// still present (for example a direct, isolated call to this function),
+// that takes precedence and knownRefNames is not consulted.
+func transformTypedEnv(envVars []corev1.EnvVar, knownRefNames map[string]struct{}, transformer Transformer) error {
 	var err error
 
 	for i := range envVars {
@@ -310,38 +324,39 @@ func transformTypedEnv(envVars []corev1.EnvVar, transformer Transformer) error {
 			}
 		}
 
-		if envVar.ValueFrom == nil {
-			continue
-		}
-
 		hasRef := false
 
-		if secretRef := envVar.ValueFrom.SecretKeyRef; secretRef != nil &&
-			secretRef.Name != "" {
+		if envVar.ValueFrom != nil {
+			if secretRef := envVar.ValueFrom.SecretKeyRef; secretRef != nil &&
+				secretRef.Name != "" {
 
-			secretRef.Name, err = transformValue(transformer, "ref", secretRef.Name)
-			if err != nil {
-				return err
+				secretRef.Name, err = transformValue(transformer, "ref", secretRef.Name)
+				if err != nil {
+					return err
+				}
+				hasRef = true
 			}
-			hasRef = true
-		}
 
-		if configMapRef := envVar.ValueFrom.ConfigMapKeyRef; configMapRef != nil &&
-			configMapRef.Name != "" {
+			if configMapRef := envVar.ValueFrom.ConfigMapKeyRef; configMapRef != nil &&
+				configMapRef.Name != "" {
 
-			configMapRef.Name, err = transformValue(transformer, "ref", configMapRef.Name)
-			if err != nil {
-				return err
+				configMapRef.Name, err = transformValue(transformer, "ref", configMapRef.Name)
+				if err != nil {
+					return err
+				}
+				hasRef = true
 			}
+
+			if envVar.ValueFrom.FieldRef != nil {
+				hasRef = true
+			}
+			if envVar.ValueFrom.ResourceFieldRef != nil {
+				hasRef = true
+			}
+		} else if _, known := knownRefNames[envVar.Name]; known {
 			hasRef = true
 		}
 
-		if envVar.ValueFrom.FieldRef != nil {
-			hasRef = true
-		}
-		if envVar.ValueFrom.ResourceFieldRef != nil {
-			hasRef = true
-		}
 		if hasRef && envVar.Name != "" {
 			envVar.Name, err = transformValue(transformer, "env", envVar.Name)
 			if err != nil {
@@ -360,7 +375,12 @@ func transformTypedEnv(envVars []corev1.EnvVar, transformer Transformer) error {
 // sensitive, while SecretKeyRef and ConfigMapKeyRef references are
 // transformed whenever present.
 
-func transformUnstructuredEnv(container map[string]any, transformer Transformer) error {
+// transformUnstructuredEnv mirrors transformTypedEnv for the unstructured
+// representation. See transformTypedEnv's doc comment for why
+// knownRefNames exists: valueFrom is normally already cleared by the time
+// this runs, so it is the only surviving signal for a reference-backed env
+// var name.
+func transformUnstructuredEnv(container map[string]any, knownRefNames map[string]struct{}, transformer Transformer) error {
 
 	rawEnv, exists := container["env"]
 	if !exists || rawEnv == nil {
@@ -395,35 +415,32 @@ func transformUnstructuredEnv(container map[string]any, transformer Transformer)
 			envVar["value"] = value
 		}
 
-		rawValueFrom, exists := envVar["valueFrom"]
-		if !exists || rawValueFrom == nil {
-			continue
-		}
-
-		valueFrom, ok := rawValueFrom.(map[string]any)
-		if !ok {
-			continue
-		}
-
 		hasRef := false
 
-		if err := transformUnstructuredReference(valueFrom, "secretKeyRef", transformer); err != nil {
-			return err
-		}
-		if _, ok := valueFrom["secretKeyRef"]; ok {
-			hasRef = true
-		}
+		rawValueFrom, exists := envVar["valueFrom"]
+		if exists && rawValueFrom != nil {
+			if valueFrom, ok := rawValueFrom.(map[string]any); ok {
+				if err := transformUnstructuredReference(valueFrom, "secretKeyRef", transformer); err != nil {
+					return err
+				}
+				if _, ok := valueFrom["secretKeyRef"]; ok {
+					hasRef = true
+				}
 
-		if err := transformUnstructuredReference(valueFrom, "configMapKeyRef", transformer); err != nil {
-			return err
-		}
-		if _, ok := valueFrom["configMapKeyRef"]; ok {
-			hasRef = true
-		}
-		if _, ok := valueFrom["fieldRef"]; ok {
-			hasRef = true
-		}
-		if _, ok := valueFrom["resourceFieldRef"]; ok {
+				if err := transformUnstructuredReference(valueFrom, "configMapKeyRef", transformer); err != nil {
+					return err
+				}
+				if _, ok := valueFrom["configMapKeyRef"]; ok {
+					hasRef = true
+				}
+				if _, ok := valueFrom["fieldRef"]; ok {
+					hasRef = true
+				}
+				if _, ok := valueFrom["resourceFieldRef"]; ok {
+					hasRef = true
+				}
+			}
+		} else if _, known := knownRefNames[name]; known {
 			hasRef = true
 		}
 

--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -15,7 +15,14 @@ import (
 // reversible encryption, or decryption using different Transformer
 // implementations.
 
-func transformContainerMetadata(resource workloadinterface.IMetadata, knownRefNames map[string]struct{}, transformer Transformer) error {
+// knownRefNames maps a container's name to the names of that container's
+// env vars that had a ValueFrom reference before removeData cleared it (see
+// removeData's doc comment in processorhandlerutils.go). It is keyed by
+// container name, not merged across the pod, because two containers in the
+// same pod can share an env var name where only one of them is
+// reference-backed — anonymizing the other would anonymize an ordinary env
+// var, which the anonymizer must never do.
+func transformContainerMetadata(resource workloadinterface.IMetadata, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 
 	if resource == nil {
 		return nil
@@ -35,10 +42,15 @@ func transformContainerMetadata(resource workloadinterface.IMetadata, knownRefNa
 	return nil
 }
 
-func transformTypedContainerList(containers []corev1.Container, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformTypedContainerList(containers []corev1.Container, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 	var err error
 
 	for i := range containers {
+		// Captured before the name itself is transformed below, so the
+		// lookup uses the real container name the scrub pass recorded
+		// against, not its anonymized replacement.
+		containerRefNames := knownRefNames[containers[i].Name]
+
 		if containers[i].Name != "" {
 			containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
 			if err != nil {
@@ -53,7 +65,7 @@ func transformTypedContainerList(containers []corev1.Container, knownRefNames ma
 			}
 		}
 
-		if err := transformTypedEnv(containers[i].Env, knownRefNames, transformer); err != nil {
+		if err := transformTypedEnv(containers[i].Env, containerRefNames, transformer); err != nil {
 			return err
 		}
 
@@ -65,10 +77,12 @@ func transformTypedContainerList(containers []corev1.Container, knownRefNames ma
 	return nil
 }
 
-func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 	var err error
 
 	for i := range containers {
+		containerRefNames := knownRefNames[containers[i].Name]
+
 		if containers[i].Name != "" {
 			containers[i].Name, err = transformValue(transformer, "ctr", containers[i].Name)
 			if err != nil {
@@ -83,7 +97,7 @@ func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer
 			}
 		}
 
-		if err := transformTypedEnv(containers[i].Env, knownRefNames, transformer); err != nil {
+		if err := transformTypedEnv(containers[i].Env, containerRefNames, transformer); err != nil {
 			return err
 		}
 
@@ -102,7 +116,7 @@ func transformTypedEphemeralContainerList(containers []corev1.EphemeralContainer
 // into generic maps or as fully unstructured manifests depending on the scan
 // source, so traversal stays representation-agnostic and delegates
 // shape-specific transformations to dedicated helpers.
-func transformPodSpecs(node any, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformPodSpecs(node any, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 
 	switch v := node.(type) {
 	case map[string]any:
@@ -182,9 +196,14 @@ func transformPodSpecs(node any, knownRefNames map[string]struct{}, transformer 
 // Different Transformer implementations can provide pseudonymization,
 // encryption, or decryption while sharing the same traversal logic.
 
-func transformContainerFields(container map[string]any, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformContainerFields(container map[string]any, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 
 	var err error
+
+	// Looked up before the name field is overwritten below, same reason as
+	// the typed path in transformTypedContainerList.
+	containerName, _ := container["name"].(string)
+	containerRefNames := knownRefNames[containerName]
 
 	if name, ok := container["name"].(string); ok && name != "" {
 		name, err = transformValue(transformer, "ctr", name)
@@ -204,7 +223,7 @@ func transformContainerFields(container map[string]any, knownRefNames map[string
 		container["image"] = image
 	}
 
-	if err := transformUnstructuredEnv(container, knownRefNames, transformer); err != nil {
+	if err := transformUnstructuredEnv(container, containerRefNames, transformer); err != nil {
 		return err
 	}
 
@@ -222,7 +241,7 @@ func transformContainerFields(container map[string]any, knownRefNames map[string
 // referenced Kubernetes resources are transformed while preserving the
 // original workload structure.
 
-func transformContainerList(obj map[string]any, key string, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformContainerList(obj map[string]any, key string, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {
@@ -259,7 +278,7 @@ func transformContainerList(obj map[string]any, key string, knownRefNames map[st
 // Container identifiers, image references, environment variables, and
 // referenced Kubernetes resources are transformed while preserving the
 // original workload structure.
-func transformEphemeralContainerList(obj map[string]any, key string, knownRefNames map[string]struct{}, transformer Transformer) error {
+func transformEphemeralContainerList(obj map[string]any, key string, knownRefNames map[string]map[string]struct{}, transformer Transformer) error {
 
 	rawContainers, ok := obj[key]
 	if !ok || rawContainers == nil {

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -1017,7 +1017,7 @@ func TestTransformContainerMetadata(t *testing.T) {
 			transformer := NewMappingTransformer()
 			resource := workloadinterface.NewWorkloadObj(test.object)
 
-			assert.NoError(t, transformContainerMetadata(resource, transformer))
+			assert.NoError(t, transformContainerMetadata(resource, nil, transformer))
 
 			spec, ok := resource.GetObject()["spec"].(map[string]any)
 			assert.True(t, ok, "expected spec to be a map[string]any")
@@ -1028,19 +1028,19 @@ func TestTransformContainerMetadata(t *testing.T) {
 }
 
 func TestTransformContainerMetadata_NilResource(t *testing.T) {
-	assert.NoError(t, transformContainerMetadata(nil, NewMappingTransformer()))
+	assert.NoError(t, transformContainerMetadata(nil, nil, NewMappingTransformer()))
 }
 
 func TestTransformContainerList_MissingKey(t *testing.T) {
 	obj := map[string]any{}
 
-	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
+	assert.NoError(t, transformContainerList(obj, "containers", nil, NewMappingTransformer()))
 }
 
 func TestTransformContainerList_NilValue(t *testing.T) {
 	obj := map[string]any{"containers": nil}
 
-	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
+	assert.NoError(t, transformContainerList(obj, "containers", nil, NewMappingTransformer()))
 }
 
 func TestTransformContainerList_InvalidType(t *testing.T) {
@@ -1048,7 +1048,7 @@ func TestTransformContainerList_InvalidType(t *testing.T) {
 		"containers": "invalid",
 	}
 
-	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
+	assert.NoError(t, transformContainerList(obj, "containers", nil, NewMappingTransformer()))
 }
 
 func TestIsSensitiveEnvName_SeparatorlessVariants(t *testing.T) {
@@ -1093,7 +1093,7 @@ func TestTransformUnstructuredEnv_LeaksAPIKeyValue(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, transformUnstructuredEnv(container, NewMappingTransformer()))
+	assert.NoError(t, transformUnstructuredEnv(container, nil, NewMappingTransformer()))
 
 	got := container["env"].([]any)[0].(map[string]any)["value"].(string)
 	if got == secret {
@@ -1112,7 +1112,7 @@ func TestTransformContainerList_TypedSlice(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, transformContainerList(obj, "containers", NewMappingTransformer()))
+	assert.NoError(t, transformContainerList(obj, "containers", nil, NewMappingTransformer()))
 
 	containers, ok := obj["containers"].([]corev1.Container)
 	assert.True(t, ok)
@@ -1133,7 +1133,7 @@ func TestTransformEphemeralContainerList_TypedSlice(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, transformEphemeralContainerList(obj, "ephemeralContainers", NewMappingTransformer()))
+	assert.NoError(t, transformEphemeralContainerList(obj, "ephemeralContainers", nil, NewMappingTransformer()))
 
 	containers, ok := obj["ephemeralContainers"].([]corev1.EphemeralContainer)
 	assert.True(t, ok)
@@ -1153,7 +1153,7 @@ func TestTransformPodSpecs_TypedContainersFromScanPipeline(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, transformPodSpecs(obj, NewMappingTransformer()))
+	assert.NoError(t, transformPodSpecs(obj, nil, NewMappingTransformer()))
 
 	spec := obj["spec"].(map[string]any)
 	containers := spec["containers"].([]corev1.Container)

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -46,8 +46,11 @@ func transformSession(session *cautils.OPASessionObj, _ *Mapping, transformer Tr
 
 		// Container-related metadata is transformed separately to preserve the
 		// existing typed/unstructured traversal behavior while supporting
-		// multiple transformation strategies.
-		if err := transformContainerMetadata(resource, transformer); err != nil {
+		// multiple transformation strategies. session.EnvVarSecretRefs[oldID]
+		// is nil for a resource whose removeData pass found no reference-backed
+		// env vars; transformTypedEnv/transformUnstructuredEnv treat that the
+		// same as "no additional names to anonymize", which is correct.
+		if err := transformContainerMetadata(resource, session.EnvVarSecretRefs[oldID], transformer); err != nil {
 			return err
 		}
 

--- a/core/pkg/opaprocessor/anonymizer_integration_test.go
+++ b/core/pkg/opaprocessor/anonymizer_integration_test.go
@@ -1,0 +1,103 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/anonymizer"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName
+// is a real, through-the-seam regression test for the bug reported in
+// kubescape#3567: removeData (called from updateResults) clears an env
+// var's ValueFrom before anonymizer.Apply ever runs, so the anonymizer's
+// hasRef-gated env-var-name anonymization could never fire in the real
+// scan+hide pipeline, only in isolated unit tests that call
+// transformTypedEnv/transformUnstructuredEnv directly with ValueFrom still
+// set.
+//
+// This runs the two real production functions in the real order: the
+// OPAProcessor's actual updateResults (which scrubs and populates
+// EnvVarSecretRefs), then the real anonymizer.Apply (--hide's entry point)
+// on the resulting session -- not a synthetic object built to look like
+// post-scrub state.
+func TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName(t *testing.T) {
+	raw := `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "payment-api", "namespace": "prod"},
+		"spec": {
+			"containers": [{
+				"name": "app",
+				"image": "nginx:latest",
+				"env": [
+					{
+						"name": "DB_PASSWORD",
+						"valueFrom": {"secretKeyRef": {"name": "db-creds", "key": "password"}}
+					},
+					{
+						"name": "LOG_LEVEL",
+						"value": "debug"
+					}
+				]
+			}]
+		}
+	}`
+
+	workload, err := workloadinterface.NewWorkload([]byte(raw))
+	require.NoError(t, err)
+	resourceID := workload.GetID()
+
+	session := cautils.NewOPASessionObjMock()
+	session.AllResources[resourceID] = workload
+
+	opap := &OPAProcessor{OPASessionObj: session}
+	opap.updateResults(context.Background())
+
+	// Sanity: the scrub itself must still behave exactly as before this
+	// change -- both env vars' values are gone, and the reference is nilled.
+	scrubbed := workloadinterface.NewWorkloadObj(session.AllResources[resourceID].GetObject())
+	containers, err := scrubbed.GetContainers()
+	require.NoError(t, err)
+	require.Len(t, containers, 1)
+	require.Len(t, containers[0].Env, 2)
+	require.Equal(t, "XXXXXX", containers[0].Env[0].Value, "scrub must still overwrite the value")
+	require.Nil(t, containers[0].Env[0].ValueFrom, "scrub must still clear the reference")
+	require.Equal(t, "XXXXXX", containers[0].Env[1].Value)
+
+	require.Len(t, opap.EnvVarSecretRefs[resourceID], 1, "removeData must record exactly the one reference-backed env var name")
+	_, recorded := opap.EnvVarSecretRefs[resourceID]["DB_PASSWORD"]
+	require.True(t, recorded)
+
+	rh := &resultshandling.ResultsHandler{ScanData: session}
+	require.NoError(t, anonymizer.Apply(rh))
+
+	// Exactly one resource must survive anonymization: the fix must not
+	// duplicate, drop, or misroute the resource while rekeying AllResources.
+	require.Len(t, rh.ScanData.AllResources, 1)
+	var anonymized *workloadinterface.Workload
+	for _, resource := range rh.ScanData.AllResources {
+		anonymized = workloadinterface.NewWorkloadObj(resource.GetObject())
+	}
+	require.NotNil(t, anonymized)
+
+	anonContainers, err := anonymized.GetContainers()
+	require.NoError(t, err)
+	require.Len(t, anonContainers, 1)
+	require.Len(t, anonContainers[0].Env, 2)
+
+	// The reference-backed env var's name must now be anonymized, even
+	// though ValueFrom was already nil by the time anonymizer.Apply ran --
+	// this is the actual fix.
+	require.NotEqual(t, "DB_PASSWORD", anonContainers[0].Env[0].Name)
+	require.Contains(t, anonContainers[0].Env[0].Name, "env-")
+
+	// The ordinary env var must be completely unaffected: its name is not a
+	// secret reference and its value/name do not look sensitive, so neither
+	// should change.
+	require.Equal(t, "LOG_LEVEL", anonContainers[0].Env[1].Name, "an ordinary env var's name must not be anonymized")
+}

--- a/core/pkg/opaprocessor/anonymizer_integration_test.go
+++ b/core/pkg/opaprocessor/anonymizer_integration_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/anonymizer"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName
@@ -69,8 +71,8 @@ func TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName(t
 	require.Nil(t, containers[0].Env[0].ValueFrom, "scrub must still clear the reference")
 	require.Equal(t, "XXXXXX", containers[0].Env[1].Value)
 
-	require.Len(t, opap.EnvVarSecretRefs[resourceID], 1, "removeData must record exactly the one reference-backed env var name")
-	_, recorded := opap.EnvVarSecretRefs[resourceID]["DB_PASSWORD"]
+	require.Len(t, opap.EnvVarSecretRefs[resourceID], 1, "removeData must record exactly the one container that had a reference-backed env var")
+	_, recorded := opap.EnvVarSecretRefs[resourceID]["app"]["DB_PASSWORD"]
 	require.True(t, recorded)
 
 	rh := &resultshandling.ResultsHandler{ScanData: session}
@@ -100,4 +102,76 @@ func TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName(t
 	// secret reference and its value/name do not look sensitive, so neither
 	// should change.
 	require.Equal(t, "LOG_LEVEL", anonContainers[0].Env[1].Name, "an ordinary env var's name must not be anonymized")
+}
+
+// TestUpdateResults_ThenAnonymizerApply_DoesNotLeakAcrossContainers is the
+// full through-the-seam version of the cross-container collision matthyx and
+// CodeRabbit flagged on PR #3579: two containers in the same pod share an
+// env var name, TOKEN, but only one of them is reference-backed. The other
+// container's ordinary TOKEN must survive anonymizer.Apply completely
+// unchanged, even though EnvVarSecretRefs has an entry for "TOKEN" somewhere
+// in this resource.
+func TestUpdateResults_ThenAnonymizerApply_DoesNotLeakAcrossContainers(t *testing.T) {
+	raw := `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "app", "namespace": "prod"},
+		"spec": {
+			"containers": [
+				{
+					"name": "has-ref",
+					"env": [
+						{"name": "TOKEN", "valueFrom": {"secretKeyRef": {"name": "creds", "key": "token"}}}
+					]
+				},
+				{
+					"name": "ordinary",
+					"env": [
+						{"name": "TOKEN", "value": "not-a-secret-just-a-literal"}
+					]
+				}
+			]
+		}
+	}`
+
+	workload, err := workloadinterface.NewWorkload([]byte(raw))
+	require.NoError(t, err)
+	resourceID := workload.GetID()
+
+	session := cautils.NewOPASessionObjMock()
+	session.AllResources[resourceID] = workload
+
+	opap := &OPAProcessor{OPASessionObj: session}
+	opap.updateResults(context.Background())
+
+	rh := &resultshandling.ResultsHandler{ScanData: session}
+	require.NoError(t, anonymizer.Apply(rh))
+
+	require.Len(t, rh.ScanData.AllResources, 1)
+	var anonymized *workloadinterface.Workload
+	for _, resource := range rh.ScanData.AllResources {
+		anonymized = workloadinterface.NewWorkloadObj(resource.GetObject())
+	}
+	require.NotNil(t, anonymized)
+
+	anonContainers, err := anonymized.GetContainers()
+	require.NoError(t, err)
+	require.Len(t, anonContainers, 2)
+
+	var hasRefContainer, ordinaryContainer *corev1.Container
+	for i := range anonContainers {
+		switch {
+		// Container names are themselves anonymized, so identify each
+		// container by its (untouched) image-free structure instead: the
+		// one whose env var name changed is the reference-backed one.
+		case anonContainers[i].Env[0].Name != "TOKEN":
+			hasRefContainer = &anonContainers[i]
+		default:
+			ordinaryContainer = &anonContainers[i]
+		}
+	}
+
+	require.NotNil(t, hasRefContainer, "expected exactly one container with its TOKEN env var name anonymized")
+	require.NotNil(t, ordinaryContainer, "expected exactly one container with TOKEN left untouched")
+	assert.Equal(t, "TOKEN", ordinaryContainer.Env[0].Name, "the ordinary container's TOKEN must not be anonymized just because a different container's TOKEN is reference-backed")
 }

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -41,7 +41,12 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 
 	// remove data from all objects
 	for i := range opap.AllResources {
-		removeData(opap.AllResources[i])
+		if refNames := removeData(opap.AllResources[i]); len(refNames) > 0 {
+			if opap.EnvVarSecretRefs == nil {
+				opap.EnvVarSecretRefs = make(map[string]map[string]struct{})
+			}
+			opap.EnvVarSecretRefs[i] = refNames
+		}
 	}
 
 	processor := exceptions.NewProcessor()
@@ -561,18 +566,28 @@ func getRuleDependencies(ctx context.Context) (map[string]string, error) {
 	return modules, nil
 }
 
-func removeData(obj workloadinterface.IMetadata) {
+// removeData strips sensitive data from obj before it reaches results
+// handling. For a Pod-shaped workload, it also returns the names of any
+// container env vars that had a ValueFrom reference (SecretKeyRef,
+// ConfigMapKeyRef, FieldRef, or ResourceFieldRef) before that reference was
+// cleared — never the reference target itself, never the value, only the
+// env var's own name. The anonymizer needs that name to keep anonymizing
+// reference-backed env var names under --hide/--encrypt after this
+// function has already cleared the reference it would otherwise inspect.
+func removeData(obj workloadinterface.IMetadata) map[string]struct{} {
 	if !k8sinterface.IsTypeWorkload(obj.GetObject()) {
-		return // remove data only from kubernetes objects
+		return nil // remove data only from kubernetes objects
 	}
 	workload := workloadinterface.NewWorkloadObj(obj.GetObject())
 	switch workload.GetKind() {
 	case "Secret":
 		removeSecretData(workload)
+		return nil
 	case "ConfigMap":
 		removeConfigMapData(workload)
+		return nil
 	default:
-		removePodData(workload)
+		return removePodData(workload)
 	}
 }
 
@@ -612,50 +627,86 @@ func removeSecretData(workload workloadinterface.IWorkload) {
 	overrideStringData(workload)
 }
 
-func removePodData(workload workloadinterface.IWorkload) {
+func removePodData(workload workloadinterface.IWorkload) map[string]struct{} {
 	workload.RemoveAnnotation("kubectl.kubernetes.io/last-applied-configuration")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "metadata", "managedFields")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "status")
 
+	var refNames map[string]struct{}
+	addRefNames := func(names map[string]struct{}) {
+		if len(names) == 0 {
+			return
+		}
+		if refNames == nil {
+			refNames = make(map[string]struct{}, len(names))
+		}
+		for name := range names {
+			refNames[name] = struct{}{}
+		}
+	}
+
 	// containers
 	if containers, err := workload.GetContainers(); err == nil && len(containers) > 0 {
-		removeContainersData(containers)
+		addRefNames(removeContainersData(containers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "containers", containers)
 	}
 
 	// init containers
 
 	if initContainers, err := workload.GetInitContainers(); err == nil && len(initContainers) > 0 {
-		removeContainersData(initContainers)
+		addRefNames(removeContainersData(initContainers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "initContainers", initContainers)
 	}
 
 	// ephemeral containers
 	if ephemeralContainers, err := workload.GetEphemeralContainers(); err == nil && len(ephemeralContainers) > 0 {
-		removeEphemeralContainersData(ephemeralContainers)
+		addRefNames(removeEphemeralContainersData(ephemeralContainers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "ephemeralContainers", ephemeralContainers)
 	}
+
+	return refNames
 }
 
-func removeContainersData(containers []corev1.Container) {
+// removeContainersData clears each env var's value and reference, returning
+// the names of the env vars that had a reference before it was cleared (see
+// removeData's doc comment for why only the name is kept).
+func removeContainersData(containers []corev1.Container) map[string]struct{} {
+	var refNames map[string]struct{}
 	for i := range containers {
 		container := &containers[i]
 		for j := range container.Env {
+			if container.Env[j].ValueFrom != nil {
+				if refNames == nil {
+					refNames = make(map[string]struct{})
+				}
+				refNames[container.Env[j].Name] = struct{}{}
+			}
 			container.Env[j].Value = "XXXXXX"
 			container.Env[j].ValueFrom = nil
 		}
 		container.EnvFrom = nil
 	}
+	return refNames
 }
-func removeEphemeralContainersData(containers []corev1.EphemeralContainer) {
+
+// removeEphemeralContainersData mirrors removeContainersData for ephemeral containers.
+func removeEphemeralContainersData(containers []corev1.EphemeralContainer) map[string]struct{} {
+	var refNames map[string]struct{}
 	for i := range containers {
 		container := &containers[i]
 		for j := range container.Env {
+			if container.Env[j].ValueFrom != nil {
+				if refNames == nil {
+					refNames = make(map[string]struct{})
+				}
+				refNames[container.Env[j].Name] = struct{}{}
+			}
 			container.Env[j].Value = "XXXXXX"
 			container.Env[j].ValueFrom = nil
 		}
 		container.EnvFrom = nil
 	}
+	return refNames
 }
 
 func ruleData(rule *reporthandling.PolicyRule) string {

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -41,11 +41,11 @@ func (opap *OPAProcessor) updateResults(ctx context.Context) {
 
 	// remove data from all objects
 	for i := range opap.AllResources {
-		if refNames := removeData(opap.AllResources[i]); len(refNames) > 0 {
+		if refsByContainer := removeData(opap.AllResources[i]); len(refsByContainer) > 0 {
 			if opap.EnvVarSecretRefs == nil {
-				opap.EnvVarSecretRefs = make(map[string]map[string]struct{})
+				opap.EnvVarSecretRefs = make(map[string]map[string]map[string]struct{})
 			}
-			opap.EnvVarSecretRefs[i] = refNames
+			opap.EnvVarSecretRefs[i] = refsByContainer
 		}
 	}
 
@@ -567,14 +567,17 @@ func getRuleDependencies(ctx context.Context) (map[string]string, error) {
 }
 
 // removeData strips sensitive data from obj before it reaches results
-// handling. For a Pod-shaped workload, it also returns the names of any
-// container env vars that had a ValueFrom reference (SecretKeyRef,
-// ConfigMapKeyRef, FieldRef, or ResourceFieldRef) before that reference was
-// cleared — never the reference target itself, never the value, only the
-// env var's own name. The anonymizer needs that name to keep anonymizing
-// reference-backed env var names under --hide/--encrypt after this
-// function has already cleared the reference it would otherwise inspect.
-func removeData(obj workloadinterface.IMetadata) map[string]struct{} {
+// handling. For a Pod-shaped workload, it also returns, per container name,
+// the names of that container's env vars that had a ValueFrom reference
+// (SecretKeyRef, ConfigMapKeyRef, FieldRef, or ResourceFieldRef) before that
+// reference was cleared — never the reference target itself, never the
+// value, only the env var's own name. The anonymizer needs that name to keep
+// anonymizing reference-backed env var names under --hide/--encrypt after
+// this function has already cleared the reference it would otherwise
+// inspect. Keyed by container name rather than merged across the whole pod,
+// since a name shared by an ordinary env var in one container and a
+// reference-backed one in another must not anonymize the ordinary one.
+func removeData(obj workloadinterface.IMetadata) map[string]map[string]struct{} {
 	if !k8sinterface.IsTypeWorkload(obj.GetObject()) {
 		return nil // remove data only from kubernetes objects
 	}
@@ -627,86 +630,105 @@ func removeSecretData(workload workloadinterface.IWorkload) {
 	overrideStringData(workload)
 }
 
-func removePodData(workload workloadinterface.IWorkload) map[string]struct{} {
+func removePodData(workload workloadinterface.IWorkload) map[string]map[string]struct{} {
 	workload.RemoveAnnotation("kubectl.kubernetes.io/last-applied-configuration")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "metadata", "managedFields")
 	workloadinterface.RemoveFromMap(workload.GetObject(), "status")
 
-	var refNames map[string]struct{}
-	addRefNames := func(names map[string]struct{}) {
-		if len(names) == 0 {
+	var refsByContainer map[string]map[string]struct{}
+	addRefsByContainer := func(byContainer map[string]map[string]struct{}) {
+		if len(byContainer) == 0 {
 			return
 		}
-		if refNames == nil {
-			refNames = make(map[string]struct{}, len(names))
+		if refsByContainer == nil {
+			refsByContainer = make(map[string]map[string]struct{}, len(byContainer))
 		}
-		for name := range names {
-			refNames[name] = struct{}{}
+		// Container names are unique across containers/initContainers/
+		// ephemeralContainers within one pod (enforced by the API server),
+		// so a name collision here would mean two container lists disagree
+		// about who owns that name -- not something to silently merge.
+		for name, refs := range byContainer {
+			refsByContainer[name] = refs
 		}
 	}
 
 	// containers
 	if containers, err := workload.GetContainers(); err == nil && len(containers) > 0 {
-		addRefNames(removeContainersData(containers))
+		addRefsByContainer(removeContainersData(containers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "containers", containers)
 	}
 
 	// init containers
 
 	if initContainers, err := workload.GetInitContainers(); err == nil && len(initContainers) > 0 {
-		addRefNames(removeContainersData(initContainers))
+		addRefsByContainer(removeContainersData(initContainers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "initContainers", initContainers)
 	}
 
 	// ephemeral containers
 	if ephemeralContainers, err := workload.GetEphemeralContainers(); err == nil && len(ephemeralContainers) > 0 {
-		addRefNames(removeEphemeralContainersData(ephemeralContainers))
+		addRefsByContainer(removeEphemeralContainersData(ephemeralContainers))
 		workloadinterface.SetInMap(workload.GetObject(), workloadinterface.PodSpec(workload.GetKind()), "ephemeralContainers", ephemeralContainers)
 	}
 
-	return refNames
+	return refsByContainer
 }
 
-// removeContainersData clears each env var's value and reference, returning
-// the names of the env vars that had a reference before it was cleared (see
-// removeData's doc comment for why only the name is kept).
-func removeContainersData(containers []corev1.Container) map[string]struct{} {
-	var refNames map[string]struct{}
+// removeContainersData clears each env var's value and reference, returning,
+// per container name, the names of that container's env vars that had a
+// reference before it was cleared (see removeData's doc comment for why
+// only the name is kept, and why this is scoped per container).
+func removeContainersData(containers []corev1.Container) map[string]map[string]struct{} {
+	var refsByContainer map[string]map[string]struct{}
 	for i := range containers {
 		container := &containers[i]
+		var refs map[string]struct{}
 		for j := range container.Env {
 			if container.Env[j].ValueFrom != nil {
-				if refNames == nil {
-					refNames = make(map[string]struct{})
+				if refs == nil {
+					refs = make(map[string]struct{})
 				}
-				refNames[container.Env[j].Name] = struct{}{}
+				refs[container.Env[j].Name] = struct{}{}
 			}
 			container.Env[j].Value = "XXXXXX"
 			container.Env[j].ValueFrom = nil
 		}
 		container.EnvFrom = nil
+		if len(refs) > 0 {
+			if refsByContainer == nil {
+				refsByContainer = make(map[string]map[string]struct{})
+			}
+			refsByContainer[container.Name] = refs
+		}
 	}
-	return refNames
+	return refsByContainer
 }
 
 // removeEphemeralContainersData mirrors removeContainersData for ephemeral containers.
-func removeEphemeralContainersData(containers []corev1.EphemeralContainer) map[string]struct{} {
-	var refNames map[string]struct{}
+func removeEphemeralContainersData(containers []corev1.EphemeralContainer) map[string]map[string]struct{} {
+	var refsByContainer map[string]map[string]struct{}
 	for i := range containers {
 		container := &containers[i]
+		var refs map[string]struct{}
 		for j := range container.Env {
 			if container.Env[j].ValueFrom != nil {
-				if refNames == nil {
-					refNames = make(map[string]struct{})
+				if refs == nil {
+					refs = make(map[string]struct{})
 				}
-				refNames[container.Env[j].Name] = struct{}{}
+				refs[container.Env[j].Name] = struct{}{}
 			}
 			container.Env[j].Value = "XXXXXX"
 			container.Env[j].ValueFrom = nil
 		}
 		container.EnvFrom = nil
+		if len(refs) > 0 {
+			if refsByContainer == nil {
+				refsByContainer = make(map[string]map[string]struct{})
+			}
+			refsByContainer[container.Name] = refs
+		}
 	}
-	return refNames
+	return refsByContainer
 }
 
 func ruleData(rule *reporthandling.PolicyRule) string {

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -175,6 +175,60 @@ func TestRemoveData(t *testing.T) {
 	}
 }
 
+// TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly guards the contract
+// removeData/removePodData/removeContainersData now carry for kubescape#3567:
+// the only signal that survives the scrub for a reference-backed env var is
+// its name, never the reference target or a plain env var's name.
+func TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly(t *testing.T) {
+	raw := `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "app", "namespace": "default"},
+		"spec": {
+			"containers": [{
+				"name": "c1",
+				"env": [
+					{"name": "DB_PASSWORD", "valueFrom": {"secretKeyRef": {"name": "creds", "key": "password"}}},
+					{"name": "LOG_LEVEL", "value": "debug"}
+				]
+			}],
+			"initContainers": [{
+				"name": "init",
+				"env": [
+					{"name": "INIT_TOKEN", "valueFrom": {"configMapKeyRef": {"name": "cfg", "key": "token"}}}
+				]
+			}]
+		}
+	}`
+
+	obj, err := workloadinterface.NewWorkload([]byte(raw))
+	require.NoError(t, err)
+
+	refNames := removeData(obj)
+
+	require.Len(t, refNames, 2, "must record exactly the reference-backed names across containers and init containers, nothing else")
+	_, hasDBPassword := refNames["DB_PASSWORD"]
+	_, hasInitToken := refNames["INIT_TOKEN"]
+	assert.True(t, hasDBPassword)
+	assert.True(t, hasInitToken)
+	_, hasLogLevel := refNames["LOG_LEVEL"]
+	assert.False(t, hasLogLevel, "an ordinary env var's name must not be recorded")
+}
+
+// TestRemoveData_SecretAndConfigMapReturnNil documents that removeData's new
+// return value is specific to Pod-shaped workloads: Secret/ConfigMap scrubbing
+// has no env vars to report on.
+func TestRemoveData_SecretAndConfigMapReturnNil(t *testing.T) {
+	for _, raw := range []string{
+		`{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s","namespace":"default"},"type":"Opaque","data":{"k":"v"}}`,
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"c","namespace":"default"},"data":{"k":"v"}}`,
+	} {
+		obj, err := workloadinterface.NewWorkload([]byte(raw))
+		require.NoError(t, err)
+		assert.Nil(t, removeData(obj))
+	}
+}
+
 func TestRemoveSecretData(t *testing.T) {
 	t.Run("stringData values are redacted", func(t *testing.T) {
 		raw := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"s","namespace":"default"},"type":"Opaque","stringData":{"token":"supersecret","apiKey":"abc123"}}`

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -178,7 +178,8 @@ func TestRemoveData(t *testing.T) {
 // TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly guards the contract
 // removeData/removePodData/removeContainersData now carry for kubescape#3567:
 // the only signal that survives the scrub for a reference-backed env var is
-// its name, never the reference target or a plain env var's name.
+// its name, never the reference target or a plain env var's name, and it is
+// scoped per container name rather than merged across the whole pod.
 func TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly(t *testing.T) {
 	raw := `{
 		"apiVersion": "v1",
@@ -204,15 +205,61 @@ func TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly(t *testing.T) {
 	obj, err := workloadinterface.NewWorkload([]byte(raw))
 	require.NoError(t, err)
 
-	refNames := removeData(obj)
+	refsByContainer := removeData(obj)
 
-	require.Len(t, refNames, 2, "must record exactly the reference-backed names across containers and init containers, nothing else")
-	_, hasDBPassword := refNames["DB_PASSWORD"]
-	_, hasInitToken := refNames["INIT_TOKEN"]
+	require.Len(t, refsByContainer, 2, "must record exactly the two containers that had a reference-backed env var")
+	require.Contains(t, refsByContainer, "c1")
+	require.Contains(t, refsByContainer, "init")
+
+	_, hasDBPassword := refsByContainer["c1"]["DB_PASSWORD"]
 	assert.True(t, hasDBPassword)
-	assert.True(t, hasInitToken)
-	_, hasLogLevel := refNames["LOG_LEVEL"]
+	_, hasLogLevel := refsByContainer["c1"]["LOG_LEVEL"]
 	assert.False(t, hasLogLevel, "an ordinary env var's name must not be recorded")
+	assert.Len(t, refsByContainer["c1"], 1)
+
+	_, hasInitToken := refsByContainer["init"]["INIT_TOKEN"]
+	assert.True(t, hasInitToken)
+}
+
+// TestRemoveData_SameEnvVarNameAcrossContainersStaysContainerScoped is the
+// direct regression test for the cross-container collision matthyx and
+// CodeRabbit flagged on PR #3579: an ordinary env var in one container must
+// not be recorded just because a different container in the same pod has a
+// reference-backed env var with the same name.
+func TestRemoveData_SameEnvVarNameAcrossContainersStaysContainerScoped(t *testing.T) {
+	raw := `{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "app", "namespace": "default"},
+		"spec": {
+			"containers": [
+				{
+					"name": "has-ref",
+					"env": [
+						{"name": "TOKEN", "valueFrom": {"secretKeyRef": {"name": "creds", "key": "token"}}}
+					]
+				},
+				{
+					"name": "ordinary",
+					"env": [
+						{"name": "TOKEN", "value": "not-a-secret-just-a-literal"}
+					]
+				}
+			]
+		}
+	}`
+
+	obj, err := workloadinterface.NewWorkload([]byte(raw))
+	require.NoError(t, err)
+
+	refsByContainer := removeData(obj)
+
+	require.Contains(t, refsByContainer, "has-ref")
+	_, recorded := refsByContainer["has-ref"]["TOKEN"]
+	assert.True(t, recorded, "the reference-backed container's TOKEN must be recorded")
+
+	_, ordinaryRecorded := refsByContainer["ordinary"]
+	assert.False(t, ordinaryRecorded, "the ordinary container must have no entry at all: its TOKEN was never reference-backed")
 }
 
 // TestRemoveData_SecretAndConfigMapReturnNil documents that removeData's new


### PR DESCRIPTION
## Summary

Fixes #3567. `removeData` (called from `OPAProcessor.updateResults`) clears an env var's `ValueFrom` before `anonymizer.Apply`/`ApplyEncrypted` ever run, so the anonymizer's existing `hasRef`-gated env-var-name anonymization in `transformTypedEnv`/`transformUnstructuredEnv` could never actually fire in a real `--hide`/`--encrypt` scan — `ValueFrom` was already `nil` by the time it got there. It only worked in isolated unit tests that construct `ValueFrom` directly.

Per maintainer guidance on #3567 (@matthyx / @jijo-OO7, Option A): preserve only the minimal signal needed to restore the existing env-var-name anonymization, not the reference target or value.

## Changes

- `removeData`/`removePodData`/`removeContainersData`/`removeEphemeralContainersData` now return the set of env var names that had a `ValueFrom` reference before it was cleared, in addition to their existing scrubbing behavior (unchanged).
- `OPASessionObj` gains `EnvVarSecretRefs`, populated by `updateResults` right where it already calls `removeData`, keyed by resource ID.
- `transformSession` threads `EnvVarSecretRefs[oldID]` through `transformContainerMetadata` down to `transformTypedEnv`/`transformUnstructuredEnv`, which now fall back to it only when `ValueFrom` is `nil`. When `ValueFrom` is still present (e.g. a direct call to these functions), original behavior is unchanged and takes precedence — this keeps every existing test passing without modification beyond signature updates.

Ordinary (non-reference) env vars are unaffected: their name is never recorded and never anonymized under this path, per the "existing behavior for ordinary env vars should remain unchanged" requirement from the issue.

`updateResults` itself (explicitly commented `// DO NOT CHANGE`) gets exactly one additive change: capturing `removeData`'s return value into the new field. No reordering, no change to its existing three documented steps.

## Test plan

New `TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName` runs the two real production functions in the real order — `updateResults`, then `anonymizer.Apply` — on a real Pod-shaped resource with a `secretKeyRef`-backed env var and an ordinary one, and confirms:

```
=== RUN   TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName
--- PASS: TestUpdateResults_ThenAnonymizerApply_AnonymizesReferenceBackedEnvVarName (0.00s)
```

Confirmed this test fails without the fix (disabled the new fallback branch) and passes with it restored.

New `TestRemoveData_ReturnsReferenceBackedEnvVarNamesOnly` and `TestRemoveData_SecretAndConfigMapReturnNil` cover `removeData`'s new return contract directly, including across containers + init containers and the Secret/ConfigMap no-op case.

All existing anonymizer/opaprocessor tests pass unchanged (only call-site signatures updated, no behavior changes to any existing assertion).

Full suite:
- `go build ./...`, `go vet ./...` — clean
- `go test -race ./core/pkg/anonymizer/... ./core/pkg/opaprocessor/... ./core/cautils/...` — clean
- `go test ./...` (full repo) — clean
- `golangci-lint run --new-from-rev=upstream/master ./core/pkg/anonymizer/... ./core/pkg/opaprocessor/... ./core/cautils/...` — 0 issues
- `gofmt -l` on changed files — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymization of environment variable names linked to secret references on a per-container basis.
  * Prevented matching environment variable names in one container from affecting unrelated variables in another.
  * Preserved correct handling across standard, init, and ephemeral containers.
  * Maintained existing behavior for Secrets and ConfigMaps.
* **Tests**
  * Added regression coverage for container-specific anonymization and sensitive reference removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->