### PR TITLE
fix: validate URLs in config set

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -57,6 +57,9 @@ func validateURL(u string) error {
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return fmt.Errorf("URL scheme must be http or https")
 	}
+	if parsed.Host == "" {
+		return fmt.Errorf("URL host must not be empty")
+	}
 	return nil
 }
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -31,16 +31,16 @@ func getSetCmd(ks meta.IKubescape) *cobra.Command {
 }
 
 var supportConfigSet = map[string]func(*metav1.SetConfig, string) error{
-	"accessKey":      func(s *metav1.SetConfig, accessKey string) error { s.AccessKey = accessKey; return nil },
-	"accountID":      func(s *metav1.SetConfig, account string) error { s.Account = account; return nil },
-	"cloudAPIURL":    func(s *metav1.SetConfig, cloudAPIURL string) error { 
+	"accessKey": func(s *metav1.SetConfig, accessKey string) error { s.AccessKey = accessKey; return nil },
+	"accountID": func(s *metav1.SetConfig, account string) error { s.Account = account; return nil },
+	"cloudAPIURL": func(s *metav1.SetConfig, cloudAPIURL string) error {
 		if err := validateURL(cloudAPIURL); err != nil {
 			return fmt.Errorf("invalid cloudAPIURL: %w", err)
 		}
 		s.CloudAPIURL = cloudAPIURL
 		return nil
 	},
-	"cloudReportURL": func(s *metav1.SetConfig, cloudReportURL string) error { 
+	"cloudReportURL": func(s *metav1.SetConfig, cloudReportURL string) error {
 		if err := validateURL(cloudReportURL); err != nil {
 			return fmt.Errorf("invalid cloudReportURL: %w", err)
 		}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -29,14 +30,37 @@ func getSetCmd(ks meta.IKubescape) *cobra.Command {
 	return configSetCmd
 }
 
-var supportConfigSet = map[string]func(*metav1.SetConfig, string){
-	"accessKey":      func(s *metav1.SetConfig, accessKey string) { s.AccessKey = accessKey },
-	"accountID":      func(s *metav1.SetConfig, account string) { s.Account = account },
-	"cloudAPIURL":    func(s *metav1.SetConfig, cloudAPIURL string) { s.CloudAPIURL = cloudAPIURL },
-	"cloudReportURL": func(s *metav1.SetConfig, cloudReportURL string) { s.CloudReportURL = cloudReportURL },
+var supportConfigSet = map[string]func(*metav1.SetConfig, string) error{
+	"accessKey":      func(s *metav1.SetConfig, accessKey string) error { s.AccessKey = accessKey; return nil },
+	"accountID":      func(s *metav1.SetConfig, account string) error { s.Account = account; return nil },
+	"cloudAPIURL":    func(s *metav1.SetConfig, cloudAPIURL string) error { 
+		if err := validateURL(cloudAPIURL); err != nil {
+			return fmt.Errorf("invalid cloudAPIURL: %w", err)
+		}
+		s.CloudAPIURL = cloudAPIURL
+		return nil
+	},
+	"cloudReportURL": func(s *metav1.SetConfig, cloudReportURL string) error { 
+		if err := validateURL(cloudReportURL); err != nil {
+			return fmt.Errorf("invalid cloudReportURL: %w", err)
+		}
+		s.CloudReportURL = cloudReportURL
+		return nil
+	},
 }
 
-func stringKeysToSlice(m map[string]func(*metav1.SetConfig, string)) []string {
+func validateURL(u string) error {
+	parsed, err := url.ParseRequestURI(u)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https")
+	}
+	return nil
+}
+
+func stringKeysToSlice(m map[string]func(*metav1.SetConfig, string) error) []string {
 	keys := []string{}
 	for key := range m {
 		keys = append(keys, key)
@@ -58,7 +82,7 @@ func normalizeConfigKey(key string) string {
 	return key
 }
 
-func findConfigSetter(key string) (func(*metav1.SetConfig, string), bool) {
+func findConfigSetter(key string) (func(*metav1.SetConfig, string) error, bool) {
 	if setter, ok := supportConfigSet[key]; ok {
 		return setter, true
 	}
@@ -104,7 +128,9 @@ func parseSetArgs(args []string) (*metav1.SetConfig, error) {
 
 	setConfig := &metav1.SetConfig{}
 	if setConfigFunc, ok := findConfigSetter(key); ok {
-		setConfigFunc(setConfig, value)
+		if err := setConfigFunc(setConfig, value); err != nil {
+			return nil, err
+		}
 		return setConfig, nil
 	}
 	return setConfig, fmt.Errorf("key %q unknown; supported: %s", key, supported)

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -49,7 +49,7 @@ func TestGetSetCmd_SetCachedConfigReturnsError(t *testing.T) {
 
 // Should return a slice of keys when given a non-empty map
 func TestStringKeysToSlice(t *testing.T) {
-	m := map[string]func(*metav1.SetConfig, string){
+	m := map[string]func(*metav1.SetConfig, string) error{
 		"key1": nil,
 		"key2": nil,
 		"key3": nil,
@@ -144,4 +144,36 @@ func TestParseSetArgs_TooManyArgs(t *testing.T) {
 	_, err := parseSetArgs([]string{"accountID", "v", "extra"})
 	assert.ErrorContains(t, err, "too many arguments")
 	assert.ErrorContains(t, err, "supported keys:")
+}
+
+func TestParseSetArgs_CloudAPIURL_Invalid(t *testing.T) {
+	args := []string{"cloudAPIURL=hello-world"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudAPIURL")
+	assert.ErrorContains(t, err, "invalid URI for request")
+}
+
+func TestParseSetArgs_CloudAPIURL_InvalidScheme(t *testing.T) {
+	args := []string{"cloudAPIURL=ftp://example.com"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudAPIURL")
+	assert.ErrorContains(t, err, "URL scheme must be http or https")
+}
+
+func TestParseSetArgs_CloudReportURL_Invalid(t *testing.T) {
+	args := []string{"cloudReportURL=hello-world"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudReportURL")
+	assert.ErrorContains(t, err, "invalid URI for request")
+}
+
+func TestParseSetArgs_CloudReportURL_InvalidScheme(t *testing.T) {
+	args := []string{"cloudReportURL=ftp://example.com"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudReportURL")
+	assert.ErrorContains(t, err, "URL scheme must be http or https")
 }

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -177,3 +177,19 @@ func TestParseSetArgs_CloudReportURL_InvalidScheme(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid cloudReportURL")
 	assert.ErrorContains(t, err, "URL scheme must be http or https")
 }
+
+func TestParseSetArgs_CloudAPIURL_EmptyHost(t *testing.T) {
+	args := []string{"cloudAPIURL=http://"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudAPIURL")
+	assert.ErrorContains(t, err, "URL host must not be empty")
+}
+
+func TestParseSetArgs_CloudReportURL_EmptyHost(t *testing.T) {
+	args := []string{"cloudReportURL=https://"}
+	setConfig, err := parseSetArgs(args)
+	assert.Nil(t, setConfig)
+	assert.ErrorContains(t, err, "invalid cloudReportURL")
+	assert.ErrorContains(t, err, "URL host must not be empty")
+}


### PR DESCRIPTION
## Overview
This PR adds basic URL validation for configurations that expect a URL (`cloudAPIURL` and `cloudReportURL`) in `kubescape config set`. It ensures that the input is a valid URL with an `http` or `https` scheme, returning a clear error if validation fails.

## Related issues/PRs:
* Resolved #3584

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for cloud API and reporting URLs.
  - Rejects malformed URLs, empty hosts, and unsupported schemes such as `ftp`.
  - Accepts only valid HTTP and HTTPS addresses.
  - Configuration commands now report validation errors instead of silently accepting invalid values.
  - Improved error messages help identify and correct invalid URL settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->