### PR TITLE
feat(list): show the control configuration a scan evaluates against

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -22,6 +22,12 @@ var (
 	
   # List all supported controls names with ids
   %[1]s list controls
+
+  # Show the configurable inputs a scan evaluates controls against
+  %[1]s list controls-config
+
+  # Show the inputs a scan would use with a local controls-config override
+  %[1]s list controls-config --controls-config ./controls-inputs.json
   
   Control documentation:
   https://kubescape.io/docs/controls/
@@ -33,7 +39,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 
 	listCmd := &cobra.Command{
 		Use:     "list <policy> [flags]",
-		Short:   "List frameworks/controls will list the supported frameworks and controls",
+		Short:   "List the supported frameworks, controls and control configuration",
 		Long:    ``,
 		Example: listExample,
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -68,6 +74,7 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccountID, "account", "", "", "Kubescape SaaS account ID. Default will load account ID from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.Format, "format", "f", "pretty-print", "output format. supported: 'pretty-print'/'json'/'yaml'/'csv'")
+	listCmd.PersistentFlags().StringVar(&listPolicies.ControlsInputs, "controls-config", "", "Path to a controls-config file, to show the inputs a scan would use with it. Only applies to 'controls-config'")
 
 	// Deprecated flags
 	var dummyID bool

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -19,7 +19,7 @@ func TestGetListCmd(t *testing.T) {
 
 	// Verify the command name and short description
 	assert.Equal(t, "list <policy> [flags]", listCmd.Use)
-	assert.Equal(t, "List frameworks/controls will list the supported frameworks and controls", listCmd.Short)
+	assert.Equal(t, "List the supported frameworks, controls and control configuration", listCmd.Short)
 	assert.Equal(t, "", listCmd.Long)
 	assert.Equal(t, listExample, listCmd.Example)
 	supported := strings.Join(core.ListSupportActions(), ",")

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -12,9 +12,11 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/utils"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/maruel/natural"
 	"sigs.k8s.io/yaml"
 )
@@ -34,7 +36,7 @@ var listFormatFunc = map[string]func(context.Context, string, []string){
 }
 
 func ListSupportActions() []string {
-	commands := []string{"controls"}
+	commands := []string{"controls", "controls-config"}
 	for key := range listFunc {
 		commands = append(commands, key)
 	}
@@ -51,6 +53,14 @@ func (ks *Kubescape) List(listPolicies *metav1.ListPolicies) (*metav1.ListResult
 		}
 		entries = naturalSortControls(entries)
 		return &metav1.ListResult{Controls: entries}, nil
+	}
+
+	if listPolicies.Target == "controls-config" {
+		entries, err := listControlsConfig(ks.Context(), listPolicies)
+		if err != nil {
+			return nil, err
+		}
+		return &metav1.ListResult{ControlsConfig: entries}, nil
 	}
 
 	if policyListerFunc, ok := listFunc[listPolicies.Target]; ok {
@@ -85,6 +95,19 @@ func PrintListResult(ctx context.Context, result *metav1.ListResult, target, for
 		default:
 			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'/'csv'", format)
 		}
+	case "controls-config":
+		switch format {
+		case "pretty-print":
+			prettyPrintControlsConfig(ctx, result.ControlsConfig)
+		case "json":
+			jsonControlsConfigFormat(result.ControlsConfig)
+		case "yaml":
+			yamlControlsConfigFormat(result.ControlsConfig)
+		case "csv":
+			csvControlsConfigFormat(result.ControlsConfig)
+		default:
+			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'/'csv'", format)
+		}
 	case "frameworks", "exceptions":
 		if listFormatFunction, ok := listFormatFunc[format]; ok {
 			listFormatFunction(ctx, target, result.Names)
@@ -92,7 +115,7 @@ func PrintListResult(ctx context.Context, result *metav1.ListResult, target, for
 			return fmt.Errorf("invalid format \"%s\", supported formats: 'pretty-print'/'json'/'yaml'/'csv'", format)
 		}
 	default:
-		return fmt.Errorf("invalid target %q, supported targets: 'controls'/'frameworks'/'exceptions'", target)
+		return fmt.Errorf("invalid target %q, supported targets: 'controls'/'controls-config'/'frameworks'/'exceptions'", target)
 	}
 	return nil
 }
@@ -314,4 +337,185 @@ func shortFormatControlRows(controlRows []table.Row) []table.Row {
 		rows = append(rows, table.Row{fmt.Sprintf("Control ID"+strings.Repeat(" ", 3)+": %+v\nControl Name"+strings.Repeat(" ", 1)+": %+v\nDocs"+strings.Repeat(" ", 9)+": %+v\nFrameworks"+strings.Repeat(" ", 3)+": %+v", controlRow[0], controlRow[1], controlRow[2], strings.ReplaceAll(controlRow[3].(string), "\n", " "))})
 	}
 	return rows
+}
+
+// listControlsConfig resolves the configurable inputs a scan evaluates controls
+// against, from the same sources a scan would use, and pairs each one with the
+// controls that read it.
+func listControlsConfig(ctx context.Context, listPolicies *metav1.ListPolicies) ([]metav1.ControlConfigEntry, error) {
+	k8s := getKubernetesApi()
+	tenant := cautils.GetTenantConfig(ctx, listPolicies.AccountID, listPolicies.AccessKey, "", "", k8s)
+
+	// Both getters fall back to the released regolibrary, and each builds its own
+	// downloader when given none, which fetches the release twice.
+	downloadReleasedPolicy := getter.NewDownloadReleasedPolicy()
+
+	// A cluster scan prefers the ControlInput CRD over the released defaults, so
+	// resolving without it would report values the next scan will not use.
+	configGetter, _, err := getConfigInputsGetterForTarget(ctx, listPolicies.ControlsInputs, tenant.GetAccountID(), downloadReleasedPolicy, k8s != nil, false, k8s)
+	if err != nil {
+		return nil, err
+	}
+	policyGetter, err := getPolicyGetter(ctx, nil, tenant.GetAccountID(), false, downloadReleasedPolicy, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return controlsConfigEntries(ctx, configGetter, policyGetter, tenant.GetContextName())
+}
+
+// controlsConfigEntries pairs the resolved configuration with the controls that
+// read it. Both lookups are required: without the values there is nothing to
+// report, and without the policies every entry would be an orphan.
+func controlsConfigEntries(ctx context.Context, configGetter getter.IControlsInputsGetter, policyGetter getter.IPolicyGetter, clusterName string) ([]metav1.ControlConfigEntry, error) {
+	values, err := configGetter.GetControlsInputs(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	frameworks, err := policyGetter.GetFrameworks()
+	if err != nil {
+		return nil, err
+	}
+
+	return buildControlsConfigEntries(values, frameworks), nil
+}
+
+// buildControlsConfigEntries indexes every configurable input declared by a
+// control against the resolved values. Inputs a control declares but the
+// configuration does not set are still listed, with no values, since an unset
+// input is what makes a configurable control fall back to its rule default.
+func buildControlsConfigEntries(values map[string][]string, frameworks []reporthandling.Framework) []metav1.ControlConfigEntry {
+	titles := map[string]string{}
+	descriptions := map[string]string{}
+	controls := map[string]map[string]struct{}{}
+
+	for i := range frameworks {
+		for j := range frameworks[i].Controls {
+			control := &frameworks[i].Controls[j]
+			for k := range control.Rules {
+				for _, input := range control.Rules[k].ControlConfigInputs {
+					key := configInputKey(input)
+					if key == "" {
+						continue
+					}
+					if _, ok := controls[key]; !ok {
+						controls[key] = map[string]struct{}{}
+					}
+					controls[key][control.ControlID] = struct{}{}
+					if titles[key] == "" {
+						titles[key] = input.Name
+					}
+					if descriptions[key] == "" {
+						descriptions[key] = input.Description
+					}
+				}
+			}
+		}
+	}
+
+	names := make([]string, 0, len(values)+len(controls))
+	seen := map[string]struct{}{}
+	for name := range values {
+		names = append(names, name)
+		seen[name] = struct{}{}
+	}
+	for name := range controls {
+		if _, ok := seen[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	entries := make([]metav1.ControlConfigEntry, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, metav1.ControlConfigEntry{
+			Name:        name,
+			Title:       titles[name],
+			Description: descriptions[name],
+			Values:      append([]string{}, values[name]...),
+			Controls:    sortedKeys(controls[name]),
+		})
+	}
+	return entries
+}
+
+// configInputKey returns the controls-config key a declared input reads. The
+// controls address it by a dotted path such as
+// settings.postureControlInputs.imageRepositoryAllowList, while a
+// controls-config file is keyed by the last segment alone.
+func configInputKey(input reporthandling.ControlConfigInputs) string {
+	if input.Path != "" {
+		if idx := strings.LastIndex(input.Path, "."); idx != -1 {
+			return input.Path[idx+1:]
+		}
+		return input.Path
+	}
+	return input.Name
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func jsonControlsConfigFormat(entries []metav1.ControlConfigEntry) {
+	j, _ := json.MarshalIndent(entries, "", "  ")
+
+	fmt.Printf("%s\n", j)
+}
+
+func yamlControlsConfigFormat(entries []metav1.ControlConfigEntry) {
+	y, err := yaml.Marshal(entries)
+	if err != nil {
+		return
+	}
+
+	fmt.Printf("%s\n", y)
+}
+
+func csvControlsConfigFormat(entries []metav1.ControlConfigEntry) {
+	writer := csv.NewWriter(os.Stdout)
+	_ = writer.Write([]string{"name", "title", "values", "controls", "description"})
+	for _, entry := range entries {
+		_ = writer.Write([]string{
+			entry.Name,
+			entry.Title,
+			strings.Join(entry.Values, ";"),
+			strings.Join(entry.Controls, ";"),
+			entry.Description,
+		})
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write csv output: %v\n", err)
+	}
+}
+
+func prettyPrintControlsConfig(ctx context.Context, entries []metav1.ControlConfigEntry) {
+	configTable := table.NewWriter()
+	configTable.SetOutputMirror(printer.GetWriter(ctx, ""))
+
+	configTable.Style().Options.SeparateHeader = true
+	configTable.Style().Options.SeparateRows = true
+	configTable.Style().Format.HeaderAlign = text.AlignLeft
+	configTable.Style().Format.Header = text.FormatDefault
+	configTable.Style().Box = table.StyleBoxRounded
+
+	rows := make([]table.Row, 0, len(entries))
+	for _, entry := range entries {
+		values := strings.Join(entry.Values, "\n")
+		if values == "" {
+			values = "<unset>"
+		}
+		rows = append(rows, table.Row{entry.Name, entry.Title, values, strings.Join(entry.Controls, "\n")})
+	}
+
+	configTable.AppendHeader(table.Row{"Key", "Configuration", "Value", "Controls"})
+	configTable.AppendRows(rows)
+	configTable.Render()
 }

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -493,7 +493,7 @@ func TestListSupportActionsNotEmpty(t *testing.T) {
 
 func TestListSupportActionsReturnsSupportedActions(t *testing.T) {
 	got := ListSupportActions()
-	want := []string{"controls", "exceptions", "frameworks"}
+	want := []string{"controls", "controls-config", "exceptions", "frameworks"}
 	sort.Strings(got)
 
 	assert.Equal(t, want, got)

--- a/core/core/listcontrolsconfig_test.go
+++ b/core/core/listcontrolsconfig_test.go
@@ -1,0 +1,218 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func configInput(path, name, description string) reporthandling.ControlConfigInputs {
+	return reporthandling.ControlConfigInputs{Path: path, Name: name, Description: description}
+}
+
+func controlWithInputs(id string, inputs ...reporthandling.ControlConfigInputs) reporthandling.Control {
+	return reporthandling.Control{
+		ControlID: id,
+		Rules:     []reporthandling.PolicyRule{{ControlConfigInputs: inputs}},
+	}
+}
+
+func frameworkWithControls(controls ...reporthandling.Control) []reporthandling.Framework {
+	return []reporthandling.Framework{{Controls: controls}}
+}
+
+func TestConfigInputKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		input reporthandling.ControlConfigInputs
+		want  string
+	}{
+		{
+			name:  "dotted path resolves to its last segment",
+			input: configInput("settings.postureControlInputs.imageRepositoryAllowList", "Allowed image repositories", ""),
+			want:  "imageRepositoryAllowList",
+		},
+		{
+			name:  "path without a separator is the key itself",
+			input: configInput("cpu_limit_max", "cpu_limit_max", ""),
+			want:  "cpu_limit_max",
+		},
+		{
+			name:  "name is the fallback when no path is declared",
+			input: configInput("", "insecureCapabilities", ""),
+			want:  "insecureCapabilities",
+		},
+		{
+			name:  "an input declaring neither is skipped",
+			input: configInput("", "", "orphan"),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, configInputKey(tt.input))
+		})
+	}
+}
+
+// TestBuildControlsConfigEntriesJoinsOnTheConfigKey pins the join: controls
+// address an input by a dotted path, a controls-config file is keyed by the last
+// segment, and the human readable name is only a label. Joining on the label
+// instead would leave every value and every control in separate entries.
+func TestBuildControlsConfigEntriesJoinsOnTheConfigKey(t *testing.T) {
+	values := map[string][]string{
+		"imageRepositoryAllowList": {"registry.example.com"},
+	}
+	frameworks := frameworkWithControls(
+		controlWithInputs("C-0078", configInput("settings.postureControlInputs.imageRepositoryAllowList", "Allowed image repositories", "Repositories images may come from.")),
+		controlWithInputs("C-0304", configInput("settings.postureControlInputs.imageRepositoryAllowList", "Allowed image repositories", "")),
+	)
+
+	entries := buildControlsConfigEntries(values, frameworks)
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "imageRepositoryAllowList", entries[0].Name)
+	assert.Equal(t, "Allowed image repositories", entries[0].Title)
+	assert.Equal(t, "Repositories images may come from.", entries[0].Description)
+	assert.Equal(t, []string{"registry.example.com"}, entries[0].Values)
+	assert.Equal(t, []string{"C-0078", "C-0304"}, entries[0].Controls)
+}
+
+func TestBuildControlsConfigEntriesListsDeclaredButUnsetInputs(t *testing.T) {
+	frameworks := frameworkWithControls(
+		controlWithInputs("C-0050", configInput("settings.postureControlInputs.cpu_limit_max", "cpu_limit_max", "")),
+	)
+
+	entries := buildControlsConfigEntries(map[string][]string{}, frameworks)
+
+	// An unset input is why a configurable control falls back to its rule
+	// default, so it has to appear rather than be filtered out.
+	require.Len(t, entries, 1)
+	assert.Equal(t, "cpu_limit_max", entries[0].Name)
+	assert.Empty(t, entries[0].Values)
+	assert.Equal(t, []string{"C-0050"}, entries[0].Controls)
+}
+
+func TestBuildControlsConfigEntriesListsValuesNoControlReads(t *testing.T) {
+	values := map[string][]string{"retiredSetting": {"true"}}
+
+	entries := buildControlsConfigEntries(values, nil)
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "retiredSetting", entries[0].Name)
+	assert.Equal(t, []string{"true"}, entries[0].Values)
+	assert.Empty(t, entries[0].Controls)
+}
+
+func TestBuildControlsConfigEntriesIsSortedAndDeduplicated(t *testing.T) {
+	values := map[string][]string{"zeta": {"1"}, "alpha": {"2"}}
+	frameworks := []reporthandling.Framework{
+		{Controls: []reporthandling.Control{controlWithInputs("C-0002", configInput("settings.postureControlInputs.middle", "Middle", ""))}},
+		{Controls: []reporthandling.Control{controlWithInputs("C-0001", configInput("settings.postureControlInputs.middle", "Middle", ""))}},
+	}
+
+	entries := buildControlsConfigEntries(values, frameworks)
+
+	require.Len(t, entries, 3)
+	assert.Equal(t, "alpha", entries[0].Name)
+	assert.Equal(t, "middle", entries[1].Name)
+	assert.Equal(t, "zeta", entries[2].Name)
+
+	// The same input declared by two frameworks yields one entry naming both.
+	assert.Equal(t, []string{"C-0001", "C-0002"}, entries[1].Controls)
+}
+
+func TestBuildControlsConfigEntriesDoesNotAliasTheConfigValues(t *testing.T) {
+	values := map[string][]string{"key": {"original"}}
+
+	entries := buildControlsConfigEntries(values, nil)
+	require.Len(t, entries, 1)
+	entries[0].Values[0] = "mutated"
+
+	assert.Equal(t, []string{"original"}, values["key"], "the caller's configuration must not be modified")
+}
+
+func TestBuildControlsConfigEntriesSkipsInputsWithoutAKey(t *testing.T) {
+	frameworks := frameworkWithControls(controlWithInputs("C-0001", configInput("", "", "")))
+
+	assert.Empty(t, buildControlsConfigEntries(map[string][]string{}, frameworks))
+}
+
+func TestListSupportActionsIncludesControlsConfig(t *testing.T) {
+	assert.Contains(t, ListSupportActions(), "controls-config")
+}
+
+func TestPrintListResultRejectsAnUnknownControlsConfigFormat(t *testing.T) {
+	result := &metav1.ListResult{ControlsConfig: []metav1.ControlConfigEntry{{Name: "key"}}}
+
+	err := PrintListResult(t.Context(), result, "controls-config", "xml")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pretty-print")
+}
+
+type stubConfigGetter struct {
+	values      map[string][]string
+	err         error
+	clusterName string
+}
+
+func (s *stubConfigGetter) GetControlsInputs(_ context.Context, clusterName string) (map[string][]string, error) {
+	s.clusterName = clusterName
+	return s.values, s.err
+}
+
+type stubPolicyGetter struct {
+	getter.IPolicyGetter
+	frameworks []reporthandling.Framework
+	err        error
+}
+
+func (s *stubPolicyGetter) GetFrameworks() ([]reporthandling.Framework, error) {
+	return s.frameworks, s.err
+}
+
+func TestControlsConfigEntriesJoinsBothLookups(t *testing.T) {
+	config := &stubConfigGetter{values: map[string][]string{"insecureCapabilities": {"SETUID"}}}
+	policies := &stubPolicyGetter{frameworks: frameworkWithControls(
+		controlWithInputs("C-0046", configInput("settings.postureControlInputs.insecureCapabilities", "Insecure capabilities", "")),
+	)}
+
+	entries, err := controlsConfigEntries(t.Context(), config, policies, "my-cluster")
+
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, []string{"SETUID"}, entries[0].Values)
+	assert.Equal(t, []string{"C-0046"}, entries[0].Controls)
+	assert.Equal(t, "my-cluster", config.clusterName, "the cluster name must reach the configuration source")
+}
+
+func TestControlsConfigEntriesSurfacesAConfigurationError(t *testing.T) {
+	config := &stubConfigGetter{err: errors.New("controls-config unreachable")}
+	policies := &stubPolicyGetter{frameworks: frameworkWithControls(controlWithInputs("C-0046"))}
+
+	_, err := controlsConfigEntries(t.Context(), config, policies, "")
+
+	// Reporting an empty configuration would read as "nothing is configured",
+	// which is not the same as "the configuration could not be read".
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controls-config unreachable")
+}
+
+func TestControlsConfigEntriesSurfacesAPolicyError(t *testing.T) {
+	config := &stubConfigGetter{values: map[string][]string{"key": {"value"}}}
+	policies := &stubPolicyGetter{err: errors.New("frameworks unavailable")}
+
+	_, err := controlsConfigEntries(t.Context(), config, policies, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "frameworks unavailable")
+}

--- a/core/meta/datastructures/v1/listpolicies.go
+++ b/core/meta/datastructures/v1/listpolicies.go
@@ -1,10 +1,11 @@
 package v1
 
 type ListPolicies struct {
-	Target    string
-	Format    string
-	AccountID string
-	AccessKey string
+	Target         string
+	Format         string
+	AccountID      string
+	AccessKey      string
+	ControlsInputs string
 }
 
 type ListResponse struct {
@@ -13,8 +14,21 @@ type ListResponse struct {
 }
 
 type ListResult struct {
-	Names    []string
-	Controls []ControlListEntry
+	Names          []string
+	Controls       []ControlListEntry
+	ControlsConfig []ControlConfigEntry
+}
+
+// ControlConfigEntry is a single configurable input a scan evaluates controls
+// against, together with the value in effect and the controls that read it.
+type ControlConfigEntry struct {
+	// Name is the key as it appears in a controls-config file.
+	Name string `json:"name"`
+	// Title is the human readable label the controls declare it by.
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Values      []string `json:"values"`
+	Controls    []string `json:"controls"`
 }
 
 // ControlListEntry is a single row emitted by "kubescape list controls --format json".

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -712,7 +712,7 @@ kubescape decrypt encrypted-report.json > decrypted-report.json
 ---
 ## kubescape list
 
-List available frameworks and controls.
+List available frameworks, controls and control configuration.
 
 ### Synopsis
 
@@ -726,6 +726,8 @@ kubescape list <type> [flags]
 |------|-------------|
 | `frameworks` | List available security frameworks |
 | `controls` | List available security controls |
+| `controls-config` | Show the configurable inputs controls are evaluated against — see [control configuration](#control-configuration) |
+| `exceptions` | List available exception policies |
 
 ### Flags
 
@@ -733,7 +735,37 @@ kubescape list <type> [flags]
 |------|-------------|---------|
 | `--account <id>` | Account ID for custom frameworks | - |
 | `--access-key <key>` | Access key | - |
+| `--controls-config <path>` | Show the inputs a scan would use with this controls-config file. Only applies to `controls-config` | downloaded |
 | `--format <format>` | Output format: `pretty-print`, `json`, `yaml`, `csv` | `pretty-print` |
+
+### Control configuration
+
+Several controls are tunable: an allowlist of image repositories, the capabilities
+considered insecure, CPU and memory bounds. A scan resolves those inputs from the
+same sources it resolves policies from, but nothing printed them, so there was no
+way to see what a control was actually evaluated against or to confirm that a
+`--controls-config` override took effect.
+
+```bash
+# what the next scan will use
+kubescape list controls-config
+
+# what it would use with a local override
+kubescape list controls-config --controls-config ./controls-inputs.json --format json
+```
+
+Each row pairs a configuration key with the controls that read it:
+
+| Column | Meaning |
+|--------|---------|
+| `name` | The key as it appears in a controls-config file |
+| `title` | The label the controls declare it by |
+| `values` | The value in effect, empty when unset |
+| `controls` | The control IDs that read it |
+
+An input with no value is not an error — it is why a configurable control falls
+back to the default written into its rule. A value no control reads is usually a
+setting left behind by an older controls-config file.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

**Root cause:** Several controls are tunable through `controls-config`, the image repositories a workload may pull from, the capabilities treated as insecure, CPU and memory bounds, and a scan resolves those inputs, feeds them to the rego evaluation and folds them into the incremental cache key, but no command ever prints them.

The values are therefore invisible. A configurable control that fails gives no indication of the threshold it was measured against, and passing `--controls-config` produces no confirmation the override was picked up. That last one matters most in exactly the case where it is hardest to notice: when the configured source is unreachable and a fallback is quietly used instead.

**What this adds:**

```bash
# what the next scan will use
kubescape list controls-config

# what it would use with a local override
kubescape list controls-config --controls-config ./controls-inputs.json --format json
```

Each row pairs a configuration key with the controls that read it:

| Column | Meaning |
|--------|---------|
| `name` | The key as it appears in a controls-config file |
| `title` | The label the controls declare it by |
| `values` | The value in effect, empty when unset |
| `controls` | The control IDs that read it |

**Files changed:**

- `core/core/list.go`: resolves the inputs and joins them to the controls that declare them, plus the four output formats the command already supports.
- `core/meta/datastructures/v1/listpolicies.go`: `ControlConfigEntry`, and `ControlsInputs` on `ListPolicies` for the override flag.
- `cmd/list/list.go`: registers `--controls-config` and the examples.
- `docs/cli-reference.md`: new type in the table plus a section on reading the output.
- `cmd/list/list_test.go`, `core/core/list_test.go`: both pin exact strings that adding a list type changes.

**Design notes:**

- **The join is on the config key, not the label.** Controls address an input by a dotted path, `settings.postureControlInputs.imageRepositoryAllowList`, while a controls-config file is keyed by the last segment alone and the human-readable name ("Allowed image repositories") is only a label. Joining on the label produces two disjoint sets, 15 entries with values, 27 with controls, almost none with both and output that looks plausible but is useless.
- **Resolution follows the scan's own precedence**, including the ControlInput CRD when a cluster is reachable. Resolving without it would report the released defaults on a cluster whose scans actually use CRD values, which is silently the wrong answer for the users most likely to run this.
- **One downloader is shared between the two getters.** Both fall back to the released regolibrary and each builds its own when given none, so the release was being fetched twice.
- **Unset inputs are listed with no value**, because an unset input is why a configurable control falls back to the default written into its rule. **Values no control reads are listed too**, being the usual sign of a setting left behind by an older controls-config file.

**What was tested:**

- The join: `TestConfigInputKey`, `TestBuildControlsConfigEntriesJoinsOnTheConfigKey`
- Entry construction: `TestBuildControlsConfigEntriesListsDeclaredButUnsetInputs`, `TestBuildControlsConfigEntriesListsValuesNoControlReads`, `TestBuildControlsConfigEntriesIsSortedAndDeduplicated`, `TestBuildControlsConfigEntriesSkipsInputsWithoutAKey`, `TestBuildControlsConfigEntriesDoesNotAliasTheConfigValues`
- Wiring and error propagation: `TestControlsConfigEntriesJoinsBothLookups`, `TestControlsConfigEntriesSurfacesAConfigurationError`, `TestControlsConfigEntriesSurfacesAPolicyError`
- Command surface: `TestListSupportActionsIncludesControlsConfig`, `TestPrintListResultRejectsAnUnknownControlsConfigFormat`
- Manual: all four formats, an invalid format and an invalid target both still rejected, existing `list` targets unchanged, and the `--controls-config` override resolving to `imageRepositoryAllowList → [C-0078 C-0304]` and `insecureCapabilities → [C-0046]`.
- `go test ./... -count=1 -short` and `-race` clean, `go vet` and `gofmt` clean, `golangci-lint` reports 0 issues on the diff.

**Related issues:** none. Found by reading the control-inputs path, not from a filed issue.

**Which issue(s) this PR fixes:**

None, no existing issue covers this. The prior work on control inputs (#2384, #2515, #2532, #2601) is all about *fetching* them and handling fetch failures; none of it surfaces the resolved values.

**Special notes for your reviewer:**

Three things worth your attention:

1. **The `Path` vs `Name` join is the part to check.** My first implementation keyed on `Name` and produced output that looked fine and told you nothing. `TestBuildControlsConfigEntriesJoinsOnTheConfigKey` pins it with a comment explaining why the label is the wrong key.
2. **This makes a cluster API call that `list controls` does not**, the CRD lookup. Measured against an unreachable cluster: `list controls` takes 98.5s and `list controls-config` 110s, both exiting 0 with correct output. The 98.5s is pre-existing, since `GetTenantConfig` already probes the cluster on every `list`; the CRD probe adds roughly 11s and falls back gracefully. I deliberately did **not** bound it with a context timeout: `getConfigInputsGetterForTarget` treats a context error as fatal rather than falling through to the defaults, so a deadline would turn a graceful degradation on a slow cluster into a command failure.
3. **Air-gapped mode is not wired**, because `isAirGappedMode` is `len(scanInfo.UseFrom) > 0` - a scan-only flag. `list frameworks` and `list controls` download too, so this is consistent with the rest of the command rather than a gap I left.

The CRD branch itself is reasoned from the scan path rather than exercised end to end; I have no cluster with a `ControlInput` CRD to hand. The no-cluster and `--controls-config` paths are verified live.

No new dependencies.

**Does this PR introduce a user-facing change?**

Yes. A new `kubescape list controls-config` shows the configurable inputs controls are evaluated against, the value in effect for each, and which controls read it, in `pretty-print`, `json`, `yaml` or `csv`. A new `--controls-config <path>` flag on `kubescape list` shows what a scan would use with that file. Existing `list` targets are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `controls-config` as a supported `list` target.
  * Display control configuration values, associated controls, metadata, and unset entries.
  * Support pretty-print, JSON, YAML, and CSV output formats.
  * Added the `--controls-config` flag for specifying a configuration file.

* **Documentation**
  * Updated CLI help and reference documentation with control configuration and exceptions listing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->