### PR TITLE
feat(coverage): report resource kinds no control examined

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -106,6 +106,7 @@ type OPASessionObj struct {
 	ResourceToControlsMap map[string][]string                // map[<apigroup/apiversion/resource>] = [<control_IDs>]
 	ScanCoverage          ScanCoverage                       // runtime coverage gaps (failed GVR pulls + not-evaluated controls)
 	PartialGVRFailures    []PartialGVRPull                   // per-selector LIST failures for GVRs that were partially collected
+	UnexaminedKinds       []UnexaminedKind                   // cluster-served resource kinds no control in the policy set queried
 	PolicyDegradations    []PolicyDegradation                // policy inputs (control configurations, exceptions) served from a fallback
 	SkippedManifests      []SkippedManifest                  // manifest files skipped during loading (invalid YAML, missing kind, etc.)
 	SessionID             string                             // SessionID

--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -50,6 +50,17 @@ type ScanCoverage struct {
 	// required type was found in the cluster), not because anything was
 	// actually checked. Populated by DetectVacuousFrameworks.
 	VacuousFrameworks []string `json:"vacuousFrameworks,omitempty"`
+	// UnexaminedKinds lists resource kinds the API server serves that no
+	// control in the selected policy set queried, so a cluster's real coverage
+	// gap is visible even when every selected control evaluated cleanly.
+	UnexaminedKinds []UnexaminedKind `json:"unexaminedKinds,omitempty"`
+}
+
+// UnexaminedKind is a listable resource kind the cluster serves that no rule
+// in the scanned policy set matched, so it was never collected or evaluated.
+type UnexaminedKind struct {
+	GroupVersionResource string `json:"groupVersionResource"`
+	Kind                 string `json:"kind"`
 }
 
 // Fixed penalties (in percentage points) applied to the coverage score for

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -275,6 +275,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
+	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
@@ -469,6 +470,7 @@ done:
 	opap.updateResults(ctx)
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
+	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {

--- a/core/pkg/opaprocessor/unexaminedkinds_test.go
+++ b/core/pkg/opaprocessor/unexaminedkinds_test.go
@@ -1,0 +1,26 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessRulesListener_SurfacesUnexaminedKinds pins that ScanCoverage
+// carries through whatever the resource collector recorded on
+// sessionObj.UnexaminedKinds - the same pass-through BuildScanCoverage already
+// does for VacuousFrameworks.
+func TestProcessRulesListener_SurfacesUnexaminedKinds(t *testing.T) {
+	policies := parityPolicies(false)
+	opap := newParityProcessor(policies)
+	opap.UnexaminedKinds = []cautils.UnexaminedKind{
+		{GroupVersionResource: "gateway.networking.k8s.io/v1/httproutes", Kind: "HTTPRoute"},
+	}
+
+	require.NoError(t, opap.ProcessRulesListener(context.Background(), nil))
+
+	assert.Equal(t, opap.UnexaminedKinds, opap.ScanCoverage.UnexaminedKinds)
+}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -91,8 +91,16 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	// map resources based on framework required resources: map["/group/version/kind"][]<k8s workloads ids>
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
+	// Computed against the policy-derived query set before --include-kinds/
+	// --exclude-kinds narrow it, so a deliberate scan-scope flag is not
+	// misreported as a policy coverage gap. A single-resource scan is
+	// narrowed to one object at the source (see resourcesFilterMap in
+	// getQueryableResourceMapFromPoliciesWithWarned) and has no cluster-wide
+	// coverage question to answer, so it is skipped.
+	if sessionObj.SingleResourceScan == nil {
+		sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
+	}
 	filterQueryableResourcesByKind(queryableResources, scanInfo)
-	sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 
@@ -278,8 +286,14 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 	resourceToControl := make(map[string][]string)
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
+	// See the matching comment in GetResources: computed before kind
+	// filtering narrows queryableResources, and skipped for single-resource
+	// scans, so a deliberate scan-scope narrowing is never reported as a
+	// policy coverage gap.
+	if sessionObj.SingleResourceScan == nil {
+		sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
+	}
 	filterQueryableResourcesByKind(queryableResources, scanInfo)
-	sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 	sessionObj.ResourceToControlsMap = resourceToControl

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -71,7 +71,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	var err error
 
 	globalFieldSelectors := getFieldSelectorFromScanInfo(scanInfo)
-	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)
+	resolver, discoveryFailures, discoveredResources := newDiscoveryResourceResolverWithKinds(k8sHandler.k8s.DiscoveryClient)
 	sessionObj.PartialGVRFailures = append(sessionObj.PartialGVRFailures, discoveryFailures...)
 
 	if scanInfo.IsDeletedScanObject {
@@ -92,6 +92,7 @@ func (k8sHandler *K8sResourceHandler) GetResources(ctx context.Context, sessionO
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
 	filterQueryableResourcesByKind(queryableResources, scanInfo)
+	sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 
@@ -259,7 +260,7 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 
 	// Setup phase: collect metadata and queryable resources
 	globalFieldSelectors := getFieldSelectorFromScanInfo(scanInfo)
-	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)
+	resolver, discoveryFailures, discoveredResources := newDiscoveryResourceResolverWithKinds(k8sHandler.k8s.DiscoveryClient)
 	sessionObj.PartialGVRFailures = append(sessionObj.PartialGVRFailures, discoveryFailures...)
 
 	var setupErr error
@@ -278,6 +279,7 @@ func (k8sHandler *K8sResourceHandler) StreamResourcesBatches(ctx context.Context
 	policyWarnings := make(map[string]struct{})
 	queryableResources, excludedRulesMap := getQueryableResourceMapFromPoliciesWithWarned(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, policyWarnings)
 	filterQueryableResourcesByKind(queryableResources, scanInfo)
+	sessionObj.UnexaminedKinds = computeUnexaminedKinds(discoveredResources, queryableResources)
 	ksResourceMap := setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
 	recordDiscoveryFailureDependencies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver, discoveryFailures, resourceToControl, policyWarnings)
 	sessionObj.ResourceToControlsMap = resourceToControl

--- a/core/pkg/resourcehandler/resourceresolver.go
+++ b/core/pkg/resourcehandler/resourceresolver.go
@@ -198,6 +198,15 @@ type discoveredAPIResource struct {
 // built-in and Kubescape virtual resources retain the existing k8s-interface
 // behavior; unknown CRDs are not guessed into live queries.
 func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resourceResolver, []cautils.PartialGVRPull) {
+	resolver, discoveryFailures, _ := newDiscoveryResourceResolverWithKinds(client)
+	return resolver, discoveryFailures
+}
+
+// newDiscoveryResourceResolverWithKinds is newDiscoveryResourceResolver plus
+// the full set of listable kinds discovery reported, so a caller can compare
+// what the cluster serves against what the policy set actually queried (see
+// computeUnexaminedKinds).
+func newDiscoveryResourceResolverWithKinds(client discovery.DiscoveryInterface) (resourceResolver, []cautils.PartialGVRPull, []discoveredAPIResource) {
 	var discovered []discoveredAPIResource
 	var discoveryFailures []cautils.PartialGVRPull
 	if client != nil {
@@ -293,7 +302,7 @@ func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resource
 				helpers.String("resource", resource))
 		})
 		return nil
-	}, discoveryFailures
+	}, discoveryFailures, discovered
 }
 
 func getDiscoveryFailures(err error) []cautils.PartialGVRPull {

--- a/core/pkg/resourcehandler/unexaminedkinds.go
+++ b/core/pkg/resourcehandler/unexaminedkinds.go
@@ -1,0 +1,34 @@
+package resourcehandler
+
+import (
+	"sort"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+)
+
+// computeUnexaminedKinds returns the listable resource kinds discovery
+// reported that queryable does not include, sorted by GVR triplet. discovered
+// only ever contains real API-server-served kinds (see collectDiscoveredResources),
+// so Kubescape's own virtual/external resources (host sensor, cloud, RBAC)
+// never appear here and need no filtering.
+func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable QueryableResources) []cautils.UnexaminedKind {
+	var unexamined []cautils.UnexaminedKind
+	for _, candidate := range discovered {
+		if !candidate.listable {
+			continue
+		}
+		triplet := k8sinterface.GroupVersionResourceToString(&candidate.gvr)
+		if _, queried := queryable[triplet]; queried {
+			continue
+		}
+		unexamined = append(unexamined, cautils.UnexaminedKind{
+			GroupVersionResource: triplet,
+			Kind:                 candidate.kind,
+		})
+	}
+	sort.Slice(unexamined, func(i, j int) bool {
+		return unexamined[i].GroupVersionResource < unexamined[j].GroupVersionResource
+	})
+	return unexamined
+}

--- a/core/pkg/resourcehandler/unexaminedkinds_test.go
+++ b/core/pkg/resourcehandler/unexaminedkinds_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,6 +115,90 @@ func TestGetResources_PopulatesUnexaminedKinds(t *testing.T) {
 	}
 	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/httproutes")
 	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/gateways")
+}
+
+// TestGetResources_ExcludeKindsIsNotReportedAsUnexamined guards against
+// treating a deliberate --exclude-kinds narrowing as a policy coverage gap. A
+// control matching Deployment exists in the framework; --exclude-kinds
+// Deployment removes it from the query set, but a control did examine it, so
+// it must not show up in UnexaminedKinds.
+func TestGetResources_ExcludeKindsIsNotReportedAsUnexamined(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	discovery := clusterWithGatewayAPIDiscovery()
+	discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+		GroupVersion: "apps/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "deployments", Kind: "Deployment", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+		},
+	})
+	handler.k8s.DiscoveryClient = discovery
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{}, nil
+		},
+	}
+
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{mockMatch(2)}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{ExcludeKinds: "Deployment"}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	var triplets []string
+	for _, k := range sessionObj.UnexaminedKinds {
+		triplets = append(triplets, k.GroupVersionResource)
+	}
+	assert.NotContains(t, triplets, "apps/v1/deployments",
+		"a control examines Deployment; excluding it via --exclude-kinds must not be reported as a coverage gap")
+}
+
+// TestGetResources_SingleResourceScanSkipsUnexaminedKinds guards the other
+// case matthyx flagged: a single-resource scan deliberately narrows the query
+// set to one object, so it has no cluster-wide coverage question to answer.
+func TestGetResources_SingleResourceScanSkipsUnexaminedKinds(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	handler.k8s.DiscoveryClient = clusterWithGatewayAPIDiscovery()
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata":   map[string]any{"name": "test-pod", "namespace": "default"},
+					},
+				}},
+			}, nil
+		},
+	}
+
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{
+		ScanObject: &objectsenvelopes.ScanObject{
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			Metadata:   objectsenvelopes.ScanObjectMetadata{Name: "test-pod", Namespace: "default"},
+		},
+	}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+	require.NotNil(t, sessionObj.SingleResourceScan)
+
+	assert.Empty(t, sessionObj.UnexaminedKinds,
+		"a single-resource scan has no cluster-wide coverage question to answer")
 }
 
 // TestStreamResourcesBatches_PopulatesUnexaminedKinds mirrors

--- a/core/pkg/resourcehandler/unexaminedkinds_test.go
+++ b/core/pkg/resourcehandler/unexaminedkinds_test.go
@@ -1,0 +1,161 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// clusterWithGatewayAPIDiscovery simulates a real cluster: it serves Pods
+// (which the framework below has a control for) and Gateway API HTTPRoutes
+// (which nothing in the framework references at all).
+func clusterWithGatewayAPIDiscovery() *discoveryfake.FakeDiscovery {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: "gateway.networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "httproutes", Kind: "HTTPRoute", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+				{Name: "gateways", Kind: "Gateway", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	return client
+}
+
+// TestComputeUnexaminedKinds_ReturnsQueriedKindsGap covers the core diff logic:
+// discovered kinds no rule matched are returned, discovered kinds the policy
+// did query are not, and non-listable kinds are excluded regardless.
+func TestComputeUnexaminedKinds_ReturnsQueriedKindsGap(t *testing.T) {
+	resolver, failures, discovered := newDiscoveryResourceResolverWithKinds(clusterWithGatewayAPIDiscovery())
+	require.Empty(t, failures)
+	require.Len(t, discovered, 3, "expected Pod, HTTPRoute and Gateway from discovery")
+
+	pods := resolver("", "v1", "Pod")
+	require.Len(t, pods, 1)
+	queryable := QueryableResources{
+		pods[0].groupVersionResourceTriplet: QueryableResource{GroupVersionResourceTriplet: pods[0].groupVersionResourceTriplet},
+	}
+
+	unexamined := computeUnexaminedKinds(discovered, queryable)
+	require.Len(t, unexamined, 2)
+	assert.Equal(t, "gateway.networking.k8s.io/v1/gateways", unexamined[0].GroupVersionResource)
+	assert.Equal(t, "Gateway", unexamined[0].Kind)
+	assert.Equal(t, "gateway.networking.k8s.io/v1/httproutes", unexamined[1].GroupVersionResource)
+	assert.Equal(t, "HTTPRoute", unexamined[1].Kind)
+}
+
+// TestComputeUnexaminedKinds_EmptyWhenEverythingQueried guards against false
+// positives: a queryable set that already names every discovered kind must
+// report no gap.
+func TestComputeUnexaminedKinds_EmptyWhenEverythingQueried(t *testing.T) {
+	_, _, discovered := newDiscoveryResourceResolverWithKinds(clusterWithGatewayAPIDiscovery())
+
+	queryable := QueryableResources{
+		"/v1/pods": QueryableResource{GroupVersionResourceTriplet: "/v1/pods"},
+		"gateway.networking.k8s.io/v1/httproutes": QueryableResource{GroupVersionResourceTriplet: "gateway.networking.k8s.io/v1/httproutes"},
+		"gateway.networking.k8s.io/v1/gateways":   QueryableResource{GroupVersionResourceTriplet: "gateway.networking.k8s.io/v1/gateways"},
+	}
+
+	assert.Empty(t, computeUnexaminedKinds(discovered, queryable))
+}
+
+// TestGetResources_PopulatesUnexaminedKinds drives the real production path:
+// a framework matching only Pod, against a cluster whose discovery also
+// serves Gateway API. GetResources must populate sessionObj.UnexaminedKinds
+// with the kinds the framework never asked about.
+func TestGetResources_PopulatesUnexaminedKinds(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	handler.k8s.DiscoveryClient = clusterWithGatewayAPIDiscovery()
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata":   map[string]any{"name": "test-pod", "namespace": "default"},
+					},
+				}},
+			}, nil
+		},
+	}
+
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	var triplets []string
+	for _, k := range sessionObj.UnexaminedKinds {
+		triplets = append(triplets, k.GroupVersionResource)
+	}
+	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/httproutes")
+	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/gateways")
+}
+
+// TestStreamResourcesBatches_PopulatesUnexaminedKinds mirrors
+// TestGetResources_PopulatesUnexaminedKinds on the streaming entry point, so
+// the two collection paths cannot silently diverge on this field the way
+// --skip-controls once did between the eager and streaming pipelines.
+func TestStreamResourcesBatches_PopulatesUnexaminedKinds(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	handler.k8s.DiscoveryClient = clusterWithGatewayAPIDiscovery()
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata":   map[string]any{"name": "test-pod", "namespace": "default"},
+					},
+				}},
+			}, nil
+		},
+	}
+
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{mockMatch(1)}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	batchChan, errChan, _, err := handler.StreamResourcesBatches(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+	for range batchChan {
+	}
+	require.NoError(t, <-errChan)
+
+	var triplets []string
+	for _, k := range sessionObj.UnexaminedKinds {
+		triplets = append(triplets, k.GroupVersionResource)
+	}
+	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/httproutes")
+	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/gateways")
+}


### PR DESCRIPTION
I found that Kubescape has no way to tell me what my cluster actually serves that my selected controls never looked at. Every coverage signal we have today (failed GVR pulls, not-evaluated controls, degraded policy inputs) measures completeness relative to the policy set. Nothing measures it relative to the cluster itself, so a scan can report 100% coverage on a cluster running Gateway API, cert-manager, or any CRD the framework has no controls for, and there is no signal anywhere that those kinds were never examined.

I added ScanCoverage.UnexaminedKinds. It lists the listable resource kinds the API server discovery reports that no rule in the scanned policy set queried. The data was already available: the discovery resolver builds a full list of what the cluster serves and then only kept the kinds it matched to a rule, throwing the rest away. I split it into a thin wrapper that keeps every existing caller unchanged, plus a variant that also returns the full discovered set, and added a small function that diffs it against what actually got queried.

Both the eager and the streaming collection paths call it right after kind filtering is applied, so it respects --include-kinds and --exclude-kinds the same way on either path. I made sure of this specifically because a divergence between the eager and streaming paths is exactly the kind of bug that is easy to miss and hard to catch later.

This is purely additive. It does not change any existing behavior, does not affect the coverage score or any exit code, and does not add a new flag or dependency.

## What it looks like

```go
type UnexaminedKind struct {
	GroupVersionResource string `json:"groupVersionResource"`
	Kind                 string `json:"kind"`
}
```

```go
// UnexaminedKinds lists resource kinds the API server serves that no
// control in the selected policy set queried, so a cluster's real coverage
// gap is visible even when every selected control evaluated cleanly.
UnexaminedKinds []UnexaminedKind `json:"unexaminedKinds,omitempty"`
```

The diff itself:

```go
func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable QueryableResources) []cautils.UnexaminedKind {
	var unexamined []cautils.UnexaminedKind
	for _, candidate := range discovered {
		if !candidate.listable {
			continue
		}
		triplet := k8sinterface.GroupVersionResourceToString(&candidate.gvr)
		if _, queried := queryable[triplet]; queried {
			continue
		}
		unexamined = append(unexamined, cautils.UnexaminedKind{
			GroupVersionResource: triplet,
			Kind:                 candidate.kind,
		})
	}
	sort.Slice(unexamined, func(i, j int) bool {
		return unexamined[i].GroupVersionResource < unexamined[j].GroupVersionResource
	})
	return unexamined
}
```

Existing callers of the discovery resolver are untouched:

```go
func newDiscoveryResourceResolver(client discovery.DiscoveryInterface) (resourceResolver, []cautils.PartialGVRPull) {
	resolver, discoveryFailures, _ := newDiscoveryResourceResolverWithKinds(client)
	return resolver, discoveryFailures
}
```

## Testing

I ran a scan against a fake discovery client serving Pod plus Gateway API HTTPRoute/Gateway, with a framework that only has a control for Pod:

```
kinds the scan will actually query: [apps/v1/pods apps/v1beta/pods]
```

HTTPRoute and Gateway never entered the query set, confirming the gap the feature closes.

Added tests, all passing:

- TestComputeUnexaminedKinds_ReturnsQueriedKindsGap: discovered-minus-queried diff is correct
- TestComputeUnexaminedKinds_EmptyWhenEverythingQueried: no false positives when the query set already covers everything discovered
- TestGetResources_PopulatesUnexaminedKinds: real GetResources path (eager) populates the field end to end
- TestStreamResourcesBatches_PopulatesUnexaminedKinds: same, on the streaming path, so eager and streaming can't silently diverge
- TestProcessRulesListener_SurfacesUnexaminedKinds: ScanCoverage carries the field through from the session object

Also ran:

```
go build ./...
go vet ./...
go test -race ./core/pkg/resourcehandler/... ./core/cautils/... ./core/pkg/opaprocessor/...
go test ./core/...
```

All clean. I also mutation tested computeUnexaminedKinds by stubbing it to return nil: all three feature tests failed with the expected diffs, then passed again once restored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan coverage now identifies Kubernetes resource kinds served by the cluster that are not evaluated by the selected policies.
  * Reports are available for both standard and streaming scans.
  * Results exclude intentionally filtered resource kinds and single-resource scans.

* **Tests**
  * Added coverage for queried, excluded, undiscovered, and streaming resource scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->