### PR TITLE
fix(resultshandling): deterministic AssociatedControls ordering across scans

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -565,6 +565,12 @@ func (opap *OPAProcessor) processScope(ctx context.Context, policies *cautils.Po
 	}
 	wg.Wait()
 
+	// Workers complete in scheduling order, so each resource's controls were
+	// appended in arbitrary sequence. Sort once, after all scopes and the
+	// whole-cluster pass have finished, so identical scans produce identically
+	// ordered results for every downstream consumer.
+	sortAssociatedControls(opap.ResourcesResult)
+
 	return errors.Join(processErrs...)
 }
 
@@ -619,6 +625,10 @@ func (opap *OPAProcessor) Process(ctx context.Context, policies *cautils.Policie
 			processErrs = append(processErrs, err)
 		}
 	}
+
+	// Same deterministic-layout guarantee as the streaming path: sort only
+	// after every scope and the whole-cluster pass have finished appending.
+	sortAssociatedControls(opap.ResourcesResult)
 
 	return errors.Join(processErrs...)
 }
@@ -772,6 +782,20 @@ func policyControlSortKey(item policyControl) string {
 		return item.control.ControlID
 	}
 	return item.key
+}
+
+// sortAssociatedControls orders each resource's controls by ControlID so
+// identical scans produce identically ordered reports. processScope dispatches
+// controls in sorted order, but its workers append verdicts in completion
+// order; this restores a stable layout once evaluation has finished.
+func sortAssociatedControls(resourcesResult map[string]resourcesresults.Result) {
+	for id := range resourcesResult {
+		result := resourcesResult[id]
+		slices.SortFunc(result.AssociatedControls, func(a, b resourcesresults.ResourceAssociatedControl) int {
+			return strings.Compare(a.ControlID, b.ControlID)
+		})
+		resourcesResult[id] = result
+	}
 }
 
 // controlRequiresWholeClusterInput reports whether a control joins objects

--- a/core/pkg/opaprocessor/processorhandler_parity_test.go
+++ b/core/pkg/opaprocessor/processorhandler_parity_test.go
@@ -190,14 +190,13 @@ func referenceProcess(t *testing.T, opap *OPAProcessor, policies *cautils.Polici
 	return results
 }
 
-// normalize makes two result sets comparable. Control and rule ordering is an
-// artefact of map iteration; path ordering reflects the order Rego yielded a
-// rule's findings, which is a set and therefore not ordered either.
+// normalize makes two result sets comparable. Control ordering is guaranteed
+// deterministic by the processor (sortAssociatedControls), but rule ordering
+// reflects the order scopes first saw each rule and path ordering reflects the
+// order Rego yielded a rule's findings — both are sets, so they are sorted here
+// before comparison.
 func normalize(results map[string]resourcesresults.Result) map[string]resourcesresults.Result {
 	for resourceID, result := range results {
-		sort.Slice(result.AssociatedControls, func(i, j int) bool {
-			return result.AssociatedControls[i].ControlID < result.AssociatedControls[j].ControlID
-		})
 		for i := range result.AssociatedControls {
 			rules := result.AssociatedControls[i].ResourceAssociatedRules
 			sort.Slice(rules, func(a, b int) bool { return rules[a].Name < rules[b].Name })

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -300,6 +301,14 @@ func finalizeResults(results []resourcesresults.Result, resourcesResult map[stri
 
 	for index, resourceID := range resourceIDs {
 		results[index] = resourcesResult[resourceID]
+
+		// Deterministic per-resource layout: AssociatedControls arrive in
+		// whatever order concurrent evaluation appended them (or however a
+		// session built outside the processor assembled them), so sort by
+		// ControlID before the report leaves this function.
+		slices.SortFunc(results[index].AssociatedControls, func(a, b resourcesresults.ResourceAssociatedControl) int {
+			return strings.Compare(a.ControlID, b.ControlID)
+		})
 
 		// Add prioritization information to the result
 		if v, exist := prioritizedResources[resourceID]; exist {

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -1232,6 +1232,37 @@ func TestFinalizeResults_SortsResultsAndResourcesByResourceID(t *testing.T) {
 	}
 }
 
+// TestFinalizeResults_SortsAssociatedControlsByControlID pins deterministic
+// per-resource layout: identical scans must emit each resource's controls in
+// the same order regardless of the order concurrent evaluation appended them.
+func TestFinalizeResults_SortsAssociatedControlsByControlID(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+
+	resource := createWorkloadWithLabels("alpha", "default", nil)
+	result := resourcesresults.Result{ResourceID: resource.GetID()}
+
+	// Insert controls in deliberately shuffled order, mirroring whatever order
+	// concurrent evaluation workers happened to complete in.
+	for _, controlID := range []string{"C-0009", "C-0001", "C-0005", "C-0012", "C-0002"} {
+		result.AssociatedControls = append(result.AssociatedControls,
+			resourcesresults.ResourceAssociatedControl{ControlID: controlID})
+	}
+	session.ResourcesResult[resource.GetID()] = result
+
+	want := []string{"C-0001", "C-0002", "C-0005", "C-0009", "C-0012"}
+	for i := 0; i < 16; i++ {
+		report := FinalizeResults(session)
+		require.NotNil(t, report)
+		require.Len(t, report.Results, 1)
+
+		got := make([]string, 0, len(report.Results[0].AssociatedControls))
+		for _, control := range report.Results[0].AssociatedControls {
+			got = append(got, control.ControlID)
+		}
+		require.Equalf(t, want, got, "associated controls iteration %d", i)
+	}
+}
+
 func Test_mapInfoToPrintInfo_stableMarkers(t *testing.T) {
 	skipReasons := map[string]string{
 		"C-0001": "no cluster connection",


### PR DESCRIPTION
Closes #3587.

## Overview

**Current behavior:** `processScope` dispatches controls through `controlChan` in sorted order, but its `GOMAXPROCS(0)` workers append verdicts into `ResourcesResult[resourceID].AssociatedControls` in completion order. The mutex makes this race-free — but nothing fixes append order — so identical scans can list the same resource's controls in different positions between runs (e.g. `controls[0]` is C-0016 in one run and C-0017 in the next). `FinalizeResults` sorted top-level results by ResourceID but preserved each result's inner slice as-is.

**Future behavior:** each resource's `AssociatedControls` is sorted by ControlID before results leave the processor and again at the report funnel, so identical scans produce identically ordered reports. This completes the determinism guarantee started in #2773 (top-level arrays) for the inner per-resource slice.

## Changes

1. **Source fix** (`core/pkg/opaprocessor/processorhandler.go`): new `sortAssociatedControls` helper, called once after all scopes and the whole-cluster pass finish — in **both** `Process` and `ProcessWithStreaming`. Sorting inside a single `processScope` call would be undone by later scopes appending, so it belongs after all processing completes.
2. **Defense-in-depth** (`core/pkg/resultshandling/printer/v2/utils.go`): `finalizeResults` applies the same sort, covering sessions built outside the processor entry points.
3. **Test cleanup** (`processorhandler_parity_test.go`): `normalize` no longer needs to sort `AssociatedControls` before comparing — production now guarantees that order natively. Rule/path ordering is still normalized there as before.

## Additional Information

- No behavior change beyond stable ordering; scoring, statuses, and findings are untouched.
- Ordering stability only — reports still differ per run in `generationTime` by design.
- One correction to my Slack message: I suggested sorting in `finalizeResults` alone would let us drop the parity-test workaround; on implementation, the sort needed to go at the processor source (both entry points) for that to hold — `finalizeResults` is kept as defense-in-depth. The RWMutex-in-`OPASessionObj` idea remains a possible future direction, deferred as discussed.
- Confirmed with @matthyx.

## How to Test

```bash
go build ./...
go vet ./core/pkg/opaprocessor/... ./core/pkg/resultshandling/... ./cmd/scan/... ./cmd/shared/...
go test ./core/pkg/resultshandling/... ./core/pkg/opaprocessor/... -count=1
go test ./cmd/scan/ ./cmd/shared/ -count=1
```

Manual repro from the issue:
```bash
kubescape scan <target> --format json --output run1.json
kubescape scan <target> --format json --output run2.json
diff run1.json run2.json   # AssociatedControls order no longer differs
```

New regression test: `TestFinalizeResults_SortsAssociatedControlsByControlID` (shuffled insertion → 16 × `FinalizeResults` → identical ascending ControlID order).

## Related Issues/PRs

* Closes #3587
* Completes #2773

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of resource-associated control ordering in both streaming and non-streaming results.
  * Ensured controls are presented in deterministic Control ID order across repeated runs.
  * Prevented varying insertion order from affecting result prioritization and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->