### PR TITLE
fix(vapreconcile): correct binding-scope coverage for cluster-scoped resources and Namespaces

### DIFF
--- a/core/pkg/vapreconcile/coverage.go
+++ b/core/pkg/vapreconcile/coverage.go
@@ -13,10 +13,12 @@ import (
 )
 
 // ResourceInfo is the minimal identity a coverage check needs for one
-// scanned resource: which namespace it lives in (empty for cluster-scoped)
-// and its own labels, for objectSelector matching.
+// scanned resource: what it is, which namespace it lives in (empty for
+// cluster-scoped) and its own labels, for objectSelector matching.
 type ResourceInfo struct {
 	ResourceID string
+	APIVersion string
+	Kind       string
 	Namespace  string
 	Labels     map[string]string
 }
@@ -103,19 +105,23 @@ type bindingScope struct {
 	objectSelector    labels.Selector
 }
 
-// matches reports whether a resource falls within this binding's scope.
+// matches reports whether a resource falls within this binding's scope. It
+// takes the whole ResourceInfo because the two selectors read different parts
+// of it, and the apiserver's own namespace matcher also branches on what the
+// resource is, not just on where it lives.
+//
 // namespaceLabelsKnown is false when the resource's Namespace object was not
 // collected by the scan (out of scope, or the scan predates namespace
 // collection): a namespaceSelector then cannot be evaluated, so the binding
 // is treated as not matching rather than optimistically matching --
 // silently over-crediting a binding's coverage would defeat the point of
 // this check.
-func (s *bindingScope) matches(resourceNamespace string, resourceLabels, namespaceLabels map[string]string, namespaceLabelsKnown bool) (bool, string) {
-	if !s.objectSelector.Empty() && !s.objectSelector.Matches(labels.Set(resourceLabels)) {
+func (s *bindingScope) matches(res ResourceInfo, namespaceLabels map[string]string, namespaceLabelsKnown bool) (bool, string) {
+	if !s.objectSelector.Empty() && !s.objectSelector.Matches(labels.Set(res.Labels)) {
 		return false, "objectSelector does not match the resource's labels"
 	}
 	if !s.namespaceSelector.Empty() {
-		if resourceNamespace == "" {
+		if res.Namespace == "" {
 			return false, "namespaceSelector is set but the resource is cluster-scoped"
 		}
 		if !namespaceLabelsKnown {
@@ -284,7 +290,7 @@ func BuildCoverage(
 			policyLoop:
 				for _, scopes := range scopesByPolicy {
 					for _, scope := range scopes {
-						ok, whyNot := scope.matches(res.Namespace, res.Labels, nsLabels, known)
+						ok, whyNot := scope.matches(res, nsLabels, known)
 						if ok {
 							covered = true
 							break policyLoop
@@ -326,6 +332,8 @@ func CollectFailingResourcesByControl(
 		}
 		info := ResourceInfo{
 			ResourceID: resourceID,
+			APIVersion: resource.GetApiVersion(),
+			Kind:       resource.GetKind(),
 			Namespace:  resource.GetNamespace(),
 			Labels:     resourceLabels(resource),
 		}

--- a/core/pkg/vapreconcile/coverage.go
+++ b/core/pkg/vapreconcile/coverage.go
@@ -122,7 +122,12 @@ func (s *bindingScope) matches(res ResourceInfo, namespaceLabels map[string]stri
 	}
 	if !s.namespaceSelector.Empty() {
 		if res.Namespace == "" {
-			return false, "namespaceSelector is set but the resource is cluster-scoped"
+			// A cluster-scoped resource has no namespace whose labels the
+			// selector could be read against, and the apiserver does not
+			// exempt it for that: its namespace matcher returns "matches"
+			// before it ever parses the selector. Reporting it uncovered
+			// understated the reach of every binding scoped by namespace.
+			return true, ""
 		}
 		if !namespaceLabelsKnown {
 			return false, "namespaceSelector is set but the resource's Namespace object was not collected by the scan"

--- a/core/pkg/vapreconcile/coverage.go
+++ b/core/pkg/vapreconcile/coverage.go
@@ -23,6 +23,19 @@ type ResourceInfo struct {
 	Labels     map[string]string
 }
 
+// The core/v1 Namespace identity, which a namespaceSelector reads
+// differently from every other kind (see bindingScope.matches).
+const (
+	namespaceAPIVersion = "v1"
+	namespaceKind       = "Namespace"
+)
+
+// isNamespace reports whether the resource is a Namespace object. It carries
+// no metadata.namespace of its own, so scope has to be decided on the kind.
+func (r ResourceInfo) isNamespace() bool {
+	return r.APIVersion == namespaceAPIVersion && r.Kind == namespaceKind
+}
+
 // ResourceCoverage reports whether one specific resource that failed a
 // control actually falls within the scope of a live, bound VAPBinding for
 // that control's policy -- as opposed to merely having *some* binding exist
@@ -121,6 +134,16 @@ func (s *bindingScope) matches(res ResourceInfo, namespaceLabels map[string]stri
 		return false, "objectSelector does not match the resource's labels"
 	}
 	if !s.namespaceSelector.Empty() {
+		if res.isNamespace() {
+			// The namespace a Namespace is "in" is itself, so the selector is
+			// read against the object's own labels. Falling through to the
+			// cluster-scoped arm below covered it unconditionally, which
+			// overstated the reach of a binding that excludes it.
+			if !s.namespaceSelector.Matches(labels.Set(res.Labels)) {
+				return false, "namespaceSelector does not match the namespace's own labels"
+			}
+			return true, ""
+		}
 		if res.Namespace == "" {
 			// A cluster-scoped resource has no namespace whose labels the
 			// selector could be read against, and the apiserver does not
@@ -360,7 +383,7 @@ func CollectFailingResourcesByControl(
 func CollectNamespaceLabels(allResources map[string]workloadinterface.IMetadata) map[string]map[string]string {
 	nsLabels := make(map[string]map[string]string)
 	for _, resource := range allResources {
-		if resource == nil || resource.GetApiVersion() != "v1" || resource.GetKind() != "Namespace" {
+		if resource == nil || resource.GetApiVersion() != namespaceAPIVersion || resource.GetKind() != namespaceKind {
 			continue
 		}
 		name := resource.GetName()

--- a/core/pkg/vapreconcile/coverage_test.go
+++ b/core/pkg/vapreconcile/coverage_test.go
@@ -158,21 +158,20 @@ func TestBuildCoverage_UnknownNamespaceTreatedAsNotCovered(t *testing.T) {
 	assert.Contains(t, c.Resources[0].Reason, "not collected")
 }
 
-func TestBuildCoverage_ClusterScopedResourceWithNamespaceSelectorNotCovered(t *testing.T) {
+func TestBuildCoverage_ClusterScopedResourceIsNeverExemptedByNamespaceSelector(t *testing.T) {
 	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
 	bindings := []unstructured.Unstructured{
 		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
 	}
 	failing := map[string][]ResourceInfo{
-		"C-0001": {{ResourceID: "res-1", Namespace: ""}}, // cluster-scoped
+		"C-0001": {{ResourceID: "res-1", APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
 	}
 
 	coverage := BuildCoverage(policies, bindings, failing, nil)
 
 	c := coverage["C-0001"]
 	require.NotNil(t, c)
-	assert.False(t, c.Resources[0].Covered)
-	assert.Contains(t, c.Resources[0].Reason, "cluster-scoped")
+	assert.True(t, c.FullyCovered(), "the apiserver enforces the binding on a cluster-scoped resource whatever the namespaceSelector says")
 }
 
 func TestBuildCoverage_MultipleBindingsOrSemantics(t *testing.T) {

--- a/core/pkg/vapreconcile/coverage_test.go
+++ b/core/pkg/vapreconcile/coverage_test.go
@@ -174,6 +174,73 @@ func TestBuildCoverage_ClusterScopedResourceIsNeverExemptedByNamespaceSelector(t
 	assert.True(t, c.FullyCovered(), "the apiserver enforces the binding on a cluster-scoped resource whatever the namespaceSelector says")
 }
 
+func TestBuildCoverage_ClusterScopedResourceStillHonorsObjectSelector(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), matchLabels("tier", "critical")),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{
+			ResourceID: "res-1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+			Labels:     map[string]string{"tier": "internal"},
+		}},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.Resources[0].Covered, "the namespaceSelector does not apply, but the objectSelector still does")
+	assert.Contains(t, c.Resources[0].Reason, "objectSelector")
+}
+
+func TestBuildCoverage_NamespaceMatchedOnItsOwnLabels(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{
+			ResourceID: "res-1",
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Labels:     map[string]string{"env": "prod"},
+		}},
+	}
+
+	// The collected-namespace index is deliberately empty: a Namespace is
+	// matched on the labels it carries itself, never through this map.
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.True(t, c.FullyCovered())
+}
+
+func TestBuildCoverage_NamespaceExcludedByItsOwnLabels(t *testing.T) {
+	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
+	bindings := []unstructured.Unstructured{
+		makeVAPBScoped("binding-a", "policy-a", matchLabels("env", "prod"), nil),
+	}
+	failing := map[string][]ResourceInfo{
+		"C-0001": {{
+			ResourceID: "res-1",
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Labels:     map[string]string{"env": "dev"},
+		}},
+	}
+
+	coverage := BuildCoverage(policies, bindings, failing, nil)
+
+	c := coverage["C-0001"]
+	require.NotNil(t, c)
+	assert.False(t, c.Resources[0].Covered)
+	assert.Contains(t, c.Resources[0].Reason, "own labels")
+}
+
 func TestBuildCoverage_MultipleBindingsOrSemantics(t *testing.T) {
 	policies := []unstructured.Unstructured{makeVAP("policy-a", "C-0001")}
 	bindings := []unstructured.Unstructured{
@@ -320,6 +387,8 @@ func TestCollectFailingResourcesByControl_OnlyIncludesFailedControls(t *testing.
 	require.Len(t, byControl["C-0001"], 1)
 	assert.Equal(t, resourceID, byControl["C-0001"][0].ResourceID)
 	assert.Equal(t, "default", byControl["C-0001"][0].Namespace)
+	assert.Equal(t, "apps/v1", byControl["C-0001"][0].APIVersion)
+	assert.Equal(t, "Deployment", byControl["C-0001"][0].Kind)
 	assert.Equal(t, map[string]string{"tier": "critical"}, byControl["C-0001"][0].Labels)
 
 	assert.NotContains(t, byControl, "C-0002", "passed controls must not be reported as failing")


### PR DESCRIPTION
`BuildCoverage` refines the coarse "some binding exists" signal by checking each failing resource against a binding's `matchResources` selectors, and its own doc says the approximation may overstate coverage but never understates it. The namespaceSelector branch breaks that in two ways, because it treats "the resource has no namespace" as "the selector cannot be satisfied".

The first case is any cluster-scoped resource. A ClusterRole, a PersistentVolume, a Node, a cluster-scoped CRD: none of them carry a `metadata.namespace`, so `matches` reported them uncovered with the reason "namespaceSelector is set but the resource is cluster-scoped". The apiserver does the opposite. Its namespace matcher, which the VAP binding path reuses through `policy/matching`, returns a match for a cluster-scoped request before it even parses the selector, with the comment "if the request is about a cluster scoped resource, and it is not a namespace, it is never exempted". So a binding narrowed to one namespace does enforce on every cluster-scoped resource its policy matches, and coverage was reporting the reach of that binding as zero. This is easy to hit with a binding that kubescape itself writes, since `vap create-policy-binding --namespace` emits exactly that namespaceSelector.

The second case is a Namespace object. It has no `metadata.namespace` either, so it fell into the same branch and read as uncovered. The apiserver special cases it the other way: when the request is about a namespace, the selector is matched against that object's own labels. That one goes in the overstating direction once the first fix lands, so both had to move together, and a Namespace is now matched on the labels it carries itself rather than through the collected namespace index.

Everything else stays where it was. The objectSelector still applies to cluster-scoped resources, since the apiserver applies it to every request regardless of scope, and there is a test pinning that so the new "cluster-scoped always matches" arm cannot be read as "cluster-scoped is always covered". A namespaced resource whose Namespace object the scan never collected is still reported uncovered rather than optimistically credited.

The detail most likely to regress is the ordering inside `matches`. The Namespace check has to come before the empty-namespace check, because a Namespace satisfies both and only the first arm reads the right labels. Swapping them silently covers every Namespace whatever the selector says, which is why `TestBuildCoverage_NamespaceExcludedByItsOwnLabels` asserts on the reason string and not just on the boolean.

`TestBuildCoverage_ClusterScopedResourceWithNamespaceSelectorNotCovered` asserted the old behaviour, so it is replaced rather than added to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy coverage matching for cluster-scoped resources and Namespace objects.
  * Namespace selectors now evaluate Namespace labels correctly.
  * Cluster-scoped resources are no longer incorrectly filtered by namespace selectors.
  * Resource details now retain API version and kind information in coverage results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->