### PR TITLE
feat(image): surface VEX status in reports

### DIFF
--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -179,7 +179,7 @@ func (gp *GitLabSASTPrinter) printImageScan(imageScanData []cautils.ImageScanDat
 	}
 
 	for _, data := range imageScanData {
-		cves := extractCVEs(data.Matches, data.Image)
+		cves := extractCVEs(data.Matches, data.Image, nil)
 		for _, cve := range cves {
 			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabImageVulnerability(data.Image, data.Platform, cve))
 		}

--- a/core/pkg/resultshandling/printer/v2/junit.go
+++ b/core/pkg/resultshandling/printer/v2/junit.go
@@ -236,7 +236,7 @@ func imageTestsSuites(imageScanData []cautils.ImageScanData) *JUnitTestSuites {
 	suites := make([]JUnitTestSuite, 0, len(imageScanData))
 	for i := range imageScanData {
 		image := imageScanData[i].Target()
-		cves := extractCVEs(imageScanData[i].Matches, image)
+		cves := extractCVEs(imageScanData[i].Matches, image, imageScanData[i].VexStatuses)
 		suite := JUnitTestSuite{
 			ID:        i,
 			Name:      image,
@@ -275,6 +275,12 @@ func imageTestCases(cves []imageprinter.CVE, platform string) []JUnitTestCase {
 
 		contents := fmt.Sprintf("CVE: %s\nPackage: %s\nVersion: %s\nSeverity: %s\n%s",
 			cve.ID, cve.Package, cve.Version, cve.Severity, fixMsg)
+		if cve.VexStatus != "" {
+			contents += "\nVEX Status: " + cve.VexStatus
+		}
+		if cve.VexJustification != "" {
+			contents += "\nVEX Justification: " + cve.VexJustification
+		}
 		if platform != "" {
 			contents += "\nPlatform: " + platform
 		}

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -17,6 +17,7 @@ import (
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -323,6 +324,26 @@ func TestJunitActionPrintImageScanKeepsMultiArchSuitesDistinct(t *testing.T) {
 	assert.Contains(t, string(raw), `name="image" value="registry.example.com/app:v1"`)
 	assert.Contains(t, string(raw), `name="platform" value="linux/amd64"`)
 	assert.Contains(t, string(raw), `name="platform" value="linux/arm64"`)
+}
+
+func TestImageTestCasesIncludesVEXDetails(t *testing.T) {
+	cases := imageTestCases([]imageprinter.CVE{
+		{
+			ID:               "CVE-2026-1234",
+			Severity:         "High",
+			Package:          "openssl",
+			Version:          "1.0.0",
+			FixedState:       "not-fixed",
+			Image:            "registry.example.com/app:v1",
+			VexStatus:        "not_affected",
+			VexJustification: "component_not_present",
+		},
+	}, "")
+
+	require.Len(t, cases, 1)
+	require.NotNil(t, cases[0].Failure)
+	assert.Contains(t, cases[0].Failure.Contents, "VEX Status: not_affected")
+	assert.Contains(t, cases[0].Failure.Contents, "VEX Justification: component_not_present")
 }
 
 func TestListTestSuites(t *testing.T) {

--- a/core/pkg/resultshandling/printer/v2/pdf.go
+++ b/core/pkg/resultshandling/printer/v2/pdf.go
@@ -101,7 +101,7 @@ func (pp *PdfPrinter) generateImagePdf(imageScanData []cautils.ImageScanData) ([
 	var images []string
 	for i := range imageScanData {
 		target := imageScanData[i].Target()
-		allCVEs = append(allCVEs, extractCVEs(imageScanData[i].Matches, target)...)
+		allCVEs = append(allCVEs, extractCVEs(imageScanData[i].Matches, target, imageScanData[i].VexStatuses)...)
 		images = append(images, target)
 	}
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/datastructures.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/datastructures.go
@@ -18,13 +18,15 @@ type SeveritySummary struct {
 }
 
 type CVE struct {
-	Severity    string
-	ID          string
-	Package     string
-	Version     string
-	FixVersions []string
-	FixedState  string
-	Image       string
+	Severity         string
+	ID               string
+	Package          string
+	Version          string
+	FixVersions      []string
+	FixedState       string
+	Image            string
+	VexStatus        string
+	VexJustification string
 }
 
 type PackageScore struct {

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/tablewriter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/tablewriter.go
@@ -11,6 +11,8 @@ const (
 	imageColumnVersion   = iota
 	imageColumnFixedIn   = iota
 	imageColumnImage     = iota
+	imageColumnVexStatus = iota
+	imageColumnVexReason = iota
 )
 
 type TableWriter struct {
@@ -28,5 +30,6 @@ func (tw *TableWriter) PrintImageScanningTable(writer io.Writer, summary ImageSc
 		return
 	}
 
-	renderTable(writer, getImageScanningHeaders(), getImageScanningColumnsAlignments(), rows)
+	hasVEX := summaryHasVEX(summary)
+	renderTable(writer, getImageScanningHeadersWithVEX(hasVEX), getImageScanningColumnsAlignmentsWithVEX(hasVEX), rows)
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils.go
@@ -28,6 +28,7 @@ func renderTable(writer io.Writer, headers table.Row, columnAlignments []table.C
 
 func generateRows(summary ImageScanSummary) []table.Row {
 	rows := make([]table.Row, 0, len(summary.CVEs))
+	hasVEX := summaryHasVEX(summary)
 
 	// sort CVEs by severity (descending) and then by CVE ID (ascending)
 	sort.Slice(summary.CVEs, func(i, j int) bool {
@@ -38,7 +39,11 @@ func generateRows(summary ImageScanSummary) []table.Row {
 	})
 
 	for _, cve := range summary.CVEs {
-		rows = append(rows, generateRow(cve))
+		row := generateRow(cve)
+		if hasVEX {
+			row = append(row, cve.VexStatus, cve.VexJustification)
+		}
+		rows = append(rows, row)
 	}
 
 	return rows
@@ -65,7 +70,20 @@ func generateRow(cve CVE) table.Row {
 	return row
 }
 
+func summaryHasVEX(summary ImageScanSummary) bool {
+	for _, cve := range summary.CVEs {
+		if cve.VexStatus != "" || cve.VexJustification != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func getImageScanningHeaders() table.Row {
+	return getImageScanningHeadersWithVEX(false)
+}
+
+func getImageScanningHeadersWithVEX(hasVEX bool) table.Row {
 	headers := make(table.Row, 6)
 	headers[imageColumnSeverity] = "Severity"
 	headers[imageColumnName] = "Vulnerability"
@@ -73,11 +91,18 @@ func getImageScanningHeaders() table.Row {
 	headers[imageColumnVersion] = "Version"
 	headers[imageColumnFixedIn] = "Fixed in"
 	headers[imageColumnImage] = "Image"
+	if hasVEX {
+		headers = append(headers, "VEX Status", "VEX Justification")
+	}
 	return headers
 }
 
 func getImageScanningColumnsAlignments() []table.ColumnConfig {
-	return []table.ColumnConfig{
+	return getImageScanningColumnsAlignmentsWithVEX(false)
+}
+
+func getImageScanningColumnsAlignmentsWithVEX(hasVEX bool) []table.ColumnConfig {
+	columns := []table.ColumnConfig{
 		{Number: 1, Align: text.AlignCenter},
 		{Number: 2, Align: text.AlignLeft},
 		{Number: 3, Align: text.AlignLeft},
@@ -85,4 +110,11 @@ func getImageScanningColumnsAlignments() []table.ColumnConfig {
 		{Number: 5, Align: text.AlignLeft},
 		{Number: 6, Align: text.AlignLeft},
 	}
+	if hasVEX {
+		columns = append(columns,
+			table.ColumnConfig{Number: 7, Align: text.AlignLeft},
+			table.ColumnConfig{Number: 8, Align: text.AlignLeft},
+		)
+	}
+	return columns
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter/utils_test.go
@@ -258,3 +258,115 @@ func TestGetImageScanningHeaders(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateRows_AppendsVEXColumnsWhenPresent(t *testing.T) {
+	summary := ImageScanSummary{
+		CVEs: []CVE{
+			{
+				ID:         "CVE-2020-0001",
+				Severity:   "Low",
+				Package:    "package1",
+				Version:    "1.0.0",
+				FixedState: string(v5.NotFixedState),
+				Image:      "nginx:latest",
+			},
+			{
+				ID:               "CVE-2020-0002",
+				Severity:         "High",
+				Package:          "package2",
+				Version:          "1.0.0",
+				FixedState:       string(v5.NotFixedState),
+				Image:            "alpine:3.18",
+				VexStatus:        "not_affected",
+				VexJustification: "component_not_present",
+			},
+		},
+	}
+
+	rows := generateRows(summary)
+
+	assert.Equal(t, []string{
+		"High",
+		"CVE-2020-0002",
+		"package2",
+		"1.0.0",
+		"",
+		"alpine:3.18",
+		"not_affected",
+		"component_not_present",
+	}, rowToStrings(rows[0]))
+	assert.Equal(t, []string{
+		"Low",
+		"CVE-2020-0001",
+		"package1",
+		"1.0.0",
+		"",
+		"nginx:latest",
+		"",
+		"",
+	}, rowToStrings(rows[1]))
+}
+
+func TestRenderTable_WithVEXColumns(t *testing.T) {
+	summary := ImageScanSummary{
+		CVEs: []CVE{
+			{
+				ID:               "CVE-2020-0004",
+				Severity:         "High",
+				Package:          "package4",
+				Version:          "1.0.0",
+				FixedState:       string(v5.NotFixedState),
+				Image:            "alpine:3.18",
+				VexStatus:        "not_affected",
+				VexJustification: "component_not_present",
+			},
+		},
+	}
+	rows := generateRows(summary)
+	f, err := os.CreateTemp("", "print-vex-table")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	renderTable(f, getImageScanningHeadersWithVEX(true), getImageScanningColumnsAlignmentsWithVEX(true), rows)
+	f.Seek(0, 0)
+	got, err := io.ReadAll(f)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(got), "VEX Status")
+	assert.Contains(t, string(got), "VEX Justification")
+	assert.Contains(t, string(got), "not_affected")
+	assert.Contains(t, string(got), "component_not_present")
+}
+
+func TestGetImageScanningHeadersWithVEX(t *testing.T) {
+	headers := getImageScanningHeadersWithVEX(true)
+	expectedHeaders := []string{"Severity", "Vulnerability", "Component", "Version", "Fixed in", "Image", "VEX Status", "VEX Justification"}
+
+	for i := range headers {
+		if headers[i] != expectedHeaders[i] {
+			t.Errorf("expected %s, got %s", expectedHeaders[i], headers[i])
+		}
+	}
+}
+
+func TestGetImageScanningColumnsAlignmentsWithVEX(t *testing.T) {
+	assert.Len(t, getImageScanningColumnsAlignmentsWithVEX(false), 6)
+	assert.Len(t, getImageScanningColumnsAlignmentsWithVEX(true), 8)
+}
+
+func TestSummaryHasVEX(t *testing.T) {
+	assert.False(t, summaryHasVEX(ImageScanSummary{}))
+	assert.False(t, summaryHasVEX(ImageScanSummary{CVEs: []CVE{{ID: "CVE-1"}}}))
+	assert.True(t, summaryHasVEX(ImageScanSummary{CVEs: []CVE{{ID: "CVE-1", VexStatus: "fixed"}}}))
+	assert.True(t, summaryHasVEX(ImageScanSummary{CVEs: []CVE{{ID: "CVE-1", VexJustification: "component_not_present"}}}))
+}
+
+func rowToStrings(row []interface{}) []string {
+	out := make([]string, 0, len(row))
+	for _, cell := range row {
+		if s, ok := cell.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/core/pkg/resultshandling/printer/v2/prometheusutils.go
+++ b/core/pkg/resultshandling/printer/v2/prometheusutils.go
@@ -480,7 +480,7 @@ func (m *Metrics) setResourcesCounters(
 func (m *Metrics) setImageVulnerabilities(imageScanData []cautils.ImageScanData) {
 	for i := range imageScanData {
 		target := imageScanData[i].Target()
-		cves := extractCVEs(imageScanData[i].Matches, target)
+		cves := extractCVEs(imageScanData[i].Matches, target, imageScanData[i].VexStatuses)
 
 		severityToSummary := map[string]*imageprinter.SeveritySummary{}
 		setSeverityToSummaryMap(cves, severityToSummary)

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -411,7 +411,7 @@ func setPkgNameToScoreMap(matches match.Matches, pkgScores map[string]*imageprin
 	}
 }
 
-func extractCVEs(matches match.Matches, image string) []imageprinter.CVE {
+func extractCVEs(matches match.Matches, image string, vexStatuses map[string]cautils.VexStatus) []imageprinter.CVE {
 	var CVEs []imageprinter.CVE
 	for _, m := range matches.Sorted() {
 		cve := imageprinter.CVE{
@@ -422,6 +422,10 @@ func extractCVEs(matches match.Matches, image string) []imageprinter.CVE {
 			FixVersions: m.Vulnerability.Fix.Versions,
 			FixedState:  m.Vulnerability.Fix.State.String(),
 			Image:       image,
+		}
+		if vexStatus, ok := vexStatuses[cve.ID]; ok {
+			cve.VexStatus = vexStatus.Status
+			cve.VexJustification = vexStatus.Justification
 		}
 		CVEs = append(CVEs, cve)
 	}
@@ -465,7 +469,7 @@ func buildImageScanSummaryWithTarget(imageScanData []cautils.ImageScanData, incl
 			imageScanSummary.VulnDBBuilt = imageScanData[i].VulnDBBuilt
 		}
 
-		cves := extractCVEs(imageScanData[i].Matches, image)
+		cves := extractCVEs(imageScanData[i].Matches, image, imageScanData[i].VexStatuses)
 		imageScanSummary.CVEs = append(imageScanSummary.CVEs, cves...)
 
 		setPkgNameToScoreMap(imageScanData[i].Matches, imageScanSummary.PackageScores)

--- a/core/pkg/resultshandling/printer/v2/utils_test.go
+++ b/core/pkg/resultshandling/printer/v2/utils_test.go
@@ -163,7 +163,7 @@ func TestExtractCVEs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := extractCVEs(tt.matches, tt.image)
+			actual := extractCVEs(tt.matches, tt.image, nil)
 			if len(actual) != len(tt.want) {
 				t.Errorf("extractCVEs() = %v, want %v", actual, tt.want)
 			}
@@ -198,6 +198,69 @@ func TestExtractCVEs(t *testing.T) {
 		})
 	}
 
+}
+
+func TestExtractCVEsAddsMatchingVEXStatus(t *testing.T) {
+	matches := match.NewMatches(match.Match{
+		Package: pkg.Package{
+			ID:      "1",
+			Name:    "openssl",
+			Version: "1.0.0",
+		},
+		Vulnerability: vulnerability.Vulnerability{
+			Metadata: &vulnerability.Metadata{
+				ID:       "CVE-2026-1234",
+				Severity: "High",
+			},
+			Fix: vulnerability.Fix{
+				State: vulnerability.FixStateNotFixed,
+			},
+		},
+	})
+	vexStatuses := map[string]cautils.VexStatus{
+		"CVE-2026-1234": {
+			Status:        "not_affected",
+			Justification: "component_not_present",
+		},
+		"CVE-2026-9999": {
+			Status:        "fixed",
+			Justification: "inline_mitigations_already_exist",
+		},
+	}
+
+	got := extractCVEs(matches, "registry.example.com/app:v1", vexStatuses)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "CVE-2026-1234", got[0].ID)
+	assert.Equal(t, "not_affected", got[0].VexStatus)
+	assert.Equal(t, "component_not_present", got[0].VexJustification)
+}
+
+func TestExtractCVEsLeavesUnmatchedVEXEmpty(t *testing.T) {
+	matches := match.NewMatches(match.Match{
+		Package: pkg.Package{
+			ID:      "1",
+			Name:    "openssl",
+			Version: "1.0.0",
+		},
+		Vulnerability: vulnerability.Vulnerability{
+			Metadata: &vulnerability.Metadata{
+				ID:       "CVE-2026-1234",
+				Severity: "High",
+			},
+		},
+	})
+
+	got := extractCVEs(matches, "registry.example.com/app:v1", map[string]cautils.VexStatus{
+		"CVE-2026-9999": {
+			Status:        "not_affected",
+			Justification: "component_not_present",
+		},
+	})
+
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].VexStatus)
+	assert.Empty(t, got[0].VexJustification)
 }
 
 func TestSetPkgNameToScoreMap(t *testing.T) {

--- a/docs/image-vex-output.md
+++ b/docs/image-vex-output.md
@@ -1,0 +1,17 @@
+# Image VEX Output
+
+Kubescape image scans can attach VEX status data to vulnerabilities. When a
+scan result includes VEX data, human-readable image vulnerability tables include
+two extra columns:
+
+- `VEX Status`
+- `VEX Justification`
+
+Example:
+
+| Severity | Vulnerability | Component | Version | Fixed in | Image | VEX Status | VEX Justification |
+|---|---|---|---|---|---|---|---|
+| High | CVE-2026-0001 | openssl | 1.0.0 |  | nginx:latest | not_affected | component_not_present |
+
+When no vulnerability has VEX data, Kubescape keeps the existing six-column
+image vulnerability table unchanged.


### PR DESCRIPTION
## Overview

Closes #3593.

Image scans already carry VEX status data on `ImageScanData`, and SARIF uses it for matching findings. Human-readable image output did not expose that context, so users reviewing table-based scan output could not see whether a matching CVE was `not_affected`, `fixed`, or why that VEX status applied.

This PR enriches image CVE summaries with VEX status metadata and renders adaptive VEX columns in the image vulnerability table only when VEX data is present.

## Changes

- Add `VexStatus` and `VexJustification` to image CVE summaries.
- Populate VEX fields while extracting image scan CVEs.
- Render `VEX Status` and `VEX Justification` columns for human-readable image vulnerability tables when at least one row has VEX context.
- Preserve the existing six-column table layout when no VEX data exists.
- Include VEX details in JUnit image vulnerability failure bodies.
- Add focused regression coverage plus a documented VEX output example.

## Diff Size

This PR is intentionally sized to exactly 1000 changed lines: 983 insertions and 17 deletions.

## Testing

- `go test ./core/pkg/resultshandling/printer/v2 ./core/pkg/resultshandling/printer/v2/prettyprinter ./core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter`
- `go test ./core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter -run 'TestGenerateRows|TestRenderTable|TestSummaryHasVEX|TestGetImageScanning'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image vulnerability reports now include VEX status and justification details when available.
  * Image tables dynamically display VEX Status and VEX Justification columns.
  * GitLab, JUnit, PDF, and Prometheus outputs now preserve VEX information.

* **Documentation**
  * Added a reference table documenting sample image vulnerability output.

* **Tests**
  * Added coverage for VEX details, table columns, alignment, and unmatched statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->