### PR TITLE
fix(patch): filesystem-safe intermediate filenames and update-all nil guard

### DIFF
--- a/cmd/patch/patch.go
+++ b/cmd/patch/patch.go
@@ -168,6 +168,13 @@ func validateImagePatchInfo(patchInfo *metav1.PatchInfo) error {
 	}
 	patchInfo.Image = named.String()
 
+	// Capture the source tag whenever the reference has one, independent of
+	// the patched-tag defaulting below. A digest-pinned reference carries no
+	// tag; that must not be treated as an error here.
+	if taggedName, ok := named.(reference.Tagged); ok {
+		patchInfo.ImageTag = taggedName.Tag()
+	}
+
 	// If no patched image tag is provided, default to '<image-tag>-patched'
 	if patchInfo.PatchedImageTag == "" {
 

--- a/cmd/patch/patch_test.go
+++ b/cmd/patch/patch_test.go
@@ -300,6 +300,41 @@ func Test_validateImagePatchInfo_DefaultsTagAndPatchedTag(t *testing.T) {
 	assert.Equal(t, "nginx", patchInfo.ImageName)
 }
 
+// A digest-pinned reference combined with an explicit --tag must not error:
+// the patched-tag defaulting branch never runs, so capturing the source tag
+// has to be best-effort rather than a hard type-assertion failure.
+func Test_validateImagePatchInfo_DigestRefWithExplicitTag(t *testing.T) {
+	patchInfo := &metav1.PatchInfo{
+		Image:           "nginx@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		PatchedImageTag: "patched",
+		OutputMode:      "docker",
+	}
+
+	err := validateImagePatchInfo(patchInfo)
+
+	assert.NoError(t, err)
+	assert.Empty(t, patchInfo.ImageTag,
+		"a digest-pinned reference carries no tag; it must not be fabricated")
+	assert.Equal(t, "patched", patchInfo.PatchedImageTag)
+}
+
+// An explicit --tag must not leave ImageTag empty: the intermediate report
+// filename derives from fields that must stay well-formed regardless of flags.
+func Test_validateImagePatchInfo_ExplicitTagStillCapturesSourceTag(t *testing.T) {
+	patchInfo := &metav1.PatchInfo{
+		Image:           "nginx:1.22",
+		PatchedImageTag: "my-patched",
+		OutputMode:      "docker",
+	}
+
+	err := validateImagePatchInfo(patchInfo)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1.22", patchInfo.ImageTag,
+		"the source tag must be captured even when --tag is provided")
+	assert.Equal(t, "my-patched", patchInfo.PatchedImageTag)
+}
+
 func Test_validateImagePatchInfo_DigestOnlyReturnsError(t *testing.T) {
 	patchInfo := &metav1.PatchInfo{
 		Image:      "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/core/core/patch.go
+++ b/core/core/patch.go
@@ -92,8 +92,10 @@ func (ks *Kubescape) Patch(patchInfo *ksmetav1.PatchInfo, scanInfo *cautils.Scan
 	// Save the scan results to a file in json format
 	pres := grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: scanResults.SBOM})
 
-	fileName := fmt.Sprintf("%s:%s.json", patchInfo.ImageName, patchInfo.ImageTag)
-	fileName = strings.ReplaceAll(fileName, "/", "-")
+	// The intermediate name must be filesystem-safe on every OS: image
+	// references legally contain ':' (tags, registry ports) and '@'
+	// (digests), which are reserved filename characters on Windows.
+	fileName := fmt.Sprintf("%s.json", sanitizeImageRefForFilename(patchInfo.Image))
 
 	writer, err := printer.GetWriterNoFallback(fileName)
 	if err != nil {
@@ -182,6 +184,25 @@ func buildPatchedImageName(image, patchedTag string) (string, error) {
 		return "", fmt.Errorf("failed to parse image reference %q: %w", image, err)
 	}
 	return fmt.Sprintf("%s:%s", ref.Name(), patchedTag), nil
+}
+
+// sanitizeImageRefForFilename converts an image reference into a filename
+// component that is safe on every supported OS. Image references legally
+// contain ':' (tag separators, registry ports), '/' (repository paths) and '@'
+// (digests); ':' is a reserved character on Windows, where os.Create on such a
+// name fails outright.
+func sanitizeImageRefForFilename(image string) string {
+	replacer := strings.NewReplacer(":", "-", "/", "-", "@", "-", " ", "-")
+	return replacer.Replace(strings.TrimSpace(image))
+}
+
+// updatesCount reports how many package updates are targeted, tolerating the
+// update-all mode where no scanner report is provided and updates is nil.
+func updatesCount(updates *unversioned.UpdateManifest) int {
+	if updates == nil {
+		return 0
+	}
+	return len(updates.Updates)
 }
 
 // runWithCopaLoggerMuted mutes copa's logrus output for the duration of fn,
@@ -334,7 +355,7 @@ func patchWithContext(ctx context.Context, buildkitAddr, image, reportFile, patc
 			}
 		}
 
-		log.Infof("Patching %d vulnerabilities", len(updates.Updates))
+		log.Infof("Patching %d vulnerabilities", updatesCount(updates))
 		patchedImageState, errPkgs, err := manager.InstallUpdates(ctx, updates, ignoreError)
 		if err != nil {
 			return nil, fmt.Errorf("copa: error installing updates :: %w", err)

--- a/core/core/patch_test.go
+++ b/core/core/patch_test.go
@@ -8,15 +8,53 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/moby/buildkit/client"
+	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestSanitizeImageRefForFilename pins the cross-platform filename guarantee:
+// image references legally contain ':', '/', '@' and whitespace, all of which
+// are illegal or hazardous in filenames on at least one supported OS.
+func TestSanitizeImageRefForFilename(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{name: "tagged image", image: "nginx:1.22", want: "nginx-1.22"},
+		{name: "name-only image", image: "nginx", want: "nginx"},
+		{name: "repository path", image: "myrepo/myapp:2.0", want: "myrepo-myapp-2.0"},
+		{name: "registry with port", image: "registry.example.com:8443/myapp:3.1", want: "registry.example.com-8443-myapp-3.1"},
+		{name: "digest-pinned reference", image: "myrepo/myapp@sha256:9f86d081", want: "myrepo-myapp-sha256-9f86d081"},
+		{name: "surrounding whitespace trimmed", image: "  nginx:1.22  ", want: "nginx-1.22"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeImageRefForFilename(tt.image)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, ":")
+			assert.NotContains(t, got, "/")
+			assert.NotContains(t, got, "@")
+		})
+	}
+}
+
+// TestUpdatesCountToleratesUpdateAllMode guards the update-all path: with no
+// scanner report there are no updates, and reading len on a nil value must
+// never panic.
+func TestUpdatesCountToleratesUpdateAllMode(t *testing.T) {
+	assert.Equal(t, 0, updatesCount(nil))
+	assert.Equal(t, 0, updatesCount(&unversioned.UpdateManifest{}))
+	assert.Equal(t, 2, updatesCount(&unversioned.UpdateManifest{
+		Updates: unversioned.UpdatePackages{{}, {}},
+	}))
+}
 
 // TestBuildPatchedImageName guards the fix for kubescape/kubescape#2189: the
 // patched image must be exported under its canonical reference so containerd
@@ -371,10 +409,8 @@ func TestPatchIntermediateFileCleanup(t *testing.T) {
 	require.NoError(t, os.Chdir(tmpDir))
 	t.Cleanup(func() { _ = os.Chdir(origWD) })
 
-	imageName := "test-image"
-	imageTag := "1.0"
-	fileName := fmt.Sprintf("%s:%s.json", imageName, imageTag)
-	fileName = strings.ReplaceAll(fileName, "/", "-")
+	// Mirror the sanitized scheme Patch() now uses for its intermediate name.
+	fileName := fmt.Sprintf("%s.json", sanitizeImageRefForFilename("test-image:1.0"))
 
 	// Simulate the file creation and deferred cleanup pattern used in Patch()
 	cleanupFn := func(simulateFailure bool) error {


### PR DESCRIPTION
Closes #3595.

## Overview

**Current behavior:** three defects in `kubescape patch`'s intermediate scan-report handling:

1. **Windows broken entirely** — the intermediate grype report filename embeds `:" (`fmt.Sprintf("%s:%s.json", ...)`), a reserved filename character on Windows, so `os.Create` fails before buildkit is ever contacted. Official Windows binaries ship via goreleaser.
2. **Malformed name with `--tag`** — `patchInfo.ImageTag` is only populated inside the patched-tag defaulting branch (`cmd/patch/patch.go:172-188`). Passing an explicit `--tag my-patched` skips it, leaving the intermediate file as `image:.json`.
3. **Guaranteed panic in update-all mode** — `copaPatch`'s `reportFile == ""` branch sets `updates = nil`, and the next statement reads `len(updates.Updates)`.

**Future behavior:** the intermediate filename derives from the sanitized full image reference (`:`, `/`, `@` and whitespace mapped to `-`) — handling tags, registry ports, and digest-pinned references in one place. `ImageTag` is captured whenever the reference carries a tag (digest refs no longer error when `--tag` is provided). The update-all counter is nil-guarded.

## Changes

1. **`core/core/patch.go`** — new `sanitizeImageRefForFilename` helper; intermediate name now derives from the full sanitized reference. New `updatesCount` helper guards the update-all log line.
2. **`cmd/patch/patch.go`** — capture `ImageTag` via best-effort type-assertion *before* the patched-tag defaulting branch: populated whenever the reference has a tag, never a hard error for digest refs (preserving today's working digest + `--tag` combination).
3. **Regression tests** for each exact failure case: sanitizer table (tagged / name-only / registry-port / digest / whitespace), `updatesCount` nil/empty/populated, digest-ref + `--tag` no-error pin, explicit-`--tag` source-tag capture pin.

## Additional Information

- No behavior change beyond correct filenames; scanning, patching, and output modes are untouched.
- **Disclosed limitation:** the update-all nil-guard fixes the panic location; full end-to-end validation of that mode requires a live buildkit environment and remains future work.
- Confirmed with @matthyx in Slack ("ok fix it" / "add the nil guard").

## How to Test

```bash
go build ./...
go vet ./core/core/... ./cmd/patch/...
go test ./core/core/ ./cmd/patch/ -count=1
```

Manual checks:
- Windows: `kubescape patch --image nginx:1.22` no longer fails at intermediate-file creation.
- Any OS with `--tag`: intermediate file is named `nginx-1.22.json`, not `nginx:.json`.

## Related Issues/PRs

* Closes #3595

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image references with explicit tags and digest-pinned references during patch validation.
  * Prevented incorrect image tag capture for digest-only references.
  * Made intermediate patch files use safe, consistent filenames across platforms.
  * Improved update reporting when no manifest is available.
* **Tests**
  * Added coverage for tagged, digest-pinned, registry-based, whitespace-containing, and update-all image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->