### PR TITLE
fix(vap): report a namespace selector that cannot narrow a policy's cluster-scoped resources

### DIFF
--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -477,6 +477,15 @@ func parseResourceRule(rule string) (admissionv1.NamedRuleWithOperations, error)
 	}, nil
 }
 
+// parsedResourceRule is one --resource-rule as both the value the caller typed
+// and the binding rule it parses to. The two travel together so a message about
+// a rule can echo it the way it was typed without walking a second slice
+// alongside this one.
+type parsedResourceRule struct {
+	raw  string
+	rule admissionv1.NamedRuleWithOperations
+}
+
 // parseResourceRules turns the whole --resource-rule set into the binding rules
 // it becomes. Both the checks that reason about the emitted binding's surface
 // and the binding itself read the flag through here, so what the command
@@ -484,19 +493,33 @@ func parseResourceRule(rule string) (admissionv1.NamedRuleWithOperations, error)
 //
 // An empty flag stays nil rather than an empty slice: matchResources.resourceRules
 // is omitted from the emitted YAML when the caller did not narrow anything.
-func parseResourceRules(rules []string) ([]admissionv1.NamedRuleWithOperations, error) {
+func parseResourceRules(rules []string) ([]parsedResourceRule, error) {
 	if len(rules) == 0 {
 		return nil, nil
 	}
-	parsed := make([]admissionv1.NamedRuleWithOperations, 0, len(rules))
-	for _, rule := range rules {
-		rule, err := parseResourceRule(rule)
+	parsed := make([]parsedResourceRule, 0, len(rules))
+	for _, raw := range rules {
+		rule, err := parseResourceRule(raw)
 		if err != nil {
 			return nil, err
 		}
-		parsed = append(parsed, rule)
+		parsed = append(parsed, parsedResourceRule{raw: strings.TrimSpace(raw), rule: rule})
 	}
 	return parsed, nil
+}
+
+// bindingResourceRules drops the typed form, for the callers that want only the
+// rules the binding carries. A nil set stays nil, so an unnarrowed binding still
+// omits matchResources.resourceRules.
+func bindingResourceRules(parsed []parsedResourceRule) []admissionv1.NamedRuleWithOperations {
+	if len(parsed) == 0 {
+		return nil
+	}
+	rules := make([]admissionv1.NamedRuleWithOperations, 0, len(parsed))
+	for _, entry := range parsed {
+		rules = append(rules, entry.rule)
+	}
+	return rules
 }
 
 // validateRuleSegment checks one segment of a resource rule, accepting the "*"
@@ -598,14 +621,14 @@ func checkResourceRulesInPolicyScope(rules []string, controlID, policyName strin
 	if err != nil {
 		return err
 	}
-	for i, rule := range parsed {
-		switch classifyResourceRule(rule, constraints.ResourceRules) {
+	for _, entry := range parsed {
+		switch classifyResourceRule(entry.rule, constraints.ResourceRules) {
 		case ruleOutsidePolicy:
 			return fmt.Errorf("resource rule %q is outside the matchConstraints of policy %s, so the binding would match nothing; the policy matches %s",
-				strings.TrimSpace(rules[i]), policyName, describeResourceRules(constraints.ResourceRules))
+				entry.raw, policyName, describeResourceRules(constraints.ResourceRules))
 		case ruleConvertsToPolicy:
 			logger.L().Warning("resource rule names another API group or version than the policy constrains; the binding matches only if the cluster serves them as equivalent forms of one resource",
-				helpers.String("rule", strings.TrimSpace(rules[i])),
+				helpers.String("rule", entry.raw),
 				helpers.String("policy", policyName),
 				helpers.String("policyMatches", describeResourceRules(constraints.ResourceRules)))
 		}
@@ -892,7 +915,7 @@ func checkNamespaceSelectorScope(namespaces, resourceRules []string, controlID, 
 		return err
 	}
 
-	reach := resolveNamespaceSelectorReach(constraints.ResourceRules, bindingRules)
+	reach := resolveNamespaceSelectorReach(constraints.ResourceRules, bindingResourceRules(bindingRules))
 	if len(reach.alwaysMatched) == 0 {
 		return nil
 	}
@@ -942,7 +965,7 @@ func createPolicyBinding(bindingName string, policyName string, actions []admiss
 	if err != nil {
 		return "", err
 	}
-	policyBinding.Spec.MatchResources.ResourceRules = resourceRules
+	policyBinding.Spec.MatchResources.ResourceRules = bindingResourceRules(resourceRules)
 
 	policyBinding.Spec.ValidationActions = actions
 	paramAction := admissionv1.DenyAction

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -158,7 +158,7 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 	_ = createPolicyBindingCmd.MarkFlagRequired("name") // #nosec G104 -- flag is defined on this command; MarkFlagRequired only errors for an unknown flag
 	createPolicyBindingCmd.Flags().StringVarP(&policyName, "policy", "p", "", "Name of the ValidatingAdmissionPolicy to bind resources to")
 	createPolicyBindingCmd.Flags().StringVarP(&controlID, "control", "c", "", "Kubescape control ID to bind resources to")
-	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector")
+	createPolicyBindingCmd.Flags().StringSliceVar(&namespaceArr, "namespace", []string{}, "Resource namespace selector. Narrows only the namespaced resources the policy matches: the apiserver never exempts a cluster-scoped one from a binding's namespaceSelector, so use --resource-rule to drop those")
 	createPolicyBindingCmd.Flags().StringSliceVar(&labelArr, "label", []string{}, "Resource label selector")
 	createPolicyBindingCmd.Flags().StringSliceVarP(&actionArr, "action", "a", []string{string(admissionv1.Deny)}, "Action to take when policy fails, repeatable (Deny, Warn, Audit). Deny and Warn cannot be combined")
 	createPolicyBindingCmd.Flags().StringSliceVar(&resourceRuleArr, "resource-rule", []string{}, "Restrict the binding to a group/version/resource the policy already matches, repeatable (e.g. apps/v1/deployments, /v1/pods). Omit to bind everything the policy matches")

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -473,6 +473,28 @@ func parseResourceRule(rule string) (admissionv1.NamedRuleWithOperations, error)
 	}, nil
 }
 
+// parseResourceRules turns the whole --resource-rule set into the binding rules
+// it becomes. Both the checks that reason about the emitted binding's surface
+// and the binding itself read the flag through here, so what the command
+// validates and what it writes cannot drift apart.
+//
+// An empty flag stays nil rather than an empty slice: matchResources.resourceRules
+// is omitted from the emitted YAML when the caller did not narrow anything.
+func parseResourceRules(rules []string) ([]admissionv1.NamedRuleWithOperations, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	parsed := make([]admissionv1.NamedRuleWithOperations, 0, len(rules))
+	for _, rule := range rules {
+		rule, err := parseResourceRule(rule)
+		if err != nil {
+			return nil, err
+		}
+		parsed = append(parsed, rule)
+	}
+	return parsed, nil
+}
+
 // validateRuleSegment checks one segment of a resource rule, accepting the "*"
 // wildcard the admission API allows in any of them.
 func validateRuleSegment(kind string, value string, validate func(string) []string) error {
@@ -568,18 +590,18 @@ func checkResourceRulesInPolicyScope(rules []string, controlID, policyName strin
 	if constraints == nil || len(constraints.ResourceRules) == 0 {
 		return nil
 	}
-	for _, rule := range rules {
-		parsed, err := parseResourceRule(rule)
-		if err != nil {
-			return err
-		}
-		switch classifyResourceRule(parsed, constraints.ResourceRules) {
+	parsed, err := parseResourceRules(rules)
+	if err != nil {
+		return err
+	}
+	for i, rule := range parsed {
+		switch classifyResourceRule(rule, constraints.ResourceRules) {
 		case ruleOutsidePolicy:
 			return fmt.Errorf("resource rule %q is outside the matchConstraints of policy %s, so the binding would match nothing; the policy matches %s",
-				strings.TrimSpace(rule), policyName, describeResourceRules(constraints.ResourceRules))
+				strings.TrimSpace(rules[i]), policyName, describeResourceRules(constraints.ResourceRules))
 		case ruleConvertsToPolicy:
 			logger.L().Warning("resource rule names another API group or version than the policy constrains; the binding matches only if the cluster serves them as equivalent forms of one resource",
-				helpers.String("rule", strings.TrimSpace(rule)),
+				helpers.String("rule", strings.TrimSpace(rules[i])),
 				helpers.String("policy", policyName),
 				helpers.String("policyMatches", describeResourceRules(constraints.ResourceRules)))
 		}
@@ -741,13 +763,11 @@ func createPolicyBinding(bindingName string, policyName string, actions []admiss
 
 	// Left empty, matchResources binds everything the policy matches, so a rule
 	// is only emitted when the caller asked to narrow it.
-	for _, rule := range resourceRuleArr {
-		parsed, err := parseResourceRule(rule)
-		if err != nil {
-			return "", err
-		}
-		policyBinding.Spec.MatchResources.ResourceRules = append(policyBinding.Spec.MatchResources.ResourceRules, parsed)
+	resourceRules, err := parseResourceRules(resourceRuleArr)
+	if err != nil {
+		return "", err
 	}
+	policyBinding.Spec.MatchResources.ResourceRules = resourceRules
 
 	policyBinding.Spec.ValidationActions = actions
 	paramAction := admissionv1.DenyAction

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -792,6 +792,10 @@ const namespacesResource = "namespaces"
 // A resource neither source knows stays unknown rather than guessed: a wrong
 // guess either suppresses a warning the caller needs or raises one they cannot
 // act on.
+//
+// What the scope field keeps out of the covered surface in the first place is
+// scopedGroups' business, upstream of this. A resource reaching here is one the
+// rule does match, and the only question left is what a selector does to it.
 func resourceSelectorReach(scope *admissionv1.ScopeType, groups []string, resource string) selectorReach {
 	// A subresource lives wherever its parent does.
 	resource, _ = splitSubresource(strings.ToLower(strings.TrimSpace(resource)))
@@ -827,6 +831,10 @@ func resourceSelectorReach(scope *admissionv1.ScopeType, groups []string, resour
 // namespaceSelector does to it: a Namespace is cluster-scoped here even though a
 // selector still narrows it by its own labels. The two matchers read the same
 // resource differently, so what asks about the rules matcher asks here.
+//
+// A wildcard group accepts the table's answer, the way the rest of this file
+// reads one. A caller that must not take a wildcard for the built-in group asks
+// a group at a time instead.
 func resourceScope(groups []string, resource string) *admissionv1.ScopeType {
 	resource, _ = splitSubresource(strings.ToLower(strings.TrimSpace(resource)))
 	if resource == "" || resource == "*" {
@@ -915,7 +923,8 @@ func resolveNamespaceSelectorReach(constraints, bindingRules []admissionv1.Named
 func bindingCoverage(constraint *admissionv1.NamedRuleWithOperations, resource string, bindingRules []admissionv1.NamedRuleWithOperations) []coveredResource {
 	var covered []coveredResource
 	keep := func(candidate coveredResource) {
-		if scopeExcludes(constraint.Scope, candidate.groups, candidate.resource) {
+		candidate.groups = scopedGroups(constraint.Scope, candidate.groups, candidate.resource)
+		if len(candidate.groups) == 0 {
 			return
 		}
 		covered = append(covered, candidate)
@@ -939,28 +948,50 @@ func bindingCoverage(constraint *admissionv1.NamedRuleWithOperations, resource s
 	return covered
 }
 
-// scopeExcludes reports whether a constraint's own scope field rules out a
-// resource that would otherwise be in the surface it covers.
+// scopedGroups drops the groups a constraint's own scope field rules the
+// resource out at, and reports the ones left. None left means the constraint
+// matches no request for that resource at all, so the emitted binding does not
+// cover it: nothing there for a selector to reach, and nothing for a message
+// about one to name. Without this a policy declaring scope Cluster over "*",
+// narrowed to apps/v1/deployments, is refused for covering only cluster-scoped
+// resources and names a namespaced one as the reason.
 //
 // A rule declaring Namespaced never matches a cluster-scoped request and one
-// declaring Cluster never matches a namespaced request, so a resource on the
-// wrong side of it is not covered at all: nothing there for a selector to reach,
-// and nothing for a message about one to name. Without this a policy declaring
-// scope Cluster over "*", narrowed to apps/v1/deployments, is refused for
-// covering only cluster-scoped resources and names a namespaced one as the
-// reason.
+// declaring Cluster never matches a namespaced request: the rules matcher reads
+// the scope field before it reads anything else. Every other value rules nothing
+// out — "*" by definition, and one this version does not know because a scope it
+// cannot read is no grounds for going quiet about a resource.
 //
-// Only the built-in table is contradicted, and only where it can speak: a
-// declared scope stays the answer for the custom resources it exists to speak
-// for. The table's answer here is the resource's API scope, so scope Cluster
-// over namespaces is no conflict — the rules matcher counts a Namespace as
-// cluster-scoped, whatever a namespaceSelector then does with it.
-func scopeExcludes(declared *admissionv1.ScopeType, groups []string, resource string) bool {
-	if declared == nil || *declared == admissionv1.AllScopes {
-		return false
+// The scope is contradicted a group at a time, and only by a built-in table that
+// can speak for that group. A wildcard group is one it cannot: a rule covering
+// every group covers the ones the table has no answer for too, and there the
+// declared scope is the only word on the resource. So scope Cluster over
+// "*"/roles keeps covering the cluster-scoped roles some group of its own
+// defines, and only naming the group the table serves roles from gives that up.
+//
+// Where that reading of a wildcard parts ways with the one resourceSelectorReach
+// takes, both err the same way: toward naming a resource rather than going quiet
+// about one.
+//
+// The table's answer here is the resource's own API scope, so scope Cluster over
+// namespaces is no conflict — the rules matcher counts a Namespace as
+// cluster-scoped, whatever a namespaceSelector then does with it — and scope
+// Namespaced over namespaces covers nothing, which is the same rule read from
+// the other side.
+func scopedGroups(declared *admissionv1.ScopeType, groups []string, resource string) []string {
+	if declared == nil || (*declared != admissionv1.ClusterScope && *declared != admissionv1.NamespacedScope) {
+		return groups
 	}
-	known := resourceScope(groups, resource)
-	return known != nil && *known != *declared
+	scoped := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if group != "*" {
+			if known := resourceScope([]string{group}, resource); known != nil && *known != *declared {
+				continue
+			}
+		}
+		scoped = append(scoped, group)
+	}
+	return scoped
 }
 
 // narrowResource is the more specific of a policy resource and a binding

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -809,14 +809,38 @@ func resourceSelectorReach(scope *admissionv1.ScopeType, groups []string, resour
 	if resource == "*" {
 		return reachAlwaysMatches // the rule sweeps cluster-scoped resources too
 	}
+	switch known := resourceScope(groups, resource); {
+	case known == nil:
+		return reachUnknown
+	case *known == admissionv1.NamespacedScope:
+		return reachNarrows
+	default:
+		return reachAlwaysMatches
+	}
+}
+
+// resourceScope is where a resource lives according to the built-in resource
+// table, nil where the table cannot speak for it — a custom resource, or a
+// built-in plural named at a group the table does not serve it from.
+//
+// Unlike resourceSelectorReach this is the resource's API scope, not what a
+// namespaceSelector does to it: a Namespace is cluster-scoped here even though a
+// selector still narrows it by its own labels. The two matchers read the same
+// resource differently, so what asks about the rules matcher asks here.
+func resourceScope(groups []string, resource string) *admissionv1.ScopeType {
+	resource, _ = splitSubresource(strings.ToLower(strings.TrimSpace(resource)))
+	if resource == "" || resource == "*" {
+		return nil
+	}
 	gvr, err := k8sinterface.GetGroupVersionResource(resource)
 	if err != nil || gvr.Resource == "" || !valuesOverlap(groups, []string{gvr.Group}) {
-		return reachUnknown
+		return nil
 	}
+	scope := admissionv1.ClusterScope
 	if k8sinterface.IsNamespaceScope(&gvr) {
-		return reachNarrows
+		scope = admissionv1.NamespacedScope
 	}
-	return reachAlwaysMatches
+	return &scope
 }
 
 // namespaceSelectorReach splits the surface an emitted binding covers by what
@@ -889,16 +913,23 @@ func resolveNamespaceSelectorReach(constraints, bindingRules []admissionv1.Named
 // names nothing for the binding to reach past, and nothing for a message about
 // it to echo.
 func bindingCoverage(constraint *admissionv1.NamedRuleWithOperations, resource string, bindingRules []admissionv1.NamedRuleWithOperations) []coveredResource {
-	if len(bindingRules) == 0 {
-		return []coveredResource{{groups: constraint.APIGroups, versions: constraint.APIVersions, resource: resource}}
-	}
 	var covered []coveredResource
+	keep := func(candidate coveredResource) {
+		if scopeExcludes(constraint.Scope, candidate.groups, candidate.resource) {
+			return
+		}
+		covered = append(covered, candidate)
+	}
+	if len(bindingRules) == 0 {
+		keep(coveredResource{groups: constraint.APIGroups, versions: constraint.APIVersions, resource: resource})
+		return covered
+	}
 	for i := range bindingRules {
 		for _, bound := range bindingRules[i].Resources {
 			if !resourcesOverlap([]string{resource}, []string{bound}) {
 				continue
 			}
-			covered = append(covered, coveredResource{
+			keep(coveredResource{
 				groups:   narrowWildcards(constraint.APIGroups, bindingRules[i].APIGroups),
 				versions: narrowWildcards(constraint.APIVersions, bindingRules[i].APIVersions),
 				resource: narrowResource(resource, bound),
@@ -906,6 +937,30 @@ func bindingCoverage(constraint *admissionv1.NamedRuleWithOperations, resource s
 		}
 	}
 	return covered
+}
+
+// scopeExcludes reports whether a constraint's own scope field rules out a
+// resource that would otherwise be in the surface it covers.
+//
+// A rule declaring Namespaced never matches a cluster-scoped request and one
+// declaring Cluster never matches a namespaced request, so a resource on the
+// wrong side of it is not covered at all: nothing there for a selector to reach,
+// and nothing for a message about one to name. Without this a policy declaring
+// scope Cluster over "*", narrowed to apps/v1/deployments, is refused for
+// covering only cluster-scoped resources and names a namespaced one as the
+// reason.
+//
+// Only the built-in table is contradicted, and only where it can speak: a
+// declared scope stays the answer for the custom resources it exists to speak
+// for. The table's answer here is the resource's API scope, so scope Cluster
+// over namespaces is no conflict — the rules matcher counts a Namespace as
+// cluster-scoped, whatever a namespaceSelector then does with it.
+func scopeExcludes(declared *admissionv1.ScopeType, groups []string, resource string) bool {
+	if declared == nil || *declared == admissionv1.AllScopes {
+		return false
+	}
+	known := resourceScope(groups, resource)
+	return known != nil && *known != *declared
 }
 
 // narrowResource is the more specific of a policy resource and a binding

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -871,8 +871,11 @@ func bindingCoversResource(rules []admissionv1.NamedRuleWithOperations, resource
 // ClusterRoleBinding in the cluster. Three shipped controls mix the two
 // (C-0225, C-0262, C-0280).
 //
-// A warning rather than a refusal: the namespaced half of the binding is exactly
-// what was asked for, and --resource-rule can drop the rest.
+// A warning rather than a refusal while some of the surface is still narrowed:
+// that half of the binding is exactly what was asked for, and --resource-rule
+// can drop the rest. A --namespace that narrows nothing at all is refused, the
+// way --label is when it selects nothing — the emitted binding is then no
+// narrower than one carrying neither flag, and nothing else would say so.
 func checkNamespaceSelectorScope(namespaces, resourceRules []string, controlID, policyName string) error {
 	if len(namespaces) == 0 {
 		return nil
@@ -892,6 +895,10 @@ func checkNamespaceSelectorScope(namespaces, resourceRules []string, controlID, 
 	reach := resolveNamespaceSelectorReach(constraints.ResourceRules, bindingRules)
 	if len(reach.alwaysMatched) == 0 {
 		return nil
+	}
+	if !reach.narrowable {
+		return fmt.Errorf("--namespace narrows nothing on %s: every resource the binding covers is cluster-scoped (%s), and a namespaceSelector never exempts a cluster-scoped request; omit --namespace, or point --resource-rule at a namespaced resource the policy matches",
+			describeBoundPolicy(controlID, policyName), strings.Join(reach.alwaysMatched, ", "))
 	}
 	logger.L().Warning("--namespace does not narrow the cluster-scoped resources this policy matches; the apiserver never exempts a cluster-scoped request from a binding's namespaceSelector, so the binding enforces on them cluster-wide",
 		helpers.String("policy", policyName),

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -831,35 +831,38 @@ type namespaceSelectorReach struct {
 	narrowable bool
 }
 
+// coveredResource is one resource the emitted binding covers, at the groups and
+// versions it covers it at.
+type coveredResource struct {
+	groups   []string
+	versions []string
+	resource string
+}
+
 // resolveNamespaceSelectorReach walks the surface the emitted binding covers —
 // the policy's matchConstraints, intersected with the binding's own resource
 // rules when the caller gave any — and reports what its namespaceSelector does
 // to it.
-//
-// The intersection is by resource name alone, the way classifyResourceRule
-// compares one: matchPolicy Equivalent lets a binding rule bridge a group or
-// version gap, but never turns one resource into another.
 func resolveNamespaceSelectorReach(constraints, bindingRules []admissionv1.NamedRuleWithOperations) namespaceSelectorReach {
 	var reach namespaceSelectorReach
 	seen := make(map[string]struct{})
 	for i := range constraints {
 		constraint := &constraints[i]
 		for _, resource := range constraint.Resources {
-			if !bindingCoversResource(bindingRules, resource) {
-				continue
-			}
-			if resourceSelectorReach(constraint.Scope, constraint.APIGroups, resource) != reachAlwaysMatches {
-				reach.narrowable = true
-				continue
-			}
-			for _, group := range constraint.APIGroups {
-				for _, version := range constraint.APIVersions {
-					entry := strings.Join([]string{group, version, resource}, "/")
-					if _, duplicate := seen[entry]; duplicate {
-						continue
+			for _, covered := range bindingCoverage(constraint, resource, bindingRules) {
+				if resourceSelectorReach(constraint.Scope, covered.groups, covered.resource) != reachAlwaysMatches {
+					reach.narrowable = true
+					continue
+				}
+				for _, group := range covered.groups {
+					for _, version := range covered.versions {
+						entry := strings.Join([]string{group, version, covered.resource}, "/")
+						if _, duplicate := seen[entry]; duplicate {
+							continue
+						}
+						seen[entry] = struct{}{}
+						reach.alwaysMatched = append(reach.alwaysMatched, entry)
 					}
-					seen[entry] = struct{}{}
-					reach.alwaysMatched = append(reach.alwaysMatched, entry)
 				}
 			}
 		}
@@ -867,19 +870,79 @@ func resolveNamespaceSelectorReach(constraints, bindingRules []admissionv1.Named
 	return reach
 }
 
-// bindingCoversResource reports whether the binding's own resource rules keep
-// one of the policy's resources in scope. No rules is the default: the binding
-// covers everything the policy matches.
-func bindingCoversResource(rules []admissionv1.NamedRuleWithOperations, resource string) bool {
-	if len(rules) == 0 {
-		return true
+// bindingCoverage resolves what one resource of a policy constraint still
+// covers once the binding's own resource rules are applied, as nothing where
+// they drop it entirely. No rules is the default: the binding covers the
+// constraint as it stands.
+//
+// A request has to match the policy and the binding both, so what the emitted
+// binding acts on is their intersection — and it is the intersection, not the
+// constraint, whose scope decides what the selector can narrow. A policy
+// constraining "*" bound with --resource-rule apps/v1/deployments acts on
+// deployments alone, which a namespaceSelector narrows, however wide the
+// constraint reads on its own.
+//
+// The intersection is by resource name alone, the way classifyResourceRule
+// compares one: matchPolicy Equivalent lets a binding rule bridge a group or
+// version gap, but never turns one resource into another. So group and version
+// stay as the policy states them, except where it states a wildcard — that
+// names nothing for the binding to reach past, and nothing for a message about
+// it to echo.
+func bindingCoverage(constraint *admissionv1.NamedRuleWithOperations, resource string, bindingRules []admissionv1.NamedRuleWithOperations) []coveredResource {
+	if len(bindingRules) == 0 {
+		return []coveredResource{{groups: constraint.APIGroups, versions: constraint.APIVersions, resource: resource}}
 	}
-	for i := range rules {
-		if resourcesOverlap(rules[i].Resources, []string{resource}) {
-			return true
+	var covered []coveredResource
+	for i := range bindingRules {
+		for _, bound := range bindingRules[i].Resources {
+			if !resourcesOverlap([]string{resource}, []string{bound}) {
+				continue
+			}
+			covered = append(covered, coveredResource{
+				groups:   narrowWildcards(constraint.APIGroups, bindingRules[i].APIGroups),
+				versions: narrowWildcards(constraint.APIVersions, bindingRules[i].APIVersions),
+				resource: narrowResource(resource, bound),
+			})
 		}
 	}
-	return false
+	return covered
+}
+
+// narrowResource is the more specific of a policy resource and a binding
+// resource that overlaps it, resource name and subresource each taken from
+// whichever side names one.
+func narrowResource(resource, bound string) string {
+	name, subresource := splitSubresource(resource)
+	boundName, boundSubresource := splitSubresource(bound)
+	name, subresource = narrowWildcard(name, boundName), narrowWildcard(subresource, boundSubresource)
+	if subresource == "" {
+		return name
+	}
+	return name + "/" + subresource
+}
+
+// narrowWildcards replaces a wildcard the policy states with the values the
+// binding narrows it to. Anything the policy names stays as it named it.
+func narrowWildcards(values, bound []string) []string {
+	if len(bound) == 0 {
+		return values
+	}
+	narrowed := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "*" {
+			narrowed = append(narrowed, value)
+			continue
+		}
+		narrowed = append(narrowed, bound...)
+	}
+	return narrowed
+}
+
+func narrowWildcard(value, bound string) string {
+	if value == "*" {
+		return bound
+	}
+	return value
 }
 
 // checkNamespaceSelectorScope reports on a --namespace the apiserver will not

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
 	"github.com/spf13/cobra"
@@ -128,6 +129,9 @@ func getCreatePolicyBindingCmd() *cobra.Command {
 				if err := isValidNamespace(namespace); err != nil {
 					return fmt.Errorf("invalid namespace %s: %w", namespace, err)
 				}
+			}
+			if err := checkNamespaceSelectorScope(namespaceArr, resourceRuleArr, normalizedControlID, resolvedPolicyName); err != nil {
+				return err
 			}
 			if _, err := parseObjectSelectorLabels(labelArr); err != nil {
 				return err
@@ -730,6 +734,170 @@ func describeResourceRules(rules []admissionv1.NamedRuleWithOperations) string {
 		}
 	}
 	return strings.Join(described, ", ")
+}
+
+// selectorReach is what a binding's namespaceSelector does to one resource its
+// policy constrains.
+type selectorReach int
+
+const (
+	// reachUnknown: a custom resource whose rule declares no scope. Where it
+	// lives is a cluster fact, so nothing is concluded from it.
+	reachUnknown selectorReach = iota
+	// reachNarrows: the selector decides whether the resource is in scope.
+	reachNarrows
+	// reachAlwaysMatches: the apiserver admits the resource before it ever
+	// parses the selector, so the selector cannot narrow it.
+	reachAlwaysMatches
+)
+
+// namespacesResource is the one resource carrying no namespace of its own that
+// a namespaceSelector still narrows: the apiserver reads the selector against a
+// Namespace's own labels rather than exempting it as cluster-scoped.
+const namespacesResource = "namespaces"
+
+// resourceSelectorReach resolves what a namespaceSelector does to one resource a
+// policy rule names.
+//
+// The rule's own scope field wins over the built-in resource table: it is the
+// only source that can speak for a custom resource, and an author who set it has
+// stated the answer. The table answers for the rest, but only where the rule
+// names the resource at the group that table serves it from — pairing a custom
+// group with a built-in plural ("custom.io" + "roles") names a different
+// resource that happens to share a name.
+//
+// A resource neither source knows stays unknown rather than guessed: a wrong
+// guess either suppresses a warning the caller needs or raises one they cannot
+// act on.
+func resourceSelectorReach(scope *admissionv1.ScopeType, groups []string, resource string) selectorReach {
+	// A subresource lives wherever its parent does.
+	resource, _ = splitSubresource(strings.ToLower(strings.TrimSpace(resource)))
+	if resource == namespacesResource && valuesOverlap(groups, []string{""}) {
+		return reachNarrows
+	}
+	if scope != nil {
+		switch *scope {
+		case admissionv1.ClusterScope:
+			return reachAlwaysMatches
+		case admissionv1.NamespacedScope:
+			return reachNarrows
+		}
+	}
+	if resource == "*" {
+		return reachAlwaysMatches // the rule sweeps cluster-scoped resources too
+	}
+	gvr, err := k8sinterface.GetGroupVersionResource(resource)
+	if err != nil || gvr.Resource == "" || !valuesOverlap(groups, []string{gvr.Group}) {
+		return reachUnknown
+	}
+	if k8sinterface.IsNamespaceScope(&gvr) {
+		return reachNarrows
+	}
+	return reachAlwaysMatches
+}
+
+// namespaceSelectorReach splits the surface an emitted binding covers by what
+// its namespaceSelector does to each part.
+type namespaceSelectorReach struct {
+	// alwaysMatched are the resources the selector cannot narrow, in the
+	// group/version/resource form --resource-rule takes.
+	alwaysMatched []string
+	// narrowable reports whether the selector reaches anything at all. A
+	// resource of unknown scope counts, so this is false only where nothing the
+	// binding covers could be narrowed.
+	narrowable bool
+}
+
+// resolveNamespaceSelectorReach walks the surface the emitted binding covers —
+// the policy's matchConstraints, intersected with the binding's own resource
+// rules when the caller gave any — and reports what its namespaceSelector does
+// to it.
+//
+// The intersection is by resource name alone, the way classifyResourceRule
+// compares one: matchPolicy Equivalent lets a binding rule bridge a group or
+// version gap, but never turns one resource into another.
+func resolveNamespaceSelectorReach(constraints, bindingRules []admissionv1.NamedRuleWithOperations) namespaceSelectorReach {
+	var reach namespaceSelectorReach
+	seen := make(map[string]struct{})
+	for i := range constraints {
+		constraint := &constraints[i]
+		for _, resource := range constraint.Resources {
+			if !bindingCoversResource(bindingRules, resource) {
+				continue
+			}
+			if resourceSelectorReach(constraint.Scope, constraint.APIGroups, resource) != reachAlwaysMatches {
+				reach.narrowable = true
+				continue
+			}
+			for _, group := range constraint.APIGroups {
+				for _, version := range constraint.APIVersions {
+					entry := strings.Join([]string{group, version, resource}, "/")
+					if _, duplicate := seen[entry]; duplicate {
+						continue
+					}
+					seen[entry] = struct{}{}
+					reach.alwaysMatched = append(reach.alwaysMatched, entry)
+				}
+			}
+		}
+	}
+	return reach
+}
+
+// bindingCoversResource reports whether the binding's own resource rules keep
+// one of the policy's resources in scope. No rules is the default: the binding
+// covers everything the policy matches.
+func bindingCoversResource(rules []admissionv1.NamedRuleWithOperations, resource string) bool {
+	if len(rules) == 0 {
+		return true
+	}
+	for i := range rules {
+		if resourcesOverlap(rules[i].Resources, []string{resource}) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkNamespaceSelectorScope reports on a --namespace the apiserver will not
+// apply the way the flag reads.
+//
+// --namespace emits a namespaceSelector, and the apiserver's namespace matcher
+// returns "matched" for a cluster-scoped request before it ever parses the
+// selector (webhook/predicates/namespace matcher.go, which the VAP binding path
+// reuses). So the flag narrows the namespaced resources a policy constrains and
+// leaves its cluster-scoped ones enforced cluster-wide, silently: with the
+// default Deny action, a rollout meant for one namespace denies every
+// ClusterRoleBinding in the cluster. Three shipped controls mix the two
+// (C-0225, C-0262, C-0280).
+//
+// A warning rather than a refusal: the namespaced half of the binding is exactly
+// what was asked for, and --resource-rule can drop the rest.
+func checkNamespaceSelectorScope(namespaces, resourceRules []string, controlID, policyName string) error {
+	if len(namespaces) == 0 {
+		return nil
+	}
+	constraints, err := policyMatchConstraints(controlID, policyName)
+	if err != nil {
+		return err
+	}
+	if constraints == nil || len(constraints.ResourceRules) == 0 {
+		return nil
+	}
+	bindingRules, err := parseResourceRules(resourceRules)
+	if err != nil {
+		return err
+	}
+
+	reach := resolveNamespaceSelectorReach(constraints.ResourceRules, bindingRules)
+	if len(reach.alwaysMatched) == 0 {
+		return nil
+	}
+	logger.L().Warning("--namespace does not narrow the cluster-scoped resources this policy matches; the apiserver never exempts a cluster-scoped request from a binding's namespaceSelector, so the binding enforces on them cluster-wide",
+		helpers.String("policy", policyName),
+		helpers.String("clusterScoped", strings.Join(reach.alwaysMatched, ", ")),
+		helpers.String("hint", "drop them from the binding with --resource-rule"))
+	return nil
 }
 
 // Create a policy binding

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1467,6 +1467,199 @@ func TestCreatePolicyBindingCmdResourceRuleScope(t *testing.T) {
 	})
 }
 
+// TestResourceSelectorReach covers what the command can conclude offline about
+// one resource a policy constrains. The apiserver's namespace matcher returns
+// "matched" for a cluster-scoped request before it parses the selector, so a
+// namespaceSelector narrows only what this reports as narrowable.
+func TestResourceSelectorReach(t *testing.T) {
+	cluster, namespaced := admissionv1.ClusterScope, admissionv1.NamespacedScope
+
+	tests := []struct {
+		name     string
+		scope    *admissionv1.ScopeType
+		groups   []string
+		resource string
+		want     selectorReach
+	}{
+		{name: "built-in namespaced resource", groups: []string{""}, resource: "pods", want: reachNarrows},
+		{name: "built-in cluster-scoped resource", groups: []string{"rbac.authorization.k8s.io"}, resource: "clusterroles", want: reachAlwaysMatches},
+		{name: "built-in resource in another group is a different resource", groups: []string{"custom.io"}, resource: "roles", want: reachUnknown},
+		{name: "wildcard group accepts the built-in answer", groups: []string{"*"}, resource: "clusterrolebindings", want: reachAlwaysMatches},
+
+		// The one resource with no namespace of its own that the selector still
+		// narrows: it is read against the Namespace's own labels.
+		{name: "namespaces are narrowed by their own labels", groups: []string{""}, resource: "namespaces", want: reachNarrows},
+		{name: "namespaces outrank a declared cluster scope", scope: &cluster, groups: []string{""}, resource: "namespaces", want: reachNarrows},
+		{name: "namespaces in another group are not the core one", groups: []string{"custom.io"}, resource: "namespaces", want: reachUnknown},
+
+		{name: "a declared scope answers for a custom resource", scope: &cluster, groups: []string{"agents.x-k8s.io"}, resource: "sandboxes", want: reachAlwaysMatches},
+		{name: "a declared namespaced scope narrows a custom resource", scope: &namespaced, groups: []string{"ate.dev"}, resource: "workerpools", want: reachNarrows},
+		{name: "an undeclared custom resource stays unknown", groups: []string{"agents.x-k8s.io"}, resource: "sandboxes", want: reachUnknown},
+
+		{name: "a wildcard resource sweeps cluster-scoped ones", groups: []string{"*"}, resource: "*", want: reachAlwaysMatches},
+		{name: "a subresource lives where its parent does", groups: []string{""}, resource: "pods/exec", want: reachNarrows},
+		{name: "an empty resource concludes nothing", groups: []string{""}, resource: "", want: reachUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resourceSelectorReach(tt.scope, tt.groups, tt.resource))
+		})
+	}
+}
+
+// TestResolveNamespaceSelectorReach covers the surface the emitted binding
+// actually carries: the policy's matchConstraints, less whatever the caller's
+// own --resource-rule set drops.
+func TestResolveNamespaceSelectorReach(t *testing.T) {
+	constraint := func(group, version string, resources ...string) admissionv1.NamedRuleWithOperations {
+		rule, err := parseResourceRule(strings.Join([]string{group, version, resources[0]}, "/"))
+		require.NoError(t, err)
+		rule.Resources = resources
+		return rule
+	}
+	const rbac = "rbac.authorization.k8s.io"
+
+	t.Run("a mixed policy is partly narrowable", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	t.Run("a resource rule drops what it does not name", func(t *testing.T) {
+		bindingRules, err := parseResourceRules([]string{rbac + "/v1/rolebindings"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingRules)
+		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	// The resource name is what a binding rule is compared on: matchPolicy
+	// Equivalent may bridge a group or version, never one resource to another.
+	t.Run("a resource rule at another version still keeps the resource", func(t *testing.T) {
+		bindingRules, err := parseResourceRules([]string{rbac + "/v1beta1/clusterrolebindings"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingRules)
+		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("a resource of unknown scope keeps the binding narrowable", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			constraint("agents.x-k8s.io", "v1beta1", "sandboxes"),
+			constraint(rbac, "v1", "clusterroles"),
+		}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterroles"}, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	t.Run("each group and version of a cluster-scoped resource is named once", func(t *testing.T) {
+		rule := constraint(rbac, "v1", "clusterroles")
+		rule.APIVersions = []string{"v1", "v1beta1"}
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{rule, rule}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterroles", rbac + "/v1beta1/clusterroles"}, reach.alwaysMatched)
+	})
+}
+
+// TestCheckNamespaceSelectorScope covers --namespace against the policies the
+// bundle actually ships. C-0225, C-0262 and C-0280 each constrain a namespaced
+// resource alongside a cluster-scoped one, which the emitted namespaceSelector
+// cannot narrow.
+func TestCheckNamespaceSelectorScope(t *testing.T) {
+	const (
+		rbac        = "rbac.authorization.k8s.io"
+		c0016Policy = "kubescape-c-0016-allow-privilege-escalation"
+		c0280Policy = "kubescape-c-0280-deny-access-to-csr-approval-subresource"
+	)
+
+	t.Run("a fully namespaced policy is accepted", func(t *testing.T) {
+		require.NoError(t, checkNamespaceSelectorScope([]string{"prod"}, nil, "C-0016", c0016Policy))
+	})
+
+	// Accepted, because the namespaced half of the binding is what was asked
+	// for. What the warning names is pinned on the constraints themselves.
+	t.Run("a mixed policy is accepted with a warning", func(t *testing.T) {
+		for control, clusterScoped := range map[string]string{
+			"C-0225": rbac + "/v1/clusterrolebindings",
+			"C-0262": rbac + "/v1/clusterrolebindings",
+			"C-0280": rbac + "/v1/clusterroles",
+		} {
+			constraints, err := policyMatchConstraints(control, "")
+			require.NoError(t, err)
+			require.NotNil(t, constraints)
+
+			reach := resolveNamespaceSelectorReach(constraints.ResourceRules, nil)
+			assert.Equal(t, []string{clusterScoped}, reach.alwaysMatched, control)
+			assert.True(t, reach.narrowable, control)
+
+			require.NoError(t, checkNamespaceSelectorScope([]string{"prod"}, nil, control, ""))
+		}
+	})
+
+	// Narrowed to the cluster-scoped half, the selector has nothing left to act
+	// on: the binding is exactly as broad as one carrying no --namespace.
+	t.Run("a binding covering only cluster-scoped resources is refused", func(t *testing.T) {
+		err := checkNamespaceSelectorScope([]string{"prod"}, []string{rbac + "/v1/clusterroles"}, "C-0280", c0280Policy)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "narrows nothing")
+		assert.Contains(t, err.Error(), rbac+"/v1/clusterroles")
+		assert.Contains(t, err.Error(), "control C-0280", "the refusal echoes the flag that was typed")
+	})
+
+	t.Run("narrowing to the namespaced half is accepted", func(t *testing.T) {
+		require.NoError(t, checkNamespaceSelectorScope([]string{"prod"}, []string{rbac + "/v1/roles"}, "C-0280", c0280Policy))
+	})
+
+	t.Run("no namespace is nothing to check", func(t *testing.T) {
+		require.NoError(t, checkNamespaceSelectorScope(nil, nil, "C-0280", c0280Policy))
+	})
+
+	t.Run("a policy outside the bundle is left unchecked", func(t *testing.T) {
+		require.NoError(t, checkNamespaceSelectorScope([]string{"prod"}, nil, "", "my-own-sandbox-policy"))
+	})
+
+	t.Run("an unresolvable control is reported", func(t *testing.T) {
+		require.Error(t, checkNamespaceSelectorScope([]string{"prod"}, nil, "C-9999", "kubescape-c-9999"))
+	})
+}
+
+// TestCreatePolicyBindingCmdNamespaceScope covers the command end to end: a
+// --namespace that narrows part of the policy still emits its binding, and one
+// that narrows none of it fails before anything is written.
+func TestCreatePolicyBindingCmdNamespaceScope(t *testing.T) {
+	const rbac = "rbac.authorization.k8s.io"
+
+	t.Run("a mixed policy still emits its binding", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0262", "--namespace", "prod", "--output", outputFile})
+		require.NoError(t, cmd.Execute())
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		var binding admissionv1.ValidatingAdmissionPolicyBinding
+		require.NoError(t, yaml.Unmarshal(content, &binding))
+		require.NotNil(t, binding.Spec.MatchResources.NamespaceSelector)
+	})
+
+	t.Run("a namespace narrowing nothing fails the command", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "binding.yaml")
+		cmd := getCreatePolicyBindingCmd()
+		cmd.SetArgs([]string{"--name", "my-binding", "--control", "C-0280", "--namespace", "prod", "--resource-rule", rbac + "/v1/clusterroles", "--output", outputFile})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "narrows nothing")
+
+		_, statErr := os.Stat(outputFile)
+		assert.True(t, os.IsNotExist(statErr), "the binding must not be written")
+	})
+}
+
 func TestParseObjectSelectorLabels(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1508,6 +1508,35 @@ func TestResourceSelectorReach(t *testing.T) {
 	}
 }
 
+// TestResourceScope pins the resource's own API scope, which is what a
+// constraint's scope field is compared against. It reads a Namespace the way the
+// apiserver's rules matcher does — cluster-scoped — where a namespaceSelector
+// still narrows one by its own labels.
+func TestResourceScope(t *testing.T) {
+	cluster, namespaced := admissionv1.ClusterScope, admissionv1.NamespacedScope
+
+	tests := []struct {
+		name     string
+		groups   []string
+		resource string
+		want     *admissionv1.ScopeType
+	}{
+		{name: "a built-in namespaced resource", groups: []string{""}, resource: "pods", want: &namespaced},
+		{name: "a built-in cluster-scoped resource", groups: []string{"rbac.authorization.k8s.io"}, resource: "clusterroles", want: &cluster},
+		{name: "a namespace is cluster-scoped to the rules matcher", groups: []string{""}, resource: "namespaces", want: &cluster},
+		{name: "a subresource lives where its parent does", groups: []string{""}, resource: "pods/exec", want: &namespaced},
+		{name: "a built-in plural in another group is another resource", groups: []string{"custom.io"}, resource: "roles", want: nil},
+		{name: "a custom resource is not in the table", groups: []string{"agents.x-k8s.io"}, resource: "sandboxes", want: nil},
+		{name: "a wildcard names no one resource", groups: []string{"*"}, resource: "*", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resourceScope(tt.groups, tt.resource))
+		})
+	}
+}
+
 // TestResolveNamespaceSelectorReach covers the surface the emitted binding
 // actually carries: the policy's matchConstraints, less whatever the caller's
 // own --resource-rule set drops.
@@ -1627,6 +1656,76 @@ func TestResolveNamespaceSelectorReach(t *testing.T) {
 
 		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("apps", "v1", "deployments")}, bindingResourceRules(parsed))
 		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	// A constraint's scope field also decides what it does not cover: a rule
+	// declaring one scope never matches a request of the other, so a resource on
+	// the wrong side of it is outside the surface rather than part of it.
+	scoped := func(scope admissionv1.ScopeType, rule admissionv1.NamedRuleWithOperations) admissionv1.NamedRuleWithOperations {
+		rule.Scope = &scope
+		return rule
+	}
+
+	t.Run("a declared cluster scope drops the namespaced resource beside it", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ClusterScope, constraint(rbac, "v1", "rolebindings", "clusterrolebindings")),
+		}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	// Refusing this named a namespaced resource as the cluster-scoped reason for
+	// the refusal. The constraint matches no deployment at all, so the binding
+	// covers nothing and there is nothing to report either way.
+	t.Run("a declared cluster scope drops what a rule narrows a wildcard to", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"apps/v1/deployments"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ClusterScope, constraint("*", "*", "*")),
+		}, bindingResourceRules(parsed))
+		assert.Empty(t, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("a declared namespaced scope drops a cluster-scoped rule", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{rbac + "/v1/clusterroles"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.NamespacedScope, constraint("*", "*", "*")),
+		}, bindingResourceRules(parsed))
+		assert.Empty(t, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	// The table is contradicted only where it can speak. A declared scope stays
+	// the answer for the custom resources it exists to answer for.
+	t.Run("a declared scope still answers for a custom resource", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ClusterScope, constraint("agents.x-k8s.io", "v1beta1", "sandboxes")),
+		}, nil)
+		assert.Equal(t, []string{"agents.x-k8s.io/v1beta1/sandboxes"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	// The asymmetry, from the other side: a Namespace is cluster-scoped to the
+	// rules matcher, so a cluster-scoped constraint covers it — and the selector
+	// still narrows it by its own labels.
+	t.Run("a declared cluster scope still covers narrowable namespaces", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ClusterScope, constraint("", "v1", "namespaces")),
+		}, nil)
+		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	t.Run("a scope of all scopes drops nothing", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.AllScopes, constraint(rbac, "v1", "rolebindings", "clusterrolebindings")),
+		}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
 		assert.True(t, reach.narrowable)
 	})
 }

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1728,6 +1728,48 @@ func TestResolveNamespaceSelectorReach(t *testing.T) {
 		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
 		assert.True(t, reach.narrowable)
 	})
+
+	// A scope this version cannot read is no grounds for going quiet: an
+	// unreadable one has to leave the surface exactly as no scope at all does.
+	t.Run("an unreadable scope drops nothing", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ScopeType("Sideways"), constraint(rbac, "v1", "rolebindings", "clusterrolebindings")),
+		}, nil)
+		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	// The scope is contradicted a group at a time. A wildcard group covers the
+	// groups the table cannot speak for as well, so the built-in namespaced
+	// "roles" is no proof a scope Cluster rule over it covers nothing — whatever
+	// cluster-scoped roles a group of its own defines, it still covers.
+	t.Run("a wildcard group survives a conflicting built-in", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.ClusterScope, constraint("*", "v1", "roles")),
+		}, nil)
+		assert.Equal(t, []string{"*/v1/roles"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("only the group the table speaks for is dropped", func(t *testing.T) {
+		rule := scoped(admissionv1.ClusterScope, constraint(rbac, "v1", "roles"))
+		rule.APIGroups = []string{rbac, "foo.io"}
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{rule}, nil)
+		assert.Equal(t, []string{"foo.io/v1/roles"}, reach.alwaysMatched, "the rbac roles a cluster-scoped rule never matches is not part of the surface")
+		assert.False(t, reach.narrowable)
+	})
+
+	// The namespaces asymmetry from the third side: the rules matcher excludes
+	// namespaces from Namespaced scope outright, so such a rule covers nothing
+	// and the selector's reach over a Namespace never comes up.
+	t.Run("a declared namespaced scope covers no namespaces", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{
+			scoped(admissionv1.NamespacedScope, constraint("", "v1", "namespaces")),
+		}, nil)
+		assert.Empty(t, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
 }
 
 // TestCheckNamespaceSelectorScope covers --namespace against the policies the

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1527,10 +1527,10 @@ func TestResolveNamespaceSelectorReach(t *testing.T) {
 	})
 
 	t.Run("a resource rule drops what it does not name", func(t *testing.T) {
-		bindingRules, err := parseResourceRules([]string{rbac + "/v1/rolebindings"})
+		parsed, err := parseResourceRules([]string{rbac + "/v1/rolebindings"})
 		require.NoError(t, err)
 
-		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingRules)
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingResourceRules(parsed))
 		assert.Empty(t, reach.alwaysMatched)
 		assert.True(t, reach.narrowable)
 	})
@@ -1538,10 +1538,10 @@ func TestResolveNamespaceSelectorReach(t *testing.T) {
 	// The resource name is what a binding rule is compared on: matchPolicy
 	// Equivalent may bridge a group or version, never one resource to another.
 	t.Run("a resource rule at another version still keeps the resource", func(t *testing.T) {
-		bindingRules, err := parseResourceRules([]string{rbac + "/v1beta1/clusterrolebindings"})
+		parsed, err := parseResourceRules([]string{rbac + "/v1beta1/clusterrolebindings"})
 		require.NoError(t, err)
 
-		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingRules)
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint(rbac, "v1", "rolebindings", "clusterrolebindings")}, bindingResourceRules(parsed))
 		assert.Equal(t, []string{rbac + "/v1/clusterrolebindings"}, reach.alwaysMatched)
 		assert.False(t, reach.narrowable)
 	})

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1562,6 +1562,73 @@ func TestResolveNamespaceSelectorReach(t *testing.T) {
 		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{rule, rule}, nil)
 		assert.Equal(t, []string{rbac + "/v1/clusterroles", rbac + "/v1beta1/clusterroles"}, reach.alwaysMatched)
 	})
+
+	// A wildcard constraint sweeps cluster-scoped resources only as far as the
+	// binding lets it. What the selector has to reach is the intersection, so a
+	// binding narrowed to a namespaced resource is narrowable however wide the
+	// constraint reads on its own — reading the reach off "*" instead refuses a
+	// binding that is exactly what --namespace is for.
+	t.Run("a resource rule narrows a wildcard constraint", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"apps/v1/deployments"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")}, bindingResourceRules(parsed))
+		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	t.Run("a wildcard constraint narrowed to a cluster-scoped resource names it", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{rbac + "/v1/clusterroles"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")}, bindingResourceRules(parsed))
+		assert.Equal(t, []string{rbac + "/v1/clusterroles"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("only the rules covering a resource narrow it", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"apps/v1/deployments", rbac + "/v1/clusterroles"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")}, bindingResourceRules(parsed))
+		assert.Equal(t, []string{rbac + "/v1/clusterroles"}, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	t.Run("an unnarrowed wildcard constraint keeps its whole reach", func(t *testing.T) {
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")}, nil)
+		assert.Equal(t, []string{"*/*/*"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("a wildcard resource rule narrows nothing off a wildcard constraint", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"*/*/*"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*")}, bindingResourceRules(parsed))
+		assert.Equal(t, []string{"*/*/*"}, reach.alwaysMatched)
+		assert.False(t, reach.narrowable)
+	})
+
+	t.Run("a subresource rule narrows a wildcard constraint to its parent's scope", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"/v1/pods/exec"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("*", "*", "*/*")}, bindingResourceRules(parsed))
+		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
+
+	// Only a wildcard gives way: a rule at another group covers the resource the
+	// constraint names, at the group the constraint names it at.
+	t.Run("a named constraint group outranks the rule's", func(t *testing.T) {
+		parsed, err := parseResourceRules([]string{"extensions/v1beta1/deployments"})
+		require.NoError(t, err)
+
+		reach := resolveNamespaceSelectorReach([]admissionv1.NamedRuleWithOperations{constraint("apps", "v1", "deployments")}, bindingResourceRules(parsed))
+		assert.Empty(t, reach.alwaysMatched)
+		assert.True(t, reach.narrowable)
+	})
 }
 
 // TestCheckNamespaceSelectorScope covers --namespace against the policies the


### PR DESCRIPTION
The `namespace` flag on `kubescape vap create-policy-binding` emits a `matchResources.namespaceSelector` keyed on `kubernetes.io/metadata.name`, and it reads like it scopes the whole binding to those namespaces. For a policy that only constrains namespaced resources that is exactly what happens. For a policy that also constrains a cluster-scoped one it is not, and nothing says so.

The apiserver's namespace matcher, which the VAP binding path reuses through `plugin/policy/matching`, returns matched for a cluster-scoped request before it ever parses the selector:

> If the request is about a cluster scoped resource, and it is not a namespace, it is never exempted.

Three controls in the bundle we ship mix the two kinds. C-0225 constrains serviceaccounts, rolebindings and clusterrolebindings, C-0262 constrains rolebindings and clusterrolebindings, and C-0280 constrains roles and clusterroles. Bind any of them with `namespace prod`, leave the action at its Deny default, apply it, and every ClusterRoleBinding or ClusterRole create and update in the cluster is denied rather than only the ones in prod. That is the opposite of the staged rollout the flag gets reached for, and the emitted YAML gives no hint of it, because the selector on it looks perfectly ordinary.

So the command now works out offline what the binding it is about to write actually covers, and splits that surface by whether the selector can act on it. A binding that still narrows part of what it covers gets a warning naming the resources it does not narrow, since the namespaced half is exactly what was asked for and there is nothing wrong with keeping it. A binding where the selector reaches nothing at all is refused instead, the same way a `label` that selects nothing is already refused, because that binding ends up no narrower than one carrying neither flag.

The resource I want to call out is Namespace itself. It carries no `metadata.namespace`, so the obvious reading is that it belongs with the cluster-scoped group, but the matcher excludes `namespaces` from the never-exempted branch and reads the selector against the Namespace's own labels instead. A namespaces rule therefore stays narrowable. It is the same asymmetry I pinned on the coverage side in #3592, it is the detail here most likely to regress, and there are tests for both directions of it.

Scope itself comes from the rule's own `scope` field first and the built-in resource table second, and a resource neither source can speak for stays unknown rather than being guessed. A custom resource is then never guessed into a warning the caller cannot act on, while an Agent Sandbox or Agent Substrate policy that does declare `scope: Cluster` on its rule still gets one. The check also honours the binding's own `resource-rule` set, so narrowing to the namespaced half silences the warning, which is what the warning suggests doing.

The first commit is plumbing. The flag was being parsed in three separate places, and the new check needs the parsed rules to know what the binding still covers, so parsing now goes through one helper.

The new tests do not compile against master, since they name functions this branch adds, so I checked they are not vacuous by stubbing the check out to return nil and confirming they fail as assertions rather than passing quietly. I also ran the three cases through the built binary: C-0016 stays silent, C-0262 warns and still writes its binding, and C-0280 narrowed to clusterroles is refused before anything is written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resource-scope awareness to namespace-selector analysis.
  * Added support for filtering coverage by namespaced, cluster-scoped, or all-scope declarations.
  * Improved handling of built-in and custom resources, including narrow namespace selections.

* **Bug Fixes**
  * Prevented resources from being incorrectly treated as covered when their scope conflicts with a policy rule.
  * Improved handling of wildcard groups and resources with unreadable scope information.
  * Improved reachability results for namespace-scoped policy bindings and mixed resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->