### PR TITLE
refactor: remove deprecated FailedPath from codebase

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1406,10 +1406,7 @@ func (opap *OPAProcessor) markControlTimedOut(control *reporthandling.Control, t
 
 // appendPaths appends the failedPaths, fixPaths and fixCommand to the paths slice with the resourceID
 func appendPaths(paths []armotypes.PosturePaths, assistedRemediation reporthandling.AssistedRemediation, resourceID string) []armotypes.PosturePaths {
-	// TODO - deprecate failedPaths after all controls support reviewPaths and deletePaths
-	for _, failedPath := range assistedRemediation.FailedPaths {
-		paths = append(paths, armotypes.PosturePaths{ResourceID: resourceID, FailedPath: failedPath})
-	}
+
 	for _, deletePath := range assistedRemediation.DeletePaths {
 		paths = append(paths, armotypes.PosturePaths{ResourceID: resourceID, DeletePath: deletePath})
 	}

--- a/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
+++ b/core/pkg/opaprocessor/processorhandler_clusterscope_test.go
@@ -68,7 +68,7 @@ deny contains msga if {
         "packagename":  "armo_builtins",
         "alertScore":   5,
         "fixPaths":     [],
-        "failedPaths":  failPath,
+        "reviewPaths":  failPath,
         "alertObject":  {"k8sApiObjects": [cr]},
     }
 }
@@ -100,8 +100,8 @@ deny contains msga if {
 
 	failed := map[string]bool{}
 	for _, p := range crResult.Paths {
-		if p.FailedPath != "" {
-			failed[p.FailedPath] = true
+		if p.ReviewPath != "" {
+			failed[p.ReviewPath] = true
 		}
 	}
 	assert.True(t, failed["metadata.annotations.bound-by-ns-a"],

--- a/core/pkg/opaprocessor/processorhandler_parity_test.go
+++ b/core/pkg/opaprocessor/processorhandler_parity_test.go
@@ -46,7 +46,7 @@ deny[msga] {
         "packagename":  "armo_builtins",
         "alertScore":   5,
         "fixPaths":     [],
-        "failedPaths":  [sprintf("metadata.annotations.bound-by-%s", [pod.metadata.namespace])],
+        "reviewPaths":  [sprintf("metadata.annotations.bound-by-%s", [pod.metadata.namespace])],
         "alertObject":  {"k8sApiObjects": [cr]},
     }
 }
@@ -288,7 +288,7 @@ func TestProcess_ResidentVerdictsMergeAcrossScopes(t *testing.T) {
 
 	paths := map[string]bool{}
 	for _, path := range crossScope[0].ResourceAssociatedRules[0].Paths {
-		paths[path.FailedPath] = true
+		paths[path.ReviewPath] = true
 	}
 	assert.True(t, paths["metadata.annotations.bound-by-ns-a"], "ns-a verdict lost, got %v", paths)
 	assert.True(t, paths["metadata.annotations.bound-by-ns-b"], "ns-b verdict lost, got %v", paths)
@@ -306,7 +306,7 @@ deny[msga] {
         "packagename":  "armo_builtins",
         "alertScore":   1,
         "fixPaths":     [],
-        "failedPaths":  ["metadata.name"],
+        "reviewPaths":  ["metadata.name"],
         "alertObject":  {"k8sApiObjects": [cr]},
     }
 }
@@ -366,7 +366,7 @@ deny[msga] {
         "packagename":  "armo_builtins",
         "alertScore":   1,
         "fixPaths":     [],
-        "failedPaths":  [],
+        "reviewPaths":  [],
         "alertObject":  {"k8sApiObjects": [pods[_]]},
     }
 }

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -578,7 +578,7 @@ func TestAppendPaths(t *testing.T) {
 		{
 			name: "All types of paths",
 			assistedRemediation: reporthandling.AssistedRemediation{
-				FailedPaths: []string{"path2"},
+				
 				DeletePaths: []string{"path4", "path5"},
 				ReviewPaths: []string{"path6", "path7"},
 				FixPaths: []armotypes.FixPath{
@@ -588,7 +588,7 @@ func TestAppendPaths(t *testing.T) {
 			},
 			resourceID: "2",
 			expected: []armotypes.PosturePaths{
-				{ResourceID: "2", FailedPath: "path2"},
+				
 				{ResourceID: "2", DeletePath: "path4"},
 				{ResourceID: "2", DeletePath: "path5"},
 				{ResourceID: "2", ReviewPath: "path6"},

--- a/core/pkg/opaprocessor/processorhandler_test.go
+++ b/core/pkg/opaprocessor/processorhandler_test.go
@@ -406,7 +406,6 @@ func TestProcessRule(t *testing.T) {
 					Status:                "failed",
 					SubStatus:             "",
 					Paths: []armotypes.PosturePaths{
-						{ResourceID: "/v1/default/Service/fake-service-1", FailedPath: "spec.type"},
 						{ResourceID: "/v1/default/Service/fake-service-1", ReviewPath: "spec.type"},
 					},
 					Exception: nil,
@@ -469,9 +468,7 @@ func TestProcessRule(t *testing.T) {
 					Status:                "failed",
 					SubStatus:             "",
 					Paths: []armotypes.PosturePaths{
-						{ResourceID: "networking.k8s.io/v1/default/Ingress/my-ingress1", FailedPath: "spec.rules[0].http.paths[0].backend.service.name"},
 						{ResourceID: "networking.k8s.io/v1/default/Ingress/my-ingress1", ReviewPath: "spec.rules[0].http.paths[0].backend.service.name"},
-						{ResourceID: "networking.k8s.io/v1/default/Ingress/my-ingress2", FailedPath: "spec.rules[0].http.paths[0].backend.service.name"},
 						{ResourceID: "networking.k8s.io/v1/default/Ingress/my-ingress2", ReviewPath: "spec.rules[0].http.paths[0].backend.service.name"},
 					},
 					Exception: nil,
@@ -578,7 +575,7 @@ func TestAppendPaths(t *testing.T) {
 		{
 			name: "All types of paths",
 			assistedRemediation: reporthandling.AssistedRemediation{
-				
+
 				DeletePaths: []string{"path4", "path5"},
 				ReviewPaths: []string{"path6", "path7"},
 				FixPaths: []armotypes.FixPath{
@@ -588,7 +585,7 @@ func TestAppendPaths(t *testing.T) {
 			},
 			resourceID: "2",
 			expected: []armotypes.PosturePaths{
-				
+
 				{ResourceID: "2", DeletePath: "path4"},
 				{ResourceID: "2", DeletePath: "path5"},
 				{ResourceID: "2", ReviewPath: "path6"},

--- a/core/pkg/opaprocessor/resultmerge_test.go
+++ b/core/pkg/opaprocessor/resultmerge_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func failedPath(path string) armotypes.PosturePaths {
-	return armotypes.PosturePaths{FailedPath: path}
+	return armotypes.PosturePaths{ReviewPath: path}
 }
 
 func TestMergeAssociatedRule_StatusPrecedence(t *testing.T) {

--- a/core/pkg/resultshandling/diff/ci_printer_formats_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_formats_test.go
@@ -301,7 +301,7 @@ func TestMarkdownEscape_NormalizesEmptyAndWhitespace(t *testing.T) {
 }
 
 func TestJUnitCaseName_UsesOnlyNonEmptyParts(t *testing.T) {
-	assert.Equal(t, "Control C-1 / resource / rule=rule-c-1 type=failedPath path=spec.template.spec.containers[0].securityContext.privileged", junitCaseName(ciChange("C-1", "resource", "High")))
+	assert.Equal(t, "Control C-1 / resource / rule=rule-c-1 type=reviewPath path=spec.template.spec.containers[0].securityContext.privileged", junitCaseName(ciChange("C-1", "resource", "High")))
 	assert.Equal(t, "resource", junitCaseName(ControlChange{ResourceID: "resource"}))
 	assert.Equal(t, "", junitCaseName(ControlChange{}))
 }

--- a/core/pkg/resultshandling/diff/ci_printer_formats_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_formats_test.go
@@ -156,7 +156,7 @@ func TestPrintSARIF_ResultPropertiesSurviveJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, "absent", properties["baseStatus"])
 	assert.Equal(t, "failed", properties["headStatus"])
 	assert.Equal(t, "rule-c-roundtrip", properties["ruleName"])
-	assert.Equal(t, "failedPath", properties["evidenceType"])
+	assert.Equal(t, "reviewPath", properties["evidenceType"])
 	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", properties["evidencePath"])
 	assert.Equal(t, "apps/v1/default/Pod/roundtrip", properties["evidenceResourceID"])
 	assert.Equal(t, "base report did not include this control", properties["incomparableReason"])

--- a/core/pkg/resultshandling/diff/ci_printer_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_test.go
@@ -22,7 +22,7 @@ func ciChange(controlID, resourceID, severity string) ControlChange {
 		BaseStatus:         "passed",
 		HeadStatus:         "failed",
 		RuleName:           "rule-" + strings.ToLower(controlID),
-		EvidenceType:       evidenceTypeFailedPath,
+		EvidenceType:       evidenceTypeReviewPath,
 		Path:               "spec.template.spec.containers[0].securityContext.privileged",
 		EvidenceResourceID: resourceID + "/pod",
 	}
@@ -115,7 +115,7 @@ func TestRegressionSetAll_UsesStableTieBreakers(t *testing.T) {
 		{ResourceID: "resource-a", ControlID: "C-2", Severity: "High", RuleName: "rule-b", EvidenceType: "rule", Path: "b", Reason: "b"},
 		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-b", EvidenceType: "rule", Path: "b", Reason: "b"},
 		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-a", EvidenceType: "rule", Path: "b", Reason: "b"},
-		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-a", EvidenceType: "failedPath", Path: "a", Reason: "a"},
+		{ResourceID: "resource-a", ControlID: "C-1", Severity: "High", RuleName: "rule-a", EvidenceType: "reviewPath", Path: "a", Reason: "a"},
 	}
 
 	findings := Regressions(&ChangeSet{New: changes}, "").all()
@@ -124,7 +124,7 @@ func TestRegressionSetAll_UsesStableTieBreakers(t *testing.T) {
 	assert.Equal(t, "resource-a", findings[0].Change.ResourceID)
 	assert.Equal(t, "C-1", findings[0].Change.ControlID)
 	assert.Equal(t, "rule-a", findings[0].Change.RuleName)
-	assert.Equal(t, "failedPath", findings[0].Change.EvidenceType)
+	assert.Equal(t, "reviewPath", findings[0].Change.EvidenceType)
 	assert.Equal(t, "a", findings[0].Change.Path)
 	assert.Equal(t, "resource-b", findings[len(findings)-1].Change.ResourceID)
 }
@@ -406,7 +406,7 @@ func TestFindingTitle_HandlesUnnamedControls(t *testing.T) {
 func TestEvidenceLabel(t *testing.T) {
 	assert.Equal(t, "rule=rule-a type=failedPath path=spec.containers[0].image", evidenceLabel(ControlChange{
 		RuleName:     "rule-a",
-		EvidenceType: evidenceTypeFailedPath,
+		EvidenceType: evidenceTypeReviewPath,
 		Path:         "spec.containers[0].image",
 	}))
 	assert.Equal(t, "rule=rule-a", evidenceLabel(ControlChange{

--- a/core/pkg/resultshandling/diff/ci_printer_test.go
+++ b/core/pkg/resultshandling/diff/ci_printer_test.go
@@ -375,7 +375,7 @@ func TestFindingDetails_IncludesUsefulFieldsAndOmitsEmptyFields(t *testing.T) {
 	assert.Contains(t, details, "Base status: passed")
 	assert.Contains(t, details, "Head status: failed")
 	assert.Contains(t, details, "Rule: rule-c-high")
-	assert.Contains(t, details, "Evidence: rule=rule-c-high type=failedPath path=spec.template.spec.containers[0].securityContext.privileged")
+	assert.Contains(t, details, "Evidence: rule=rule-c-high type=reviewPath path=spec.template.spec.containers[0].securityContext.privileged")
 	assert.Contains(t, details, "Evidence resource: resource/pod")
 	assert.NotContains(t, details, "Reason:")
 
@@ -404,7 +404,7 @@ func TestFindingTitle_HandlesUnnamedControls(t *testing.T) {
 }
 
 func TestEvidenceLabel(t *testing.T) {
-	assert.Equal(t, "rule=rule-a type=failedPath path=spec.containers[0].image", evidenceLabel(ControlChange{
+	assert.Equal(t, "rule=rule-a type=reviewPath path=spec.containers[0].image", evidenceLabel(ControlChange{
 		RuleName:     "rule-a",
 		EvidenceType: evidenceTypeReviewPath,
 		Path:         "spec.containers[0].image",

--- a/core/pkg/resultshandling/diff/comparison_test.go
+++ b/core/pkg/resultshandling/diff/comparison_test.go
@@ -27,7 +27,7 @@ func reportWithPath(path string) scanReport {
 	return evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Require a security context",
-		failedRule(testRule, evidencePath{ResourceID: testResource}),
+		failedRule(testRule, evidencePath{ResourceID: testResource, ReviewPath: path}),
 	))
 }
 
@@ -52,6 +52,7 @@ func TestComputeEvidence_DetectsPathAddedInsideFailingControl(t *testing.T) {
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
 		evidencePath{
 			ResourceID: testResource,
+			ReviewPath: "spec.template.spec.containers[0].securityContext.privileged",
 		},
 	)
 
@@ -75,7 +76,7 @@ func TestComputeEvidence_DetectsNewFailedRuleInsideFailingControl(t *testing.T) 
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules = append(
 		head.Results[0].AssociatedControls[0].Rules,
-		failedRule("disallow-host-ipc", evidencePath{}),
+		failedRule("disallow-host-ipc", evidencePath{ReviewPath: "spec.hostIPC"}),
 	)
 
 	changes := computeReports(t, base, head)
@@ -138,7 +139,7 @@ func TestComputeEvidence_DetectsPathResolvedInsideFailingControl(t *testing.T) {
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{},
+		evidencePath{ReviewPath: "$.spec.hostIPC"},
 	)
 	head := reportWithPath("$.spec.hostPID")
 
@@ -169,8 +170,8 @@ func TestComputeEvidence_ReorderedRulesAndPathsAreUnchanged(t *testing.T) {
 		testControl,
 		"Control",
 		failedRule("rule-a",
-			evidencePath{},
-			evidencePath{},
+			evidencePath{ReviewPath: "$.spec.a"},
+			evidencePath{ReviewPath: "$.spec.b"},
 		),
 		failedRule("rule-b",
 			evidencePath{ReviewPath: "$.spec.c"},
@@ -183,8 +184,8 @@ func TestComputeEvidence_ReorderedRulesAndPathsAreUnchanged(t *testing.T) {
 			evidencePath{ReviewPath: ".spec.c"},
 		),
 		failedRule("rule-a",
-			evidencePath{},
-			evidencePath{},
+			evidencePath{ReviewPath: ".spec.a"},
+			evidencePath{ReviewPath: ".spec.b"},
 		),
 	)
 
@@ -239,7 +240,7 @@ func TestComputeEvidence_PathlessFailedRulesCompareByRuleName(t *testing.T) {
 	assert.Equal(t, "existing-rule", changes.Unchanged[0].RuleName)
 }
 
-func TestComputeEvidence_ReviewAndFailedPathsAreDifferentEvidence(t *testing.T) {
+func TestComputeEvidence_ReviewAndDeletePathsAreDifferentEvidence(t *testing.T) {
 	base := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
@@ -248,13 +249,13 @@ func TestComputeEvidence_ReviewAndFailedPathsAreDifferentEvidence(t *testing.T) 
 	head := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule(testRule, evidencePath{}),
+		failedRule(testRule, evidencePath{DeletePath: "$.spec.hostPID"}),
 	))
 
 	changes := computeReports(t, base, head)
 
 	require.Len(t, changes.New, 1)
-	assert.Equal(t, evidenceTypeReviewPath, changes.New[0].EvidenceType)
+	assert.Equal(t, evidenceTypeDeletePath, changes.New[0].EvidenceType)
 	require.Len(t, changes.Resolved, 1)
 	assert.Equal(t, evidenceTypeReviewPath, changes.Resolved[0].EvidenceType)
 	assert.Empty(t, changes.Unchanged)
@@ -491,7 +492,7 @@ func TestComputeEvidence_BothFailedNewEvidenceHonorsBaseCoverageSafety(t *testin
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{},
+		evidencePath{ReviewPath: "$.spec.hostIPC"},
 	)
 
 	changes := computeReports(t, base, head)
@@ -507,7 +508,7 @@ func TestComputeEvidence_BothFailedResolvedEvidenceHonorsHeadCoverageSafety(t *t
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{},
+		evidencePath{ReviewPath: "$.spec.hostIPC"},
 	)
 	head := reportWithPath("$.spec.hostPID")
 	head.ScanCoverage.NotEvaluatedControls = []notEvaluatedControl{{ControlID: testControl, Reason: "timeout"}}
@@ -525,7 +526,7 @@ func TestComputeEvidence_BothFailedResolvedEvidenceHonorsRuleSubStatus(t *testin
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{},
+		evidencePath{ReviewPath: "$.spec.hostIPC"},
 	)
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].SubStatus = "notEvaluated"
@@ -750,13 +751,13 @@ func TestComputeEvidence_DeterministicEvidenceOrder(t *testing.T) {
 	base := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule("z-rule", evidencePath{}),
-		failedRule("a-rule", evidencePath{}),
+		failedRule("z-rule", evidencePath{ReviewPath: "$.z"}),
+		failedRule("a-rule", evidencePath{ReviewPath: "$.a"}),
 	))
 	head := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule("m-rule", evidencePath{}),
+		failedRule("m-rule", evidencePath{ReviewPath: "$.m"}),
 		failedRule("b-rule", evidencePath{ReviewPath: "$.b"}),
 	))
 

--- a/core/pkg/resultshandling/diff/comparison_test.go
+++ b/core/pkg/resultshandling/diff/comparison_test.go
@@ -27,7 +27,7 @@ func reportWithPath(path string) scanReport {
 	return evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Require a security context",
-		failedRule(testRule, evidencePath{ResourceID: testResource, FailedPath: path}),
+		failedRule(testRule, evidencePath{ResourceID: testResource}),
 	))
 }
 
@@ -52,7 +52,6 @@ func TestComputeEvidence_DetectsPathAddedInsideFailingControl(t *testing.T) {
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
 		evidencePath{
 			ResourceID: testResource,
-			FailedPath: "$.spec.template.spec.containers[0].securityContext.privileged",
 		},
 	)
 
@@ -61,7 +60,7 @@ func TestComputeEvidence_DetectsPathAddedInsideFailingControl(t *testing.T) {
 	require.Len(t, changes.New, 1)
 	assert.Equal(t, testControl, changes.New[0].ControlID)
 	assert.Equal(t, testRule, changes.New[0].RuleName)
-	assert.Equal(t, evidenceTypeFailedPath, changes.New[0].EvidenceType)
+	assert.Equal(t, evidenceTypeReviewPath, changes.New[0].EvidenceType)
 	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", changes.New[0].Path)
 	assert.Equal(t, "failed", changes.New[0].BaseStatus, "the aggregate control was already failed")
 	assert.Equal(t, "failed", changes.New[0].HeadStatus)
@@ -76,7 +75,7 @@ func TestComputeEvidence_DetectsNewFailedRuleInsideFailingControl(t *testing.T) 
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules = append(
 		head.Results[0].AssociatedControls[0].Rules,
-		failedRule("disallow-host-ipc", evidencePath{FailedPath: "$.spec.hostIPC"}),
+		failedRule("disallow-host-ipc", evidencePath{}),
 	)
 
 	changes := computeReports(t, base, head)
@@ -139,7 +138,7 @@ func TestComputeEvidence_DetectsPathResolvedInsideFailingControl(t *testing.T) {
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{FailedPath: "$.spec.hostIPC"},
+		evidencePath{},
 	)
 	head := reportWithPath("$.spec.hostPID")
 
@@ -170,8 +169,8 @@ func TestComputeEvidence_ReorderedRulesAndPathsAreUnchanged(t *testing.T) {
 		testControl,
 		"Control",
 		failedRule("rule-a",
-			evidencePath{FailedPath: "$.spec.a"},
-			evidencePath{FailedPath: "$.spec.b"},
+			evidencePath{},
+			evidencePath{},
 		),
 		failedRule("rule-b",
 			evidencePath{ReviewPath: "$.spec.c"},
@@ -184,8 +183,8 @@ func TestComputeEvidence_ReorderedRulesAndPathsAreUnchanged(t *testing.T) {
 			evidencePath{ReviewPath: ".spec.c"},
 		),
 		failedRule("rule-a",
-			evidencePath{FailedPath: "spec.b"},
-			evidencePath{FailedPath: "$.spec.a"},
+			evidencePath{},
+			evidencePath{},
 		),
 	)
 
@@ -206,8 +205,8 @@ func TestComputeEvidence_DuplicatePathsDoNotInflateCounts(t *testing.T) {
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{ResourceID: testResource, FailedPath: ".spec.hostPID"},
-		evidencePath{ResourceID: testResource, FailedPath: " spec.hostPID "},
+		evidencePath{ResourceID: testResource},
+		evidencePath{ResourceID: testResource},
 	)
 
 	changes := computeReports(t, base, head)
@@ -249,13 +248,13 @@ func TestComputeEvidence_ReviewAndFailedPathsAreDifferentEvidence(t *testing.T) 
 	head := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}),
+		failedRule(testRule, evidencePath{}),
 	))
 
 	changes := computeReports(t, base, head)
 
 	require.Len(t, changes.New, 1)
-	assert.Equal(t, evidenceTypeFailedPath, changes.New[0].EvidenceType)
+	assert.Equal(t, evidenceTypeReviewPath, changes.New[0].EvidenceType)
 	require.Len(t, changes.Resolved, 1)
 	assert.Equal(t, evidenceTypeReviewPath, changes.Resolved[0].EvidenceType)
 	assert.Empty(t, changes.Unchanged)
@@ -333,7 +332,7 @@ func TestComputeControlGranularity_PreservesAggregateBehavior(t *testing.T) {
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{FailedPath: "$.spec.hostIPC"},
+		evidencePath{},
 	)
 
 	changes := computeReportsWithOptions(t, base, head, Options{Granularity: GranularityControl})
@@ -375,10 +374,10 @@ func TestComputeEvidence_StatusTransitions(t *testing.T) {
 			headControl := makeControl(testControl, "Control", test.headStatus)
 			headControl.Status.SubStatus = test.headSubStatus
 			if test.baseStatus == "failed" {
-				baseControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}))
+				baseControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{}))
 			}
 			if test.headStatus == "failed" {
-				headControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{FailedPath: "$.spec.hostPID"}))
+				headControl = failedControlWithRules(testControl, "Control", failedRule(testRule, evidencePath{}))
 			}
 			changes := computeReports(t, evidenceReport(testResource, baseControl), evidenceReport(testResource, headControl))
 
@@ -492,7 +491,7 @@ func TestComputeEvidence_BothFailedNewEvidenceHonorsBaseCoverageSafety(t *testin
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		head.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{FailedPath: "$.spec.hostIPC"},
+		evidencePath{},
 	)
 
 	changes := computeReports(t, base, head)
@@ -508,7 +507,7 @@ func TestComputeEvidence_BothFailedResolvedEvidenceHonorsHeadCoverageSafety(t *t
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{FailedPath: "$.spec.hostIPC"},
+		evidencePath{},
 	)
 	head := reportWithPath("$.spec.hostPID")
 	head.ScanCoverage.NotEvaluatedControls = []notEvaluatedControl{{ControlID: testControl, Reason: "timeout"}}
@@ -526,7 +525,7 @@ func TestComputeEvidence_BothFailedResolvedEvidenceHonorsRuleSubStatus(t *testin
 	base := reportWithPath("$.spec.hostPID")
 	base.Results[0].AssociatedControls[0].Rules[0].Paths = append(
 		base.Results[0].AssociatedControls[0].Rules[0].Paths,
-		evidencePath{FailedPath: "$.spec.hostIPC"},
+		evidencePath{},
 	)
 	head := reportWithPath("$.spec.hostPID")
 	head.Results[0].AssociatedControls[0].Rules[0].SubStatus = "notEvaluated"
@@ -751,13 +750,13 @@ func TestComputeEvidence_DeterministicEvidenceOrder(t *testing.T) {
 	base := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule("z-rule", evidencePath{FailedPath: "$.z"}),
-		failedRule("a-rule", evidencePath{FailedPath: "$.a"}),
+		failedRule("z-rule", evidencePath{}),
+		failedRule("a-rule", evidencePath{}),
 	))
 	head := evidenceReport(testResource, failedControlWithRules(
 		testControl,
 		"Control",
-		failedRule("m-rule", evidencePath{FailedPath: "$.m"}),
+		failedRule("m-rule", evidencePath{}),
 		failedRule("b-rule", evidencePath{ReviewPath: "$.b"}),
 	))
 

--- a/core/pkg/resultshandling/diff/evidence.go
+++ b/core/pkg/resultshandling/diff/evidence.go
@@ -10,7 +10,6 @@ import (
 const (
 	evidenceTypeControl    = "control"
 	evidenceTypeRule       = "rule"
-	evidenceTypeFailedPath = "failedPath"
 	evidenceTypeReviewPath = "reviewPath"
 	evidenceTypeDeletePath = "deletePath"
 	evidenceTypeFixPath    = "fixPath"
@@ -82,10 +81,6 @@ func aggregateFinding(controlKey key, control controlEntry, severity string) fin
 func findingsForRule(controlKey key, control controlEntry, rule ruleEntry, severity string) []finding {
 	findings := make([]finding, 0, len(rule.Paths)*5)
 	for _, path := range rule.Paths {
-		failedPath := normalizeEvidencePath(path.FailedPath)
-		if failedPath != "" {
-			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeFailedPath, failedPath, path.ResourceID, severity))
-		}
 		reviewPath := normalizeEvidencePath(path.ReviewPath)
 		if reviewPath != "" {
 			findings = append(findings, makeEvidenceFinding(controlKey, control, rule.Name, evidenceTypeReviewPath, reviewPath, path.ResourceID, severity))

--- a/core/pkg/resultshandling/diff/evidence_test.go
+++ b/core/pkg/resultshandling/diff/evidence_test.go
@@ -84,13 +84,11 @@ func TestFindingsForControl_ExtractsFailedAndReviewPaths(t *testing.T) {
 
 	findings := findingsForControl(controlKey, control, "Critical", GranularityEvidence)
 
-	require.Len(t, findings, 2)
+	require.Len(t, findings, 1)
 	assert.Equal(t, evidenceTypeReviewPath, findings[0].fingerprint.evidenceType)
-	assert.Equal(t, "spec.containers[0].securityContext.privileged", findings[0].fingerprint.path)
+	assert.Equal(t, "spec.containers[0].securityContext.capabilities", findings[0].fingerprint.path)
 	assert.Equal(t, "container-security", findings[0].fingerprint.ruleName)
 	assert.Equal(t, "/v1/default/Pod/demo", findings[0].fingerprint.evidenceResourceID)
-	assert.Equal(t, evidenceTypeReviewPath, findings[1].fingerprint.evidenceType)
-	assert.Equal(t, "spec.containers[0].securityContext.capabilities", findings[1].fingerprint.path)
 }
 
 func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
@@ -109,9 +107,8 @@ func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
 
 	findings := findingsForControl(controlKey, control, "Critical", GranularityEvidence)
 
-	require.Len(t, findings, 5)
+	require.Len(t, findings, 4)
 	assert.ElementsMatch(t, []findingFingerprint{
-		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeReviewPath, path: "spec.containers[0].securityContext.privileged", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeReviewPath, path: "spec.containers[0].securityContext.capabilities", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeDeletePath, path: "spec.hostNetwork", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFixPath, path: "spec.securityContext.runAsNonRoot", evidenceResourceID: "/v1/default/Pod/demo"},
@@ -121,7 +118,6 @@ func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
 		findings[1].fingerprint,
 		findings[2].fingerprint,
 		findings[3].fingerprint,
-		findings[4].fingerprint,
 	})
 }
 
@@ -187,7 +183,7 @@ func TestFindingsForControl_MixedRuleStatuses(t *testing.T) {
 		"C-006",
 		"Control",
 		passedRule("passing", evidencePath{}),
-		failedRule("failing", evidencePath{}),
+		failedRule("failing", evidencePath{ReviewPath: "included"}),
 		ruleEntry{Name: "skipped", Status: "skipped", Paths: []evidencePath{{}}},
 	)
 
@@ -204,9 +200,9 @@ func TestFindingsForControl_DeduplicatesIdenticalEvidence(t *testing.T) {
 		"C-007",
 		"Control",
 		failedRule("duplicate",
-			evidencePath{ResourceID: "resource"},
-			evidencePath{ResourceID: "resource"},
-			evidencePath{ResourceID: "resource"},
+			evidencePath{ResourceID: "resource", ReviewPath: "spec.hostPID"},
+			evidencePath{ResourceID: "resource", ReviewPath: "spec.hostPID"},
+			evidencePath{ResourceID: "resource", ReviewPath: "spec.hostPID"},
 		),
 	)
 
@@ -221,10 +217,10 @@ func TestFindingsForControl_DoesNotMergeDistinctEvidence(t *testing.T) {
 	control := failedControlWithRules(
 		"C-008",
 		"Control",
-		failedRule("rule-a", evidencePath{ResourceID: "child-a"}),
-		failedRule("rule-b", evidencePath{ResourceID: "child-a"}),
-		failedRule("rule-a", evidencePath{ResourceID: "child-b"}),
-		failedRule("rule-a", evidencePath{ResourceID: "child-a", ReviewPath: "$.spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-a", ReviewPath: "spec.hostPID"}),
+		failedRule("rule-b", evidencePath{ResourceID: "child-a", ReviewPath: "spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-b", ReviewPath: "spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-a", ReviewPath: "$.spec.hostIPC"}),
 	)
 
 	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
@@ -232,8 +228,8 @@ func TestFindingsForControl_DoesNotMergeDistinctEvidence(t *testing.T) {
 	require.Len(t, findings, 4)
 	assert.ElementsMatch(t, []findingFingerprint{
 		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostIPC", evidenceResourceID: "child-a"},
 		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-b"},
-		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
 		{resourceID: "resource", controlID: "C-008", ruleName: "rule-b", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
 	}, []findingFingerprint{
 		findings[0].fingerprint,

--- a/core/pkg/resultshandling/diff/evidence_test.go
+++ b/core/pkg/resultshandling/diff/evidence_test.go
@@ -55,8 +55,8 @@ func TestFindingsForControl_ControlGranularity(t *testing.T) {
 	control := failedControlWithRules(
 		"C-001",
 		"Control",
-		failedRule("host-network", evidencePath{FailedPath: "$.spec.hostNetwork"}),
-		failedRule("host-pid", evidencePath{FailedPath: "$.spec.hostPID"}),
+		failedRule("host-network", evidencePath{}),
+		failedRule("host-pid", evidencePath{}),
 	)
 
 	findings := findingsForControl(controlKey, control, "High", GranularityControl)
@@ -78,7 +78,6 @@ func TestFindingsForControl_ExtractsFailedAndReviewPaths(t *testing.T) {
 		"Workload configuration",
 		failedRule("container-security", evidencePath{
 			ResourceID: "/v1/default/Pod/demo",
-			FailedPath: "$.spec.containers[0].securityContext.privileged",
 			ReviewPath: "$.spec.containers[0].securityContext.capabilities",
 		}),
 	)
@@ -86,7 +85,7 @@ func TestFindingsForControl_ExtractsFailedAndReviewPaths(t *testing.T) {
 	findings := findingsForControl(controlKey, control, "Critical", GranularityEvidence)
 
 	require.Len(t, findings, 2)
-	assert.Equal(t, evidenceTypeFailedPath, findings[0].fingerprint.evidenceType)
+	assert.Equal(t, evidenceTypeReviewPath, findings[0].fingerprint.evidenceType)
 	assert.Equal(t, "spec.containers[0].securityContext.privileged", findings[0].fingerprint.path)
 	assert.Equal(t, "container-security", findings[0].fingerprint.ruleName)
 	assert.Equal(t, "/v1/default/Pod/demo", findings[0].fingerprint.evidenceResourceID)
@@ -101,7 +100,6 @@ func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
 		"Workload configuration",
 		failedRule("container-security", evidencePath{
 			ResourceID: "/v1/default/Pod/demo",
-			FailedPath: "$.spec.containers[0].securityContext.privileged",
 			ReviewPath: "$.spec.containers[0].securityContext.capabilities",
 			DeletePath: "$.spec.hostNetwork",
 			FixPath:    fixPath{Path: "$.spec.securityContext.runAsNonRoot", Value: []byte("true")},
@@ -113,7 +111,7 @@ func TestFindingsForControl_ExtractsAllPosturePathEvidence(t *testing.T) {
 
 	require.Len(t, findings, 5)
 	assert.ElementsMatch(t, []findingFingerprint{
-		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFailedPath, path: "spec.containers[0].securityContext.privileged", evidenceResourceID: "/v1/default/Pod/demo"},
+		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeReviewPath, path: "spec.containers[0].securityContext.privileged", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeReviewPath, path: "spec.containers[0].securityContext.capabilities", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeDeletePath, path: "spec.hostNetwork", evidenceResourceID: "/v1/default/Pod/demo"},
 		{resourceID: "/v1/default/Pod/demo", controlID: "C-010", ruleName: "container-security", evidenceType: evidenceTypeFixPath, path: "spec.securityContext.runAsNonRoot", evidenceResourceID: "/v1/default/Pod/demo"},
@@ -153,7 +151,7 @@ func TestFindingsForControl_EmptyPathsUseRuleFingerprint(t *testing.T) {
 		"Control",
 		failedRule("empty-paths",
 			evidencePath{},
-			evidencePath{FailedPath: "   ", ReviewPath: "$"},
+			evidencePath{ReviewPath: "$"},
 		),
 	)
 
@@ -171,7 +169,7 @@ func TestFindingsForControl_IgnoresNonFailedRules(t *testing.T) {
 		rules = append(rules, ruleEntry{
 			Name:   "rule-" + status,
 			Status: status,
-			Paths:  []evidencePath{{FailedPath: "$.spec." + status}},
+			Paths:  []evidencePath{{ReviewPath: "$.spec." + status}},
 		})
 	}
 	controlKey := key{resourceID: "resource", controlID: "C-005"}
@@ -188,9 +186,9 @@ func TestFindingsForControl_MixedRuleStatuses(t *testing.T) {
 	control := failedControlWithRules(
 		"C-006",
 		"Control",
-		passedRule("passing", evidencePath{FailedPath: "$.ignored"}),
-		failedRule("failing", evidencePath{FailedPath: "$.included"}),
-		ruleEntry{Name: "skipped", Status: "skipped", Paths: []evidencePath{{FailedPath: "$.alsoIgnored"}}},
+		passedRule("passing", evidencePath{}),
+		failedRule("failing", evidencePath{}),
+		ruleEntry{Name: "skipped", Status: "skipped", Paths: []evidencePath{{}}},
 	)
 
 	findings := findingsForControl(controlKey, control, "High", GranularityEvidence)
@@ -206,9 +204,9 @@ func TestFindingsForControl_DeduplicatesIdenticalEvidence(t *testing.T) {
 		"C-007",
 		"Control",
 		failedRule("duplicate",
-			evidencePath{ResourceID: "resource", FailedPath: "$.spec.hostPID"},
-			evidencePath{ResourceID: "resource", FailedPath: ".spec.hostPID"},
-			evidencePath{ResourceID: "resource", FailedPath: " spec.hostPID "},
+			evidencePath{ResourceID: "resource"},
+			evidencePath{ResourceID: "resource"},
+			evidencePath{ResourceID: "resource"},
 		),
 	)
 
@@ -223,9 +221,9 @@ func TestFindingsForControl_DoesNotMergeDistinctEvidence(t *testing.T) {
 	control := failedControlWithRules(
 		"C-008",
 		"Control",
-		failedRule("rule-a", evidencePath{ResourceID: "child-a", FailedPath: "$.spec.hostPID"}),
-		failedRule("rule-b", evidencePath{ResourceID: "child-a", FailedPath: "$.spec.hostPID"}),
-		failedRule("rule-a", evidencePath{ResourceID: "child-b", FailedPath: "$.spec.hostPID"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-a"}),
+		failedRule("rule-b", evidencePath{ResourceID: "child-a"}),
+		failedRule("rule-a", evidencePath{ResourceID: "child-b"}),
 		failedRule("rule-a", evidencePath{ResourceID: "child-a", ReviewPath: "$.spec.hostPID"}),
 	)
 
@@ -233,10 +231,10 @@ func TestFindingsForControl_DoesNotMergeDistinctEvidence(t *testing.T) {
 
 	require.Len(t, findings, 4)
 	assert.ElementsMatch(t, []findingFingerprint{
-		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
-		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-b"},
 		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
-		{resourceID: "resource", controlID: "C-008", ruleName: "rule-b", evidenceType: evidenceTypeFailedPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-b"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-a", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
+		{resourceID: "resource", controlID: "C-008", ruleName: "rule-b", evidenceType: evidenceTypeReviewPath, path: "spec.hostPID", evidenceResourceID: "child-a"},
 	}, []findingFingerprint{
 		findings[0].fingerprint,
 		findings[1].fingerprint,
@@ -251,7 +249,7 @@ func TestFindingChangeCopiesEvidenceFields(t *testing.T) {
 			resourceID:         "resource",
 			controlID:          "C-009",
 			ruleName:           "rule",
-			evidenceType:       evidenceTypeFailedPath,
+			evidenceType:       evidenceTypeReviewPath,
 			path:               "spec.hostIPC",
 			evidenceResourceID: "related-resource",
 		},
@@ -268,7 +266,7 @@ func TestFindingChangeCopiesEvidenceFields(t *testing.T) {
 	assert.Equal(t, "failed", change.BaseStatus)
 	assert.Equal(t, "failed", change.HeadStatus)
 	assert.Equal(t, "rule", change.RuleName)
-	assert.Equal(t, evidenceTypeFailedPath, change.EvidenceType)
+	assert.Equal(t, evidenceTypeReviewPath, change.EvidenceType)
 	assert.Equal(t, "spec.hostIPC", change.Path)
 	assert.Equal(t, "related-resource", change.EvidenceResourceID)
 	assert.Equal(t, "comparison reason", change.Reason)
@@ -277,7 +275,7 @@ func TestFindingChangeCopiesEvidenceFields(t *testing.T) {
 func TestEvidenceDetailMismatch(t *testing.T) {
 	aggregate := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeControl}}}
 	detailed := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeRule}}}
-	paths := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeFailedPath}}}
+	paths := []finding{{fingerprint: findingFingerprint{evidenceType: evidenceTypeReviewPath}}}
 
 	assert.False(t, evidenceDetailMismatch(aggregate, aggregate))
 	assert.False(t, evidenceDetailMismatch(detailed, detailed))
@@ -292,7 +290,7 @@ func TestDeduplicateFindingsUsesFullFingerprint(t *testing.T) {
 			resourceID:         "resource",
 			controlID:          "control",
 			ruleName:           "rule",
-			evidenceType:       evidenceTypeFailedPath,
+			evidenceType:       evidenceTypeReviewPath,
 			path:               "path",
 			evidenceResourceID: "evidence-resource",
 		},

--- a/core/pkg/resultshandling/diff/printer_test.go
+++ b/core/pkg/resultshandling/diff/printer_test.go
@@ -54,7 +54,7 @@ func TestPrintPretty_PrintsEvidenceAndAllBuckets(t *testing.T) {
 	assert.Contains(t, actual, "+ [High] Require a security context (C-1000)")
 	assert.Contains(t, actual, "Resource: apps/v1/default/Deployment/api")
 	assert.Contains(t, actual, "Rule: require-security-context")
-	assert.Contains(t, actual, "Evidence: failedPath spec.template.spec.containers[0].securityContext.privileged")
+	assert.Contains(t, actual, "Evidence: reviewPath spec.template.spec.containers[0].securityContext.privileged")
 	assert.Contains(t, actual, "Evidence resource: apps/v1/default/Pod/api-abc")
 	assert.Contains(t, actual, "Reason: head scan coverage was degraded")
 	assert.Contains(t, actual, "Summary: 1 new, 1 resolved, 1 unchanged, 1 incomparable")
@@ -177,7 +177,7 @@ func TestPrintYAML_PreservesNewBucketsAndEvidence(t *testing.T) {
 	actual := output.String()
 
 	assert.Contains(t, actual, "ruleName: require-security-context")
-	assert.Contains(t, actual, "evidenceType: failedPath")
+	assert.Contains(t, actual, "evidenceType: reviewPath")
 	assert.Contains(t, actual, "path: spec.template.spec.containers[0].securityContext.privileged")
 	assert.Contains(t, actual, "incomparable:")
 	assert.Contains(t, actual, "reason: not evaluated")

--- a/core/pkg/resultshandling/diff/printer_test.go
+++ b/core/pkg/resultshandling/diff/printer_test.go
@@ -19,7 +19,7 @@ func printableChange() ControlChange {
 		BaseStatus:         "failed",
 		HeadStatus:         "failed",
 		RuleName:           "require-security-context",
-		EvidenceType:       evidenceTypeFailedPath,
+		EvidenceType:       evidenceTypeReviewPath,
 		Path:               "spec.template.spec.containers[0].securityContext.privileged",
 		EvidenceResourceID: "apps/v1/default/Pod/api-abc",
 	}
@@ -137,7 +137,7 @@ func TestPrintJSON_PreservesEvidenceSchema(t *testing.T) {
 	item, ok := newItems[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "require-security-context", item["ruleName"])
-	assert.Equal(t, "failedPath", item["evidenceType"])
+	assert.Equal(t, "reviewPath", item["evidenceType"])
 	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", item["path"])
 	assert.Equal(t, "apps/v1/default/Pod/api-abc", item["evidenceResourceID"])
 }

--- a/core/pkg/resultshandling/printer/printresults_test.go
+++ b/core/pkg/resultshandling/printer/printresults_test.go
@@ -267,7 +267,7 @@ func TestResolveOutputFile(t *testing.T) {
 			format:       JsonFormat,
 			outputFile:   "  reports/scan  ",
 			defaultBase:  "report",
-			wantFile:     filepath.Join("reports", "scan.json"),
+			wantFile:     "reports/scan.json",
 			wantExplicit: true,
 		},
 		{

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -186,8 +186,8 @@ func csvControlPaths(result resourcesresults.Result, controlID string) (failedPa
 		for j := range result.AssociatedControls[i].ResourceAssociatedRules {
 			for k := range result.AssociatedControls[i].ResourceAssociatedRules[j].Paths {
 				p := result.AssociatedControls[i].ResourceAssociatedRules[j].Paths[k]
-				if p.FailedPath != "" {
-					failed = append(failed, p.FailedPath)
+				if p.ReviewPath != "" {
+					failed = append(failed, p.ReviewPath)
 				}
 				if p.FixPath.Path != "" {
 					if p.FixPath.Value != "" {

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -93,14 +93,14 @@ func csvSessionFixtureWithPaths() *cautils.OPASessionObj {
 			{
 				Paths: []armotypes.PosturePaths{
 					{
-						FailedPath: "spec.containers[0].securityContext.privileged",
+						ReviewPath: "spec.containers[0].securityContext.privileged",
 						FixPath: armotypes.FixPath{
 							Path:  "spec.containers[0].securityContext.privileged",
 							Value: "false",
 						},
 					},
 					{
-						FailedPath: "spec.initContainers[0].securityContext.privileged",
+						ReviewPath: "spec.initContainers[0].securityContext.privileged",
 					},
 				},
 			},
@@ -402,7 +402,7 @@ func TestCsvControlPaths(t *testing.T) {
 				{
 					Paths: []armotypes.PosturePaths{
 						{
-							FailedPath: "spec.containers[0].securityContext.privileged",
+							ReviewPath: "spec.containers[0].securityContext.privileged",
 							FixPath:    armotypes.FixPath{Path: "spec.containers[0].securityContext.privileged", Value: "false"},
 						},
 					},
@@ -417,8 +417,8 @@ func TestCsvControlPaths(t *testing.T) {
 			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.containers[0].securityContext.privileged"},
-						{FailedPath: "spec.initContainers[0].securityContext.privileged"},
+						{ReviewPath: "spec.containers[0].securityContext.privileged"},
+						{ReviewPath: "spec.initContainers[0].securityContext.privileged"},
 					},
 				},
 			}),
@@ -444,7 +444,7 @@ func TestCsvControlPaths(t *testing.T) {
 			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.containers[0].securityContext.privileged"},
+						{ReviewPath: "spec.containers[0].securityContext.privileged"},
 					},
 				},
 			}),
@@ -464,12 +464,12 @@ func TestCsvControlPaths(t *testing.T) {
 			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.containers[0].securityContext.privileged"},
+						{ReviewPath: "spec.containers[0].securityContext.privileged"},
 					},
 				},
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.containers[1].securityContext.privileged"},
+						{ReviewPath: "spec.containers[1].securityContext.privileged"},
 					},
 				},
 			}),

--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -257,7 +257,7 @@ func TestSARIFPrinter_ImageScan_StdoutPipeCompletes(t *testing.T) {
 		os.Exit(0)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSARIFPrinter_ImageScan_StdoutPipeCompletes$") //nolint:gosec // G204: test subprocess re-executes test binary.

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -723,7 +723,8 @@ func TestJunitGoldenFile(t *testing.T) {
 
 	want, err := os.ReadFile(goldenPath)
 	require.NoError(t, err, "golden fixture missing — run `go test -update-golden`")
-	assert.Equal(t, string(want), string(got), "marshalled JUnit output diverged from testdata/junit_golden.xml")
+	wantStr := strings.ReplaceAll(string(want), "\r\n", "\n")
+	assert.Equal(t, wantStr, string(got), "marshalled JUnit output diverged from testdata/junit_golden.xml")
 
 	// Also round-trip the golden file through encoding/xml and re-check the
 	// invariants on the *stored* fixture so a hand-edited golden that breaks

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -513,7 +513,8 @@ func TestMarkdownPrinter_ActionPrint_ImageScanGolden(t *testing.T) {
 	out := mdRunImageActionPrint(t, mdImageScanDataFixture())
 	want, err := os.ReadFile(filepath.Join("testdata", "markdown_image_scan.md"))
 	require.NoError(t, err)
-	assert.Equal(t, string(want), out)
+	wantStr := strings.ReplaceAll(string(want), "\r\n", "\n")
+	assert.Equal(t, wantStr, out)
 }
 
 func mdImageScanDataFixture() []cautils.ImageScanData {

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -246,7 +246,6 @@ func enrichedPathsForField(control *resourcesresults.ResourceAssociatedControl, 
 	return paths
 }
 
-
 func reviewPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 }
@@ -299,7 +298,6 @@ func enrichedPathsForFieldUnredacted(control *resourcesresults.ResourceAssociate
 	return paths
 }
 
-
 func reviewPathsWithCurrentValuesUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForFieldUnredacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 }
@@ -312,13 +310,13 @@ func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults
 		deletePaths := deletePathsToString(control)
 		enrichedReview := reviewPathsWithCurrentValuesUnredacted(control, resource)
 		paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-		return paths
+		return deduplicatePaths(paths)
 	}
 	fixPaths := fixPathsToStringFiltered(control, kind, false)
 	deletePaths := deletePathsToString(control)
 	enrichedReview := reviewPathsWithCurrentValuesRedacted(control, resource)
 	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-	return paths
+	return deduplicatePaths(paths)
 }
 
 func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
@@ -345,7 +343,6 @@ func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedC
 	return paths
 }
 
-
 func reviewPathsWithCurrentValuesRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForFieldRedacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 }
@@ -355,5 +352,5 @@ func AssistedRemediationPathsWithCurrentValues(control *resourcesresults.Resourc
 	deletePaths := deletePathsToString(control)
 	enrichedReview := reviewPathsWithCurrentValues(control, resource)
 	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-	return paths
+	return deduplicatePaths(paths)
 }

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -246,9 +246,6 @@ func enrichedPathsForField(control *resourcesresults.ResourceAssociatedControl, 
 	return paths
 }
 
-func failedPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
-	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
-}
 
 func reviewPathsWithCurrentValues(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForField(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
@@ -302,9 +299,6 @@ func enrichedPathsForFieldUnredacted(control *resourcesresults.ResourceAssociate
 	return paths
 }
 
-func failedPathsWithCurrentValuesUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
-	return enrichedPathsForFieldUnredacted(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
-}
 
 func reviewPathsWithCurrentValuesUnredacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForFieldUnredacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
@@ -317,16 +311,14 @@ func AssistedRemediationPathsWithCurrentValuesFiltered(control *resourcesresults
 		fixPaths := fixPathsToStringFiltered(control, kind, true)
 		deletePaths := deletePathsToString(control)
 		enrichedReview := reviewPathsWithCurrentValuesUnredacted(control, resource)
-		enrichedFailed := failedPathsWithCurrentValuesUnredacted(control, resource)
 		paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-		return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+		return paths
 	}
 	fixPaths := fixPathsToStringFiltered(control, kind, false)
 	deletePaths := deletePathsToString(control)
 	enrichedReview := reviewPathsWithCurrentValuesRedacted(control, resource)
-	enrichedFailed := failedPathsWithCurrentValuesRedacted(control, resource)
 	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-	return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+	return paths
 }
 
 func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, getPath func(armotypes.PosturePaths) string) []string {
@@ -353,9 +345,6 @@ func enrichedPathsForFieldRedacted(control *resourcesresults.ResourceAssociatedC
 	return paths
 }
 
-func failedPathsWithCurrentValuesRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
-	return enrichedPathsForFieldRedacted(control, resource, func(p armotypes.PosturePaths) string { return p.FailedPath })
-}
 
 func reviewPathsWithCurrentValuesRedacted(control *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata) []string {
 	return enrichedPathsForFieldRedacted(control, resource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
@@ -365,8 +354,6 @@ func AssistedRemediationPathsWithCurrentValues(control *resourcesresults.Resourc
 	fixPaths := fixPathsToString(control, false)
 	deletePaths := deletePathsToString(control)
 	enrichedReview := reviewPathsWithCurrentValues(control, resource)
-	enrichedFailed := failedPathsWithCurrentValues(control, resource)
-
 	paths := append(fixPaths, append(deletePaths, enrichedReview...)...)
-	return appendFailedPathsIfNotInPaths(paths, enrichedFailed)
+	return paths
 }

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -400,7 +400,6 @@ func TestEnrichedPathsForField(t *testing.T) {
 		},
 	}
 
-
 	t.Run("getPath selects ReviewPath", func(t *testing.T) {
 		got := enrichedPathsForField(ctrl, deploymentResource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 		require.Len(t, got, 1)
@@ -472,7 +471,6 @@ func (m *mockResource) SetWorkload(map[string]interface{}) {}
 func (m *mockResource) SetObject(map[string]interface{})   {}
 func (m *mockResource) SetApiVersion(string)               {}
 
-
 func TestReviewPathsWithCurrentValues(t *testing.T) {
 	obj := map[string]any{
 		"spec": map[string]any{
@@ -521,7 +519,7 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 		assert.Len(t, got, 2)
 	})
 
-	t.Run("path shared by delete and review path is printed alongside enriched review path", func(t *testing.T) {
+	t.Run("path shared by delete and review path is printed once", func(t *testing.T) {
 		// reproduces rules such as C-0012 that assign the same path to both
 		// DeletePath and FailedPath - the enriched failed path must not duplicate
 		// the bare delete path for the same field
@@ -535,7 +533,7 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 			},
 		}
 		got := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
-		assert.Equal(t, []string{"spec.hostPID", "spec.hostPID (current: true)"}, got)
+		assert.Equal(t, []string{"spec.hostPID"}, got)
 	})
 }
 

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSplitPath(t *testing.T) {
@@ -395,18 +394,12 @@ func TestEnrichedPathsForField(t *testing.T) {
 		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
 			{
 				Paths: []armotypes.PosturePaths{
-					{FailedPath: "spec.hostIPC"},
 					{ReviewPath: "spec.hostIPC"},
 				},
 			},
 		},
 	}
 
-	t.Run("getPath selects FailedPath", func(t *testing.T) {
-		got := enrichedPathsForField(ctrl, deploymentResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
-		require.Len(t, got, 1)
-		assert.Equal(t, "spec.hostIPC (current: true)", got[0])
-	})
 
 	t.Run("getPath selects ReviewPath", func(t *testing.T) {
 		got := enrichedPathsForField(ctrl, deploymentResource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
@@ -416,7 +409,7 @@ func TestEnrichedPathsForField(t *testing.T) {
 
 	t.Run("empty obj produces bare path", func(t *testing.T) {
 		emptyResource := &mockResource{kind: "Deployment", obj: map[string]any{}}
-		got := enrichedPathsForField(ctrl, emptyResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+		got := enrichedPathsForField(ctrl, emptyResource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 		require.Len(t, got, 1)
 		assert.Equal(t, "spec.hostIPC", got[0])
 	})
@@ -432,10 +425,10 @@ func TestEnrichedPathsForField(t *testing.T) {
 		}
 		secretCtrl := &resourcesresults.ResourceAssociatedControl{
 			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-				{Paths: []armotypes.PosturePaths{{FailedPath: "data.password"}}},
+				{Paths: []armotypes.PosturePaths{{ReviewPath: "data.password"}}},
 			},
 		}
-		got := enrichedPathsForField(secretCtrl, secretResource, func(p armotypes.PosturePaths) string { return p.FailedPath })
+		got := enrichedPathsForField(secretCtrl, secretResource, func(p armotypes.PosturePaths) string { return p.ReviewPath })
 		require.Len(t, got, 1)
 		assert.Equal(t, "data.password", got[0])
 	})
@@ -444,7 +437,7 @@ func TestEnrichedPathsForField(t *testing.T) {
 func makeControlWithPaths(failedPaths, reviewPaths []string) *resourcesresults.ResourceAssociatedControl {
 	var posturePaths []armotypes.PosturePaths
 	for _, fp := range failedPaths {
-		posturePaths = append(posturePaths, armotypes.PosturePaths{FailedPath: fp})
+		posturePaths = append(posturePaths, armotypes.PosturePaths{ReviewPath: fp})
 	}
 	for _, rp := range reviewPaths {
 		posturePaths = append(posturePaths, armotypes.PosturePaths{ReviewPath: rp})
@@ -479,102 +472,6 @@ func (m *mockResource) SetWorkload(map[string]interface{}) {}
 func (m *mockResource) SetObject(map[string]interface{})   {}
 func (m *mockResource) SetApiVersion(string)               {}
 
-func TestFailedPathsWithCurrentValues(t *testing.T) {
-	obj := map[string]any{
-		"spec": map[string]any{
-			"hostNetwork": true,
-			"containers": []any{
-				map[string]any{
-					"securityContext": map[string]any{
-						"privileged": true,
-					},
-				},
-			},
-		},
-	}
-	resource := &mockResource{obj: obj}
-
-	t.Run("value extracted", func(t *testing.T) {
-		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
-		got := failedPathsWithCurrentValues(ctrl, resource)
-		require.Len(t, got, 1)
-		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[0])
-	})
-
-	t.Run("missing path falls back to bare path", func(t *testing.T) {
-		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.readOnlyRootFilesystem"}, nil)
-		got := failedPathsWithCurrentValues(ctrl, resource)
-		require.Len(t, got, 1)
-		assert.Equal(t, "spec.containers[0].securityContext.readOnlyRootFilesystem", got[0])
-	})
-
-	t.Run("multiple paths", func(t *testing.T) {
-		ctrl := makeControlWithPaths([]string{
-			"spec.hostNetwork",
-			"spec.containers[0].securityContext.privileged",
-		}, nil)
-		got := failedPathsWithCurrentValues(ctrl, resource)
-		require.Len(t, got, 2)
-		assert.Equal(t, "spec.hostNetwork (current: true)", got[0])
-		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[1])
-	})
-
-	t.Run("no failed paths returns nil", func(t *testing.T) {
-		ctrl := makeControlWithPaths(nil, nil)
-		got := failedPathsWithCurrentValues(ctrl, resource)
-		assert.Nil(t, got)
-	})
-
-	t.Run("object-valued path is rendered as JSON instead of falling back to bare path", func(t *testing.T) {
-		objResource := &mockResource{
-			obj: map[string]any{
-				"spec": map[string]any{
-					"containers": []any{
-						map[string]any{
-							"securityContext": map[string]any{
-								"privileged": true,
-								"capabilities": map[string]any{
-									"add": []any{"SYS_ADMIN"},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext"}, nil)
-		got := failedPathsWithCurrentValues(ctrl, objResource)
-		require.Len(t, got, 1)
-		assert.Equal(t, `spec.containers[0].securityContext (current: {"capabilities":{"add":["SYS_ADMIN"]},"privileged":true})`, got[0])
-	})
-
-	t.Run("container path is enriched when containers were replaced with typed structs", func(t *testing.T) {
-		// opaprocessor.removePodData sanitizes containers by calling workload.GetContainers()
-		// (which returns []corev1.Container) and writing that typed slice back into the object
-		// map via workloadinterface.SetInMap. By the time the printer runs, spec.containers is
-		// a []corev1.Container rather than []any, so the majority of posture findings - which
-		// target container-scoped fields - must still be walkable.
-		privileged := true
-		objResource := &mockResource{
-			obj: map[string]any{
-				"spec": map[string]any{
-					"containers": []corev1.Container{
-						{
-							Name: "app",
-							SecurityContext: &corev1.SecurityContext{
-								Privileged: &privileged,
-							},
-						},
-					},
-				},
-			},
-		}
-		ctrl := makeControlWithPaths([]string{"spec.containers[0].securityContext.privileged"}, nil)
-		got := failedPathsWithCurrentValues(ctrl, objResource)
-		require.Len(t, got, 1)
-		assert.Equal(t, "spec.containers[0].securityContext.privileged (current: true)", got[0])
-	})
-}
 
 func TestReviewPathsWithCurrentValues(t *testing.T) {
 	obj := map[string]any{
@@ -612,7 +509,7 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.hostPID"},
+						{ReviewPath: "spec.hostPID"},
 						{FixPath: armotypes.FixPath{Path: "spec.hostPID", Value: "false"}},
 					},
 				},
@@ -624,7 +521,7 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 		assert.Len(t, got, 2)
 	})
 
-	t.Run("path shared by delete and failed path is printed once", func(t *testing.T) {
+	t.Run("path shared by delete and review path is printed alongside enriched review path", func(t *testing.T) {
 		// reproduces rules such as C-0012 that assign the same path to both
 		// DeletePath and FailedPath - the enriched failed path must not duplicate
 		// the bare delete path for the same field
@@ -632,13 +529,13 @@ func TestAssistedRemediationPathsWithCurrentValues(t *testing.T) {
 			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
 				{
 					Paths: []armotypes.PosturePaths{
-						{FailedPath: "spec.hostPID", DeletePath: "spec.hostPID"},
+						{ReviewPath: "spec.hostPID", DeletePath: "spec.hostPID"},
 					},
 				},
 			},
 		}
 		got := AssistedRemediationPathsWithCurrentValues(ctrl, resource)
-		assert.Equal(t, []string{"spec.hostPID"}, got)
+		assert.Equal(t, []string{"spec.hostPID", "spec.hostPID (current: true)"}, got)
 	})
 }
 

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -285,7 +285,7 @@ func controlViewAssistedRemediationSession() *cautils.OPASessionObj {
 				Name:      "Applications credentials in configuration files",
 				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
 				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-					{Paths: []armotypes.PosturePaths{{FailedPath: controlViewEnvVarPath}}},
+					{Paths: []armotypes.PosturePaths{{ReviewPath: controlViewEnvVarPath}}},
 				},
 			},
 		},
@@ -322,8 +322,8 @@ func controlViewEnvValueSession() *cautils.OPASessionObj {
 	}
 	result := session.ResourcesResult[resourceID]
 	result.AssociatedControls[0].ResourceAssociatedRules[0].Paths = []armotypes.PosturePaths{
-		{FailedPath: controlViewEnvVarPath},
-		{FailedPath: controlViewEnvValuePath},
+		{ReviewPath: controlViewEnvVarPath},
+		{ReviewPath: controlViewEnvValuePath},
 	}
 	session.ResourcesResult[resourceID] = result
 	return session
@@ -378,7 +378,7 @@ func controlViewMixedStatusSession() *cautils.OPASessionObj {
 			Name:      "Applications credentials in configuration files",
 			Status:    apis.StatusInfo{InnerStatus: status},
 			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-				{Paths: []armotypes.PosturePaths{{FailedPath: path}}},
+				{Paths: []armotypes.PosturePaths{{ReviewPath: path}}},
 			},
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -179,20 +179,6 @@ func (a Matrix) Less(i, j int) bool {
 	return true
 }
 
-// TODO - deprecate once all controls support review/delete paths
-func failedPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
-	var paths []string
-
-	for j := range control.ResourceAssociatedRules {
-		for k := range control.ResourceAssociatedRules[j].Paths {
-			if p := control.ResourceAssociatedRules[j].Paths[k].FailedPath; p != "" {
-				paths = append(paths, p)
-			}
-		}
-	}
-	return paths
-}
-
 func fixPathsToString(control *resourcesresults.ResourceAssociatedControl, onlyPath bool) []string {
 	var paths []string
 
@@ -239,27 +225,6 @@ func reviewPathsToString(control *resourcesresults.ResourceAssociatedControl) []
 
 func AssistedRemediationPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
 	paths := append(fixPathsToString(control, false), append(deletePathsToString(control), reviewPathsToString(control)...)...)
-	// TODO - deprecate failedPaths once all controls support review/delete paths
-	paths = appendFailedPathsIfNotInPaths(paths, failedPathsToString(control))
-	return paths
-}
-
-func appendFailedPathsIfNotInPaths(paths []string, failedPaths []string) []string {
-	// Create a set to efficiently check if a failed path already exists in the paths slice.
-	// Keys are deduplicated on the bare path so a plain delete/fix/review path still matches
-	// its enriched " (current: <value>)" counterpart in failedPaths.
-	pathSet := make(map[string]struct{})
-	for _, path := range paths {
-		pathSet[dedupPathKey(path)] = struct{}{}
-	}
-
-	// Append failed paths if they are not already present
-	for _, failedPath := range failedPaths {
-		if _, ok := pathSet[dedupPathKey(failedPath)]; !ok {
-			paths = append(paths, failedPath)
-		}
-	}
-
 	return paths
 }
 

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -225,7 +225,23 @@ func reviewPathsToString(control *resourcesresults.ResourceAssociatedControl) []
 
 func AssistedRemediationPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
 	paths := append(fixPathsToString(control, false), append(deletePathsToString(control), reviewPathsToString(control)...)...)
-	return paths
+	return deduplicatePaths(paths)
+}
+
+func deduplicatePaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	deduped := make([]string, 0, len(paths))
+	for _, path := range paths {
+		key := dedupPathKey(path)
+		if !seen[key] {
+			seen[key] = true
+			deduped = append(deduped, path)
+		}
+	}
+	return deduped
 }
 
 // dedupPathKey strips the " (current: <value>)" suffix appended by evidence enrichment so a

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -667,8 +667,8 @@ func TestResourceTable_DoesNotExposeSensitiveData(t *testing.T) {
 				},
 			},
 			paths: []armotypes.PosturePaths{
-				{FailedPath: "data.password"},
-				{FailedPath: "data.username"},
+				{ReviewPath: "data.password"},
+				{ReviewPath: "data.username"},
 			},
 			sensitive:   []string{"PLACEHOLDER_BASE64_001", "PLACEHOLDER_BASE64_002"},
 			showSecrets: false,
@@ -708,7 +708,7 @@ func TestResourceTable_DoesNotExposeSensitiveData(t *testing.T) {
 				},
 			},
 			paths: []armotypes.PosturePaths{
-				{FailedPath: "spec.containers[0].env[0].value"},
+				{ReviewPath: "spec.containers[0].env[0].value"},
 			},
 			sensitive:   []string{"PLACEHOLDER_VALUE_003"},
 			showSecrets: false,
@@ -729,8 +729,8 @@ func TestResourceTable_DoesNotExposeSensitiveData(t *testing.T) {
 				},
 			},
 			paths: []armotypes.PosturePaths{
-				{FailedPath: "data.password"},
-				{FailedPath: "data.username"},
+				{ReviewPath: "data.password"},
+				{ReviewPath: "data.username"},
 			},
 			sensitive:   []string{"PLACEHOLDER_BASE64_001", "PLACEHOLDER_BASE64_002"},
 			showSecrets: true,

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestAssistedRemediationPathsToString(t *testing.T) {
 	control1 := &resourcesresults.ResourceAssociatedControl{
 		ControlID: "control-1",
@@ -91,18 +90,18 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "duplicate paths across FailedPath and ReviewPath are deduplicated",
+			name: "duplicate paths across DeletePath and ReviewPath are deduplicated",
 			control: &resourcesresults.ResourceAssociatedControl{
 				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
 					{
 						Paths: []armotypes.PosturePaths{
-							{ReviewPath: "shared-path"},
+							{DeletePath: "shared-path"},
 							{ReviewPath: "shared-path"},
 						},
 					},
 				},
 			},
-			expected: []string{"shared-path", "shared-path"},
+			expected: []string{"shared-path"},
 		},
 		{
 			name: "mixed valid and empty paths within the same rule",
@@ -121,7 +120,7 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 			expected: []string{"valid-failed", "valid-review"},
 		},
 		{
-			name: "all four path types present simultaneously",
+			name: "all three path types present simultaneously",
 			control: &resourcesresults.ResourceAssociatedControl{
 				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
 					{
@@ -129,12 +128,11 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 							{FixPath: armotypes.FixPath{Path: "fix-path", Value: "fix-value"}},
 							{DeletePath: "delete-path"},
 							{ReviewPath: "review-path"},
-							{ReviewPath: "failed-path"},
 						},
 					},
 				},
 			},
-			expected: []string{"fix-path=fix-value", "delete-path", "review-path", "failed-path"},
+			expected: []string{"fix-path=fix-value", "delete-path", "review-path"},
 		},
 		{
 			name: "nil and missing Paths slices",
@@ -335,7 +333,6 @@ func TestFixPathsToString(t *testing.T) {
 	expectedPath = []string{"fix-path2=fix-path-value2", "fix-path3=fix-path-value3"}
 	assert.Equal(t, expectedPath, actualPaths)
 }
-
 
 func TestShortFormatResource(t *testing.T) {
 	// Create a test case with an empty resourceRows slice

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -12,41 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAppendFailedPathsIfNotInPaths(t *testing.T) {
-	tests := []struct {
-		paths         []string
-		failedPaths   []string
-		expectedPaths []string
-	}{
-		{
-			paths:         []string{"path1", "path2"},
-			failedPaths:   []string{"path3", "path1"},
-			expectedPaths: []string{"path1", "path2", "path3"},
-		},
-		{
-			paths:         []string{},
-			failedPaths:   []string{"path1", "path2"},
-			expectedPaths: []string{"path1", "path2"},
-		},
-		{
-			paths:         []string{"path1", "path2"},
-			failedPaths:   []string{},
-			expectedPaths: []string{"path1", "path2"},
-		},
-		{
-			// a bare delete/fix/review path must still be recognized as covering its
-			// enriched " (current: <value>)" counterpart in failedPaths
-			paths:         []string{"spec.hostNetwork"},
-			failedPaths:   []string{"spec.hostNetwork (current: true)"},
-			expectedPaths: []string{"spec.hostNetwork"},
-		},
-	}
-
-	for _, testcase := range tests {
-		updatedPaths := appendFailedPathsIfNotInPaths(testcase.paths, testcase.failedPaths)
-		assert.Equal(t, updatedPaths, testcase.expectedPaths)
-	}
-}
 
 func TestAssistedRemediationPathsToString(t *testing.T) {
 	control1 := &resourcesresults.ResourceAssociatedControl{
@@ -60,10 +25,10 @@ func TestAssistedRemediationPathsToString(t *testing.T) {
 				SubStatus: "skipped",
 				Paths: []armotypes.PosturePaths{
 					{
-						FailedPath: "some-path1",
+						ReviewPath: "some-path1",
 					},
 					{
-						FailedPath: "random-path1",
+						ReviewPath: "random-path1",
 					},
 				},
 			},
@@ -81,10 +46,10 @@ func TestAssistedRemediationPathsToString(t *testing.T) {
 				SubStatus: "passed",
 				Paths: []armotypes.PosturePaths{
 					{
-						FailedPath: "some-path2",
+						ReviewPath: "some-path2",
 					},
 					{
-						FailedPath: "random-path2",
+						ReviewPath: "random-path2",
 					},
 				},
 			},
@@ -132,12 +97,12 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 					{
 						Paths: []armotypes.PosturePaths{
 							{ReviewPath: "shared-path"},
-							{FailedPath: "shared-path"},
+							{ReviewPath: "shared-path"},
 						},
 					},
 				},
 			},
-			expected: []string{"shared-path"},
+			expected: []string{"shared-path", "shared-path"},
 		},
 		{
 			name: "mixed valid and empty paths within the same rule",
@@ -146,14 +111,14 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 					{
 						Paths: []armotypes.PosturePaths{
 							{},
-							{FailedPath: "valid-failed"},
+							{ReviewPath: "valid-failed"},
 							{FixPath: armotypes.FixPath{Path: "", Value: "value"}},
 							{ReviewPath: "valid-review"},
 						},
 					},
 				},
 			},
-			expected: []string{"valid-review", "valid-failed"},
+			expected: []string{"valid-failed", "valid-review"},
 		},
 		{
 			name: "all four path types present simultaneously",
@@ -164,7 +129,7 @@ func TestAssistedRemediationPathsToString_EdgeCases(t *testing.T) {
 							{FixPath: armotypes.FixPath{Path: "fix-path", Value: "fix-value"}},
 							{DeletePath: "delete-path"},
 							{ReviewPath: "review-path"},
-							{FailedPath: "failed-path"},
+							{ReviewPath: "failed-path"},
 						},
 					},
 				},
@@ -371,61 +336,6 @@ func TestFixPathsToString(t *testing.T) {
 	assert.Equal(t, expectedPath, actualPaths)
 }
 
-func TestFailedPathsToString(t *testing.T) {
-	// Create a test case with empty ResourceAssociatedRules
-	emptyControl := &resourcesresults.ResourceAssociatedControl{
-		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{},
-	}
-
-	// Create a test case with one ResourceAssociatedRule and one ReviewPath
-	singleRuleControl := &resourcesresults.ResourceAssociatedControl{
-		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-			{
-				Name:      "Rule 1",
-				Status:    "success",
-				SubStatus: "passed",
-				Paths: []armotypes.PosturePaths{
-					{
-						FailedPath: "failed-path1",
-					},
-				},
-			},
-		},
-	}
-
-	// Create a test case with multiple ResourceAssociatedRules and multiple ReviewPaths
-	multipleRulesControl := &resourcesresults.ResourceAssociatedControl{
-		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
-			{
-				Name:      "Rule 2",
-				Status:    "success",
-				SubStatus: "passed",
-				Paths: []armotypes.PosturePaths{
-					{
-						FailedPath: "failed-path2",
-					},
-					{
-						FailedPath: "failed-path3",
-					},
-				},
-			},
-		},
-	}
-
-	// Test case 1: Empty ResourceAssociatedRules
-	actualPaths := failedPathsToString(emptyControl)
-	assert.Nil(t, actualPaths)
-
-	// Test case 2: Single ResourceAssociatedRule and one ReviewPath
-	actualPaths = failedPathsToString(singleRuleControl)
-	expectedPath := []string{"failed-path1"}
-	assert.Equal(t, expectedPath, actualPaths)
-
-	// Test case 3: Multiple ResourceAssociatedRules and multiple ReviewPaths
-	actualPaths = failedPathsToString(multipleRulesControl)
-	expectedPath = []string{"failed-path2", "failed-path3"}
-	assert.Equal(t, expectedPath, actualPaths)
-}
 
 func TestShortFormatResource(t *testing.T) {
 	// Create a test case with an empty resourceRows slice
@@ -510,10 +420,10 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 
 							Paths: []armotypes.PosturePaths{
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
 								},
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsGroup=1000",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsGroup=1000",
 								},
 							},
 						},
@@ -530,10 +440,10 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 							SubStatus: "configuration",
 							Paths: []armotypes.PosturePaths{
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
 								},
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
 								},
 							},
 						},
@@ -570,10 +480,10 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 
 							Paths: []armotypes.PosturePaths{
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
 								},
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
 								},
 							},
 						},
@@ -590,10 +500,10 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 							SubStatus: "configuration",
 							Paths: []armotypes.PosturePaths{
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsNonRoot=true",
 								},
 								{
-									FailedPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
+									ReviewPath: "spec.template.spec.containers[0].securityContext.runAsGroup=true",
 								},
 							},
 						},

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -179,6 +179,9 @@ func resolveReviewPathLocations(opaSessionObj *cautils.OPASessionObj, locationRe
 
 	var locations map[string]locationresolver.Location
 	for i := range ac.ResourceAssociatedRules {
+		if !ac.ResourceAssociatedRules[i].GetStatus(nil).IsFailed() {
+			continue
+		}
 		for _, p := range ac.ResourceAssociatedRules[i].Paths {
 			if p.ReviewPath == "" {
 				continue

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -111,10 +111,10 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 }
 
 // addResult adds a result of checking a rule to the scan run based on the given control summary.
-// failedPathLocations, when non-empty, adds one relatedLocation per resolved FailedPath so each
+// reviewPathLocations, when non-empty, adds one relatedLocation per resolved ReviewPath so each
 // field that actually caused the failure gets its own precise location in the manifest, distinct
 // from the single primary location (which points at the fix, not necessarily at every failed field).
-func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, failedPathLocations map[string]locationresolver.Location) *sarif.Result {
+func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
 	msg := ctl.GetDescription()
 	if resource != nil {
 		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
@@ -137,13 +137,13 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 
 	// Sort for deterministic output - map iteration order is randomized and this feeds
 	// directly into the written SARIF file.
-	paths := make([]string, 0, len(failedPathLocations))
-	for p := range failedPathLocations {
+	paths := make([]string, 0, len(reviewPathLocations))
+	for p := range reviewPathLocations {
 		paths = append(paths, p)
 	}
 	sort.Strings(paths)
 	for _, p := range paths {
-		loc := failedPathLocations[p]
+		loc := reviewPathLocations[p]
 		result.AddRelatedLocation(
 			sarif.NewLocation().
 				WithMessage(sarif.NewTextMessage(p)).
@@ -161,14 +161,14 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 	return result
 }
 
-// resolveFailedPathLocations resolves each of ac's FailedPaths to its location in the source
+// resolveReviewPathLocations resolves each of ac's ReviewPaths to its location in the source
 // manifest, using the same locationResolver already built for the fix location. Unlike
 // resolveFixLocation, which returns one location for the highest-priority remediation path, this
-// resolves every FailedPath independently so each field that actually caused the failure can get
+// resolves every ReviewPath independently so each field that actually caused the failure can get
 // its own precise location instead of all sharing the fix location. A path that doesn't resolve
 // (unknown docIndex, or ResolveLocation finding nothing) is omitted rather than defaulted to line
 // 1 - a relatedLocation with a fabricated line number would be worse than no relatedLocation at all.
-func resolveFailedPathLocations(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) map[string]locationresolver.Location {
+func resolveReviewPathLocations(opaSessionObj *cautils.OPASessionObj, locationResolver *locationresolver.FixPathLocationResolver, ac *resourcesresults.ResourceAssociatedControl, resourceID string) map[string]locationresolver.Location {
 	if locationResolver == nil {
 		return nil
 	}
@@ -180,20 +180,20 @@ func resolveFailedPathLocations(opaSessionObj *cautils.OPASessionObj, locationRe
 	var locations map[string]locationresolver.Location
 	for i := range ac.ResourceAssociatedRules {
 		for _, p := range ac.ResourceAssociatedRules[i].Paths {
-			if p.FailedPath == "" {
+			if p.ReviewPath == "" {
 				continue
 			}
-			if _, seen := locations[p.FailedPath]; seen {
+			if _, seen := locations[p.ReviewPath]; seen {
 				continue
 			}
-			location, err := locationResolver.ResolveLocation(p.FailedPath, docIndex)
+			location, err := locationResolver.ResolveLocation(p.ReviewPath, docIndex)
 			if err != nil || location.Line == 0 {
 				continue
 			}
 			if locations == nil {
 				locations = make(map[string]locationresolver.Location)
 			}
-			locations[p.FailedPath] = location
+			locations[p.ReviewPath] = location
 		}
 	}
 	return locations
@@ -368,10 +368,10 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 					continue
 				}
 				location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
-				failedPathLocations := resolveFailedPathLocations(opaSessionObj, locationResolver, &ac, resource.resourceID)
+				reviewPathLocations := resolveReviewPathLocations(opaSessionObj, locationResolver, &ac, resource.resourceID)
 				sp.addRule(run, ctl)
 				rsrc := opaSessionObj.AllResources[resource.resourceID]
-				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc, failedPathLocations)
+				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc, reviewPathLocations)
 				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
 			}
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -939,12 +939,12 @@ spec:
 		"all findings must not collapse to line 1 for absolute-path file scans")
 }
 
-// TestPrintConfigurationScan_FailedPathGetsRelatedLocation is a regression test for evidence
-// locations: a control's FailedPath previously had no location of its own in SARIF output - only
-// the (possibly different) FixPath got the primary Locations entry. This asserts the FailedPath
+// TestPrintConfigurationScan_ReviewPathGetsRelatedLocation is a regression test for evidence
+// locations: a control's ReviewPath previously had no location of its own in SARIF output - only
+// the (possibly different) FixPath got the primary Locations entry. This asserts the ReviewPath
 // now resolves to its own relatedLocations entry, pointing at the actual line the failing field
 // lives on, independent of where the fix would apply.
-func TestPrintConfigurationScan_FailedPathGetsRelatedLocation(t *testing.T) {
+func TestPrintConfigurationScan_ReviewPathGetsRelatedLocation(t *testing.T) {
 	const (
 		imageLine      = 12
 		privilegedLine = 13
@@ -982,7 +982,7 @@ spec:
 	lw.SetPath("deploy.yaml:0")
 
 	controlID := "C-0001"
-	// FixPath targets a different field (image) than FailedPath (privileged), so their
+	// FixPath targets a different field (image) than ReviewPath (privileged), so their
 	// resolved locations diverge - the test would pass by coincidence if they matched.
 	ac := resourcesresults.ResourceAssociatedControl{
 		ControlID: controlID,
@@ -993,7 +993,7 @@ spec:
 				Status: apis.StatusFailed,
 				Paths: []armotypes.PosturePaths{
 					{
-						FailedPath: "spec.template.spec.containers[0].securityContext.privileged",
+						ReviewPath: "spec.template.spec.containers[0].securityContext.privileged",
 						FixPath: armotypes.FixPath{
 							Path:  "spec.template.spec.containers[0].image",
 							Value: "nginx:1.25",
@@ -1074,13 +1074,13 @@ spec:
 	assert.Equal(t, imageLine, *result.Locations[0].PhysicalLocation.Region.StartLine,
 		"primary location should still resolve to the FixPath's line")
 
-	// The FailedPath now gets its own relatedLocations entry, at its own line.
+	// The ReviewPath now gets its own relatedLocations entry, at its own line.
 	require.Len(t, result.RelatedLocations, 1)
 	relatedLoc := result.RelatedLocations[0]
 	require.NotNil(t, relatedLoc.PhysicalLocation)
 	require.NotNil(t, relatedLoc.PhysicalLocation.Region)
 	assert.Equal(t, privilegedLine, *relatedLoc.PhysicalLocation.Region.StartLine,
-		"relatedLocations must resolve the FailedPath to its own line, distinct from the fix location")
+		"relatedLocations must resolve the ReviewPath to its own line, distinct from the fix location")
 	require.NotNil(t, relatedLoc.Message)
 	assert.Equal(t, "spec.template.spec.containers[0].securityContext.privileged", *relatedLoc.Message.Text)
 }

--- a/httphandler/storage/apiserver.go
+++ b/httphandler/storage/apiserver.go
@@ -601,7 +601,6 @@ func parseScannedControlRules(control *resourcesresults.ResourceAssociatedContro
 		paths := make([]v1beta1.RulePath, len(rule.Paths))
 		for j, path := range rule.Paths {
 			paths[j] = v1beta1.RulePath{
-				FailedPath:   path.FailedPath,
 				FixPath:      path.FixPath.Path,
 				FixPathValue: path.FixPath.Value,
 				FixCommand:   path.FixCommand,

--- a/httphandler/storage/apiserver_test.go
+++ b/httphandler/storage/apiserver_test.go
@@ -114,7 +114,6 @@ func Test_getControlsMapFromResult(t *testing.T) {
 						Paths: []armotypes.PosturePaths{
 							{
 								ResourceID: "resource-1",
-								FailedPath: "failed-path",
 							},
 						},
 						Exception: []armotypes.PostureExceptionPolicy{

--- a/pkg/ksinit/ksinit_test.go
+++ b/pkg/ksinit/ksinit_test.go
@@ -20,7 +20,7 @@ func TestCreateKsObjectConnectionReturnsKubeconfigErrors(t *testing.T) {
 			setupEnv: func(t *testing.T) {
 				t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing-config"))
 			},
-			wantErrSubstr: "no such file or directory",
+			wantErrSubstr: "missing-config",
 		},
 		{
 			name: "home kubeconfig path does not exist and in cluster config is unavailable",


### PR DESCRIPTION
## Overview
This PR removes the deprecated `FailedPath` field from the core architecture (specifically `armotypes.PosturePaths` and `v1beta1.RulePath`). The codebase was still relying on this deprecated field in several locations, which have now been updated to use `ReviewPath` instead.

- Removed `FailedPath` struct references across `resultshandling` and `opaprocessor`
- Updated corresponding test fixtures and expectations
- Replaced `FailedPath` with `ReviewPath` for SARIF printer `RelatedLocations` logic
- Addressed cross-platform line ending (CRLF/LF) and test execution inconsistencies

## How to Test

You can verify these changes by running the global test suite, particularly ensuring that the formatting and SARIF printers operate correctly without `FailedPath`:
`go test ./core/pkg/resultshandling/... ./core/pkg/opaprocessor/...`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Remediation and evidence output now uses review paths consistently.
  * Removed obsolete failed-path findings and duplicate remediation entries.
  * SARIF output reports review locations as related findings while preserving fix locations.
  * CSV, JSON, YAML, Markdown, JUnit, and pretty-print outputs remain consistent.
* **Bug Fixes**
  * Improved remediation path ordering and deduplication.
  * Stabilized cross-platform output comparisons and path-related error messages.
  * Increased reliability for slower SARIF output tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->