### PR TITLE
fix: deduplicate included namespaces in splitNamespaces

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -14,16 +14,20 @@ const (
 )
 
 // splitNamespaces parses a comma-separated namespace list (as passed to
-// --include-namespaces / --exclude-namespaces) into a clean slice. Empty
-// entries and surrounding whitespace are dropped.
+// --include-namespaces / --exclude-namespaces) into a deduplicated slice.
+// Empty entries, surrounding whitespace, and duplicate values are dropped.
 func splitNamespaces(s string) []string {
 	if s == "" {
 		return nil
 	}
+	seen := make(map[string]struct{})
 	var out []string
 	for p := range strings.SplitSeq(s, ",") {
 		if v := strings.TrimSpace(p); v != "" {
-			out = append(out, v)
+			if _, exists := seen[v]; !exists {
+				seen[v] = struct{}{}
+				out = append(out, v)
+			}
 		}
 	}
 	return out

--- a/core/pkg/resourcehandler/k8sresourcesutils_test.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils_test.go
@@ -276,4 +276,6 @@ func TestSplitNamespaces(t *testing.T) {
 	assert.Nil(t, splitNamespaces(",,"))
 	assert.Equal(t, []string{"default"}, splitNamespaces("default,"))
 	assert.Equal(t, []string{"default", "prod"}, splitNamespaces(" default , prod "))
+	assert.Equal(t, []string{"default"}, splitNamespaces("default,default"))
+	assert.Equal(t, []string{"a", "b"}, splitNamespaces("a,b,a,b"))
 }


### PR DESCRIPTION
This PR addresses a minor edge case where duplicate namespace names in `--include-namespaces` (e.g. `default,default`) would result in double-counting resources during cluster size estimation and double processing in namespace progress counting. 

`splitNamespaces` now returns a deduplicated slice of namespaces.

/cc @matthyx (addressing the review comment from #3538)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate namespace entries during namespace selection.
  * Continued trimming whitespace and ignoring empty entries.
  * Preserved the order of unique namespaces.

* **Tests**
  * Added coverage to verify duplicate removal and ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->