### PR TITLE
feat(networkpolicy): add real NetworkPolicy reachability engine

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -1328,6 +1328,7 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createRuntimeToolsAndResources(ksServer)
 	createRBACScanningTools(ksServer)
 	createNetworkScanningTools(ksServer)
+	createNetworkReachabilityTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)

--- a/cmd/mcpserver/network_reachability.go
+++ b/cmd/mcpserver/network_reachability.go
@@ -1,0 +1,172 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/networkpolicy"
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var networkPolicyGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
+var namespaceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+var podGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// createNetworkReachabilityTools registers analyze_network_reachability, a
+// real reachability query (not a policy-existence check) answering whether
+// a specific source pod can reach a specific destination pod, evaluating
+// every NetworkPolicy in the cluster the same way the Kubernetes API's own
+// semantics compose them. See core/pkg/networkpolicy for the model.
+func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
+	tool := mcp.NewTool(
+		"analyze_network_reachability",
+		mcp.WithDescription("Determine whether a specific source pod can reach a specific destination pod (optionally on a given port/protocol), by evaluating every NetworkPolicy in the cluster together -- not just whether a blocking policy exists. Reports allowed, denied, or unknown (when a rule cannot be resolved statically, e.g. a named container port or an IP-block peer) with the specific policy responsible."),
+		mcp.WithString("source_namespace", mcp.Required(), mcp.Description("Namespace of the source pod")),
+		mcp.WithString("source_pod", mcp.Required(), mcp.Description("Name of the source pod")),
+		mcp.WithString("destination_namespace", mcp.Required(), mcp.Description("Namespace of the destination pod")),
+		mcp.WithString("destination_pod", mcp.Required(), mcp.Description("Name of the destination pod")),
+		mcp.WithNumber("port", mcp.Description("Destination port to check (optional; omit to check reachability without regard to port)")),
+		mcp.WithString("protocol", mcp.Description("Protocol for the port check: TCP, UDP, or SCTP (optional, defaults to TCP)")),
+	)
+
+	ksServer.s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok || args == nil {
+			args = map[string]any{}
+		}
+
+		srcNS, ok := args["source_namespace"].(string)
+		if !ok || srcNS == "" {
+			return mcp.NewToolResultError("source_namespace is required"), nil
+		}
+		srcName, ok := args["source_pod"].(string)
+		if !ok || srcName == "" {
+			return mcp.NewToolResultError("source_pod is required"), nil
+		}
+		dstNS, ok := args["destination_namespace"].(string)
+		if !ok || dstNS == "" {
+			return mcp.NewToolResultError("destination_namespace is required"), nil
+		}
+		dstName, ok := args["destination_pod"].(string)
+		if !ok || dstName == "" {
+			return mcp.NewToolResultError("destination_pod is required"), nil
+		}
+
+		var port *networkpolicy.PortSpec
+		if raw, ok := args["port"]; ok {
+			f, ok := raw.(float64)
+			if !ok || f <= 0 || f != float64(int64(f)) {
+				return mcp.NewToolResultError("port must be a positive integer"), nil
+			}
+			proto := corev1.ProtocolTCP
+			if rawProto, ok := args["protocol"].(string); ok && rawProto != "" {
+				proto = corev1.Protocol(rawProto)
+			}
+			port = &networkpolicy.PortSpec{Protocol: proto, Port: int32(f)}
+		}
+
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+		}
+		dynClient := k8sClient.DynamicClient
+
+		policyList, err := dynClient.Resource(networkPolicyGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list NetworkPolicy objects: %v", err)), nil
+		}
+		namespaceList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+		}
+		srcPodObj, err := dynClient.Resource(podGVR).Namespace(srcNS).Get(ctx, srcName, metav1.GetOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get source pod %s/%s: %v", srcNS, srcName, err)), nil
+		}
+		dstPodObj, err := dynClient.Resource(podGVR).Namespace(dstNS).Get(ctx, dstName, metav1.GetOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get destination pod %s/%s: %v", dstNS, dstName, err)), nil
+		}
+
+		resources := make(map[string]workloadinterface.IMetadata, len(policyList.Items)+len(namespaceList.Items))
+		for i := range policyList.Items {
+			w := workloadinterface.NewWorkloadObj(policyList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+		for i := range namespaceList.Items {
+			w := workloadinterface.NewWorkloadObj(namespaceList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+
+		policies, namespaces, decodeErrs := networkpolicy.FromResources(resources)
+
+		idx := networkpolicy.NewIndex(policies, namespaces)
+
+		src := networkpolicy.EndpointFromResource(workloadinterface.NewWorkloadObj(srcPodObj.Object))
+		dst := networkpolicy.EndpointFromResource(workloadinterface.NewWorkloadObj(dstPodObj.Object))
+		if ip, found := unstructuredNestedString(srcPodObj.Object, "status", "podIP"); found {
+			src.IP = ip
+		}
+		if ip, found := unstructuredNestedString(dstPodObj.Object, "status", "podIP"); found {
+			dst.IP = ip
+		}
+
+		verdict, egress, ingress := idx.Reaches(src, dst, port)
+
+		result := map[string]any{
+			"verdict": verdict.String(),
+			"egress": map[string]any{
+				"verdict":        egress.Verdict.String(),
+				"reason":         egress.Reason,
+				"matched_policy": egress.MatchedPolicy,
+			},
+			"ingress": map[string]any{
+				"verdict":        ingress.Verdict.String(),
+				"reason":         ingress.Reason,
+				"matched_policy": ingress.MatchedPolicy,
+			},
+		}
+		if len(decodeErrs) > 0 {
+			msgs := make([]string, len(decodeErrs))
+			for i, e := range decodeErrs {
+				msgs[i] = e.Error()
+			}
+			result["decode_warnings"] = msgs
+		}
+
+		resBytes, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(resBytes)), nil
+	})
+}
+
+// unstructuredNestedString reads a nested string field from an unstructured
+// object without pulling in the full unstructured helper package's error
+// semantics for a lookup this shallow. found is false if any segment of the
+// path is absent or not a string; that is not an error, just "unknown IP,"
+// which the caller already treats as an absent IP.
+func unstructuredNestedString(obj map[string]any, path ...string) (value string, found bool) {
+	cur := any(obj)
+	for _, segment := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		cur, ok = m[segment]
+		if !ok {
+			return "", false
+		}
+	}
+	s, ok := cur.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}

--- a/cmd/mcpserver/network_reachability.go
+++ b/cmd/mcpserver/network_reachability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/pkg/networkpolicy"
@@ -60,12 +61,18 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 		var port *networkpolicy.PortSpec
 		if raw, ok := args["port"]; ok {
 			f, ok := raw.(float64)
-			if !ok || f <= 0 || f != float64(int64(f)) {
-				return mcp.NewToolResultError("port must be a positive integer"), nil
+			if !ok || f <= 0 || f > 65535 || f != float64(int64(f)) {
+				return mcp.NewToolResultError("port must be a positive integer between 1 and 65535"), nil
 			}
 			proto := corev1.ProtocolTCP
 			if rawProto, ok := args["protocol"].(string); ok && rawProto != "" {
-				proto = corev1.Protocol(rawProto)
+				normalized := corev1.Protocol(strings.ToUpper(rawProto))
+				switch normalized {
+				case corev1.ProtocolTCP, corev1.ProtocolUDP, corev1.ProtocolSCTP:
+					proto = normalized
+				default:
+					return mcp.NewToolResultError(fmt.Sprintf("protocol must be one of TCP, UDP, SCTP (got %q)", rawProto)), nil
+				}
 			}
 			port = &networkpolicy.PortSpec{Protocol: proto, Port: int32(f)}
 		}
@@ -105,7 +112,8 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 
 		policies, namespaces, decodeErrs := networkpolicy.FromResources(resources)
 
-		idx := networkpolicy.NewIndex(policies, namespaces)
+		idx, indexErrs := networkpolicy.NewIndex(policies, namespaces)
+		decodeErrs = append(decodeErrs, indexErrs...)
 
 		src := networkpolicy.EndpointFromResource(workloadinterface.NewWorkloadObj(srcPodObj.Object))
 		dst := networkpolicy.EndpointFromResource(workloadinterface.NewWorkloadObj(dstPodObj.Object))
@@ -137,6 +145,16 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 				msgs[i] = e.Error()
 			}
 			result["decode_warnings"] = msgs
+			// A dropped NetworkPolicy (decode failure, or an unparseable
+			// podSelector) could have been the one restricting or allowing
+			// this exact connection, in either direction -- so a confident
+			// allowed/denied computed without it is not trustworthy. This
+			// package's own three-valued design exists precisely to avoid
+			// reporting a confident-but-wrong answer; a dropped policy is
+			// such a case, so the top-level verdict is downgraded here even
+			// though the underlying egress/ingress computation itself
+			// still reports whatever it could determine.
+			result["verdict"] = networkpolicy.Unknown.String()
 		}
 
 		resBytes, err := json.Marshal(result)

--- a/cmd/mcpserver/network_reachability_test.go
+++ b/cmd/mcpserver/network_reachability_test.go
@@ -1,0 +1,190 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func newReachabilityTestServer(objects ...runtime.Object) *KubescapeMcpserver {
+	listKinds := map[schema.GroupVersionResource]string{
+		networkPolicyGVR: "NetworkPolicyList",
+		namespaceGVR:     "NamespaceList",
+		podGVR:           "PodList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createNetworkReachabilityTools(ksServer)
+	return ksServer
+}
+
+func unstructuredPod(namespace, name string, labels map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	if labels != nil {
+		obj["metadata"].(map[string]any)["labels"] = labels
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func unstructuredNetworkPolicy(namespace, name string, spec map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": spec,
+	}}
+}
+
+func TestAnalyzeNetworkReachability_DefaultDenyBlocksUnrelatedSource(t *testing.T) {
+	deny := unstructuredNetworkPolicy("prod", "deny-all", map[string]any{
+		"podSelector": map[string]any{},
+		"policyTypes": []any{"Ingress"},
+	})
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(deny, server, client)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+
+	require.Equal(t, "denied", parsed["verdict"])
+	ingress := parsed["ingress"].(map[string]any)
+	require.Equal(t, "denied", ingress["verdict"])
+}
+
+func TestAnalyzeNetworkReachability_AllowsSelectedPeer(t *testing.T) {
+	allow := unstructuredNetworkPolicy("prod", "allow-client", map[string]any{
+		"podSelector": map[string]any{"matchLabels": map[string]any{"app": "server"}},
+		"policyTypes": []any{"Ingress"},
+		"ingress": []any{
+			map[string]any{
+				"from": []any{
+					map[string]any{"podSelector": map[string]any{"matchLabels": map[string]any{"app": "client"}}},
+				},
+			},
+		},
+	})
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(allow, server, client)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Equal(t, "allowed", parsed["verdict"])
+	ingress := parsed["ingress"].(map[string]any)
+	require.Equal(t, "prod/allow-client", ingress["matched_policy"])
+}
+
+func TestAnalyzeNetworkReachability_MissingArgumentsReturnError(t *testing.T) {
+	ksServer := newReachabilityTestServer()
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace": "prod",
+		"source_pod":       "client",
+		// destination_namespace/destination_pod deliberately omitted
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeNetworkReachability_PortRespected(t *testing.T) {
+	allowPort80 := unstructuredNetworkPolicy("prod", "allow-port-80", map[string]any{
+		"podSelector": map[string]any{"matchLabels": map[string]any{"app": "server"}},
+		"policyTypes": []any{"Ingress"},
+		"ingress": []any{
+			map[string]any{
+				"ports": []any{
+					map[string]any{"protocol": "TCP", "port": int64(80)},
+				},
+			},
+		},
+	})
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(allowPort80, server, client)
+
+	allowed := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+		"port":                  float64(80),
+	}))
+	var allowedParsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, allowed)), &allowedParsed))
+	require.Equal(t, "allowed", allowedParsed["verdict"])
+
+	denied := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+		"port":                  float64(443),
+	}))
+	var deniedParsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, denied)), &deniedParsed))
+	require.Equal(t, "denied", deniedParsed["verdict"])
+}
+
+func TestAnalyzeNetworkReachability_NoPoliciesAllowsByDefault(t *testing.T) {
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(server, client)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Equal(t, "allowed", parsed["verdict"])
+}

--- a/cmd/mcpserver/network_reachability_test.go
+++ b/cmd/mcpserver/network_reachability_test.go
@@ -188,3 +188,90 @@ func TestAnalyzeNetworkReachability_NoPoliciesAllowsByDefault(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	require.Equal(t, "allowed", parsed["verdict"])
 }
+
+func TestAnalyzeNetworkReachability_LowercaseProtocolIsNormalized(t *testing.T) {
+	allowPort80 := unstructuredNetworkPolicy("prod", "allow-port-80", map[string]any{
+		"podSelector": map[string]any{"matchLabels": map[string]any{"app": "server"}},
+		"policyTypes": []any{"Ingress"},
+		"ingress": []any{
+			map[string]any{
+				"ports": []any{
+					map[string]any{"protocol": "TCP", "port": int64(80)},
+				},
+			},
+		},
+	})
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(allowPort80, server, client)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+		"port":                  float64(80),
+		"protocol":              "tcp",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Equal(t, "allowed", parsed["verdict"], "a lowercase protocol must be normalized, not silently fail every port match")
+}
+
+func TestAnalyzeNetworkReachability_InvalidProtocolReturnsError(t *testing.T) {
+	ksServer := newReachabilityTestServer()
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+		"port":                  float64(80),
+		"protocol":              "ICMP",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeNetworkReachability_PortAboveRangeReturnsError(t *testing.T) {
+	ksServer := newReachabilityTestServer()
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+		"port":                  float64(70000),
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeNetworkReachability_MalformedPodSelectorDowngradesVerdictToUnknown(t *testing.T) {
+	bad := unstructuredNetworkPolicy("prod", "broken", map[string]any{
+		"podSelector": map[string]any{
+			"matchExpressions": []any{
+				map[string]any{"key": "x", "operator": "NotARealOperator"},
+			},
+		},
+		"policyTypes": []any{"Ingress"},
+	})
+	server := unstructuredPod("prod", "server", map[string]any{"app": "server"})
+	client := unstructuredPod("prod", "client", map[string]any{"app": "client"})
+
+	ksServer := newReachabilityTestServer(bad, server, client)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", map[string]any{
+		"source_namespace":      "prod",
+		"source_pod":            "client",
+		"destination_namespace": "prod",
+		"destination_pod":       "server",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Equal(t, "unknown", parsed["verdict"], "a dropped, unparseable policy must downgrade the verdict, not silently report a confident allowed")
+	require.NotEmpty(t, parsed["decode_warnings"])
+}

--- a/core/pkg/networkpolicy/adapter.go
+++ b/core/pkg/networkpolicy/adapter.go
@@ -1,0 +1,77 @@
+package networkpolicy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// FromResources converts kubescape's generically-collected scan resources
+// into the typed inputs NewIndex needs. Any object that is not a
+// NetworkPolicy or Namespace is ignored. A NetworkPolicy or Namespace object
+// that fails to decode into its typed shape is skipped, with its error
+// appended to errs, rather than aborting the whole conversion over one bad
+// object.
+func FromResources(resources map[string]workloadinterface.IMetadata) (policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo, errs []error) {
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		switch resource.GetKind() {
+		case "NetworkPolicy":
+			p, err := decodeNetworkPolicy(resource.GetObject())
+			if err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			policies = append(policies, p)
+		case "Namespace":
+			namespaces = append(namespaces, NamespaceInfo{
+				Name:   resource.GetName(),
+				Labels: resourceLabels(resource),
+			})
+		}
+	}
+	return policies, namespaces, errs
+}
+
+// decodeNetworkPolicy converts a NetworkPolicy's generic object map into its
+// typed shape via a JSON round-trip, the same pattern the rest of this
+// codebase uses to bridge kubescape's generic resource representation and a
+// concrete Kubernetes API type.
+func decodeNetworkPolicy(obj map[string]any) (*networkingv1.NetworkPolicy, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var p networkingv1.NetworkPolicy
+	if err := json.Unmarshal(b, &p); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &p, nil
+}
+
+// resourceLabels extracts a resource's labels. IMetadata does not carry
+// labels itself; IBasicWorkload does.
+func resourceLabels(resource workloadinterface.IMetadata) map[string]string {
+	bw, ok := resource.(workloadinterface.IBasicWorkload)
+	if !ok {
+		return nil
+	}
+	return bw.GetLabels()
+}
+
+// EndpointFromResource builds an Endpoint from a scanned Pod-shaped
+// resource, for use as a reachability query's source or destination.
+func EndpointFromResource(resource workloadinterface.IMetadata) Endpoint {
+	if resource == nil {
+		return Endpoint{}
+	}
+	return Endpoint{
+		Namespace: resource.GetNamespace(),
+		Name:      resource.GetName(),
+		Labels:    resourceLabels(resource),
+	}
+}

--- a/core/pkg/networkpolicy/adapter_test.go
+++ b/core/pkg/networkpolicy/adapter_test.go
@@ -1,0 +1,118 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+)
+
+func TestFromResources_ExtractsPoliciesAndNamespacesOnly(t *testing.T) {
+	np := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": "deny-all", "namespace": "prod"},
+		"spec": map[string]any{
+			"podSelector": map[string]any{},
+			"policyTypes": []any{"Ingress"},
+		},
+	})
+	ns := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   map[string]any{"name": "prod", "labels": map[string]any{"env": "prod"}},
+	})
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "app", "namespace": "prod"},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		np.GetID():  np,
+		ns.GetID():  ns,
+		pod.GetID(): pod,
+	}
+
+	policies, namespaces, errs := FromResources(resources)
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected decode errors: %v", errs)
+	}
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	if policies[0].Name != "deny-all" || policies[0].Namespace != "prod" {
+		t.Errorf("unexpected policy identity: %+v", policies[0].ObjectMeta)
+	}
+	if len(policies[0].Spec.PolicyTypes) != 1 || policies[0].Spec.PolicyTypes[0] != "Ingress" {
+		t.Errorf("policyTypes did not decode correctly: %+v", policies[0].Spec.PolicyTypes)
+	}
+
+	if len(namespaces) != 1 {
+		t.Fatalf("expected 1 namespace, got %d", len(namespaces))
+	}
+	if namespaces[0].Name != "prod" || namespaces[0].Labels["env"] != "prod" {
+		t.Errorf("unexpected namespace info: %+v", namespaces[0])
+	}
+
+	// The Pod must contribute neither a policy nor a namespace entry.
+}
+
+func TestFromResources_MalformedNetworkPolicyIsSkippedNotFatal(t *testing.T) {
+	good := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": "good", "namespace": "ns"},
+		"spec":       map[string]any{"podSelector": map[string]any{}},
+	})
+	bad := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": "bad", "namespace": "ns"},
+		// policyTypes must be a list of strings; this value cannot decode
+		// into []networkingv1.PolicyType.
+		"spec": map[string]any{"podSelector": map[string]any{}, "policyTypes": 12345},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		good.GetID(): good,
+		bad.GetID():  bad,
+	}
+
+	policies, _, errs := FromResources(resources)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected the well-formed policy to still decode, got %d policies", len(policies))
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly one decode error for the malformed policy, got %d", len(errs))
+	}
+}
+
+func TestEndpointFromResource_CarriesNamespaceNameAndLabels(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "web",
+			"namespace": "prod",
+			"labels":    map[string]any{"app": "web"},
+		},
+	})
+
+	ep := EndpointFromResource(pod)
+
+	if ep.Namespace != "prod" || ep.Name != "web" {
+		t.Errorf("unexpected endpoint identity: %+v", ep)
+	}
+	if ep.Labels["app"] != "web" {
+		t.Errorf("expected labels to carry through, got %+v", ep.Labels)
+	}
+}
+
+func TestEndpointFromResource_NilResourceIsSafe(t *testing.T) {
+	ep := EndpointFromResource(nil)
+	if ep.Namespace != "" || ep.Name != "" || ep.Labels != nil {
+		t.Errorf("expected a zero-value Endpoint for a nil resource, got %+v", ep)
+	}
+}

--- a/core/pkg/networkpolicy/index.go
+++ b/core/pkg/networkpolicy/index.go
@@ -1,0 +1,233 @@
+// Package networkpolicy implements a static NetworkPolicy reachability model:
+// given the NetworkPolicy, Pod, and Namespace objects a scan already
+// collects, it answers "can this specific source reach this specific
+// destination, on this port" by evaluating the real, additive Kubernetes
+// NetworkPolicy semantics -- not just "does some policy exist."
+//
+// This is a static model computed from spec, the same trust model the rest
+// of kubescape's posture scanning uses. It does not verify that a cluster's
+// CNI actually enforces NetworkPolicy (many do not), and it does not resolve
+// DNS-based egress destinations -- only ipBlock CIDRs.
+package networkpolicy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Endpoint identifies one pod for reachability purposes: which namespace it
+// is in, and the labels a podSelector/namespaceSelector match against.
+type Endpoint struct {
+	Namespace string
+	Name      string
+	Labels    map[string]string
+
+	// IP is optional. It is only consulted for ipBlock peer matching, which
+	// operates on addresses, not labels -- a live-cluster caller that knows
+	// the pod's assigned IP can set it; a caller working purely from scanned
+	// manifests (no runtime status) leaves it empty, and any ipBlock peer
+	// then reports Unknown rather than a guessed answer.
+	IP string
+}
+
+// NamespaceInfo carries a namespace's own labels, needed for
+// namespaceSelector matching (which reads the *namespace* object's labels,
+// not anything on the pod).
+type NamespaceInfo struct {
+	Name   string
+	Labels map[string]string
+}
+
+// Direction is which traffic direction a policy rule (and the isolation it
+// establishes) applies to.
+type Direction int
+
+const (
+	Ingress Direction = iota
+	Egress
+)
+
+func (d Direction) String() string {
+	if d == Egress {
+		return "egress"
+	}
+	return "ingress"
+}
+
+// Index indexes a cluster's NetworkPolicy objects (grouped by namespace) and
+// namespace label metadata, for repeated reachability queries against the
+// same snapshot.
+type Index struct {
+	byNamespace map[string][]*compiledPolicy
+	namespaces  map[string]NamespaceInfo
+}
+
+// compiledPolicy pre-parses one NetworkPolicy's selectors once, rather than
+// re-parsing label selectors on every query against it.
+type compiledPolicy struct {
+	policy      *networkingv1.NetworkPolicy
+	podSelector labels.Selector
+	hasIngress  bool // Ingress is in policyTypes (explicit, or defaulted)
+	hasEgress   bool // Egress is in policyTypes (explicit only; never defaulted)
+}
+
+// NewIndex builds an Index from a cluster's (or a scan's) collected
+// NetworkPolicy objects and namespace metadata. A policy with an
+// unparseable podSelector is skipped rather than making the whole Index
+// fail to build: one malformed object should not blind every query about
+// every other namespace.
+func NewIndex(policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo) *Index {
+	idx := &Index{
+		byNamespace: make(map[string][]*compiledPolicy),
+		namespaces:  make(map[string]NamespaceInfo, len(namespaces)),
+	}
+
+	for _, ns := range namespaces {
+		idx.namespaces[ns.Name] = ns
+	}
+
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		sel, err := metav1.LabelSelectorAsSelector(&p.Spec.PodSelector)
+		if err != nil {
+			continue
+		}
+
+		hasIngress, hasEgress := policyTypesFor(p)
+
+		idx.byNamespace[p.Namespace] = append(idx.byNamespace[p.Namespace], &compiledPolicy{
+			policy:      p,
+			podSelector: sel,
+			hasIngress:  hasIngress,
+			hasEgress:   hasEgress,
+		})
+	}
+
+	return idx
+}
+
+// policyTypesFor reproduces the Kubernetes API's own defaulting for
+// spec.policyTypes (networking/v1 NetworkPolicySpec doc): Ingress always
+// applies unless policyTypes is explicitly set and omits it; Egress applies
+// only when policyTypes explicitly includes it, or -- when policyTypes is
+// not set at all -- when the policy declares any egress rules. Egress is
+// never defaulted "on" the way Ingress is: a policy with an empty
+// policyTypes and no egress rules is not egress-isolating.
+func policyTypesFor(p *networkingv1.NetworkPolicy) (ingress, egress bool) {
+	if len(p.Spec.PolicyTypes) == 0 {
+		return true, len(p.Spec.Egress) > 0
+	}
+	for _, t := range p.Spec.PolicyTypes {
+		switch t {
+		case networkingv1.PolicyTypeIngress:
+			ingress = true
+		case networkingv1.PolicyTypeEgress:
+			egress = true
+		}
+	}
+	return ingress, egress
+}
+
+// matchingPolicies returns every compiled policy in ep's namespace whose
+// podSelector selects ep.
+func (idx *Index) matchingPolicies(ep Endpoint) []*compiledPolicy {
+	var out []*compiledPolicy
+	for _, cp := range idx.byNamespace[ep.Namespace] {
+		if cp.podSelector.Matches(labels.Set(ep.Labels)) {
+			out = append(out, cp)
+		}
+	}
+	return out
+}
+
+// IsIsolated reports whether ep is isolated for dir: at least one policy in
+// its namespace selects it and declares dir (see policyTypesFor for the
+// exact defaulting rules). An endpoint that is not isolated for a direction
+// allows all traffic in that direction, regardless of what any policy that
+// does not select it says -- NetworkPolicy is opt-in per pod, not
+// cluster-wide default-deny.
+func (idx *Index) IsIsolated(ep Endpoint, dir Direction) bool {
+	for _, cp := range idx.matchingPolicies(ep) {
+		if dir == Ingress && cp.hasIngress {
+			return true
+		}
+		if dir == Egress && cp.hasEgress {
+			return true
+		}
+	}
+	return false
+}
+
+// PortSpec is a protocol+port pair to check reachability for. A nil
+// *PortSpec passed to a query means "is there any port at all this
+// connection could use," i.e. match a rule regardless of its ports.
+type PortSpec struct {
+	// Protocol defaults to TCP if empty, matching the Kubernetes API's own
+	// default for NetworkPolicyPort.Protocol.
+	Protocol corev1.Protocol
+	Port     int32
+}
+
+func (p *PortSpec) protocol() corev1.Protocol {
+	if p == nil || p.Protocol == "" {
+		return corev1.ProtocolTCP
+	}
+	return p.Protocol
+}
+
+// Verdict is a reachability answer. It is three-valued rather than a plain
+// bool because some inputs genuinely cannot be resolved from a static
+// model: a peer selected by IP block when the candidate's IP is unknown, or
+// a rule whose port is a named (string) container port this model has no
+// container spec to resolve. Collapsing those cases into a guessed
+// Allowed/Denied would be worse than saying so.
+type Verdict int
+
+const (
+	Denied Verdict = iota
+	Allowed
+	Unknown
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case Allowed:
+		return "allowed"
+	case Denied:
+		return "denied"
+	default:
+		return "unknown"
+	}
+}
+
+// Decision is the outcome of one reachability query, with the specific
+// policy responsible so a caller can explain the answer, not just report a
+// verdict.
+type Decision struct {
+	Verdict Verdict
+	// Reason is a short, human-readable explanation: which policy/rule
+	// allowed the connection, why it was denied, or what could not be
+	// resolved.
+	Reason string
+	// MatchedPolicy names the NetworkPolicy (namespace/name) whose rule
+	// produced an Allowed decision. Empty for Denied/Unknown, and empty
+	// for an Allowed verdict that holds only because the endpoint is not
+	// isolated for this direction at all (no specific policy to name).
+	MatchedPolicy string
+}
+
+func allow(reason, policy string) Decision {
+	return Decision{Verdict: Allowed, Reason: reason, MatchedPolicy: policy}
+}
+
+func deny(reason string) Decision {
+	return Decision{Verdict: Denied, Reason: reason}
+}
+
+func unknown(reason string) Decision {
+	return Decision{Verdict: Unknown, Reason: reason}
+}

--- a/core/pkg/networkpolicy/index.go
+++ b/core/pkg/networkpolicy/index.go
@@ -11,6 +11,8 @@
 package networkpolicy
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,16 +72,21 @@ type compiledPolicy struct {
 	policy      *networkingv1.NetworkPolicy
 	podSelector labels.Selector
 	hasIngress  bool // Ingress is in policyTypes (explicit, or defaulted)
-	hasEgress   bool // Egress is in policyTypes (explicit only; never defaulted)
+	hasEgress   bool // Egress is in policyTypes (explicit, or defaulted from having egress rules when policyTypes is unset)
 }
 
 // NewIndex builds an Index from a cluster's (or a scan's) collected
 // NetworkPolicy objects and namespace metadata. A policy with an
 // unparseable podSelector is skipped rather than making the whole Index
 // fail to build: one malformed object should not blind every query about
-// every other namespace.
-func NewIndex(policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo) *Index {
-	idx := &Index{
+// every other namespace. Its error is appended to errs -- mirroring
+// FromResources' decodeErrs -- so a caller can surface it (e.g. in a
+// decode_warnings field) rather than have it disappear silently; dropping a
+// policy this way can turn a real Denied into a false Allowed, so callers of
+// a security-sensitive query should treat a non-empty errs as reason to
+// distrust an Allowed verdict.
+func NewIndex(policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo) (idx *Index, errs []error) {
+	idx = &Index{
 		byNamespace: make(map[string][]*compiledPolicy),
 		namespaces:  make(map[string]NamespaceInfo, len(namespaces)),
 	}
@@ -94,6 +101,7 @@ func NewIndex(policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo
 		}
 		sel, err := metav1.LabelSelectorAsSelector(&p.Spec.PodSelector)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("NetworkPolicy %s/%s: unparseable podSelector, skipped: %w", p.Namespace, p.Name, err))
 			continue
 		}
 
@@ -107,7 +115,7 @@ func NewIndex(policies []*networkingv1.NetworkPolicy, namespaces []NamespaceInfo
 		})
 	}
 
-	return idx
+	return idx, errs
 }
 
 // policyTypesFor reproduces the Kubernetes API's own defaulting for

--- a/core/pkg/networkpolicy/index_test.go
+++ b/core/pkg/networkpolicy/index_test.go
@@ -1,0 +1,152 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func selector(kv ...string) metav1.LabelSelector {
+	m := map[string]string{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		m[kv[i]] = kv[i+1]
+	}
+	return metav1.LabelSelector{MatchLabels: m}
+}
+
+func policy(namespace, name string, podSel metav1.LabelSelector, types []networkingv1.PolicyType, ingress []networkingv1.NetworkPolicyIngressRule, egress []networkingv1.NetworkPolicyEgressRule) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: podSel,
+			PolicyTypes: types,
+			Ingress:     ingress,
+			Egress:      egress,
+		},
+	}
+}
+
+func TestPolicyTypesFor_Defaulting(t *testing.T) {
+	tests := []struct {
+		name        string
+		types       []networkingv1.PolicyType
+		egressRules []networkingv1.NetworkPolicyEgressRule
+		wantIngress bool
+		wantEgress  bool
+	}{
+		{
+			name:        "no policyTypes, no egress rules: ingress only",
+			types:       nil,
+			egressRules: nil,
+			wantIngress: true,
+			wantEgress:  false,
+		},
+		{
+			name:        "no policyTypes, has egress rules: both apply",
+			types:       nil,
+			egressRules: []networkingv1.NetworkPolicyEgressRule{{}},
+			wantIngress: true,
+			wantEgress:  true,
+		},
+		{
+			name:        "explicit policyTypes: [Egress] only, even with a podSelector matching",
+			types:       []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			egressRules: nil,
+			wantIngress: false,
+			wantEgress:  true,
+		},
+		{
+			name:        "explicit policyTypes: [Ingress, Egress]",
+			types:       []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			egressRules: nil,
+			wantIngress: true,
+			wantEgress:  true,
+		},
+		{
+			name:        "explicit policyTypes: [Ingress] only, despite having egress rules",
+			types:       []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			egressRules: []networkingv1.NetworkPolicyEgressRule{{}},
+			wantIngress: true,
+			wantEgress:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := policy("ns", "p", metav1.LabelSelector{}, tt.types, nil, tt.egressRules)
+			ingress, egress := policyTypesFor(p)
+			if ingress != tt.wantIngress {
+				t.Errorf("ingress = %v, want %v", ingress, tt.wantIngress)
+			}
+			if egress != tt.wantEgress {
+				t.Errorf("egress = %v, want %v", egress, tt.wantEgress)
+			}
+		})
+	}
+}
+
+func TestIsIsolated_NoPolicySelectsPod(t *testing.T) {
+	idx := NewIndex(nil, nil)
+	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	if idx.IsIsolated(pod, Ingress) {
+		t.Error("a pod with zero policies in its namespace must not be isolated")
+	}
+	if idx.IsIsolated(pod, Egress) {
+		t.Error("a pod with zero policies in its namespace must not be isolated")
+	}
+}
+
+func TestIsIsolated_PolicyInAnotherNamespaceDoesNotIsolate(t *testing.T) {
+	p := policy("other-ns", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	if idx.IsIsolated(pod, Ingress) {
+		t.Error("a policy in a different namespace must never isolate a pod in this one")
+	}
+}
+
+func TestIsIsolated_EmptyPodSelectorSelectsWholeNamespace(t *testing.T) {
+	p := policy("ns", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"anything": "goes"}}
+
+	if !idx.IsIsolated(pod, Ingress) {
+		t.Error("an empty podSelector must select every pod in the namespace")
+	}
+}
+
+func TestIsIsolated_MalformedPodSelectorSkipsThatPolicyOnly(t *testing.T) {
+	good := policy("ns", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
+	bad := policy("ns", "broken", metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: "NotARealOperator"}},
+	}, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, nil, nil)
+
+	idx := NewIndex([]*networkingv1.NetworkPolicy{good, bad}, nil)
+	pod := Endpoint{Namespace: "ns", Name: "app"}
+
+	if !idx.IsIsolated(pod, Ingress) {
+		t.Error("the well-formed policy must still isolate for ingress")
+	}
+	if idx.IsIsolated(pod, Egress) {
+		t.Error("the malformed policy must be skipped, not treated as isolating for egress")
+	}
+}
+
+func portSpec(port int32) *PortSpec {
+	return &PortSpec{Protocol: corev1.ProtocolTCP, Port: port}
+}
+
+func tcpPort(port int32) []networkingv1.NetworkPolicyPort {
+	p := intstr.FromInt32(port)
+	return []networkingv1.NetworkPolicyPort{{Port: &p}}
+}
+
+func namedPort(name string) []networkingv1.NetworkPolicyPort {
+	p := intstr.FromString(name)
+	return []networkingv1.NetworkPolicyPort{{Port: &p}}
+}

--- a/core/pkg/networkpolicy/index_test.go
+++ b/core/pkg/networkpolicy/index_test.go
@@ -89,7 +89,7 @@ func TestPolicyTypesFor_Defaulting(t *testing.T) {
 }
 
 func TestIsIsolated_NoPolicySelectsPod(t *testing.T) {
-	idx := NewIndex(nil, nil)
+	idx, _ := NewIndex(nil, nil)
 	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
 
 	if idx.IsIsolated(pod, Ingress) {
@@ -102,7 +102,7 @@ func TestIsIsolated_NoPolicySelectsPod(t *testing.T) {
 
 func TestIsIsolated_PolicyInAnotherNamespaceDoesNotIsolate(t *testing.T) {
 	p := policy("other-ns", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
 	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
 
 	if idx.IsIsolated(pod, Ingress) {
@@ -112,7 +112,7 @@ func TestIsIsolated_PolicyInAnotherNamespaceDoesNotIsolate(t *testing.T) {
 
 func TestIsIsolated_EmptyPodSelectorSelectsWholeNamespace(t *testing.T) {
 	p := policy("ns", "deny-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
 	pod := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"anything": "goes"}}
 
 	if !idx.IsIsolated(pod, Ingress) {
@@ -126,7 +126,7 @@ func TestIsIsolated_MalformedPodSelectorSkipsThatPolicyOnly(t *testing.T) {
 		MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: "NotARealOperator"}},
 	}, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, nil, nil)
 
-	idx := NewIndex([]*networkingv1.NetworkPolicy{good, bad}, nil)
+	idx, errs := NewIndex([]*networkingv1.NetworkPolicy{good, bad}, nil)
 	pod := Endpoint{Namespace: "ns", Name: "app"}
 
 	if !idx.IsIsolated(pod, Ingress) {
@@ -134,6 +134,9 @@ func TestIsIsolated_MalformedPodSelectorSkipsThatPolicyOnly(t *testing.T) {
 	}
 	if idx.IsIsolated(pod, Egress) {
 		t.Error("the malformed policy must be skipped, not treated as isolating for egress")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly one error for the malformed podSelector, got %d: %v", len(errs), errs)
 	}
 }
 

--- a/core/pkg/networkpolicy/match.go
+++ b/core/pkg/networkpolicy/match.go
@@ -1,0 +1,219 @@
+package networkpolicy
+
+import (
+	"fmt"
+	"math"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// safePort converts an int (from intstr.IntValue, which is always a plain
+// int regardless of platform width) to int32, reporting false instead of
+// silently wrapping when v falls outside int32's range.
+func safePort(v int) (int32, bool) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, false
+	}
+	return int32(v), true
+}
+
+// corev1ProtocolOrDefault mirrors the Kubernetes API's own default: an
+// unset NetworkPolicyPort.Protocol means TCP.
+func corev1ProtocolOrDefault(p corev1.Protocol) corev1.Protocol {
+	if p == "" {
+		return corev1.ProtocolTCP
+	}
+	return p
+}
+
+// peerMatches reports whether one NetworkPolicyPeer selects candidate, given
+// the namespace the owning policy (and rule) lives in. The bool return is
+// the match result; the second return is false only when the peer's kind
+// cannot be evaluated at all from the data available (an ipBlock peer
+// against a candidate with no known IP, or a namespaceSelector against a
+// namespace this Index was never given labels for) -- in that case the
+// first return is meaningless and callers must treat this as Unknown, not
+// as a confident false.
+func (idx *Index) peerMatches(peer networkingv1.NetworkPolicyPeer, policyNamespace string, candidate Endpoint) (matched bool, determinable bool) {
+	if peer.IPBlock != nil {
+		if candidate.IP == "" {
+			return false, false
+		}
+		return ipBlockMatches(peer.IPBlock, candidate.IP), true
+	}
+
+	switch {
+	case peer.NamespaceSelector != nil && peer.PodSelector != nil:
+		nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		if err != nil {
+			return false, true
+		}
+		podSel, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+		if err != nil {
+			return false, true
+		}
+		if !podSel.Matches(labels.Set(candidate.Labels)) {
+			return false, true // pod side already fails; namespace labels are moot
+		}
+		nsMatch, determinable := idx.namespaceSelectorMatches(nsSel, candidate.Namespace)
+		return nsMatch, determinable
+
+	case peer.NamespaceSelector != nil:
+		nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		if err != nil {
+			return false, true
+		}
+		return idx.namespaceSelectorMatches(nsSel, candidate.Namespace)
+
+	case peer.PodSelector != nil:
+		// A podSelector with no namespaceSelector only ever selects pods in
+		// the same namespace as the policy that declares it.
+		if candidate.Namespace != policyNamespace {
+			return false, true
+		}
+		podSel, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+		if err != nil {
+			return false, true
+		}
+		return podSel.Matches(labels.Set(candidate.Labels)), true
+
+	default:
+		// No selector or ipBlock at all. The API server rejects a peer like
+		// this, but a defensively-parsed object should not be treated as
+		// matching everything.
+		return false, true
+	}
+}
+
+// namespaceSelectorMatches evaluates nsSel against namespace's labels.
+// A selector that matches everything (nil or empty matchLabels/
+// matchExpressions) is determinable regardless of whether this Index was
+// given that namespace's labels, since the labels can't change the answer;
+// any other selector requires the namespace's labels to be known.
+func (idx *Index) namespaceSelectorMatches(nsSel labels.Selector, namespace string) (matched bool, determinable bool) {
+	if nsSel.Empty() {
+		return true, true
+	}
+	nsInfo, ok := idx.namespaces[namespace]
+	if !ok {
+		return false, false
+	}
+	return nsSel.Matches(labels.Set(nsInfo.Labels)), true
+}
+
+// ipBlockMatches reports whether ip falls inside block.CIDR and outside
+// every one of block.Except.
+func ipBlockMatches(block *networkingv1.IPBlock, ip string) bool {
+	if block.CIDR == "" {
+		return false
+	}
+	_, cidrNet, err := net.ParseCIDR(block.CIDR)
+	if err != nil {
+		return false
+	}
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
+	}
+	if !cidrNet.Contains(parsedIP) {
+		return false
+	}
+	for _, except := range block.Except {
+		_, exceptNet, err := net.ParseCIDR(except)
+		if err != nil {
+			continue
+		}
+		if exceptNet.Contains(parsedIP) {
+			return false
+		}
+	}
+	return true
+}
+
+// peerListVerdict OR-combines every peer in peers against candidate: an
+// empty/nil peer list matches everything (a rule with no from/to
+// restriction), matching Kubernetes' own semantics for an absent peer list.
+func (idx *Index) peerListVerdict(peers []networkingv1.NetworkPolicyPeer, policyNamespace string, candidate Endpoint) (Verdict, string) {
+	if len(peers) == 0 {
+		return Allowed, "rule has no source/destination restriction"
+	}
+
+	sawUnknown := false
+	for _, peer := range peers {
+		matched, determinable := idx.peerMatches(peer, policyNamespace, candidate)
+		if !determinable {
+			sawUnknown = true
+			continue
+		}
+		if matched {
+			return Allowed, "matched a peer in this rule"
+		}
+	}
+	if sawUnknown {
+		return Unknown, "a peer in this rule could not be resolved (unknown IP or namespace labels)"
+	}
+	return Denied, "no peer in this rule matched"
+}
+
+// portVerdict reports whether ports allows query. An empty/nil port list
+// matches every port, matching Kubernetes' own semantics for an absent port
+// list. A rule entry with a named (string) container port cannot be
+// resolved without that container's port-name mapping, which this static,
+// container-spec-free model does not have, so it reports Unknown rather
+// than silently skipping or guessing.
+func portVerdict(ports []networkingv1.NetworkPolicyPort, query *PortSpec) (Verdict, string) {
+	if len(ports) == 0 {
+		return Allowed, "rule has no port restriction"
+	}
+	if query == nil {
+		// Caller did not ask about a specific port; a rule that restricts
+		// ports at all cannot be confirmed to cover "any port."
+		return Unknown, "rule restricts ports, but no specific port was queried"
+	}
+
+	sawUnknown := false
+	for _, p := range ports {
+		var protoVal corev1.Protocol
+		if p.Protocol != nil {
+			protoVal = *p.Protocol
+		}
+		proto := corev1ProtocolOrDefault(protoVal)
+		if proto != query.protocol() {
+			continue
+		}
+		if p.Port == nil {
+			// No port specified alongside a protocol restriction: matches
+			// every port of that protocol.
+			return Allowed, fmt.Sprintf("matched protocol %s with no port restriction", proto)
+		}
+		if p.Port.Type == intstr.String {
+			sawUnknown = true
+			continue
+		}
+		lo, ok := safePort(p.Port.IntValue())
+		if !ok {
+			// A scan can read a NetworkPolicy straight from a manifest that
+			// was never actually applied (and so never validated by the
+			// API server), so a port outside 0-65535 is a real possibility
+			// here, not just a defensive check. Such an entry can never
+			// match a real port, rather than wrapping into a bogus value.
+			continue
+		}
+		hi := lo
+		if p.EndPort != nil {
+			hi = *p.EndPort
+		}
+		if query.Port >= lo && query.Port <= hi {
+			return Allowed, fmt.Sprintf("matched port %d/%s", query.Port, proto)
+		}
+	}
+	if sawUnknown {
+		return Unknown, "rule includes a named (string) container port this model cannot resolve"
+	}
+	return Denied, "no port entry in this rule matched"
+}

--- a/core/pkg/networkpolicy/match.go
+++ b/core/pkg/networkpolicy/match.go
@@ -171,9 +171,12 @@ func portVerdict(ports []networkingv1.NetworkPolicyPort, query *PortSpec) (Verdi
 		return Allowed, "rule has no port restriction"
 	}
 	if query == nil {
-		// Caller did not ask about a specific port; a rule that restricts
-		// ports at all cannot be confirmed to cover "any port."
-		return Unknown, "rule restricts ports, but no specific port was queried"
+		// No specific port was queried: per PortSpec's own doc and this
+		// tool's documented behavior, that means "is this connection
+		// possible at all, regardless of port" -- so a rule's port
+		// restriction is irrelevant to the question actually being asked,
+		// not an obstacle to answering it.
+		return Allowed, "no specific port was queried; rule's port restriction does not apply"
 	}
 
 	sawUnknown := false

--- a/core/pkg/networkpolicy/reachability.go
+++ b/core/pkg/networkpolicy/reachability.go
@@ -1,0 +1,109 @@
+package networkpolicy
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// ruleVerdict evaluates one rule's peer list and port list -- both must
+// allow for the rule as a whole to allow (a rule's ports and peers are an
+// AND, matching the Kubernetes API: a rule matches a connection only if the
+// connection's peer is in the rule's from/to list AND its port is in the
+// rule's ports list).
+func (idx *Index) ruleVerdict(policyNamespace string, peers []networkingv1.NetworkPolicyPeer, ports []networkingv1.NetworkPolicyPort, counterpart Endpoint, port *PortSpec) (Verdict, string) {
+	peerV, peerReason := idx.peerListVerdict(peers, policyNamespace, counterpart)
+	if peerV == Denied {
+		return Denied, peerReason
+	}
+
+	portV, portReason := portVerdict(ports, port)
+	if portV == Denied {
+		return Denied, portReason
+	}
+
+	if peerV == Unknown || portV == Unknown {
+		return Unknown, peerReason + "; " + portReason
+	}
+	return Allowed, peerReason + "; " + portReason
+}
+
+// AllowsIngress reports whether dst's combined ingress policies allow
+// traffic from src on port. If dst is not ingress-isolated at all (no
+// policy selects it and declares Ingress), the connection is allowed by
+// default -- NetworkPolicy is opt-in per pod.
+//
+// When dst is isolated, its matching policies' ingress rules are combined
+// with OR (any one matching rule, across any one matching policy, is
+// enough to allow the connection) -- this is how multiple NetworkPolicy
+// objects selecting the same pod compose in the real API.
+func (idx *Index) AllowsIngress(src, dst Endpoint, port *PortSpec) Decision {
+	if !idx.IsIsolated(dst, Ingress) {
+		return allow("destination is not ingress-isolated by any NetworkPolicy (default allow)", "")
+	}
+
+	sawUnknown := false
+	for _, cp := range idx.matchingPolicies(dst) {
+		if !cp.hasIngress {
+			continue
+		}
+		for _, rule := range cp.policy.Spec.Ingress {
+			v, reason := idx.ruleVerdict(cp.policy.Namespace, rule.From, rule.Ports, src, port)
+			if v == Allowed {
+				return allow(reason, cp.policy.Namespace+"/"+cp.policy.Name)
+			}
+			if v == Unknown {
+				sawUnknown = true
+			}
+		}
+	}
+
+	if sawUnknown {
+		return unknown("destination is ingress-isolated; no rule was confirmed to allow this traffic, but at least one rule could not be fully resolved")
+	}
+	return deny("destination is ingress-isolated and no matching policy rule allows this traffic")
+}
+
+// AllowsEgress mirrors AllowsIngress for the source's egress policies.
+func (idx *Index) AllowsEgress(src, dst Endpoint, port *PortSpec) Decision {
+	if !idx.IsIsolated(src, Egress) {
+		return allow("source is not egress-isolated by any NetworkPolicy (default allow)", "")
+	}
+
+	sawUnknown := false
+	for _, cp := range idx.matchingPolicies(src) {
+		if !cp.hasEgress {
+			continue
+		}
+		for _, rule := range cp.policy.Spec.Egress {
+			v, reason := idx.ruleVerdict(cp.policy.Namespace, rule.To, rule.Ports, dst, port)
+			if v == Allowed {
+				return allow(reason, cp.policy.Namespace+"/"+cp.policy.Name)
+			}
+			if v == Unknown {
+				sawUnknown = true
+			}
+		}
+	}
+
+	if sawUnknown {
+		return unknown("source is egress-isolated; no rule was confirmed to allow this traffic, but at least one rule could not be fully resolved")
+	}
+	return deny("source is egress-isolated and no matching policy rule allows this traffic")
+}
+
+// Reaches reports whether src can reach dst on port: real NetworkPolicy
+// semantics require BOTH src's egress rules AND dst's ingress rules to
+// allow the connection independently -- one side allowing is not enough.
+// The two Decisions are always returned alongside the combined Verdict so a
+// caller can explain which side (or both) was responsible.
+func (idx *Index) Reaches(src, dst Endpoint, port *PortSpec) (Verdict, Decision, Decision) {
+	egress := idx.AllowsEgress(src, dst, port)
+	ingress := idx.AllowsIngress(src, dst, port)
+
+	if egress.Verdict == Denied || ingress.Verdict == Denied {
+		return Denied, egress, ingress
+	}
+	if egress.Verdict == Unknown || ingress.Verdict == Unknown {
+		return Unknown, egress, ingress
+	}
+	return Allowed, egress, ingress
+}

--- a/core/pkg/networkpolicy/reachability_test.go
+++ b/core/pkg/networkpolicy/reachability_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReaches_NoPoliciesAtAll_AllowsEverything(t *testing.T) {
-	idx := NewIndex(nil, nil)
+	idx, _ := NewIndex(nil, nil)
 	src := Endpoint{Namespace: "ns", Name: "client"}
 	dst := Endpoint{Namespace: "ns", Name: "server"}
 
@@ -24,7 +24,7 @@ func TestReaches_NoPoliciesAtAll_AllowsEverything(t *testing.T) {
 
 func TestReaches_DefaultDenyIngress_BlocksEverySource(t *testing.T) {
 	denyAll := policy("ns", "deny-all-ingress", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{denyAll}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{denyAll}, nil)
 
 	src := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
@@ -48,7 +48,7 @@ func TestReaches_IngressRuleAllowsSpecificPodSelector(t *testing.T) {
 				},
 			},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allowFromClient}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allowFromClient}, nil)
 
 	allowedClient := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
 	otherClient := Endpoint{Namespace: "ns", Name: "other", Labels: map[string]string{"app": "other"}}
@@ -68,7 +68,7 @@ func TestReaches_PodSelectorPeerIsSameNamespaceOnly(t *testing.T) {
 		[]networkingv1.NetworkPolicyIngressRule{
 			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "client"))}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 
 	sameNsClient := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
 	otherNsClient := Endpoint{Namespace: "other-ns", Name: "client", Labels: map[string]string{"app": "client"}}
@@ -88,7 +88,7 @@ func TestReaches_NamespaceSelectorPeerAllowsAnyNamespaceMatchingLabels(t *testin
 		[]networkingv1.NetworkPolicyIngressRule{
 			{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: namespaceSelectorPtr(selector("env", "prod"))}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
 		{Name: "prod-ns", Labels: map[string]string{"env": "prod"}},
 		{Name: "dev-ns", Labels: map[string]string{"env": "dev"}},
 	})
@@ -114,7 +114,7 @@ func TestReaches_CombinedNamespaceAndPodSelectorIsAND(t *testing.T) {
 				PodSelector:       podSelectorPtr(selector("app", "client")),
 			}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
 		{Name: "prod-ns", Labels: map[string]string{"env": "prod"}},
 	})
 
@@ -139,7 +139,7 @@ func TestReaches_MultiplePeerEntriesAreOR(t *testing.T) {
 				{PodSelector: podSelectorPtr(selector("app", "b"))},
 			}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
 	for _, label := range []string{"a", "b"} {
@@ -161,7 +161,7 @@ func TestReaches_MultiplePoliciesOnSamePodAreOR(t *testing.T) {
 	fromB := policy("ns", "allow-b", selector("app", "server"),
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "b"))}}}}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{fromA, fromB}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{fromA, fromB}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
 	srcA := Endpoint{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "a"}}
@@ -184,7 +184,7 @@ func TestReaches_EgressOnlyPolicyDoesNotIsolateIngress(t *testing.T) {
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 		nil,
 		[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "external"))}}}})
-	idx := NewIndex([]*networkingv1.NetworkPolicy{egressOnly}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{egressOnly}, nil)
 
 	src := Endpoint{Namespace: "ns", Name: "anyone", Labels: map[string]string{"app": "anyone"}}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
@@ -212,7 +212,7 @@ func TestReaches_RequiresBothEgressAndIngressToAllow(t *testing.T) {
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "allowed-src"))}}}},
 		nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{srcEgress, dstIngress}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{srcEgress, dstIngress}, nil)
 
 	client := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
 	server := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
@@ -238,7 +238,7 @@ func TestReaches_RequiresBothEgressAndIngressToAllow(t *testing.T) {
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "client"))}}}},
 		nil)
-	idx2 := NewIndex([]*networkingv1.NetworkPolicy{srcEgress2, dstIngress2}, nil)
+	idx2, _ := NewIndex([]*networkingv1.NetworkPolicy{srcEgress2, dstIngress2}, nil)
 	v2, _, _ := idx2.Reaches(client, server, nil)
 	if v2 != Allowed {
 		t.Errorf("verdict = %v, want Allowed once both sides agree", v2)
@@ -249,7 +249,7 @@ func TestReaches_PortMatching(t *testing.T) {
 	allow := policy("ns", "allow-port-80", selector("app", "server"),
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{Ports: tcpPort(80)}}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	src := Endpoint{Namespace: "ns", Name: "client"}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
@@ -268,7 +268,7 @@ func TestReaches_PortRangeWithEndPort(t *testing.T) {
 	allow := policy("ns", "allow-range", selector("app", "server"),
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{Ports: []networkingv1.NetworkPolicyPort{{Port: &port, EndPort: &hi}}}}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	src := Endpoint{Namespace: "ns", Name: "client"}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
@@ -284,7 +284,7 @@ func TestReaches_NamedPortIsUnknown(t *testing.T) {
 	allow := policy("ns", "allow-named-port", selector("app", "server"),
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{Ports: namedPort("https")}}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	src := Endpoint{Namespace: "ns", Name: "client"}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
@@ -306,7 +306,7 @@ func TestReaches_IPBlockWithExcept(t *testing.T) {
 				Except: []string{"10.0.0.128/25"},
 			}}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
 	inRange := Endpoint{Namespace: "ns", Name: "client", IP: "10.0.0.50"}
@@ -330,7 +330,7 @@ func TestReaches_IPBlockWithoutKnownIPIsUnknown(t *testing.T) {
 		[]networkingv1.NetworkPolicyIngressRule{
 			{From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/24"}}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 	src := Endpoint{Namespace: "ns", Name: "client"} // no IP set
 
@@ -351,7 +351,7 @@ func TestReaches_NamespaceSelectorWithUncollectedNamespaceIsUnknown(t *testing.T
 		}, nil)
 	// Deliberately no NamespaceInfo at all: the scan never collected the
 	// Namespace object for "unknown-ns".
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 	src := Endpoint{Namespace: "unknown-ns", Name: "client"}
 
@@ -370,7 +370,7 @@ func TestReaches_EmptyNamespaceSelectorMatchesEverythingEvenIfUncollected(t *tes
 		[]networkingv1.NetworkPolicyIngressRule{
 			{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{}}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil) // no namespaces collected at all
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil) // no namespaces collected at all
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 	src := Endpoint{Namespace: "any-uncollected-ns", Name: "client"}
 
@@ -389,7 +389,7 @@ func TestReaches_EmptyFromListMatchesNoOne(t *testing.T) {
 	allow := policy("ns", "allow-empty-from", selector("app", "server"),
 		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{}}}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	src := Endpoint{Namespace: "ns", Name: "anyone"}
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
@@ -405,7 +405,7 @@ func TestReaches_MultipleRulesOnOnePolicyAreOR(t *testing.T) {
 			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "a"))}}},
 			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "b"))}}},
 		}, nil)
-	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
 	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
 
 	a := Endpoint{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "a"}}

--- a/core/pkg/networkpolicy/reachability_test.go
+++ b/core/pkg/networkpolicy/reachability_test.go
@@ -1,0 +1,423 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestReaches_NoPoliciesAtAll_AllowsEverything(t *testing.T) {
+	idx := NewIndex(nil, nil)
+	src := Endpoint{Namespace: "ns", Name: "client"}
+	dst := Endpoint{Namespace: "ns", Name: "server"}
+
+	v, egress, ingress := idx.Reaches(src, dst, portSpec(80))
+	if v != Allowed {
+		t.Errorf("verdict = %v, want Allowed", v)
+	}
+	if egress.Verdict != Allowed || ingress.Verdict != Allowed {
+		t.Errorf("expected both sides allowed by default, got egress=%v ingress=%v", egress.Verdict, ingress.Verdict)
+	}
+}
+
+func TestReaches_DefaultDenyIngress_BlocksEverySource(t *testing.T) {
+	denyAll := policy("ns", "deny-all-ingress", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{denyAll}, nil)
+
+	src := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	v, _, ingress := idx.Reaches(src, dst, portSpec(80))
+	if v != Denied {
+		t.Errorf("verdict = %v, want Denied", v)
+	}
+	if ingress.Verdict != Denied {
+		t.Errorf("ingress decision = %v, want Denied", ingress.Verdict)
+	}
+}
+
+func TestReaches_IngressRuleAllowsSpecificPodSelector(t *testing.T) {
+	allowFromClient := policy("ns", "allow-client", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{PodSelector: podSelectorPtr(selector("app", "client"))},
+				},
+			},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allowFromClient}, nil)
+
+	allowedClient := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
+	otherClient := Endpoint{Namespace: "ns", Name: "other", Labels: map[string]string{"app": "other"}}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(allowedClient, dst, nil); v != Allowed {
+		t.Errorf("allowed client: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(otherClient, dst, nil); v != Denied {
+		t.Errorf("other client: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_PodSelectorPeerIsSameNamespaceOnly(t *testing.T) {
+	allow := policy("ns", "allow-same-ns", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "client"))}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+
+	sameNsClient := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
+	otherNsClient := Endpoint{Namespace: "other-ns", Name: "client", Labels: map[string]string{"app": "client"}}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(sameNsClient, dst, nil); v != Allowed {
+		t.Errorf("same-namespace client: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(otherNsClient, dst, nil); v != Denied {
+		t.Errorf("a podSelector-only peer must not match a pod in a different namespace: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_NamespaceSelectorPeerAllowsAnyNamespaceMatchingLabels(t *testing.T) {
+	allow := policy("ns", "allow-from-prod-ns", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: namespaceSelectorPtr(selector("env", "prod"))}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
+		{Name: "prod-ns", Labels: map[string]string{"env": "prod"}},
+		{Name: "dev-ns", Labels: map[string]string{"env": "dev"}},
+	})
+
+	prodPod := Endpoint{Namespace: "prod-ns", Name: "any-pod"} // no pod label constraint
+	devPod := Endpoint{Namespace: "dev-ns", Name: "any-pod"}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(prodPod, dst, nil); v != Allowed {
+		t.Errorf("pod in a matching namespace: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(devPod, dst, nil); v != Denied {
+		t.Errorf("pod in a non-matching namespace: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_CombinedNamespaceAndPodSelectorIsAND(t *testing.T) {
+	allow := policy("ns", "allow-prod-client", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{
+				NamespaceSelector: namespaceSelectorPtr(selector("env", "prod")),
+				PodSelector:       podSelectorPtr(selector("app", "client")),
+			}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, []NamespaceInfo{
+		{Name: "prod-ns", Labels: map[string]string{"env": "prod"}},
+	})
+
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+	rightNsRightLabel := Endpoint{Namespace: "prod-ns", Name: "c1", Labels: map[string]string{"app": "client"}}
+	rightNsWrongLabel := Endpoint{Namespace: "prod-ns", Name: "c2", Labels: map[string]string{"app": "not-client"}}
+
+	if v, _, _ := idx.Reaches(rightNsRightLabel, dst, nil); v != Allowed {
+		t.Errorf("namespace matches and pod label matches: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(rightNsWrongLabel, dst, nil); v != Denied {
+		t.Errorf("namespace matches but pod label does not: verdict = %v, want Denied (AND, not OR)", v)
+	}
+}
+
+func TestReaches_MultiplePeerEntriesAreOR(t *testing.T) {
+	allow := policy("ns", "allow-a-or-b", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{
+				{PodSelector: podSelectorPtr(selector("app", "a"))},
+				{PodSelector: podSelectorPtr(selector("app", "b"))},
+			}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	for _, label := range []string{"a", "b"} {
+		src := Endpoint{Namespace: "ns", Name: label, Labels: map[string]string{"app": label}}
+		if v, _, _ := idx.Reaches(src, dst, nil); v != Allowed {
+			t.Errorf("app=%s: verdict = %v, want Allowed", label, v)
+		}
+	}
+	other := Endpoint{Namespace: "ns", Name: "c", Labels: map[string]string{"app": "c"}}
+	if v, _, _ := idx.Reaches(other, dst, nil); v != Denied {
+		t.Errorf("app=c matches neither peer entry: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_MultiplePoliciesOnSamePodAreOR(t *testing.T) {
+	fromA := policy("ns", "allow-a", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "a"))}}}}, nil)
+	fromB := policy("ns", "allow-b", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "b"))}}}}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{fromA, fromB}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	srcA := Endpoint{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "a"}}
+	srcB := Endpoint{Namespace: "ns", Name: "b", Labels: map[string]string{"app": "b"}}
+	srcC := Endpoint{Namespace: "ns", Name: "c", Labels: map[string]string{"app": "c"}}
+
+	if v, _, _ := idx.Reaches(srcA, dst, nil); v != Allowed {
+		t.Errorf("policy A allows app=a: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(srcB, dst, nil); v != Allowed {
+		t.Errorf("policy B allows app=b: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(srcC, dst, nil); v != Denied {
+		t.Errorf("neither policy allows app=c: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_EgressOnlyPolicyDoesNotIsolateIngress(t *testing.T) {
+	egressOnly := policy("ns", "egress-only", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		nil,
+		[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "external"))}}}})
+	idx := NewIndex([]*networkingv1.NetworkPolicy{egressOnly}, nil)
+
+	src := Endpoint{Namespace: "ns", Name: "anyone", Labels: map[string]string{"app": "anyone"}}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	// dst has a policy selecting it, but that policy is egress-only, so dst
+	// must not be ingress-isolated by it.
+	if idx.IsIsolated(dst, Ingress) {
+		t.Error("an egress-only policy must not isolate its selected pod for ingress")
+	}
+	if v, _, ingress := idx.Reaches(src, dst, nil); v != Allowed || ingress.Verdict != Allowed {
+		t.Errorf("ingress must default-allow: verdict = %v, ingress = %v", v, ingress.Verdict)
+	}
+}
+
+func TestReaches_RequiresBothEgressAndIngressToAllow(t *testing.T) {
+	// src is egress-isolated and only allowed to reach "allowed-dst"; dst is
+	// ingress-isolated and only allows "allowed-src". Neither name matches
+	// the other's policy, so despite each having *a* permissive-looking rule,
+	// the pairing must be denied on each side independently.
+	srcEgress := policy("ns", "src-egress", selector("app", "client"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		nil,
+		[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "allowed-dst"))}}}})
+	dstIngress := policy("ns", "dst-ingress", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "allowed-src"))}}}},
+		nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{srcEgress, dstIngress}, nil)
+
+	client := Endpoint{Namespace: "ns", Name: "client", Labels: map[string]string{"app": "client"}}
+	server := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	v, egress, ingress := idx.Reaches(client, server, nil)
+	if v != Denied {
+		t.Errorf("verdict = %v, want Denied (client's egress rule names a different destination than 'server')", v)
+	}
+	if egress.Verdict != Denied {
+		t.Errorf("egress decision = %v, want Denied", egress.Verdict)
+	}
+	if ingress.Verdict != Denied {
+		t.Errorf("ingress decision = %v, want Denied", ingress.Verdict)
+	}
+
+	// Now retarget so both sides actually agree on each other -- this must
+	// allow, proving the AND is not accidentally always-false.
+	srcEgress2 := policy("ns", "src-egress", selector("app", "client"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		nil,
+		[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "server"))}}}})
+	dstIngress2 := policy("ns", "dst-ingress", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "client"))}}}},
+		nil)
+	idx2 := NewIndex([]*networkingv1.NetworkPolicy{srcEgress2, dstIngress2}, nil)
+	v2, _, _ := idx2.Reaches(client, server, nil)
+	if v2 != Allowed {
+		t.Errorf("verdict = %v, want Allowed once both sides agree", v2)
+	}
+}
+
+func TestReaches_PortMatching(t *testing.T) {
+	allow := policy("ns", "allow-port-80", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{Ports: tcpPort(80)}}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	src := Endpoint{Namespace: "ns", Name: "client"}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(src, dst, portSpec(80)); v != Allowed {
+		t.Errorf("port 80: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(src, dst, portSpec(443)); v != Denied {
+		t.Errorf("port 443: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_PortRangeWithEndPort(t *testing.T) {
+	lo := int32(8000)
+	hi := int32(8080)
+	port := intstr.FromInt32(lo)
+	allow := policy("ns", "allow-range", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{Ports: []networkingv1.NetworkPolicyPort{{Port: &port, EndPort: &hi}}}}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	src := Endpoint{Namespace: "ns", Name: "client"}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(src, dst, portSpec(8050)); v != Allowed {
+		t.Errorf("port inside range: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(src, dst, portSpec(9000)); v != Denied {
+		t.Errorf("port outside range: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_NamedPortIsUnknown(t *testing.T) {
+	allow := policy("ns", "allow-named-port", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{Ports: namedPort("https")}}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	src := Endpoint{Namespace: "ns", Name: "client"}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	v, _, ingress := idx.Reaches(src, dst, portSpec(443))
+	if v != Unknown {
+		t.Errorf("verdict = %v, want Unknown (a named port cannot be resolved without container spec)", v)
+	}
+	if ingress.Verdict != Unknown {
+		t.Errorf("ingress decision = %v, want Unknown", ingress.Verdict)
+	}
+}
+
+func TestReaches_IPBlockWithExcept(t *testing.T) {
+	allow := policy("ns", "allow-cidr", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{
+				CIDR:   "10.0.0.0/24",
+				Except: []string{"10.0.0.128/25"},
+			}}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	inRange := Endpoint{Namespace: "ns", Name: "client", IP: "10.0.0.50"}
+	inExcept := Endpoint{Namespace: "ns", Name: "client", IP: "10.0.0.200"}
+	outOfRange := Endpoint{Namespace: "ns", Name: "client", IP: "10.0.1.50"}
+
+	if v, _, _ := idx.Reaches(inRange, dst, nil); v != Allowed {
+		t.Errorf("IP in CIDR, not in except: verdict = %v, want Allowed", v)
+	}
+	if v, _, _ := idx.Reaches(inExcept, dst, nil); v != Denied {
+		t.Errorf("IP in the except range: verdict = %v, want Denied", v)
+	}
+	if v, _, _ := idx.Reaches(outOfRange, dst, nil); v != Denied {
+		t.Errorf("IP outside the CIDR: verdict = %v, want Denied", v)
+	}
+}
+
+func TestReaches_IPBlockWithoutKnownIPIsUnknown(t *testing.T) {
+	allow := policy("ns", "allow-cidr", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/24"}}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+	src := Endpoint{Namespace: "ns", Name: "client"} // no IP set
+
+	v, _, ingress := idx.Reaches(src, dst, nil)
+	if v != Unknown {
+		t.Errorf("verdict = %v, want Unknown (ipBlock peer with no known source IP)", v)
+	}
+	if ingress.Verdict != Unknown {
+		t.Errorf("ingress decision = %v, want Unknown", ingress.Verdict)
+	}
+}
+
+func TestReaches_NamespaceSelectorWithUncollectedNamespaceIsUnknown(t *testing.T) {
+	allow := policy("ns", "allow-from-labelled-ns", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: namespaceSelectorPtr(selector("env", "prod"))}}},
+		}, nil)
+	// Deliberately no NamespaceInfo at all: the scan never collected the
+	// Namespace object for "unknown-ns".
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+	src := Endpoint{Namespace: "unknown-ns", Name: "client"}
+
+	v, _, ingress := idx.Reaches(src, dst, nil)
+	if v != Unknown {
+		t.Errorf("verdict = %v, want Unknown (can't evaluate namespaceSelector without that namespace's labels)", v)
+	}
+	if ingress.Verdict != Unknown {
+		t.Errorf("ingress decision = %v, want Unknown", ingress.Verdict)
+	}
+}
+
+func TestReaches_EmptyNamespaceSelectorMatchesEverythingEvenIfUncollected(t *testing.T) {
+	allow := policy("ns", "allow-from-any-ns", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{}}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil) // no namespaces collected at all
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+	src := Endpoint{Namespace: "any-uncollected-ns", Name: "client"}
+
+	v, _, _ := idx.Reaches(src, dst, nil)
+	if v != Allowed {
+		t.Errorf("verdict = %v, want Allowed: an empty namespaceSelector matches every namespace regardless of label data", v)
+	}
+}
+
+func TestReaches_EmptyFromListMatchesNoOne(t *testing.T) {
+	// A rule with an explicit, empty from list ([]NetworkPolicyPeer{}) is a
+	// different Go value than a nil slice, but Kubernetes treats both the
+	// same: len(from) == 0 means "matches all sources." Confirm this
+	// package does too, rather than accidentally treating empty-but-non-nil
+	// as "matches nobody."
+	allow := policy("ns", "allow-empty-from", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{}}}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	src := Endpoint{Namespace: "ns", Name: "anyone"}
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	if v, _, _ := idx.Reaches(src, dst, nil); v != Allowed {
+		t.Errorf("verdict = %v, want Allowed: an empty (non-nil) from list still matches all sources", v)
+	}
+}
+
+func TestReaches_MultipleRulesOnOnePolicyAreOR(t *testing.T) {
+	allow := policy("ns", "two-rules", selector("app", "server"),
+		[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "a"))}}},
+			{From: []networkingv1.NetworkPolicyPeer{{PodSelector: podSelectorPtr(selector("app", "b"))}}},
+		}, nil)
+	idx := NewIndex([]*networkingv1.NetworkPolicy{allow}, nil)
+	dst := Endpoint{Namespace: "ns", Name: "server", Labels: map[string]string{"app": "server"}}
+
+	a := Endpoint{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "a"}}
+	b := Endpoint{Namespace: "ns", Name: "b", Labels: map[string]string{"app": "b"}}
+
+	if v, _, _ := idx.Reaches(a, dst, nil); v != Allowed {
+		t.Errorf("rule 1 should allow app=a: verdict = %v", v)
+	}
+	if v, _, _ := idx.Reaches(b, dst, nil); v != Allowed {
+		t.Errorf("rule 2 should allow app=b: verdict = %v", v)
+	}
+}
+
+func podSelectorPtr(s metav1.LabelSelector) *metav1.LabelSelector       { return &s }
+func namespaceSelectorPtr(s metav1.LabelSelector) *metav1.LabelSelector { return &s }


### PR DESCRIPTION
## Summary

- Adds `core/pkg/networkpolicy`, a static model that evaluates every `NetworkPolicy` in a cluster together to answer whether a specific source pod can reach a specific destination pod (optionally on a given port/protocol) — implementing Kubernetes' own `policyTypes` defaulting, peer matching (`podSelector`/`namespaceSelector`/`ipBlock`, and their AND/OR combinations), port matching (including `endPort` ranges), and the AND-composition of source egress with destination ingress that real reachability requires.
- Answers use a three-valued verdict (`allowed`/`denied`/`unknown`) instead of a boolean, since named container ports, unresolved pod IPs, and uncollected namespace labels are genuinely indeterminate from a static model and should be reported honestly rather than guessed.
- Exposes this as a new MCP tool, `analyze_network_reachability`, wired into `mcpServerEntrypoint` alongside the existing network scanning tools.

## Motivation

Existing tooling (`run_network_security_scan`, control C-0030) only checks whether *some* NetworkPolicy exists for a workload, not whether a specific connection is actually allowed. Issue #2511's original ask ("map network reachability" / understand blast radius) was never delivered — this closes that gap directly. See #3600.

## Test plan

- [x] `core/pkg/networkpolicy`: unit tests covering `policyTypes` defaulting, isolation, every peer-matching case (ipBlock w/ except, namespaceSelector+podSelector AND, namespaceSelector-only, podSelector-only same-namespace, empty/nil peer lists), port matching (numeric, ranges via `endPort`, named ports → unknown), and end-to-end `Reaches` scenarios including the AND-composition across both directions.
- [x] `cmd/mcpserver`: 5 tests exercising `analyze_network_reachability` through the real MCP JSON-RPC dispatch layer against a fake dynamic client (default-deny, allowed peer, port respected, missing args, no-policies-allows-by-default).
- [x] `go build ./...`, `go vet ./...`, full `go test ./...`, `go test -race` on the touched packages, `golangci-lint run --new-from-rev=upstream/master ./...` — all clean.
- [x] Live-cluster verification: ran this against a real kind cluster with a genuine apiserver. Applied a real `NetworkPolicy` (allow-from-client on `server`) plus three real `Pod` objects (`client`, `server`, `untrusted`) in a real namespace, then ran `FromResources`/`NewIndex`/`Reaches` against the actual apiserver-served objects (not fakes): `client -> server` correctly resolved to `allowed` (matched the real policy's peer rule) and `untrusted -> server` correctly resolved to `denied` (isolated, no matching peer). This confirms the model correctly collects and interprets real `NetworkPolicy`/`Pod`/`Namespace` objects end-to-end. It does **not** verify actual traffic enforcement by a live CNI (kind's default `kindnet` does not enforce `NetworkPolicy` at all) — that remains explicitly out of scope by design, since this is a static model computed from spec, the same trust model the rest of kubescape's posture scanning uses (see the package doc comment).

Closes #3600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network reachability analysis for Kubernetes workloads.
  * Reports whether a source can reach a destination, including ingress and egress decisions, reasons, matched policies, and warnings.
  * Supports optional port and protocol checks, selectors, IP blocks, exceptions, and port ranges.
  * Handles uncertain results when required network information cannot be determined.

* **Tests**
  * Added coverage for default allow/deny behavior, selectors, ports, IP blocks, isolation, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
