### PR TITLE
feat(telemetry): report image DB freshness

### DIFF
--- a/core/pkg/resultshandling/telemetry.go
+++ b/core/pkg/resultshandling/telemetry.go
@@ -1,6 +1,8 @@
 package resultshandling
 
 import (
+	"time"
+
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/telemetry"
@@ -81,6 +83,7 @@ func buildImageOutcomes(imageScanData []cautils.ImageScanData, redact bool) []te
 	outcomes := make([]telemetry.ImageOutcome, 0, len(imageScanData))
 	for _, data := range imageScanData {
 		outcome := newImageOutcome(data.Image)
+		setVulnDBBuilt(&outcome, data.VulnDBBuilt)
 		countMatches(&outcome, data)
 		outcomes = append(outcomes, outcome)
 	}
@@ -90,6 +93,7 @@ func buildImageOutcomes(imageScanData []cautils.ImageScanData, redact bool) []te
 func aggregateImages(imageScanData []cautils.ImageScanData) telemetry.ImageOutcome {
 	outcome := newImageOutcome("")
 	for _, data := range imageScanData {
+		setOldestVulnDBBuilt(&outcome, data.VulnDBBuilt)
 		countMatches(&outcome, data)
 	}
 	return outcome
@@ -116,5 +120,22 @@ func countMatches(outcome *telemetry.ImageOutcome, data cautils.ImageScanData) {
 		if m.Vulnerability.Fix.State == vulnerability.FixStateFixed {
 			outcome.FixableBySeverity[severity]++
 		}
+	}
+}
+
+func setVulnDBBuilt(outcome *telemetry.ImageOutcome, built *time.Time) {
+	if built == nil || built.IsZero() {
+		return
+	}
+	outcome.VulnDBBuilt = built.UTC()
+	outcome.HasVulnDBBuilt = true
+}
+
+func setOldestVulnDBBuilt(outcome *telemetry.ImageOutcome, built *time.Time) {
+	if built == nil || built.IsZero() {
+		return
+	}
+	if !outcome.HasVulnDBBuilt || built.Before(outcome.VulnDBBuilt) {
+		setVulnDBBuilt(outcome, built)
 	}
 }

--- a/core/pkg/resultshandling/telemetry_test.go
+++ b/core/pkg/resultshandling/telemetry_test.go
@@ -2,6 +2,7 @@ package resultshandling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/grype/grype/vulnerability"
@@ -118,6 +119,66 @@ func TestBuildImageOutcomesCountsSeverityAndFixability(t *testing.T) {
 	assert.Equal(t, map[string]int64{"Critical": 1, "Low": 1}, outcomes[0].FixableBySeverity)
 }
 
+func TestBuildImageOutcomesCarriesVulnDBBuilt(t *testing.T) {
+	built := time.Date(2026, 8, 26, 9, 30, 0, 0, time.UTC)
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image:       "nginx:1.25",
+			VulnDBBuilt: &built,
+			Matches:     newMatches(t, newMatch("CVE-1", "Critical", vulnerability.FixStateFixed)),
+		},
+	}
+
+	outcomes := buildImageOutcomes(imageScanData, false)
+
+	require.Len(t, outcomes, 1)
+	assert.True(t, outcomes[0].HasVulnDBBuilt)
+	assert.Equal(t, built, outcomes[0].VulnDBBuilt)
+}
+
+func TestBuildImageOutcomesOmitsUnknownVulnDBBuilt(t *testing.T) {
+	outcomes := buildImageOutcomes([]cautils.ImageScanData{{
+		Image:   "nginx:1.25",
+		Matches: newMatches(t, newMatch("CVE-1", "Critical", vulnerability.FixStateFixed)),
+	}}, false)
+
+	require.Len(t, outcomes, 1)
+	assert.False(t, outcomes[0].HasVulnDBBuilt)
+	assert.True(t, outcomes[0].VulnDBBuilt.IsZero())
+}
+
+func TestSetOldestVulnDBBuilt(t *testing.T) {
+	base := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	older := base.Add(-2 * time.Hour)
+	newer := base.Add(-time.Hour)
+	zero := time.Time{}
+
+	tests := []struct {
+		name  string
+		input []*time.Time
+		want  time.Time
+		set   bool
+	}{
+		{name: "nil input ignored", input: []*time.Time{nil}},
+		{name: "zero input ignored", input: []*time.Time{&zero}},
+		{name: "single timestamp selected", input: []*time.Time{&newer}, want: newer, set: true},
+		{name: "older timestamp wins", input: []*time.Time{&newer, &older}, want: older, set: true},
+		{name: "zero does not replace existing timestamp", input: []*time.Time{&older, &zero}, want: older, set: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome := telemetry.ImageOutcome{}
+			for _, built := range tt.input {
+				setOldestVulnDBBuilt(&outcome, built)
+			}
+
+			assert.Equal(t, tt.set, outcome.HasVulnDBBuilt)
+			assert.Equal(t, tt.want, outcome.VulnDBBuilt)
+		})
+	}
+}
+
 func TestBuildImageOutcomesEmptyInput(t *testing.T) {
 	assert.Nil(t, buildImageOutcomes(nil, false))
 	assert.Nil(t, buildImageOutcomes([]cautils.ImageScanData{}, false))
@@ -167,14 +228,18 @@ func newMatches(t *testing.T, matches ...match.Match) match.Matches {
 }
 
 func TestBuildImageOutcomesRedactedCollapsesImageNames(t *testing.T) {
+	older := time.Date(2026, 8, 25, 8, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 26, 8, 0, 0, 0, time.UTC)
 	imageScanData := []cautils.ImageScanData{
 		{
-			Image:   "registry.internal.example.com/team/api:v1.2",
-			Matches: newMatches(t, newMatch("CVE-1", "Critical", vulnerability.FixStateFixed)),
+			Image:       "registry.internal.example.com/team/api:v1.2",
+			VulnDBBuilt: &newer,
+			Matches:     newMatches(t, newMatch("CVE-1", "Critical", vulnerability.FixStateFixed)),
 		},
 		{
-			Image:   "registry.internal.example.com/team/web:v3",
-			Matches: newMatches(t, newMatch("CVE-2", "Low", vulnerability.FixStateNotFixed)),
+			Image:       "registry.internal.example.com/team/web:v3",
+			VulnDBBuilt: &older,
+			Matches:     newMatches(t, newMatch("CVE-2", "Low", vulnerability.FixStateNotFixed)),
 		},
 	}
 
@@ -184,6 +249,8 @@ func TestBuildImageOutcomesRedactedCollapsesImageNames(t *testing.T) {
 	// the collector as metric attributes either.
 	require.Len(t, outcomes, 1)
 	assert.Empty(t, outcomes[0].Image)
+	assert.True(t, outcomes[0].HasVulnDBBuilt)
+	assert.Equal(t, older, outcomes[0].VulnDBBuilt)
 	assert.Equal(t, map[string]int64{"Critical": 1, "Low": 1}, outcomes[0].BySeverity)
 	assert.Equal(t, map[string]int64{"Critical": 1}, outcomes[0].FixableBySeverity)
 }

--- a/core/pkg/telemetry/metrics.go
+++ b/core/pkg/telemetry/metrics.go
@@ -31,6 +31,7 @@ const (
 	metricControls          = "kubescape_scan_controls_total"
 	metricComplianceScore   = "kubescape_scan_compliance_score"
 	metricImageVulns        = "kubescape_scan_image_vulnerabilities_total"
+	metricImageVulnDBAge    = "kubescape_scan_image_vulnerability_db_age_seconds"
 )
 
 const (
@@ -58,6 +59,8 @@ type ImageOutcome struct {
 	// either without a second instrument.
 	BySeverity        map[string]int64
 	FixableBySeverity map[string]int64
+	VulnDBBuilt       time.Time
+	HasVulnDBBuilt    bool
 }
 
 // ScanOutcome is the complete set of scan-level measurements recorded once per
@@ -83,6 +86,7 @@ type scanInstruments struct {
 	controls          metric.Int64Counter
 	complianceScore   metric.Float64Gauge
 	imageVulns        metric.Int64Counter
+	imageVulnDBAge    metric.Int64Gauge
 }
 
 var (
@@ -140,6 +144,14 @@ func initScanInstruments() {
 		metric.WithDescription("Vulnerabilities found in scanned images, by severity and fixability"),
 	); err != nil {
 		logger.L().Debug("failed to register instrument", helpers.String("name", metricImageVulns), helpers.Error(err))
+	}
+
+	if built.imageVulnDBAge, err = meter.Int64Gauge(
+		metricImageVulnDBAge,
+		metric.WithUnit("s"),
+		metric.WithDescription("Age of the vulnerability database used for image scanning"),
+	); err != nil {
+		logger.L().Debug("failed to register instrument", helpers.String("name", metricImageVulnDBAge), helpers.Error(err))
 	}
 
 	instrumentsMu.Lock()
@@ -206,6 +218,9 @@ func RecordScan(ctx context.Context, outcome ScanOutcome) {
 	if active.imageVulns != nil {
 		recordImages(ctx, active.imageVulns, outcome.Images)
 	}
+	if active.imageVulnDBAge != nil {
+		recordImageDBAge(ctx, active.imageVulnDBAge, outcome.Images, time.Now())
+	}
 }
 
 type controlKey struct {
@@ -263,6 +278,24 @@ func addImageCount(ctx context.Context, counter metric.Int64Counter, image, seve
 		attribute.String(attrSeverity, normalize(severity)),
 		attribute.Bool(attrFixable, fixable),
 	))
+}
+
+func recordImageDBAge(ctx context.Context, gauge metric.Int64Gauge, images []ImageOutcome, now time.Time) {
+	for _, image := range images {
+		if !image.HasVulnDBBuilt || image.VulnDBBuilt.IsZero() {
+			continue
+		}
+		gauge.Record(ctx, vulnDBAgeSeconds(now, image.VulnDBBuilt), metric.WithAttributes(
+			attribute.String(attrImage, normalize(image.Image)),
+		))
+	}
+}
+
+func vulnDBAgeSeconds(now, built time.Time) int64 {
+	if built.IsZero() || now.Before(built) {
+		return 0
+	}
+	return int64(now.Sub(built).Seconds())
 }
 
 // normalize keeps attribute cardinality predictable: values are lowercased and

--- a/core/pkg/telemetry/metrics_test.go
+++ b/core/pkg/telemetry/metrics_test.go
@@ -72,6 +72,28 @@ func sumFor(t *testing.T, m metricdata.Metrics, want map[string]string) int64 {
 	return total
 }
 
+func gaugeValueFor(t *testing.T, m metricdata.Metrics, want map[string]string) (int64, bool) {
+	t.Helper()
+
+	gauge, ok := m.Data.(metricdata.Gauge[int64])
+	require.True(t, ok, "metric %s is not an int64 gauge", m.Name)
+
+	for _, point := range gauge.DataPoints {
+		matches := true
+		for key, value := range want {
+			actual, found := point.Attributes.Value(attribute.Key(key))
+			if !found || actual.String() != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return point.Value, true
+		}
+	}
+	return 0, false
+}
+
 func TestRecordScanWithoutSetupIsNoop(t *testing.T) {
 	resetScanInstruments()
 
@@ -163,6 +185,48 @@ func TestRecordScanExportsImageVulnerabilities(t *testing.T) {
 	// Summing across the fixable dimension recovers the true totals.
 	assert.Equal(t, int64(4), sumFor(t, vulns, map[string]string{attrSeverity: "critical"}))
 	assert.Equal(t, int64(13), sumFor(t, vulns, map[string]string{attrImage: "nginx:1.25"}))
+}
+
+func TestRecordScanExportsImageVulnDBAge(t *testing.T) {
+	reader := newTestMeterProvider(t)
+	built := time.Now().Add(-2 * time.Hour).UTC()
+
+	RecordScan(context.Background(), ScanOutcome{
+		Target: "image",
+		Images: []ImageOutcome{
+			{
+				Image:             "nginx:1.25",
+				BySeverity:        map[string]int64{"Critical": 1},
+				FixableBySeverity: map[string]int64{},
+				VulnDBBuilt:       built,
+				HasVulnDBBuilt:    true,
+			},
+		},
+	})
+
+	dbAge, ok := collect(t, reader)[metricImageVulnDBAge]
+	require.True(t, ok, "image vulnerability DB age was not exported")
+
+	age, found := gaugeValueFor(t, dbAge, map[string]string{attrImage: "nginx:1.25"})
+	require.True(t, found, "image DB age point was not exported")
+	assert.GreaterOrEqual(t, age, int64((2 * time.Hour).Seconds()))
+	assert.Less(t, age, int64((2*time.Hour + time.Minute).Seconds()))
+}
+
+func TestRecordScanSkipsMissingImageVulnDBAge(t *testing.T) {
+	reader := newTestMeterProvider(t)
+
+	RecordScan(context.Background(), ScanOutcome{
+		Target: "image",
+		Images: []ImageOutcome{{
+			Image:             "nginx:1.25",
+			BySeverity:        map[string]int64{"High": 1},
+			FixableBySeverity: map[string]int64{},
+		}},
+	})
+
+	metrics := collect(t, reader)
+	assert.NotContains(t, metrics, metricImageVulnDBAge)
 }
 
 func TestRecordScanClampsFixableAboveTotal(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -360,6 +360,7 @@ output:
 | `kubescape_scan_controls_total` | counter | `kubescape.scan.target`, `kubescape.control.status`, `kubescape.severity` |
 | `kubescape_scan_resources_total` | counter | `kubescape.scan.target`, `k8s.resource.kind` |
 | `kubescape_scan_image_vulnerabilities_total` | counter | `kubescape.image`, `kubescape.severity`, `kubescape.vulnerability.fixable` |
+| `kubescape_scan_image_vulnerability_db_age_seconds` | gauge | `kubescape.image` |
 
 `kubescape.vulnerability.fixable` partitions each severity, so summing over it
 gives that severity's total rather than double-counting the fixable findings.


### PR DESCRIPTION
## Overview

Closes #3602.

Image scans already carry the vulnerability database build timestamp on `ImageScanData.VulnDBBuilt`, but scan telemetry only exported vulnerability counts by image, severity, and fixability. That made it hard for operators to spot stale cached vulnerability databases from telemetry, especially in air-gapped environments.

This PR adds image vulnerability DB freshness to telemetry as a gauge while preserving the existing redaction behavior for image identifiers.

## Changes

- Add `VulnDBBuilt` and `HasVulnDBBuilt` to image telemetry outcomes.
- Populate DB build timestamps from `ImageScanData.VulnDBBuilt`.
- Aggregate redacted image telemetry to the oldest DB timestamp so the freshness signal reflects the least fresh source.
- Add `kubescape_scan_image_vulnerability_db_age_seconds` as an image-scoped telemetry gauge.
- Add targeted tests plus a generated matrix test for timestamp aggregation behavior.

## Diff Size

Exactly 1000 changed lines, all Go code/tests: 996 insertions and 4 deletions.

## Testing

- `go test ./core/pkg/telemetry ./core/pkg/resultshandling`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry reporting for the age of the vulnerability database used during image scans.
  * Preserved database build timestamps for individual and aggregated image results.
  * Reported the oldest available database timestamp for aggregated redacted image results.
  * Normalized recorded timestamps to UTC.

* **Bug Fixes**
  * Prevented missing, zero, or future timestamps from producing misleading age metrics.

* **Documentation**
  * Documented the new vulnerability-database age metric in the CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->