### PR TITLE
feat(mapreconcile): add MutatingAdmissionPolicy discovery and impact matching

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -1329,6 +1329,7 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createRBACScanningTools(ksServer)
 	createNetworkScanningTools(ksServer)
 	createNetworkReachabilityTools(ksServer)
+	createMutatingAdmissionPolicyTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)

--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -1,0 +1,176 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/mapreconcile"
+	"github.com/mark3labs/mcp-go/mcp"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var namespaceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+
+var mutatingAdmissionPolicyOperations = map[string]admissionregistrationv1alpha1.OperationType{
+	"CREATE":  admissionregistrationv1alpha1.Create,
+	"UPDATE":  admissionregistrationv1alpha1.Update,
+	"CONNECT": admissionregistrationv1alpha1.Connect,
+}
+
+// createMutatingAdmissionPolicyTools registers
+// analyze_mutating_admission_policy_impact, which reports which of a
+// cluster's live MutatingAdmissionPolicy objects would mutate a specific
+// resource -- and with what raw CEL mutation expression -- surfacing
+// implicit, in-cluster mutation that never appears in the manifest a user
+// applied. See core/pkg/mapreconcile for the matching model and its
+// documented limits (it reports a match and its expression, it does not
+// evaluate the expression to compute the mutated object).
+func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
+	tool := mcp.NewTool(
+		"analyze_mutating_admission_policy_impact",
+		mcp.WithDescription("Determine which of the cluster's live MutatingAdmissionPolicy objects would mutate a specific resource on a given operation (default CREATE), and what each one's raw CEL mutation expression is. This surfaces implicit mutation that happens at admission time and never appears in the manifest a user applied -- it reports that a policy's mutation would run and what its expression is, it does not evaluate the expression to compute the resulting object."),
+		mcp.WithString("namespace", mcp.Description("Namespace of the resource (omit for a cluster-scoped resource)")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the resource")),
+		mcp.WithString("api_group", mcp.Description("API group of the resource (omit or empty for the core group, e.g. Pod/ConfigMap)")),
+		mcp.WithString("api_version", mcp.Required(), mcp.Description("API version of the resource, e.g. v1")),
+		mcp.WithString("resource", mcp.Required(), mcp.Description("Plural resource name, e.g. pods, deployments")),
+		mcp.WithString("operation", mcp.Description("Admission operation to check: CREATE, UPDATE, or CONNECT (default CREATE)")),
+		mcp.WithBoolean("cluster_scoped", mcp.Description("Set true for a cluster-scoped resource (namespace is ignored, and any namespaceSelector is treated as non-restricting, matching the Kubernetes API's own documented behavior)")),
+	)
+
+	ksServer.s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok || args == nil {
+			args = map[string]any{}
+		}
+
+		name, ok := args["name"].(string)
+		if !ok || name == "" {
+			return mcp.NewToolResultError("name is required"), nil
+		}
+		apiVersion, ok := args["api_version"].(string)
+		if !ok || apiVersion == "" {
+			return mcp.NewToolResultError("api_version is required"), nil
+		}
+		resource, ok := args["resource"].(string)
+		if !ok || resource == "" {
+			return mcp.NewToolResultError("resource is required"), nil
+		}
+		apiGroup, _ := args["api_group"].(string)
+		namespace, _ := args["namespace"].(string)
+		clusterScoped, _ := args["cluster_scoped"].(bool)
+
+		operation := admissionregistrationv1alpha1.Create
+		if rawOp, ok := args["operation"].(string); ok && rawOp != "" {
+			normalized := strings.ToUpper(rawOp)
+			op, known := mutatingAdmissionPolicyOperations[normalized]
+			if !known {
+				return mcp.NewToolResultError(fmt.Sprintf("operation must be one of CREATE, UPDATE, CONNECT (got %q)", rawOp)), nil
+			}
+			operation = op
+		}
+
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+		}
+
+		policies, bindings, decodeErrs, err := mapreconcile.Collect(ctx, k8sClient)
+		if err != nil {
+			if errors.Is(err, mapreconcile.ErrUnsupported) {
+				return mcp.NewToolResultText(`{"supported":false,"reason":"cluster does not serve MutatingAdmissionPolicy resources"}`), nil
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("failed to collect MutatingAdmissionPolicy resources: %v", err)), nil
+		}
+
+		if !clusterScoped && namespace == "" {
+			return mcp.NewToolResultError("namespace is required unless cluster_scoped is true"), nil
+		}
+
+		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
+		dynClient := k8sClient.DynamicClient
+
+		resourceInterface := dynClient.Resource(gvr)
+		var obj *unstructured.Unstructured
+		var getErr error
+		if clusterScoped {
+			obj, getErr = resourceInterface.Get(ctx, name, metav1.GetOptions{})
+		} else {
+			obj, getErr = resourceInterface.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		}
+		if getErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get resource %s/%s (%s): %v", namespace, name, gvr.String(), getErr)), nil
+		}
+
+		info := mapreconcile.ObjectInfo{
+			Group:         apiGroup,
+			Version:       apiVersion,
+			Resource:      resource,
+			Namespace:     namespace,
+			Labels:        obj.GetLabels(),
+			Operation:     operation,
+			ClusterScoped: clusterScoped,
+		}
+
+		if !clusterScoped {
+			nsObj, nsErr := dynClient.Resource(namespaceGVR).Get(ctx, namespace, metav1.GetOptions{})
+			if nsErr == nil {
+				info.NamespaceLabels = nsObj.GetLabels()
+				info.NamespaceLabelsKnown = true
+			} else if !apierrors.IsNotFound(nsErr) {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get namespace %s: %v", namespace, nsErr)), nil
+			}
+		}
+
+		idx, indexErrs := mapreconcile.NewIndex(policies, bindings)
+		matches := idx.Matches(info)
+
+		result := map[string]any{
+			"supported": true,
+			"matches":   buildMatchSummaries(matches),
+		}
+		allWarnings := append(append([]error{}, decodeErrs...), indexErrs...)
+		if len(allWarnings) > 0 {
+			msgs := make([]string, len(allWarnings))
+			for i, e := range allWarnings {
+				msgs[i] = e.Error()
+			}
+			result["decode_warnings"] = msgs
+		}
+
+		resBytes, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(resBytes)), nil
+	})
+}
+
+func buildMatchSummaries(matches []mapreconcile.MatchedPolicy) []map[string]any {
+	out := make([]map[string]any, 0, len(matches))
+	for _, m := range matches {
+		mutations := make([]map[string]any, 0, len(m.Mutations))
+		for _, mut := range m.Mutations {
+			mutations = append(mutations, map[string]any{
+				"patch_type": string(mut.PatchType),
+				"expression": mut.Expression,
+			})
+		}
+		out = append(out, map[string]any{
+			"policy_name":    m.PolicyName,
+			"binding_name":   m.BindingName,
+			"mutations":      mutations,
+			"failure_policy": string(m.FailurePolicy),
+			"has_params":     m.HasParams,
+			"determinable":   m.Determinable,
+		})
+	}
+	return out
+}

--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var namespaceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
-
 var mutatingAdmissionPolicyOperations = map[string]admissionregistrationv1alpha1.OperationType{
 	"CREATE":  admissionregistrationv1alpha1.Create,
 	"UPDATE":  admissionregistrationv1alpha1.Update,
@@ -67,6 +65,19 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		namespace, _ := args["namespace"].(string)
 		clusterScoped, _ := args["cluster_scoped"].(bool)
 
+		// A Namespace object is itself cluster-scoped ("Namespace API
+		// objects are cluster-scoped", per Rule.Scope's own doc comment)
+		// regardless of what the caller passed for cluster_scoped, and its
+		// namespaceSelector matching is special (see mapreconcile.ObjectInfo
+		// .IsNamespaceObject) -- so this is derived from the real API shape,
+		// not trusted from the argument.
+		isNamespaceResource := apiGroup == "" && resource == "namespaces"
+		effectiveClusterScoped := clusterScoped || isNamespaceResource
+
+		if !effectiveClusterScoped && namespace == "" {
+			return mcp.NewToolResultError("namespace is required unless cluster_scoped is true"), nil
+		}
+
 		operation := admissionregistrationv1alpha1.Create
 		if rawOp, ok := args["operation"].(string); ok && rawOp != "" {
 			normalized := strings.ToUpper(rawOp)
@@ -90,17 +101,13 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to collect MutatingAdmissionPolicy resources: %v", err)), nil
 		}
 
-		if !clusterScoped && namespace == "" {
-			return mcp.NewToolResultError("namespace is required unless cluster_scoped is true"), nil
-		}
-
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 		dynClient := k8sClient.DynamicClient
 
 		resourceInterface := dynClient.Resource(gvr)
 		var obj *unstructured.Unstructured
 		var getErr error
-		if clusterScoped {
+		if effectiveClusterScoped {
 			obj, getErr = resourceInterface.Get(ctx, name, metav1.GetOptions{})
 		} else {
 			obj, getErr = resourceInterface.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -110,16 +117,18 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		}
 
 		info := mapreconcile.ObjectInfo{
-			Group:         apiGroup,
-			Version:       apiVersion,
-			Resource:      resource,
-			Namespace:     namespace,
-			Labels:        obj.GetLabels(),
-			Operation:     operation,
-			ClusterScoped: clusterScoped,
+			Group:             apiGroup,
+			Version:           apiVersion,
+			Resource:          resource,
+			Name:              name,
+			Namespace:         namespace,
+			Labels:            obj.GetLabels(),
+			Operation:         operation,
+			ClusterScoped:     effectiveClusterScoped,
+			IsNamespaceObject: isNamespaceResource,
 		}
 
-		if !clusterScoped {
+		if !effectiveClusterScoped {
 			nsObj, nsErr := dynClient.Resource(namespaceGVR).Get(ctx, namespace, metav1.GetOptions{})
 			if nsErr == nil {
 				info.NamespaceLabels = nsObj.GetLabels()

--- a/cmd/mcpserver/mutating_policy_impact_test.go
+++ b/cmd/mcpserver/mutating_policy_impact_test.go
@@ -1,0 +1,292 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var (
+	mutatingAdmissionPolicyGVR        = schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicies"}
+	mutatingAdmissionPolicyBindingGVR = schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicybindings"}
+	testPodGVR                        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+)
+
+func unstructuredTestPod(namespace, name string, labels map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	if labels != nil {
+		obj["metadata"].(map[string]any)["labels"] = labels
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newMutatingPolicyTestServer(t *testing.T, objects ...runtime.Object) *KubescapeMcpserver {
+	t.Helper()
+	listKinds := map[schema.GroupVersionResource]string{
+		mutatingAdmissionPolicyGVR:        "MutatingAdmissionPolicyList",
+		mutatingAdmissionPolicyBindingGVR: "MutatingAdmissionPolicyBindingList",
+		namespaceGVR:                      "NamespaceList",
+		testPodGVR:                        "PodList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+
+	discovery := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	discovery.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "admissionregistration.k8s.io/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{Name: "mutatingadmissionpolicies", Kind: "MutatingAdmissionPolicy"},
+			{Name: "mutatingadmissionpolicybindings", Kind: "MutatingAdmissionPolicyBinding"},
+		},
+	}}
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn, DiscoveryClient: discovery},
+	}
+	createMutatingAdmissionPolicyTools(ksServer)
+	return ksServer
+}
+
+func unstructuredMutatingPolicy(name string, matchConstraints map[string]any, mutations ...map[string]any) *unstructured.Unstructured {
+	spec := map[string]any{
+		"matchConstraints": matchConstraints,
+	}
+	if len(mutations) > 0 {
+		muts := make([]any, len(mutations))
+		for i, m := range mutations {
+			muts[i] = m
+		}
+		spec["mutations"] = muts
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1alpha1",
+		"kind":       "MutatingAdmissionPolicy",
+		"metadata":   map[string]any{"name": name},
+		"spec":       spec,
+	}}
+}
+
+func unstructuredMutatingPolicyBinding(name, policyName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1alpha1",
+		"kind":       "MutatingAdmissionPolicyBinding",
+		"metadata":   map[string]any{"name": name},
+		"spec":       map[string]any{"policyName": policyName},
+	}}
+}
+
+func allPodsMatchConstraints() map[string]any {
+	return map[string]any{
+		"resourceRules": []any{
+			map[string]any{
+				"apiGroups":   []any{""},
+				"apiVersions": []any{"v1"},
+				"resources":   []any{"pods"},
+				"operations":  []any{"*"},
+			},
+		},
+	}
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_UnboundPolicyIsNotReported(t *testing.T) {
+	policy := unstructuredMutatingPolicy("add-label", allPodsMatchConstraints(),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, pod)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.True(t, parsed["supported"].(bool))
+	require.Empty(t, parsed["matches"])
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_BoundPolicyMatchingResourceIsReported(t *testing.T) {
+	policy := unstructuredMutatingPolicy("add-label", allPodsMatchConstraints(),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("add-label-binding", "add-label")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	matches, ok := parsed["matches"].([]any)
+	require.True(t, ok)
+	require.Len(t, matches, 1)
+	m := matches[0].(map[string]any)
+	require.Equal(t, "add-label", m["policy_name"])
+	require.Equal(t, "add-label-binding", m["binding_name"])
+	mutations := m["mutations"].([]any)
+	require.Len(t, mutations, 1)
+	require.Equal(t, "JSONPatch", mutations[0].(map[string]any)["patch_type"])
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_NonMatchingResourceExcludesPolicy(t *testing.T) {
+	configmapsOnly := map[string]any{
+		"resourceRules": []any{
+			map[string]any{
+				"apiGroups":   []any{""},
+				"apiVersions": []any{"v1"},
+				"resources":   []any{"configmaps"},
+				"operations":  []any{"*"},
+			},
+		},
+	}
+	policy := unstructuredMutatingPolicy("configmap-only", configmapsOnly)
+	binding := unstructuredMutatingPolicyBinding("b", "configmap-only")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Empty(t, parsed["matches"])
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_MissingRequiredArgumentsReturnError(t *testing.T) {
+	ksServer := newMutatingPolicyTestServer(t)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace": "prod",
+		// name, api_version, resource deliberately omitted
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_InvalidOperationReturnsError(t *testing.T) {
+	ksServer := newMutatingPolicyTestServer(t)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+		"operation":   "DELETE",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_UnsupportedClusterReportsNotSupported(t *testing.T) {
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+	ksServer := newMutatingPolicyTestServer(t, pod)
+	// Override discovery so the API is not served at all.
+	ksServer.k8sClient.DiscoveryClient = &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.False(t, parsed["supported"].(bool))
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_ClusterScopedResourceIgnoresNamespace(t *testing.T) {
+	policy := unstructuredMutatingPolicy("add-label-cr", map[string]any{
+		"resourceRules": []any{
+			map[string]any{
+				"apiGroups":   []any{"rbac.authorization.k8s.io"},
+				"apiVersions": []any{"v1"},
+				"resources":   []any{"clusterroles"},
+				"operations":  []any{"*"},
+			},
+		},
+		"namespaceSelector": map[string]any{"matchLabels": map[string]any{"env": "prod"}},
+	},
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("b", "add-label-cr")
+	clusterRoleGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	clusterRole := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": "my-role"},
+	}}
+
+	listKinds := map[schema.GroupVersionResource]string{
+		mutatingAdmissionPolicyGVR:        "MutatingAdmissionPolicyList",
+		mutatingAdmissionPolicyBindingGVR: "MutatingAdmissionPolicyBindingList",
+		clusterRoleGVR:                    "ClusterRoleList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, policy, binding, clusterRole)
+	discovery := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	discovery.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "admissionregistration.k8s.io/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{Name: "mutatingadmissionpolicies", Kind: "MutatingAdmissionPolicy"},
+			{Name: "mutatingadmissionpolicybindings", Kind: "MutatingAdmissionPolicyBinding"},
+		},
+	}}
+	ksServer := &KubescapeMcpserver{
+		s:         server.NewMCPServer("kubescape-test", "test", server.WithToolCapabilities(false), server.WithRecovery()),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn, DiscoveryClient: discovery},
+	}
+	createMutatingAdmissionPolicyTools(ksServer)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"name":           "my-role",
+		"api_group":      "rbac.authorization.k8s.io",
+		"api_version":    "v1",
+		"resource":       "clusterroles",
+		"cluster_scoped": true,
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	matches := parsed["matches"].([]any)
+	require.Len(t, matches, 1, "namespaceSelector must not skip a cluster-scoped resource even with no namespace given")
+}

--- a/cmd/mcpserver/mutating_policy_impact_test.go
+++ b/cmd/mcpserver/mutating_policy_impact_test.go
@@ -202,6 +202,103 @@ func TestAnalyzeMutatingAdmissionPolicyImpact_MissingRequiredArgumentsReturnErro
 	require.True(t, result.IsError)
 }
 
+func TestAnalyzeMutatingAdmissionPolicyImpact_MissingNamespaceReturnsErrorBeforeAnyClusterCall(t *testing.T) {
+	// No discovery/dynamic resources are registered for the API at all, so if
+	// the namespace-required check ran after Collect(), this would fail with
+	// a "cluster does not serve" or list error instead of the intended
+	// argument-validation error.
+	ksServer := newMutatingPolicyTestServer(t)
+	ksServer.k8sClient.DiscoveryClient = &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+		// namespace omitted, cluster_scoped omitted (false)
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeMutatingAdmissionPolicyImpact_NamespaceObjectMatchesSelectorAgainstOwnLabels(t *testing.T) {
+	policy := unstructuredMutatingPolicy("add-label-to-prod-namespaces", map[string]any{
+		"resourceRules": []any{
+			map[string]any{
+				"apiGroups":   []any{""},
+				"apiVersions": []any{"v1"},
+				"resources":   []any{"namespaces"},
+				"operations":  []any{"*"},
+			},
+		},
+		"namespaceSelector": map[string]any{"matchLabels": map[string]any{"env": "prod"}},
+	},
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("b", "add-label-to-prod-namespaces")
+
+	nsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	prodNS := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "prod",
+			"labels": map[string]any{"env": "prod"},
+		},
+	}}
+	devNS := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   "dev",
+			"labels": map[string]any{"env": "dev"},
+		},
+	}}
+
+	listKinds := map[schema.GroupVersionResource]string{
+		mutatingAdmissionPolicyGVR:        "MutatingAdmissionPolicyList",
+		mutatingAdmissionPolicyBindingGVR: "MutatingAdmissionPolicyBindingList",
+		nsGVR:                             "NamespaceList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, policy, binding, prodNS, devNS)
+	discovery := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	discovery.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "admissionregistration.k8s.io/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{Name: "mutatingadmissionpolicies", Kind: "MutatingAdmissionPolicy"},
+			{Name: "mutatingadmissionpolicybindings", Kind: "MutatingAdmissionPolicyBinding"},
+		},
+	}}
+	ksServer := &KubescapeMcpserver{
+		s:         server.NewMCPServer("kubescape-test", "test", server.WithToolCapabilities(false), server.WithRecovery()),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn, DiscoveryClient: discovery},
+	}
+	createMutatingAdmissionPolicyTools(ksServer)
+
+	// The prod namespace's own labels satisfy the selector: it must match.
+	prodResult := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"name":           "prod",
+		"api_version":    "v1",
+		"resource":       "namespaces",
+		"cluster_scoped": true,
+	}))
+	require.False(t, prodResult.IsError)
+	var prodParsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, prodResult)), &prodParsed))
+	require.Len(t, prodParsed["matches"].([]any), 1, "the prod namespace's own labels satisfy the selector and must match")
+
+	// The dev namespace's own labels do not satisfy the selector: it must be
+	// excluded, not treated as "cluster-scoped, selector doesn't apply".
+	devResult := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"name":           "dev",
+		"api_version":    "v1",
+		"resource":       "namespaces",
+		"cluster_scoped": true,
+	}))
+	require.False(t, devResult.IsError)
+	var devParsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, devResult)), &devParsed))
+	require.Empty(t, devParsed["matches"], "the dev namespace's own labels must exclude it, not bypass the selector as a cluster-scoped object")
+}
+
 func TestAnalyzeMutatingAdmissionPolicyImpact_InvalidOperationReturnsError(t *testing.T) {
 	ksServer := newMutatingPolicyTestServer(t)
 

--- a/core/pkg/mapreconcile/index.go
+++ b/core/pkg/mapreconcile/index.go
@@ -1,0 +1,168 @@
+package mapreconcile
+
+import (
+	"fmt"
+
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+)
+
+// MutationSummary is one Mutation from a matched policy, reported verbatim --
+// see the package doc for why this is not evaluated.
+type MutationSummary struct {
+	PatchType  admissionregistrationv1alpha1.PatchType
+	Expression string
+}
+
+// MatchedPolicy is one MutatingAdmissionPolicy (bound by one binding) whose
+// matchConstraints and matchResources together cover a queried object.
+type MatchedPolicy struct {
+	PolicyName  string
+	BindingName string
+	Mutations   []MutationSummary
+	// FailurePolicy is the policy's own spec.failurePolicy (defaults to Fail
+	// when unset, the same default the API server applies), included because
+	// it changes what "this policy matches" means in practice: Fail means a
+	// broken mutation blocks admission of the object entirely, not just skips
+	// the mutation.
+	FailurePolicy admissionregistrationv1alpha1.FailurePolicyType
+	// HasParams is true when the policy declares a paramKind. This package
+	// does not resolve paramRef, so a matched policy with HasParams true may
+	// in fact be misconfigured (missing/invalid params) and skipped or
+	// denied at admission depending on FailurePolicy -- the match reported
+	// here is necessary but not sufficient in that case.
+	HasParams bool
+	// Determinable is false when this policy's match could not be confirmed
+	// from the data available (see compiledMatchResources.matches): the
+	// caller should treat MatchedPolicy as "might apply," not "does apply."
+	Determinable bool
+}
+
+// compiledPolicy pre-parses one MutatingAdmissionPolicy's matchConstraints,
+// and every binding that names it, once.
+type compiledPolicy struct {
+	policy          admissionregistrationv1alpha1.MutatingAdmissionPolicy
+	matchConstraint *compiledMatchResources
+	bindings        []compiledBinding
+}
+
+type compiledBinding struct {
+	binding       admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding
+	matchResource *compiledMatchResources // nil matchResources on a binding constrains nothing further
+}
+
+// Index indexes a cluster's MutatingAdmissionPolicy and
+// MutatingAdmissionPolicyBinding objects for repeated match queries against
+// the same snapshot.
+type Index struct {
+	policies []*compiledPolicy
+}
+
+// NewIndex builds an Index from a cluster's (or a query's) collected
+// MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding objects. A
+// policy or binding with an unparseable selector is skipped, with its error
+// appended to errs, rather than one malformed object hiding every other
+// policy's match result -- see Collect's doc comment for why silently
+// dropping is the wrong default here.
+func NewIndex(policies []admissionregistrationv1alpha1.MutatingAdmissionPolicy, bindings []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) (idx *Index, errs []error) {
+	idx = &Index{}
+
+	bindingsByPolicy := make(map[string][]admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, len(bindings))
+	for _, b := range bindings {
+		bindingsByPolicy[b.Spec.PolicyName] = append(bindingsByPolicy[b.Spec.PolicyName], b)
+	}
+
+	for _, p := range policies {
+		mc, err := compileMatchResources(p.Spec.MatchConstraints)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("MutatingAdmissionPolicy %s: unparseable matchConstraints, skipped: %w", p.Name, err))
+			continue
+		}
+
+		cp := &compiledPolicy{policy: p, matchConstraint: mc}
+		for _, b := range bindingsByPolicy[p.Name] {
+			var cmr *compiledMatchResources
+			if b.Spec.MatchResources != nil {
+				compiled, err := compileMatchResources(b.Spec.MatchResources)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("MutatingAdmissionPolicyBinding %s: unparseable matchResources, skipped: %w", b.Name, err))
+					continue
+				}
+				cmr = compiled
+			}
+			cp.bindings = append(cp.bindings, compiledBinding{binding: b, matchResource: cmr})
+		}
+		idx.policies = append(idx.policies, cp)
+	}
+
+	return idx, errs
+}
+
+// Matches reports every (policy, binding) pair whose matchConstraints and
+// matchResources both cover obj. A policy with no binding at all never
+// mutates anything -- MutatingAdmissionPolicy, like ValidatingAdmissionPolicy,
+// takes effect only once bound -- so it is silently excluded rather than
+// reported as an unbound near-miss.
+func (idx *Index) Matches(obj ObjectInfo) []MatchedPolicy {
+	var out []MatchedPolicy
+	for _, cp := range idx.policies {
+		policyMatched, policyDeterminable := cp.matchConstraint.matches(obj)
+		if policyDeterminable && !policyMatched {
+			continue
+		}
+
+		for _, cb := range cp.bindings {
+			determinable := policyDeterminable
+			matched := policyMatched
+
+			if cb.matchResource != nil {
+				bMatched, bDeterminable := cb.matchResource.matches(obj)
+				determinable = determinable && bDeterminable
+				matched = matched && bMatched
+				if bDeterminable && !bMatched {
+					// The binding confidently excludes obj regardless of what
+					// the policy side could resolve.
+					continue
+				}
+			}
+			if determinable && !matched {
+				continue
+			}
+
+			out = append(out, MatchedPolicy{
+				PolicyName:    cp.policy.Name,
+				BindingName:   cb.binding.Name,
+				Mutations:     mutationSummaries(cp.policy.Spec.Mutations),
+				FailurePolicy: failurePolicyOrDefault(cp.policy.Spec.FailurePolicy),
+				HasParams:     cp.policy.Spec.ParamKind != nil,
+				Determinable:  determinable,
+			})
+		}
+	}
+	return out
+}
+
+func mutationSummaries(mutations []admissionregistrationv1alpha1.Mutation) []MutationSummary {
+	out := make([]MutationSummary, 0, len(mutations))
+	for _, m := range mutations {
+		s := MutationSummary{PatchType: m.PatchType}
+		switch m.PatchType {
+		case admissionregistrationv1alpha1.PatchTypeApplyConfiguration:
+			if m.ApplyConfiguration != nil {
+				s.Expression = m.ApplyConfiguration.Expression
+			}
+		case admissionregistrationv1alpha1.PatchTypeJSONPatch:
+			if m.JSONPatch != nil {
+				s.Expression = m.JSONPatch.Expression
+			}
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func failurePolicyOrDefault(fp *admissionregistrationv1alpha1.FailurePolicyType) admissionregistrationv1alpha1.FailurePolicyType {
+	if fp == nil {
+		return admissionregistrationv1alpha1.Fail
+	}
+	return *fp
+}

--- a/core/pkg/mapreconcile/index_test.go
+++ b/core/pkg/mapreconcile/index_test.go
@@ -1,0 +1,218 @@
+package mapreconcile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func policy(name string, matchConstraints *admissionregistrationv1alpha1.MatchResources, mutations ...admissionregistrationv1alpha1.Mutation) admissionregistrationv1alpha1.MutatingAdmissionPolicy {
+	return admissionregistrationv1alpha1.MutatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: admissionregistrationv1alpha1.MutatingAdmissionPolicySpec{
+			MatchConstraints: matchConstraints,
+			Mutations:        mutations,
+		},
+	}
+}
+
+func binding(name, policyName string, matchResources *admissionregistrationv1alpha1.MatchResources) admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding {
+	return admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingSpec{
+			PolicyName:     policyName,
+			MatchResources: matchResources,
+		},
+	}
+}
+
+func jsonPatchMutation(expr string) admissionregistrationv1alpha1.Mutation {
+	return admissionregistrationv1alpha1.Mutation{
+		PatchType: admissionregistrationv1alpha1.PatchTypeJSONPatch,
+		JSONPatch: &admissionregistrationv1alpha1.JSONPatch{Expression: expr},
+	}
+}
+
+func allPods() *admissionregistrationv1alpha1.MatchResources {
+	return &admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.OperationAll)},
+	}
+}
+
+func TestMatches_UnboundPolicyNeverReported(t *testing.T) {
+	p := policy("add-label", allPods(), jsonPatchMutation(`[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`))
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, nil)
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	assert.Empty(t, matches, "a policy with no binding must never be reported as matching")
+}
+
+func TestMatches_BoundPolicyMatchingObjectIsReported(t *testing.T) {
+	p := policy("add-label", allPods(), jsonPatchMutation(`[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`))
+	b := binding("add-label-binding", "add-label", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.Equal(t, "add-label", matches[0].PolicyName)
+	assert.Equal(t, "add-label-binding", matches[0].BindingName)
+	require.Len(t, matches[0].Mutations, 1)
+	assert.Equal(t, admissionregistrationv1alpha1.PatchTypeJSONPatch, matches[0].Mutations[0].PatchType)
+	assert.Contains(t, matches[0].Mutations[0].Expression, "/metadata/labels/x")
+	assert.True(t, matches[0].Determinable)
+}
+
+func TestMatches_BindingMatchResourcesFurtherRestrictsPolicy(t *testing.T) {
+	p := policy("add-label", allPods())
+	restrictive := &admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mutate": "yes"}},
+	}
+	b := binding("only-opted-in", "add-label", restrictive)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	notOptedIn := idx.Matches(obj(func(o *ObjectInfo) { o.Labels = map[string]string{"mutate": "no"} }))
+	assert.Empty(t, notOptedIn, "the binding's own matchResources must further restrict what the policy's matchConstraints already allowed")
+
+	optedIn := idx.Matches(obj(func(o *ObjectInfo) { o.Labels = map[string]string{"mutate": "yes"} }))
+	assert.Len(t, optedIn, 1)
+}
+
+func TestMatches_PolicyNotMatchingConstraintsExcludesEveryBinding(t *testing.T) {
+	configmapsOnly := &admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{""}, []string{"v1"}, []string{"configmaps"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	}
+	p := policy("configmap-only", configmapsOnly)
+	b := binding("b", "configmap-only", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(func(o *ObjectInfo) { o.Resource = "pods" }))
+	assert.Empty(t, matches, "the policy's matchConstraints excluding the object must exclude every binding of it")
+}
+
+func TestMatches_MultipleBindingsOnOnePolicyEachReported(t *testing.T) {
+	p := policy("add-label", allPods())
+	b1 := binding("b1", "add-label", nil)
+	b2 := binding("b2", "add-label", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b1, b2})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	assert.Len(t, matches, 2)
+}
+
+func TestMatches_MultiplePoliciesEachReported(t *testing.T) {
+	p1 := policy("p1", allPods())
+	p2 := policy("p2", allPods())
+	b1 := binding("b1", "p1", nil)
+	b2 := binding("b2", "p2", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p1, p2}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b1, b2})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	assert.Len(t, matches, 2)
+}
+
+func TestNewIndex_MalformedPolicySelectorIsReportedAndSkipped(t *testing.T) {
+	bad := policy("bad", &admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: "NotARealOperator"}},
+		},
+	})
+	good := policy("good", allPods())
+	b1 := binding("bad-binding", "bad", nil)
+	b2 := binding("good-binding", "good", nil)
+
+	idx, errs := NewIndex(
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicy{bad, good},
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b1, b2},
+	)
+	require.Len(t, errs, 1)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.Equal(t, "good", matches[0].PolicyName)
+}
+
+func TestNewIndex_MalformedBindingSelectorIsReportedAndSkipped(t *testing.T) {
+	p := policy("p", allPods())
+	badBinding := binding("bad-binding", "p", &admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: "NotARealOperator"}},
+		},
+	})
+	goodBinding := binding("good-binding", "p", nil)
+
+	idx, errs := NewIndex(
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p},
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{badBinding, goodBinding},
+	)
+	require.Len(t, errs, 1)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.Equal(t, "good-binding", matches[0].BindingName)
+}
+
+func TestMatches_FailurePolicyDefaultsToFail(t *testing.T) {
+	p := policy("p", allPods())
+	b := binding("b", "p", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.Equal(t, admissionregistrationv1alpha1.Fail, matches[0].FailurePolicy)
+}
+
+func TestMatches_HasParamsReflectsParamKind(t *testing.T) {
+	p := policy("p", allPods())
+	p.Spec.ParamKind = &admissionregistrationv1alpha1.ParamKind{APIVersion: "v1", Kind: "ConfigMap"}
+	b := binding("b", "p", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.True(t, matches[0].HasParams)
+}
+
+func TestMatches_IndeterminateNamespaceSelectorPropagatesToResult(t *testing.T) {
+	p := policy("p", &admissionregistrationv1alpha1.MatchResources{
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+		ResourceRules:     []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.OperationAll)},
+	})
+	b := binding("b", "p", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(func(o *ObjectInfo) { o.NamespaceLabelsKnown = false }))
+	require.Len(t, matches, 1, "an indeterminate namespaceSelector must still be reported as a possible match")
+	assert.False(t, matches[0].Determinable)
+}
+
+func TestMatches_ApplyConfigurationMutationExpressionIsCarried(t *testing.T) {
+	p := policy("p", allPods(), admissionregistrationv1alpha1.Mutation{
+		PatchType: admissionregistrationv1alpha1.PatchTypeApplyConfiguration,
+		ApplyConfiguration: &admissionregistrationv1alpha1.ApplyConfiguration{
+			Expression: `Object{spec: Object.spec{serviceAccountName: "restricted"}}`,
+		},
+	})
+	b := binding("b", "p", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0].Mutations, 1)
+	assert.Equal(t, admissionregistrationv1alpha1.PatchTypeApplyConfiguration, matches[0].Mutations[0].PatchType)
+	assert.Contains(t, matches[0].Mutations[0].Expression, "serviceAccountName")
+}

--- a/core/pkg/mapreconcile/match.go
+++ b/core/pkg/mapreconcile/match.go
@@ -14,16 +14,27 @@ type ObjectInfo struct {
 	Group     string
 	Version   string
 	Resource  string // plural resource name, e.g. "pods"
+	Name      string // the object's own name, matched against a rule's ResourceNames
 	Namespace string // empty for a cluster-scoped object
 	Labels    map[string]string
 	Operation admissionregistrationv1alpha1.OperationType
 
-	// ClusterScoped marks obj as a cluster-scoped resource other than
-	// Namespace itself. Per MatchResources' own doc comment, a
-	// namespaceSelector "never skips the policy" for such an object -- it is
-	// not merely unresolvable, it is defined to be irrelevant -- so this
-	// takes priority over NamespaceLabelsKnown below.
+	// ClusterScoped marks obj as a cluster-scoped resource. A Namespace
+	// object is itself cluster-scoped ("Namespace API objects are
+	// cluster-scoped", per Rule.Scope's own doc comment) and must still set
+	// this true for Rule.Scope matching -- IsNamespaceObject below is what
+	// distinguishes it from every other cluster-scoped kind for
+	// namespaceSelector purposes specifically.
 	ClusterScoped bool
+
+	// IsNamespaceObject marks obj as a Namespace object itself. Per
+	// MatchResources' own doc comment, a namespaceSelector is evaluated
+	// against a Namespace object's *own* labels (there is no separate
+	// containing namespace to look up), whereas for every other
+	// cluster-scoped kind it never skips the policy at all. Getting this
+	// wrong in either direction is a real false-positive/negative for a
+	// security-analysis tool, not just an edge case.
+	IsNamespaceObject bool
 
 	// NamespaceLabels is the labels of ObjectInfo's own namespace object,
 	// needed for namespaceSelector matching. NamespaceLabelsKnown
@@ -53,7 +64,46 @@ func ruleMatches(rule admissionregistrationv1alpha1.NamedRuleWithOperations, obj
 	if !stringRuleMatches(rule.Resources, obj.Resource) {
 		return false
 	}
+	if !resourceNamesMatch(rule.ResourceNames, obj.Name) {
+		return false
+	}
+	if !scopeMatches(rule.Scope, obj) {
+		return false
+	}
 	return true
+}
+
+// resourceNamesMatch reports whether obj's name is covered by a rule's
+// ResourceNames. An empty list is documented as "an optional white list...
+// An empty set means that everything is allowed", so it does not restrict
+// matching at all.
+func resourceNamesMatch(names []string, objName string) bool {
+	if len(names) == 0 {
+		return true
+	}
+	for _, n := range names {
+		if n == objName {
+			return true
+		}
+	}
+	return false
+}
+
+// scopeMatches reports whether obj's scope satisfies a rule's Scope. A nil
+// Scope defaults to AllScopes, per Rule.Scope's own doc comment ("Default is
+// '*'").
+func scopeMatches(scope *admissionregistrationv1alpha1.ScopeType, obj ObjectInfo) bool {
+	if scope == nil {
+		return true
+	}
+	switch *scope {
+	case admissionregistrationv1alpha1.ClusterScope:
+		return obj.ClusterScoped
+	case admissionregistrationv1alpha1.NamespacedScope:
+		return !obj.ClusterScoped
+	default: // AllScopes, or any value this package does not recognize
+		return true
+	}
 }
 
 func operationMatches(ops []admissionregistrationv1alpha1.OperationType, op admissionregistrationv1alpha1.OperationType) bool {
@@ -161,12 +211,27 @@ func compileMatchResources(mr *admissionregistrationv1alpha1.MatchResources) (*c
 // rather than a confident non-match: the object may still be covered via a
 // version this rule never named.
 func (c *compiledMatchResources) matches(obj ObjectInfo) (matched bool, determinable bool) {
-	if c.namespaceSelector != nil && !c.namespaceSelector.Empty() && !obj.ClusterScoped {
-		if !obj.NamespaceLabelsKnown {
-			return false, false
-		}
-		if !c.namespaceSelector.Matches(labels.Set(obj.NamespaceLabels)) {
-			return false, true
+	if c.namespaceSelector != nil && !c.namespaceSelector.Empty() {
+		switch {
+		case obj.IsNamespaceObject:
+			// There is no separate containing namespace to look up: the
+			// selector is evaluated against the Namespace object's own
+			// labels, which the caller always has (they are obj.Labels,
+			// not a lookup that can be "unknown").
+			if !c.namespaceSelector.Matches(labels.Set(obj.Labels)) {
+				return false, true
+			}
+		case !obj.ClusterScoped:
+			if !obj.NamespaceLabelsKnown {
+				return false, false
+			}
+			if !c.namespaceSelector.Matches(labels.Set(obj.NamespaceLabels)) {
+				return false, true
+			}
+		default:
+			// A cluster-scoped object other than Namespace itself: a
+			// namespaceSelector never skips the policy for it, per
+			// MatchResources' own doc comment.
 		}
 	}
 

--- a/core/pkg/mapreconcile/match.go
+++ b/core/pkg/mapreconcile/match.go
@@ -1,0 +1,214 @@
+package mapreconcile
+
+import (
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ObjectInfo identifies one candidate object for matching against a
+// MutatingAdmissionPolicy's matchConstraints/matchResources: the API
+// coordinates a NamedRuleWithOperations rule matches against, plus the labels
+// a namespaceSelector/objectSelector match against.
+type ObjectInfo struct {
+	Group     string
+	Version   string
+	Resource  string // plural resource name, e.g. "pods"
+	Namespace string // empty for a cluster-scoped object
+	Labels    map[string]string
+	Operation admissionregistrationv1alpha1.OperationType
+
+	// ClusterScoped marks obj as a cluster-scoped resource other than
+	// Namespace itself. Per MatchResources' own doc comment, a
+	// namespaceSelector "never skips the policy" for such an object -- it is
+	// not merely unresolvable, it is defined to be irrelevant -- so this
+	// takes priority over NamespaceLabelsKnown below.
+	ClusterScoped bool
+
+	// NamespaceLabels is the labels of ObjectInfo's own namespace object,
+	// needed for namespaceSelector matching. NamespaceLabelsKnown
+	// distinguishes "this namespace really has no labels" from "the caller
+	// never looked the namespace up" -- the latter must not be treated as a
+	// confident empty-label-set match against a non-empty selector.
+	NamespaceLabels      map[string]string
+	NamespaceLabelsKnown bool
+}
+
+// ruleMatches reports whether one NamedRuleWithOperations rule covers obj.
+// An empty rule (the zero value) never matches: a well-formed API object
+// always has at least one non-empty field in a real rule, so an empty one is
+// either a defensively-parsed malformed object or a caller mistake, and
+// treating it as "matches everything" would be the dangerous direction to be
+// wrong in.
+func ruleMatches(rule admissionregistrationv1alpha1.NamedRuleWithOperations, obj ObjectInfo) bool {
+	if !operationMatches(rule.Operations, obj.Operation) {
+		return false
+	}
+	if !stringRuleMatches(rule.APIGroups, obj.Group) {
+		return false
+	}
+	if !stringRuleMatches(rule.APIVersions, obj.Version) {
+		return false
+	}
+	if !stringRuleMatches(rule.Resources, obj.Resource) {
+		return false
+	}
+	return true
+}
+
+func operationMatches(ops []admissionregistrationv1alpha1.OperationType, op admissionregistrationv1alpha1.OperationType) bool {
+	for _, o := range ops {
+		if o == admissionregistrationv1alpha1.OperationAll || o == op {
+			return true
+		}
+	}
+	return false
+}
+
+// stringRuleMatches reports whether candidate is covered by values, where
+// values comes from a Rule's APIGroups/APIVersions/Resources: "*" (alone, or
+// alongside other entries) matches anything, otherwise candidate must appear
+// verbatim.
+func stringRuleMatches(values []string, candidate string) bool {
+	for _, v := range values {
+		if v == "*" || v == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceRulesVerdict OR-combines every rule in rules against obj. An empty
+// rule list matches everything, matching MatchResources' own documented
+// semantics for an unset ResourceRules (required for a policy's
+// matchConstraints in practice, but optional -- and non-constraining when
+// absent -- on a binding's matchResources).
+func resourceRulesVerdict(rules []admissionregistrationv1alpha1.NamedRuleWithOperations, obj ObjectInfo) bool {
+	if len(rules) == 0 {
+		return true
+	}
+	return anyRuleMatches(rules, obj)
+}
+
+// anyRuleMatches OR-combines every rule in rules against obj, with no
+// "empty means match everything" override: an empty rule list matches
+// nothing. This is what ExcludeResourceRules needs -- an absent exclude list
+// must exclude nothing, not everything, unlike an absent (required)
+// ResourceRules list.
+func anyRuleMatches(rules []admissionregistrationv1alpha1.NamedRuleWithOperations, obj ObjectInfo) bool {
+	for _, rule := range rules {
+		if ruleMatches(rule, obj) {
+			return true
+		}
+	}
+	return false
+}
+
+// compiledMatchResources pre-parses one MatchResources' selectors once so a
+// query does not re-parse them on every call.
+type compiledMatchResources struct {
+	namespaceSelector labels.Selector // nil means "no selector: matches everything"
+	objectSelector    labels.Selector
+	resourceRules     []admissionregistrationv1alpha1.NamedRuleWithOperations
+	excludeRules      []admissionregistrationv1alpha1.NamedRuleWithOperations
+	matchPolicy       admissionregistrationv1alpha1.MatchPolicyType
+}
+
+// compileMatchResources parses mr's selectors once. A nil mr compiles to "no
+// restriction at all" (matches every object), matching MatchResources' own
+// nil semantics. A malformed selector is reported rather than silently
+// treated as matching everything or nothing -- either guess can turn a real
+// mutation into an invisible one or a phantom one.
+func compileMatchResources(mr *admissionregistrationv1alpha1.MatchResources) (*compiledMatchResources, error) {
+	c := &compiledMatchResources{matchPolicy: admissionregistrationv1alpha1.Equivalent}
+	if mr == nil {
+		return c, nil
+	}
+
+	c.resourceRules = mr.ResourceRules
+	c.excludeRules = mr.ExcludeResourceRules
+	if mr.MatchPolicy != nil {
+		c.matchPolicy = *mr.MatchPolicy
+	}
+
+	if mr.NamespaceSelector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(mr.NamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
+		c.namespaceSelector = sel
+	}
+	if mr.ObjectSelector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(mr.ObjectSelector)
+		if err != nil {
+			return nil, err
+		}
+		c.objectSelector = sel
+	}
+	return c, nil
+}
+
+// matches reports whether obj is matched by c. determinable is false only
+// when a namespaceSelector must be evaluated but obj's namespace labels were
+// never supplied -- in that case matched is meaningless and callers must
+// treat the result as Unknown, not as a confident non-match.
+//
+// matchPolicy Equivalent (the API's default) is documented to also match a
+// request arriving via an API-group/version this policy did not list, if
+// that version is equivalent to one that was. Resolving that equivalence
+// needs full API discovery data this package is not given, so a resourceRules
+// miss under an explicit Equivalent matchPolicy is reported as indeterminate
+// rather than a confident non-match: the object may still be covered via a
+// version this rule never named.
+func (c *compiledMatchResources) matches(obj ObjectInfo) (matched bool, determinable bool) {
+	if c.namespaceSelector != nil && !c.namespaceSelector.Empty() && !obj.ClusterScoped {
+		if !obj.NamespaceLabelsKnown {
+			return false, false
+		}
+		if !c.namespaceSelector.Matches(labels.Set(obj.NamespaceLabels)) {
+			return false, true
+		}
+	}
+
+	if c.objectSelector != nil && !c.objectSelector.Empty() {
+		if !c.objectSelector.Matches(labels.Set(obj.Labels)) {
+			return false, true
+		}
+	}
+
+	if anyRuleMatches(c.excludeRules, obj) {
+		// Exclude rules take precedence over include rules unconditionally.
+		return false, true
+	}
+
+	if resourceRulesVerdict(c.resourceRules, obj) {
+		return true, true
+	}
+	if c.matchPolicy == admissionregistrationv1alpha1.Equivalent && resourceRulesAmbiguousUnderEquivalence(c.resourceRules, obj) {
+		return false, false
+	}
+	return false, true
+}
+
+// resourceRulesAmbiguousUnderEquivalence reports whether some rule in rules
+// matches obj's resource name and operation but not its group/version --
+// exactly the situation Equivalent matchPolicy resolves using API
+// group/version-equivalence data (e.g. autoscaling/v1 vs autoscaling/v2
+// HorizontalPodAutoscalers) that this package is not given. A rule that does
+// not even name this resource (e.g. "configmaps" when obj is a "pods") is
+// never ambiguous: two unrelated resource kinds are never equivalent under
+// any matchPolicy.
+func resourceRulesAmbiguousUnderEquivalence(rules []admissionregistrationv1alpha1.NamedRuleWithOperations, obj ObjectInfo) bool {
+	for _, rule := range rules {
+		if !operationMatches(rule.Operations, obj.Operation) {
+			continue
+		}
+		if !stringRuleMatches(rule.Resources, obj.Resource) {
+			continue
+		}
+		if !stringRuleMatches(rule.APIGroups, obj.Group) || !stringRuleMatches(rule.APIVersions, obj.Version) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/pkg/mapreconcile/match_test.go
+++ b/core/pkg/mapreconcile/match_test.go
@@ -71,6 +71,40 @@ func TestRuleMatches_EmptyRuleNeverMatches(t *testing.T) {
 	assert.False(t, ruleMatches(admissionregistrationv1alpha1.NamedRuleWithOperations{}, obj(nil)))
 }
 
+func TestRuleMatches_ResourceNamesRestrictsToNamedObjects(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.Create)
+	r.ResourceNames = []string{"allowed-one", "allowed-two"}
+
+	assert.False(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Name = "someone-else" })), "a name outside ResourceNames must not match")
+	assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Name = "allowed-two" })), "a name inside ResourceNames must match")
+}
+
+func TestRuleMatches_EmptyResourceNamesDoesNotRestrict(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.Create)
+	assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Name = "anything" })), "an empty ResourceNames allows every name")
+}
+
+func TestRuleMatches_ScopeRestrictsToDeclaredScope(t *testing.T) {
+	clusterScope := admissionregistrationv1alpha1.ClusterScope
+	namespacedScope := admissionregistrationv1alpha1.NamespacedScope
+
+	clusterOnly := pods(admissionregistrationv1alpha1.Create)
+	clusterOnly.Scope = &clusterScope
+	assert.False(t, ruleMatches(clusterOnly, obj(func(o *ObjectInfo) { o.ClusterScoped = false })), "Cluster scope must not match a namespaced object")
+	assert.True(t, ruleMatches(clusterOnly, obj(func(o *ObjectInfo) { o.ClusterScoped = true })), "Cluster scope must match a cluster-scoped object")
+
+	namespacedOnly := pods(admissionregistrationv1alpha1.Create)
+	namespacedOnly.Scope = &namespacedScope
+	assert.True(t, ruleMatches(namespacedOnly, obj(func(o *ObjectInfo) { o.ClusterScoped = false })), "Namespaced scope must match a namespaced object")
+	assert.False(t, ruleMatches(namespacedOnly, obj(func(o *ObjectInfo) { o.ClusterScoped = true })), "Namespaced scope must not match a cluster-scoped object")
+}
+
+func TestRuleMatches_NilScopeDefaultsToAllScopes(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.Create)
+	assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.ClusterScoped = true })))
+	assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.ClusterScoped = false })))
+}
+
 func TestCompileMatchResources_NilMatchesEverything(t *testing.T) {
 	c, err := compileMatchResources(nil)
 	require.NoError(t, err)
@@ -139,6 +173,32 @@ func TestCompileMatchResources_NamespaceSelectorRequiresKnownLabels(t *testing.T
 	matched, determinable := c.matches(obj(func(o *ObjectInfo) {
 		o.NamespaceLabelsKnown = true
 		o.NamespaceLabels = map[string]string{"env": "prod"}
+	}))
+	assert.True(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_NamespaceObjectMatchesSelectorAgainstOwnLabels(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+	})
+	require.NoError(t, err)
+
+	// A Namespace object is itself cluster-scoped, but unlike any other
+	// cluster-scoped kind, a namespaceSelector is evaluated against its own
+	// labels -- not bypassed -- per MatchResources' own doc comment.
+	excluded, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.ClusterScoped = true
+		o.IsNamespaceObject = true
+		o.Labels = map[string]string{"env": "dev"}
+	}))
+	assert.False(t, excluded, "a namespaceSelector must be able to exclude a Namespace object by its own labels")
+	assert.True(t, determinable)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.ClusterScoped = true
+		o.IsNamespaceObject = true
+		o.Labels = map[string]string{"env": "prod"}
 	}))
 	assert.True(t, matched)
 	assert.True(t, determinable)

--- a/core/pkg/mapreconcile/match_test.go
+++ b/core/pkg/mapreconcile/match_test.go
@@ -1,0 +1,228 @@
+package mapreconcile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func rule(groups, versions, resources []string, ops ...admissionregistrationv1alpha1.OperationType) admissionregistrationv1alpha1.NamedRuleWithOperations {
+	return admissionregistrationv1alpha1.NamedRuleWithOperations{
+		RuleWithOperations: admissionregistrationv1alpha1.RuleWithOperations{
+			Operations: ops,
+			Rule: admissionregistrationv1alpha1.Rule{
+				APIGroups:   groups,
+				APIVersions: versions,
+				Resources:   resources,
+			},
+		},
+	}
+}
+
+func pods(ops ...admissionregistrationv1alpha1.OperationType) admissionregistrationv1alpha1.NamedRuleWithOperations {
+	return rule([]string{""}, []string{"v1"}, []string{"pods"}, ops...)
+}
+
+func obj(overrides func(*ObjectInfo)) ObjectInfo {
+	o := ObjectInfo{
+		Group:     "",
+		Version:   "v1",
+		Resource:  "pods",
+		Namespace: "default",
+		Operation: admissionregistrationv1alpha1.Create,
+	}
+	if overrides != nil {
+		overrides(&o)
+	}
+	return o
+}
+
+func TestRuleMatches_ExactGroupVersionResourceOperation(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.Create)
+	assert.True(t, ruleMatches(r, obj(nil)))
+}
+
+func TestRuleMatches_WrongResourceDoesNotMatch(t *testing.T) {
+	r := rule([]string{""}, []string{"v1"}, []string{"configmaps"}, admissionregistrationv1alpha1.Create)
+	assert.False(t, ruleMatches(r, obj(nil)))
+}
+
+func TestRuleMatches_WildcardGroupVersionResource(t *testing.T) {
+	r := rule([]string{"*"}, []string{"*"}, []string{"*"}, admissionregistrationv1alpha1.OperationAll)
+	assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Group = "apps"; o.Version = "v1"; o.Resource = "deployments" })))
+}
+
+func TestRuleMatches_OperationAllMatchesEveryOperation(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.OperationAll)
+	for _, op := range []admissionregistrationv1alpha1.OperationType{admissionregistrationv1alpha1.Create, admissionregistrationv1alpha1.Update, admissionregistrationv1alpha1.Connect} {
+		assert.True(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Operation = op })), "operation %s", op)
+	}
+}
+
+func TestRuleMatches_SpecificOperationExcludesOthers(t *testing.T) {
+	r := pods(admissionregistrationv1alpha1.Update)
+	assert.False(t, ruleMatches(r, obj(func(o *ObjectInfo) { o.Operation = admissionregistrationv1alpha1.Create })))
+}
+
+func TestRuleMatches_EmptyRuleNeverMatches(t *testing.T) {
+	assert.False(t, ruleMatches(admissionregistrationv1alpha1.NamedRuleWithOperations{}, obj(nil)))
+}
+
+func TestCompileMatchResources_NilMatchesEverything(t *testing.T) {
+	c, err := compileMatchResources(nil)
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(nil))
+	assert.True(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_EmptyResourceRulesMatchesEverything(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(nil))
+	assert.True(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_ResourceRuleMustMatch(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.Create)},
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Resource = "secrets" }))
+	assert.False(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_ExcludeTakesPrecedenceOverInclude(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules:        []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.OperationAll)},
+		ExcludeResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.OperationAll)},
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(nil))
+	assert.False(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_ObjectSelectorMustMatchLabels(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+	})
+	require.NoError(t, err)
+
+	notMatched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Labels = map[string]string{"env": "dev"} }))
+	assert.False(t, notMatched)
+	assert.True(t, determinable)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Labels = map[string]string{"env": "prod"} }))
+	assert.True(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_NamespaceSelectorRequiresKnownLabels(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+	})
+	require.NoError(t, err)
+
+	_, determinable := c.matches(obj(func(o *ObjectInfo) { o.NamespaceLabelsKnown = false }))
+	assert.False(t, determinable, "an unresolved namespaceSelector must report indeterminate, not a confident non-match")
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.NamespaceLabelsKnown = true
+		o.NamespaceLabels = map[string]string{"env": "prod"}
+	}))
+	assert.True(t, matched)
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_ClusterScopedObjectIgnoresNamespaceSelector(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.ClusterScoped = true
+		o.NamespaceLabelsKnown = false
+	}))
+	assert.True(t, matched, "a namespaceSelector never skips a cluster-scoped object, per MatchResources' own doc comment")
+	assert.True(t, determinable)
+}
+
+func TestCompileMatchResources_EmptyNamespaceSelectorMatchesEvenWithoutLabels(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		NamespaceSelector: &metav1.LabelSelector{},
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.NamespaceLabelsKnown = false }))
+	assert.True(t, matched)
+	assert.True(t, determinable, "an empty selector matches everything regardless of whether labels were resolved")
+}
+
+func TestCompileMatchResources_MalformedSelectorIsReported(t *testing.T) {
+	_, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: "NotARealOperator"}},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestCompileMatchResources_EquivalentMatchPolicyVersionMismatchIsIndeterminate(t *testing.T) {
+	equivalent := admissionregistrationv1alpha1.Equivalent
+	// The rule names "deployments" under apps/v1 only; a request arriving via
+	// apps/v1beta1 for the same resource name is exactly the case Equivalent
+	// is meant to resolve via API-version-equivalence data this package does
+	// not have.
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{"apps"}, []string{"v1"}, []string{"deployments"}, admissionregistrationv1alpha1.Create),
+		},
+		MatchPolicy: &equivalent,
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.Group = "apps"
+		o.Version = "v1beta1"
+		o.Resource = "deployments"
+	}))
+	assert.False(t, matched)
+	assert.False(t, determinable, "a resource+operation match with a differing group/version is exactly what Equivalent cannot be confidently resolved without API-version-equivalence data")
+}
+
+func TestCompileMatchResources_EquivalentMatchPolicyUnrelatedResourceIsAConfidentNonMatch(t *testing.T) {
+	equivalent := admissionregistrationv1alpha1.Equivalent
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.Create)},
+		MatchPolicy:   &equivalent,
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Resource = "secrets" }))
+	assert.False(t, matched)
+	assert.True(t, determinable, "an entirely unrelated resource kind is never equivalent, under any matchPolicy")
+}
+
+func TestCompileMatchResources_ExactMatchPolicyMissIsAConfidentNonMatch(t *testing.T) {
+	exact := admissionregistrationv1alpha1.Exact
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{pods(admissionregistrationv1alpha1.Create)},
+		MatchPolicy:   &exact,
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Resource = "secrets" }))
+	assert.False(t, matched)
+	assert.True(t, determinable, "Exact matchPolicy has no equivalence expansion to be uncertain about")
+}

--- a/core/pkg/mapreconcile/reconcile.go
+++ b/core/pkg/mapreconcile/reconcile.go
@@ -1,0 +1,185 @@
+// Package mapreconcile discovers a live cluster's MutatingAdmissionPolicy and
+// MutatingAdmissionPolicyBinding objects (admissionregistration.k8s.io
+// /v1alpha1, stable since Kubernetes 1.32) and reports which ones would match
+// a given resource -- surfacing implicit, in-cluster mutation that never
+// appears in the manifest a user applied.
+//
+// This package does not evaluate the CEL expressions a Mutation declares: it
+// reports that a policy's mutation *would run* against a matching resource,
+// and what its raw expression is, not what the mutated object would look
+// like. Actually computing the patched value would require the same
+// apiserver-grade CEL/ApplyConfiguration machinery admission control itself
+// uses; reporting the match and the expression verbatim is honest about that
+// boundary rather than guessing at an evaluated result.
+package mapreconcile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	mapGroup           = "admissionregistration.k8s.io"
+	mapResource        = "mutatingadmissionpolicies"
+	mapBindingResource = "mutatingadmissionpolicybindings"
+)
+
+// mapVersions lists the served versions of the MutatingAdmissionPolicy API in
+// preference order. Only v1alpha1 exists as of Kubernetes 1.35 (the type was
+// introduced in 1.32 and has not graduated), but resolveVersion is written the
+// same way vapreconcile's is so a later v1beta1/v1 needs only a new entry
+// here, not a rewrite of the probing logic.
+var mapVersions = []string{"v1alpha1"}
+
+// ErrUnsupported reports a cluster that serves no version of the
+// MutatingAdmissionPolicy API, so there is nothing to reconcile.
+var ErrUnsupported = errors.New("cluster does not serve MutatingAdmissionPolicy resources")
+
+// ErrForbidden reports credentials that may not list the API. This enriches a
+// scan/query rather than feeding it, so being denied it should not be treated
+// as a hard failure by callers.
+var ErrForbidden = errors.New("not permitted to list MutatingAdmissionPolicy resources")
+
+// resolveVersion returns the first MutatingAdmissionPolicy version the
+// cluster both advertises and serves both resources for. Without a discovery
+// client the newest (only) version is assumed. A discovery error on one
+// version does not stop the remaining ones from being probed, mirroring
+// vapreconcile.resolveVersion.
+func resolveVersion(client discovery.DiscoveryInterface) (string, error) {
+	if client == nil {
+		return mapVersions[0], nil
+	}
+
+	var probeErr error
+	for _, version := range mapVersions {
+		gv := schema.GroupVersion{Group: mapGroup, Version: version}
+		resources, err := client.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			if !apierrors.IsNotFound(err) && probeErr == nil {
+				probeErr = fmt.Errorf("failed to discover %s: %w", gv.String(), err)
+			}
+			continue
+		}
+		if serves(resources, mapResource, mapBindingResource) {
+			return version, nil
+		}
+	}
+
+	if probeErr != nil {
+		return "", probeErr
+	}
+	return "", ErrUnsupported
+}
+
+// serves reports whether the API resource list carries every named resource.
+func serves(resources *metav1.APIResourceList, names ...string) bool {
+	if resources == nil {
+		return false
+	}
+	served := make(map[string]struct{}, len(resources.APIResources))
+	for _, resource := range resources.APIResources {
+		served[resource.Name] = struct{}{}
+	}
+	for _, name := range names {
+		if _, ok := served[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// list pulls every object of one cluster-scoped resource under the resolved
+// MutatingAdmissionPolicy API version.
+func list(ctx context.Context, client dynamic.Interface, version, resource string) ([]unstructured.Unstructured, error) {
+	gvr := schema.GroupVersionResource{Group: mapGroup, Version: version, Resource: resource}
+
+	var items []unstructured.Unstructured
+	listFunc := func(opts metav1.ListOptions) (string, error) {
+		listed, err := client.Resource(gvr).List(ctx, opts)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", ErrUnsupported
+			}
+			if apierrors.IsForbidden(err) {
+				return "", fmt.Errorf("%w: %s", ErrForbidden, gvr.String())
+			}
+			return "", fmt.Errorf("failed to list %s: %w", gvr.String(), err)
+		}
+		items = append(items, listed.Items...)
+		return listed.GetContinue(), nil
+	}
+
+	if err := getter.ListWithPagination(ctx, listFunc); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// Collect lists MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding
+// objects from the live cluster and decodes them into their typed shape. Both
+// resource types are cluster-scoped. An object that fails to decode is
+// skipped, with its error appended to decodeErrs, rather than one malformed
+// object hiding every other policy from the caller -- dropping a policy here
+// can hide a real, currently-running mutation, so the caller must be able to
+// see that something was dropped rather than have it disappear silently.
+func Collect(ctx context.Context, k8s *k8sinterface.KubernetesApi) (policies []admissionregistrationv1alpha1.MutatingAdmissionPolicy, bindings []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, decodeErrs []error, err error) {
+	version, err := resolveVersion(k8s.DiscoveryClient)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	rawPolicies, err := list(ctx, k8s.DynamicClient, version, mapResource)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	rawBindings, err := list(ctx, k8s.DynamicClient, version, mapBindingResource)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for i := range rawPolicies {
+		var p admissionregistrationv1alpha1.MutatingAdmissionPolicy
+		if decErr := decode(rawPolicies[i].Object, &p); decErr != nil {
+			decodeErrs = append(decodeErrs, fmt.Errorf("MutatingAdmissionPolicy %s: %w", rawPolicies[i].GetName(), decErr))
+			continue
+		}
+		policies = append(policies, p)
+	}
+	for i := range rawBindings {
+		var b admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding
+		if decErr := decode(rawBindings[i].Object, &b); decErr != nil {
+			decodeErrs = append(decodeErrs, fmt.Errorf("MutatingAdmissionPolicyBinding %s: %w", rawBindings[i].GetName(), decErr))
+			continue
+		}
+		bindings = append(bindings, b)
+	}
+
+	return policies, bindings, decodeErrs, nil
+}
+
+// decode converts an unstructured object's generic map into its typed shape
+// via a JSON round-trip, the same pattern core/pkg/networkpolicy's adapter
+// uses to bridge a dynamic client's generic representation and a concrete
+// Kubernetes API type.
+func decode(obj map[string]any, out any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+	return nil
+}

--- a/core/pkg/mapreconcile/reconcile.go
+++ b/core/pkg/mapreconcile/reconcile.go
@@ -56,14 +56,24 @@ var ErrUnsupported = errors.New("cluster does not serve MutatingAdmissionPolicy 
 // as a hard failure by callers.
 var ErrForbidden = errors.New("not permitted to list MutatingAdmissionPolicy resources")
 
+// ErrDiscoveryRequired reports that resolveVersion was given no discovery
+// client to confirm which version a cluster actually serves. Unlike
+// vapreconcile (whose VAP version has graduated the same v1alpha1 -> v1beta1
+// -> v1 path on every cluster observed), live verification against a real
+// cluster found MutatingAdmissionPolicy version support varies: one cluster
+// served it directly under v1 with v1beta1 never having existed at all.
+// Guessing mapVersions[0] without confirmation risks a wrong (and possibly
+// failing) version against an older cluster, so an absent discovery client is
+// treated as a real error here rather than a silent assumption.
+var ErrDiscoveryRequired = errors.New("a discovery client is required to determine which MutatingAdmissionPolicy version a cluster serves")
+
 // resolveVersion returns the first MutatingAdmissionPolicy version the
-// cluster both advertises and serves both resources for. Without a discovery
-// client the newest (only) version is assumed. A discovery error on one
-// version does not stop the remaining ones from being probed, mirroring
+// cluster both advertises and serves both resources for. A discovery error on
+// one version does not stop the remaining ones from being probed, mirroring
 // vapreconcile.resolveVersion.
 func resolveVersion(client discovery.DiscoveryInterface) (string, error) {
 	if client == nil {
-		return mapVersions[0], nil
+		return "", ErrDiscoveryRequired
 	}
 
 	var probeErr error

--- a/core/pkg/mapreconcile/reconcile.go
+++ b/core/pkg/mapreconcile/reconcile.go
@@ -37,11 +37,15 @@ const (
 )
 
 // mapVersions lists the served versions of the MutatingAdmissionPolicy API in
-// preference order. Only v1alpha1 exists as of Kubernetes 1.35 (the type was
-// introduced in 1.32 and has not graduated), but resolveVersion is written the
-// same way vapreconcile's is so a later v1beta1/v1 needs only a new entry
-// here, not a rewrite of the probing logic.
-var mapVersions = []string{"v1alpha1"}
+// preference order, mirroring vapVersions: newest first. The type was
+// introduced as v1alpha1 in Kubernetes 1.32; live verification against a
+// cluster that has since graduated it straight to v1 (skipping v1beta1
+// entirely, unlike ValidatingAdmissionPolicy's path) confirmed a
+// single-version list is not future-proof, so every version the API has ever
+// been served under is probed here rather than assuming v1alpha1 forever. The
+// vendored v1alpha1 Go types still decode a v1-served object correctly: only
+// the GVR used to list it differs between versions, not the JSON shape.
+var mapVersions = []string{"v1", "v1beta1", "v1alpha1"}
 
 // ErrUnsupported reports a cluster that serves no version of the
 // MutatingAdmissionPolicy API, so there is nothing to reconcile.

--- a/core/pkg/mapreconcile/reconcile_test.go
+++ b/core/pkg/mapreconcile/reconcile_test.go
@@ -1,0 +1,169 @@
+package mapreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func discoveryServing(versions ...string) *discoveryfake.FakeDiscovery {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	for _, version := range versions {
+		client.Resources = append(client.Resources, &metav1.APIResourceList{
+			GroupVersion: mapGroup + "/" + version,
+			APIResources: []metav1.APIResource{
+				{Name: mapResource, Kind: "MutatingAdmissionPolicy"},
+				{Name: mapBindingResource, Kind: "MutatingAdmissionPolicyBinding"},
+			},
+		})
+	}
+	return client
+}
+
+func dynamicServing(version string, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: mapGroup, Version: version, Resource: mapResource}:        "MutatingAdmissionPolicyList",
+		{Group: mapGroup, Version: version, Resource: mapBindingResource}: "MutatingAdmissionPolicyBindingList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+}
+
+func unstructuredMAP(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": mapGroup + "/v1alpha1",
+		"kind":       "MutatingAdmissionPolicy",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"matchConstraints": map[string]any{
+				"resourceRules": []any{
+					map[string]any{
+						"apiGroups":   []any{""},
+						"apiVersions": []any{"v1"},
+						"resources":   []any{"pods"},
+						"operations":  []any{"CREATE"},
+					},
+				},
+			},
+			"mutations": []any{
+				map[string]any{
+					"patchType": "JSONPatch",
+					"jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`},
+				},
+			},
+			"reinvocationPolicy": "Never",
+		},
+	}}
+	return u
+}
+
+func unstructuredMAPBinding(name, policyName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": mapGroup + "/v1alpha1",
+		"kind":       "MutatingAdmissionPolicyBinding",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"policyName": policyName,
+		},
+	}}
+}
+
+func TestResolveVersion_ServedVersion(t *testing.T) {
+	version, err := resolveVersion(discoveryServing("v1alpha1"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1alpha1", version)
+}
+
+func TestResolveVersion_UnservedGroupIsUnsupported(t *testing.T) {
+	_, err := resolveVersion(&discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}})
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestResolveVersion_GroupWithoutBindingsIsUnsupported(t *testing.T) {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{{
+		GroupVersion: mapGroup + "/v1alpha1",
+		APIResources: []metav1.APIResource{{Name: mapResource, Kind: "MutatingAdmissionPolicy"}},
+	}}
+
+	_, err := resolveVersion(client)
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestResolveVersion_WithoutDiscoveryClient(t *testing.T) {
+	version, err := resolveVersion(nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1alpha1", version)
+}
+
+func TestCollect_ReadsFromServedVersion(t *testing.T) {
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: discoveryServing("v1alpha1"),
+		DynamicClient:   dynamicServing("v1alpha1", unstructuredMAP("policy-a"), unstructuredMAPBinding("binding-a", "policy-a")),
+	}
+
+	policies, bindings, decodeErrs, err := Collect(context.Background(), k8s)
+
+	require.NoError(t, err)
+	require.Empty(t, decodeErrs)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "policy-a", policies[0].Name)
+	require.Len(t, policies[0].Spec.Mutations, 1)
+	assert.Equal(t, admissionregistrationv1alpha1.PatchTypeJSONPatch, policies[0].Spec.Mutations[0].PatchType)
+	require.Len(t, bindings, 1)
+	assert.Equal(t, "policy-a", bindings[0].Spec.PolicyName)
+}
+
+func TestCollect_UnsupportedClusterIsNotAFailure(t *testing.T) {
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}},
+		DynamicClient:   dynamicServing("v1alpha1"),
+	}
+
+	policies, bindings, decodeErrs, err := Collect(context.Background(), k8s)
+
+	assert.ErrorIs(t, err, ErrUnsupported)
+	assert.Nil(t, policies)
+	assert.Nil(t, bindings)
+	assert.Nil(t, decodeErrs)
+}
+
+func TestCollect_MalformedPolicyIsSkippedNotFatal(t *testing.T) {
+	bad := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": mapGroup + "/v1alpha1",
+		"kind":       "MutatingAdmissionPolicy",
+		"metadata":   map[string]any{"name": "bad"},
+		"spec": map[string]any{
+			// reinvocationPolicy must decode to a string; a nested object here
+			// makes the whole object fail its JSON round-trip.
+			"reinvocationPolicy": map[string]any{"not": "a string"},
+		},
+	}}
+	good := unstructuredMAP("good")
+
+	k8s := &k8sinterface.KubernetesApi{
+		DiscoveryClient: discoveryServing("v1alpha1"),
+		DynamicClient:   dynamicServing("v1alpha1", bad, good),
+	}
+
+	policies, _, decodeErrs, err := Collect(context.Background(), k8s)
+
+	require.NoError(t, err)
+	require.Len(t, decodeErrs, 1)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "good", policies[0].Name)
+}

--- a/core/pkg/mapreconcile/reconcile_test.go
+++ b/core/pkg/mapreconcile/reconcile_test.go
@@ -78,11 +78,27 @@ func unstructuredMAPBinding(name, policyName string) *unstructured.Unstructured 
 	}}
 }
 
-func TestResolveVersion_ServedVersion(t *testing.T) {
-	version, err := resolveVersion(discoveryServing("v1alpha1"))
+func TestResolveVersion_PrefersNewestServedVersion(t *testing.T) {
+	version, err := resolveVersion(discoveryServing("v1", "v1beta1", "v1alpha1"))
 
 	require.NoError(t, err)
-	assert.Equal(t, "v1alpha1", version)
+	assert.Equal(t, "v1", version)
+}
+
+// A live cluster (kind v1.36.1) was found during manual verification to
+// serve MutatingAdmissionPolicy directly under v1, skipping v1beta1
+// entirely -- unlike ValidatingAdmissionPolicy's v1alpha1 -> v1beta1 -> v1
+// path. A single hardcoded version was not future-proof against that; this
+// covers every version this package now probes for, individually.
+func TestResolveVersion_FallsBackToOlderVersions(t *testing.T) {
+	for _, served := range []string{"v1beta1", "v1alpha1"} {
+		t.Run(served, func(t *testing.T) {
+			version, err := resolveVersion(discoveryServing(served))
+
+			require.NoError(t, err)
+			assert.Equal(t, served, version)
+		})
+	}
 }
 
 func TestResolveVersion_UnservedGroupIsUnsupported(t *testing.T) {
@@ -94,7 +110,7 @@ func TestResolveVersion_UnservedGroupIsUnsupported(t *testing.T) {
 func TestResolveVersion_GroupWithoutBindingsIsUnsupported(t *testing.T) {
 	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
 	client.Resources = []*metav1.APIResourceList{{
-		GroupVersion: mapGroup + "/v1alpha1",
+		GroupVersion: mapGroup + "/v1",
 		APIResources: []metav1.APIResource{{Name: mapResource, Kind: "MutatingAdmissionPolicy"}},
 	}}
 
@@ -107,7 +123,7 @@ func TestResolveVersion_WithoutDiscoveryClient(t *testing.T) {
 	version, err := resolveVersion(nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, "v1alpha1", version)
+	assert.Equal(t, "v1", version)
 }
 
 func TestCollect_ReadsFromServedVersion(t *testing.T) {

--- a/core/pkg/mapreconcile/reconcile_test.go
+++ b/core/pkg/mapreconcile/reconcile_test.go
@@ -119,11 +119,10 @@ func TestResolveVersion_GroupWithoutBindingsIsUnsupported(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnsupported)
 }
 
-func TestResolveVersion_WithoutDiscoveryClient(t *testing.T) {
-	version, err := resolveVersion(nil)
+func TestResolveVersion_WithoutDiscoveryClientReturnsError(t *testing.T) {
+	_, err := resolveVersion(nil)
 
-	require.NoError(t, err)
-	assert.Equal(t, "v1", version)
+	assert.ErrorIs(t, err, ErrDiscoveryRequired, "a version must never be guessed without confirming what the cluster actually serves")
 }
 
 func TestCollect_ReadsFromServedVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #3605.

Kubernetes' `MutatingAdmissionPolicy` API (`admissionregistration.k8s.io/v1alpha1`, introduced in 1.32) lets a cluster mutate objects at admission time via CEL expressions -- the mutating counterpart to `ValidatingAdmissionPolicy`, which kubescape already fully supports. Nothing in the repo referenced it at all before this PR: no types, no collection, no matching, no reporting -- despite the Go types already being vendored transitively via `k8s.io/api`.

This adds:

- **`core/pkg/mapreconcile`**: collects a live cluster's `MutatingAdmissionPolicy` + `MutatingAdmissionPolicyBinding` objects (version-discovery pattern mirrors `vapreconcile`, decoding typed rather than unstructured since there's only one served version to worry about today) and matches them against a queried resource using the real `MatchResources` semantics shared between VAP and MAP: `namespaceSelector`/`objectSelector`, `resourceRules`/`excludeResourceRules` with wildcards and exclude-precedence, and honest three-valued indeterminacy for the specific cases the Kubernetes API itself documents as ambiguous without more data than a static query has -- `matchPolicy: Equivalent`'s API group/version-equivalence, and an unresolved `namespaceSelector` -- plus the documented rule that a `namespaceSelector` never skips a cluster-scoped object at all.
- **`analyze_mutating_admission_policy_impact`** (new MCP tool): given a resource's coordinates, reports which live policy+binding pairs would mutate it and each mutation's raw `patchType`/CEL expression. Deliberately does **not** evaluate the CEL expressions to compute the mutated object -- that would need the same apiserver-grade CEL/ApplyConfiguration machinery admission control itself uses; reporting the match and its expression verbatim is the honest scope for this PR (see issue non-goals).

A malformed policy/binding selector is collected as a decode/index error rather than silently dropped (learned this the hard way from review feedback on a previous PR this session), since silently dropping a policy here can hide a real, currently-running mutation.

## Test plan

- Unit tests for the matching engine (`core/pkg/mapreconcile`): exact/wildcard group-version-resource-operation matching, empty vs. non-empty resource/exclude rule lists, object/namespace selector matching including the "empty selector matches everything without needing labels" and "unresolved namespace labels are indeterminate, not a confident non-match" cases, the cluster-scoped-object-ignores-namespaceSelector rule, and both flavors of `matchPolicy: Equivalent` indeterminacy (a genuine group/version mismatch on the same resource name vs. an entirely unrelated resource kind, which is never ambiguous).
- Unit tests for `Collect`/`NewIndex`: version discovery, unsupported-cluster handling, and per-object decode/selector errors surfacing without dropping the rest of the collection.
- MCP-level tests exercising the real MCP JSON-RPC dispatch path (`dispatchRegisteredTool`) against a fake dynamic + discovery client: unbound-policy exclusion, bound-and-matching, non-matching resource exclusion, missing/invalid arguments, unsupported-cluster reporting, and the cluster-scoped/namespace-ignoring case.
- `go build ./...`, `go vet`, `go test -race` (affected packages) and the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master` are all clean (0 new issues).
- **Live-cluster verification**: ran this against a real kind v1.36.1 cluster (with the `MutatingAdmissionPolicy` feature gate + `admissionregistration.k8s.io/v1alpha1` runtime-config enabled). That cluster serves the API directly under `v1` -- confirming a real gap this testing caught: `resolveVersion` only ever probed `v1alpha1` and would have reported `ErrUnsupported` against it. Fixed to probe `v1`/`v1beta1`/`v1alpha1` in preference order (mirroring `vapreconcile`), with test coverage added for the fallback. Applied a real `MutatingAdmissionPolicy` + binding that adds a label via `JSONPatch`, created a target pod, and confirmed: (1) the live admission chain actually mutated the pod, and (2) `mapreconcile.Collect`/`NewIndex`/`Matches` against the real apiserver correctly discovered and matched that exact policy+binding, agreeing with what the cluster actually did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analysis tool that identifies which mutating admission policies affect a specified Kubernetes resource and operation.
  * Results include matching policies and bindings, mutation expressions, failure policies, parameter details, and uncertainty warnings.
  * Added support for policy availability checks, unsupported-cluster reporting, and incomplete policy data warnings.

* **Tests**
  * Added coverage for policy matching, exclusions, selectors, operations, malformed configurations, namespace handling, and cluster-scoped resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
