### PR TITLE
feat(scan): add contract report provenance

### DIFF
--- a/cmd/scan/apply_contract.go
+++ b/cmd/scan/apply_contract.go
@@ -12,6 +12,7 @@ import (
 	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,8 @@ func loadAndApplyScanContract(cmd *cobra.Command, scanInfo *cautils.ScanInfo, pa
 	}
 
 	applyContractOrdinarySettings(cmd, scanInfo, selected.Contract)
-	applyContractGateFloors(cmd, scanInfo, selected.Contract)
+	gateResolution := applyContractGateFloors(cmd, scanInfo, selected.Contract)
+	scanInfo.ScanContract = newScanContractMetadata(cmd, selected, path, scanInfo, gateResolution)
 	return selected, nil
 }
 
@@ -125,43 +127,71 @@ func applyContractOrdinarySettings(cmd *cobra.Command, scanInfo *cautils.ScanInf
 	}
 }
 
-func applyContractGateFloors(cmd *cobra.Command, scanInfo *cautils.ScanInfo, contract contractv1alpha1.Contract) {
+func applyContractGateFloors(cmd *cobra.Command, scanInfo *cautils.ScanInfo, contract contractv1alpha1.Contract) *reporthandlingv2.ScanContractGateResolution {
 	if contract.Failure == nil {
-		return
+		return nil
 	}
+	resolution := &reporthandlingv2.ScanContractGateResolution{}
 
 	if contract.Failure.SeverityAtLeast != nil {
 		contractValue := *contract.Failure.SeverityAtLeast
+		resolution.SeverityAtLeast.Contract = stringPointer(contractValue)
 		if commandFlagChanged(cmd, "severity-threshold") {
+			runnerFloor := scanInfo.FailThresholdSeverity
+			resolution.SeverityAtLeast.RunnerFloor = stringPointer(runnerFloor)
 			effective, floorWon := stricterSeverity(contractValue, scanInfo.FailThresholdSeverity)
 			scanInfo.FailThresholdSeverity = effective
 			logIgnoredWeakerGate("severityAtLeast", floorWon)
 		} else {
 			scanInfo.FailThresholdSeverity = contractValue
 		}
+		resolution.SeverityAtLeast.Effective = stringPointer(scanInfo.FailThresholdSeverity)
 	}
 	if contract.Failure.ComplianceBelow != nil {
 		contractValue := float32(*contract.Failure.ComplianceBelow)
+		contractProvenanceValue := *contract.Failure.ComplianceBelow
+		resolution.ComplianceBelow.Contract = float64Pointer(contractProvenanceValue)
+		if commandFlagChanged(cmd, "compliance-threshold") {
+			runnerFloor := float64(scanInfo.ComplianceThreshold)
+			resolution.ComplianceBelow.RunnerFloor = float64Pointer(runnerFloor)
+		}
 		floorWon := commandFlagChanged(cmd, "compliance-threshold") && scanInfo.ComplianceThreshold > contractValue
 		if contractValue > scanInfo.ComplianceThreshold {
 			scanInfo.ComplianceThreshold = contractValue
 		}
 		logIgnoredWeakerGate("complianceBelow", floorWon)
+		effective := float64(scanInfo.ComplianceThreshold)
+		resolution.ComplianceBelow.Effective = float64Pointer(effective)
 	}
 	if contract.Failure.CoverageBelow != nil {
 		contractValue := float32(*contract.Failure.CoverageBelow)
+		contractProvenanceValue := *contract.Failure.CoverageBelow
+		resolution.CoverageBelow.Contract = float64Pointer(contractProvenanceValue)
+		if commandFlagChanged(cmd, "fail-coverage-below") {
+			runnerFloor := float64(scanInfo.FailCoverageThreshold)
+			resolution.CoverageBelow.RunnerFloor = float64Pointer(runnerFloor)
+		}
 		floorWon := commandFlagChanged(cmd, "fail-coverage-below") && scanInfo.FailCoverageThreshold > contractValue
 		if contractValue > scanInfo.FailCoverageThreshold {
 			scanInfo.FailCoverageThreshold = contractValue
 		}
 		logIgnoredWeakerGate("coverageBelow", floorWon)
+		effective := float64(scanInfo.FailCoverageThreshold)
+		resolution.CoverageBelow.Effective = float64Pointer(effective)
 	}
 	if contract.Failure.DegradedPolicyInput != nil {
 		contractFails := *contract.Failure.DegradedPolicyInput == contractv1alpha1.DegradedPolicyInputFail
+		resolution.DegradedPolicyInput.Contract = boolPointer(contractFails)
+		if commandFlagChanged(cmd, "fail-on-degraded-config") {
+			runnerFloor := scanInfo.FailOnDegradedConfig
+			resolution.DegradedPolicyInput.RunnerFloor = boolPointer(runnerFloor)
+		}
 		floorWon := commandFlagChanged(cmd, "fail-on-degraded-config") && scanInfo.FailOnDegradedConfig && !contractFails
 		scanInfo.FailOnDegradedConfig = scanInfo.FailOnDegradedConfig || contractFails
 		logIgnoredWeakerGate("degradedPolicyInput", floorWon)
+		resolution.DegradedPolicyInput.Effective = boolPointer(scanInfo.FailOnDegradedConfig)
 	}
+	return resolution
 }
 
 func commandFlagChanged(cmd *cobra.Command, name string) bool {

--- a/cmd/scan/apply_contract_test.go
+++ b/cmd/scan/apply_contract_test.go
@@ -231,6 +231,77 @@ func TestContractAndCLIGateFloorsResolveMonotonically(t *testing.T) {
 	}
 }
 
+func TestScanContractCapturesResolvedProvenance(t *testing.T) {
+	scanInfo, _, err := executeCapturedScan(t, `
+      policy:
+        frameworks: [nsa]
+        controlsVersion: v2.0.307
+      scope:
+        includeNamespaces: [contract-ns]
+      evaluation:
+        scanTimeout: 2m
+      failure:
+        severityAtLeast: high
+        complianceBelow: 80
+        coverageBelow: 90
+        degradedPolicyInput: allow
+      output:
+        formats: [json]
+        omitRawResources: true`,
+		".",
+		"--controls-version", "v2.0.400",
+		"--include-namespaces", "runner-ns",
+		"--severity-threshold", "medium",
+		"--compliance-threshold", "95",
+		"--fail-coverage-below", "92",
+		"--fail-on-degraded-config",
+		"--format", "sarif",
+		"--omit-raw-resources=false")
+
+	require.ErrorIs(t, err, errContractScanReached)
+	require.NotNil(t, scanInfo)
+	provenance := scanInfo.ScanContract
+	require.NotNil(t, provenance)
+	assert.Equal(t, "config.kubescape.io/v1alpha1", provenance.APIVersion)
+	assert.Equal(t, "application-test", provenance.Name)
+	assert.Equal(t, "ci", provenance.Contract)
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, provenance.ContractDigest)
+	assert.Equal(t, "external", provenance.Source)
+	assert.Equal(t, []string{"policy", "scope", "evaluation", "failure", "output"}, provenance.AllowedSections)
+
+	require.NotNil(t, provenance.Effective)
+	require.NotNil(t, provenance.Effective.Scope)
+	assert.Equal(t, []string{"runner-ns"}, provenance.Effective.Scope.IncludeNamespaces)
+	require.NotNil(t, provenance.Effective.Output)
+	assert.Equal(t, []string{"sarif"}, provenance.Effective.Output.Formats)
+	require.NotNil(t, provenance.GateResolution)
+	assert.Equal(t, "high", *provenance.GateResolution.SeverityAtLeast.Contract)
+	assert.Equal(t, "medium", *provenance.GateResolution.SeverityAtLeast.RunnerFloor)
+	assert.Equal(t, "medium", *provenance.GateResolution.SeverityAtLeast.Effective)
+	assert.Equal(t, 80.0, *provenance.GateResolution.ComplianceBelow.Contract)
+	assert.Equal(t, 95.0, *provenance.GateResolution.ComplianceBelow.Effective)
+	assert.Equal(t, false, *provenance.GateResolution.DegradedPolicyInput.Contract)
+	assert.True(t, *provenance.GateResolution.DegradedPolicyInput.Effective)
+
+	require.NotNil(t, provenance.OrdinaryCLIOverrides)
+	require.NotNil(t, provenance.OrdinaryCLIOverrides.Policy)
+	assert.Equal(t, "v2.0.400", *provenance.OrdinaryCLIOverrides.Policy.ControlsVersion)
+	require.NotNil(t, provenance.OrdinaryCLIOverrides.Scope)
+	assert.Equal(t, []string{"runner-ns"}, *provenance.OrdinaryCLIOverrides.Scope.IncludeNamespaces)
+	require.NotNil(t, provenance.OrdinaryCLIOverrides.Output)
+	assert.Equal(t, []string{"sarif"}, *provenance.OrdinaryCLIOverrides.Output.Formats)
+	assert.False(t, *provenance.OrdinaryCLIOverrides.Output.OmitRawResources)
+}
+
+func TestSafeScanContractSource(t *testing.T) {
+	assert.Equal(t, ".kubescape/scan-contract.yaml", safeScanContractSource(".kubescape/scan-contract.yaml"))
+	assert.Equal(t, "external", safeScanContractSource("../scan-contract.yaml"))
+	assert.Equal(t, "external", safeScanContractSource(filepath.Join(t.TempDir(), "scan-contract.yaml")))
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, "scan-contract.yaml", safeScanContractSource(filepath.Join(workingDirectory, "scan-contract.yaml")))
+}
+
 func TestContractDoesNotMaskInvalidExplicitCLIGates(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/scan/contract_provenance.go
+++ b/cmd/scan/contract_provenance.go
@@ -1,0 +1,202 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/spf13/cobra"
+)
+
+// newScanContractMetadata captures the resolution that has already happened
+// at the CLI boundary. The final policy identifiers and effective-run digest
+// are filled in by cautils when the scan session is constructed, because that
+// is where the actual policy selection is known for every scan subcommand.
+func newScanContractMetadata(cmd *cobra.Command, selected *contractv1alpha1.SelectedContract, path string, scanInfo *cautils.ScanInfo, gates *reporthandlingv2.ScanContractGateResolution) *reporthandlingv2.ScanContractMetadata {
+	if selected == nil {
+		return nil
+	}
+
+	metadata := &reporthandlingv2.ScanContractMetadata{
+		APIVersion:              selected.APIVersion,
+		Name:                    selected.Metadata.Name,
+		Contract:                selected.ContractName,
+		MinimumKubescapeVersion: selected.MinimumKubescapeVersion,
+		DigestSchema:            selected.DigestSchema,
+		ContractDigest:          selected.ContractDigest,
+		Source:                  safeScanContractSource(path),
+		AllowedSections:         selectedContractSections(selected.Contract),
+		Effective:               resolvedContractSettings(cmd, selected.Contract, scanInfo),
+		GateResolution:          gates,
+		OrdinaryCLIOverrides:    ordinaryCLIOverrides(cmd, selected.Contract, scanInfo),
+	}
+	return metadata
+}
+
+func selectedContractSections(contract contractv1alpha1.Contract) []string {
+	sections := make([]string, 0, 5)
+	if contract.Policy != nil {
+		sections = append(sections, "policy")
+	}
+	if contract.Scope != nil {
+		sections = append(sections, "scope")
+	}
+	if contract.Evaluation != nil {
+		sections = append(sections, "evaluation")
+	}
+	if contract.Failure != nil {
+		sections = append(sections, "failure")
+	}
+	if contract.Output != nil {
+		sections = append(sections, "output")
+	}
+	return sections
+}
+
+func resolvedContractSettings(cmd *cobra.Command, contract contractv1alpha1.Contract, scanInfo *cautils.ScanInfo) *reporthandlingv2.ScanContractEffectiveSettings {
+	settings := &reporthandlingv2.ScanContractEffectiveSettings{}
+
+	if contract.Policy != nil {
+		settings.Policy = &reporthandlingv2.ScanContractPolicy{
+			ControlsVersion: scanInfo.ControlsVersion,
+		}
+		if contract.Policy.Frameworks != nil {
+			settings.Policy.Frameworks = append([]string(nil), (*contract.Policy.Frameworks)...)
+		}
+		if contract.Policy.Controls != nil {
+			settings.Policy.Controls = append([]string(nil), (*contract.Policy.Controls)...)
+		}
+	}
+	if contract.Scope != nil {
+		settings.Scope = &reporthandlingv2.ScanContractScope{
+			IncludeNamespaces: splitContractNamespaces(scanInfo.IncludeNamespaces),
+			ExcludeNamespaces: splitContractNamespaces(scanInfo.ExcludedNamespaces),
+		}
+	}
+	if contract.Evaluation != nil {
+		settings.Evaluation = &reporthandlingv2.ScanContractEvaluation{
+			ScanTimeout:    scanInfo.ScanTimeout.String(),
+			ControlTimeout: scanInfo.ControlTimeout.String(),
+		}
+	}
+	if contract.Failure != nil || commandFlagChanged(cmd, "severity-threshold") || commandFlagChanged(cmd, "compliance-threshold") || commandFlagChanged(cmd, "fail-coverage-below") || commandFlagChanged(cmd, "fail-on-degraded-config") {
+		settings.Failure = effectiveFailure(cmd, scanInfo, contract.Failure)
+	}
+	if contract.Output != nil {
+		settings.Output = &reporthandlingv2.ScanContractOutput{
+			Formats:          scanInfo.Formats(),
+			OmitRawResources: boolPointer(scanInfo.OmitRawResources),
+		}
+	}
+
+	if settings.Policy == nil && settings.Scope == nil && settings.Evaluation == nil && settings.Failure == nil && settings.Output == nil {
+		return nil
+	}
+	return settings
+}
+
+func effectiveFailure(cmd *cobra.Command, scanInfo *cautils.ScanInfo, contract *contractv1alpha1.Failure) *reporthandlingv2.ScanContractFailure {
+	failure := &reporthandlingv2.ScanContractFailure{}
+	if (contract != nil && contract.SeverityAtLeast != nil) || commandFlagChanged(cmd, "severity-threshold") {
+		failure.SeverityAtLeast = stringPointer(scanInfo.FailThresholdSeverity)
+	}
+	if (contract != nil && contract.ComplianceBelow != nil) || commandFlagChanged(cmd, "compliance-threshold") {
+		failure.ComplianceBelow = float64Pointer(float64(scanInfo.ComplianceThreshold))
+	}
+	if (contract != nil && contract.CoverageBelow != nil) || commandFlagChanged(cmd, "fail-coverage-below") {
+		failure.CoverageBelow = float64Pointer(float64(scanInfo.FailCoverageThreshold))
+	}
+	if (contract != nil && contract.DegradedPolicyInput != nil) || commandFlagChanged(cmd, "fail-on-degraded-config") {
+		failure.DegradedPolicyInput = boolPointer(scanInfo.FailOnDegradedConfig)
+	}
+	return failure
+}
+
+func ordinaryCLIOverrides(cmd *cobra.Command, contract contractv1alpha1.Contract, scanInfo *cautils.ScanInfo) *reporthandlingv2.ScanContractCLIOverrides {
+	overrides := &reporthandlingv2.ScanContractCLIOverrides{}
+
+	if contract.Policy != nil && contract.Policy.ControlsVersion != nil && commandFlagChanged(cmd, "controls-version") {
+		overrides.Policy = &reporthandlingv2.ScanContractPolicyOverrides{ControlsVersion: stringPointer(scanInfo.ControlsVersion)}
+	}
+	if contract.Scope != nil {
+		scope := &reporthandlingv2.ScanContractScopeOverrides{}
+		if contract.Scope.IncludeNamespaces != nil && commandFlagChanged(cmd, "include-namespaces") {
+			value := splitContractNamespaces(scanInfo.IncludeNamespaces)
+			scope.IncludeNamespaces = &value
+		}
+		if contract.Scope.ExcludeNamespaces != nil && commandFlagChanged(cmd, "exclude-namespaces") {
+			value := splitContractNamespaces(scanInfo.ExcludedNamespaces)
+			scope.ExcludeNamespaces = &value
+		}
+		if scope.IncludeNamespaces != nil || scope.ExcludeNamespaces != nil {
+			overrides.Scope = scope
+		}
+	}
+	if contract.Evaluation != nil {
+		evaluation := &reporthandlingv2.ScanContractEvaluationOverrides{}
+		if contract.Evaluation.ScanTimeout != nil && commandFlagChanged(cmd, "scan-timeout") {
+			evaluation.ScanTimeout = stringPointer(scanInfo.ScanTimeout.String())
+		}
+		if contract.Evaluation.ControlTimeout != nil && commandFlagChanged(cmd, "control-timeout") {
+			evaluation.ControlTimeout = stringPointer(scanInfo.ControlTimeout.String())
+		}
+		if evaluation.ScanTimeout != nil || evaluation.ControlTimeout != nil {
+			overrides.Evaluation = evaluation
+		}
+	}
+	if contract.Output != nil {
+		output := &reporthandlingv2.ScanContractOutputOverrides{}
+		if contract.Output.Formats != nil && commandFlagChanged(cmd, "format") {
+			value := scanInfo.Formats()
+			output.Formats = &value
+		}
+		if contract.Output.OmitRawResources != nil && commandFlagChanged(cmd, "omit-raw-resources") {
+			output.OmitRawResources = boolPointer(scanInfo.OmitRawResources)
+		}
+		if output.Formats != nil || output.OmitRawResources != nil {
+			overrides.Output = output
+		}
+	}
+
+	if overrides.Policy == nil && overrides.Scope == nil && overrides.Evaluation == nil && overrides.Output == nil {
+		return nil
+	}
+	return overrides
+}
+
+func safeScanContractSource(path string) string {
+	clean := filepath.Clean(path)
+	if filepath.IsAbs(clean) {
+		if workingDirectory, err := os.Getwd(); err == nil {
+			if relative, err := filepath.Rel(workingDirectory, clean); err == nil {
+				clean = relative
+			}
+		}
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+		return "external"
+	}
+	return filepath.ToSlash(clean)
+}
+
+func splitContractNamespaces(value string) []string {
+	if value == "" {
+		return []string{}
+	}
+	items := make([]string, 0)
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func stringPointer(value string) *string { return &value }
+
+func float64Pointer(value float64) *float64 { return &value }
+
+func boolPointer(value bool) *bool { return &value }

--- a/core/cautils/scancontract_provenance.go
+++ b/core/cautils/scancontract_provenance.go
@@ -1,0 +1,102 @@
+package cautils
+
+import (
+	"github.com/kubescape/backend/pkg/versioncheck"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+// effectiveRunDigestInput is intentionally narrower than report metadata. It
+// contains only the resolved inputs that determine scan behavior and the
+// authorization decision. The contract path and report-only provenance are not
+// part of this digest.
+type effectiveRunDigestInput struct {
+	DigestSchema     string                                          `json:"digestSchema"`
+	KubescapeVersion string                                          `json:"kubescapeVersion"`
+	Effective        *reporthandlingv2.ScanContractEffectiveSettings `json:"effective"`
+	AllowedSections  []string                                        `json:"allowedSections"`
+	DeniedSections   []string                                        `json:"deniedSections"`
+	RunnerInputs     []reporthandlingv2.ScanContractRunnerInput      `json:"runnerInputs"`
+}
+
+// finalizeScanContractMetadata runs at the point where Kubescape knows the
+// actual policy identifiers handed to the scanner. This makes report metadata
+// describe the executed selection even for scan subcommands that replace a
+// contract's policy selection.
+func finalizeScanContractMetadata(scanInfo *ScanInfo, policyIdentifiers []PolicyIdentifier) *reporthandlingv2.ScanContractMetadata {
+	if scanInfo.ScanContract == nil {
+		return nil
+	}
+
+	metadata := *scanInfo.ScanContract
+	metadata.AllowedSections = append([]string(nil), scanInfo.ScanContract.AllowedSections...)
+	metadata.DeniedSections = append([]string(nil), scanInfo.ScanContract.DeniedSections...)
+	metadata.RunnerInputs = append([]reporthandlingv2.ScanContractRunnerInput(nil), scanInfo.ScanContract.RunnerInputs...)
+	metadata.Effective = cloneEffectiveSettings(scanInfo.ScanContract.Effective)
+
+	if metadata.Effective != nil && metadata.Effective.Policy != nil && len(policyIdentifiers) > 0 {
+		policy := *metadata.Effective.Policy
+		policy.Frameworks = nil
+		policy.Controls = nil
+		for _, identifier := range policyIdentifiers {
+			switch identifier.Kind {
+			case apisv1.KindFramework:
+				policy.Frameworks = append(policy.Frameworks, identifier.Identifier)
+			case apisv1.KindControl:
+				policy.Controls = append(policy.Controls, identifier.Identifier)
+			}
+		}
+		metadata.Effective.Policy = &policy
+	}
+
+	// Controls-config and exceptions are consumed later by their getters. Do not
+	// hash them here: reading now and reopening later would create a hash-then-
+	// load race. Until that handoff preserves the exact consumed bytes, omit the
+	// effective-run digest rather than publish an incomplete reproducibility
+	// claim.
+	if scanInfo.ControlsInputs == "" && scanInfo.UseExceptions == "" {
+		digest, err := contractv1alpha1.DigestEffectiveRun(effectiveRunDigestInput{
+			DigestSchema:     contractv1alpha1.EffectiveRunDigestSchema,
+			KubescapeVersion: versioncheck.BuildNumber,
+			Effective:        metadata.Effective,
+			AllowedSections:  metadata.AllowedSections,
+			DeniedSections:   metadata.DeniedSections,
+			RunnerInputs:     metadata.RunnerInputs,
+		})
+		if err != nil {
+			logger.L().Warning("failed to derive repository scan contract effective-run digest", helpers.Error(err))
+		} else {
+			metadata.EffectiveRunDigest = digest
+		}
+	}
+
+	return &metadata
+}
+
+func cloneEffectiveSettings(settings *reporthandlingv2.ScanContractEffectiveSettings) *reporthandlingv2.ScanContractEffectiveSettings {
+	if settings == nil {
+		return nil
+	}
+	clone := *settings
+	if settings.Policy != nil {
+		policy := *settings.Policy
+		policy.Frameworks = append([]string(nil), settings.Policy.Frameworks...)
+		policy.Controls = append([]string(nil), settings.Policy.Controls...)
+		clone.Policy = &policy
+	}
+	if settings.Scope != nil {
+		scope := *settings.Scope
+		scope.IncludeNamespaces = append([]string(nil), settings.Scope.IncludeNamespaces...)
+		scope.ExcludeNamespaces = append([]string(nil), settings.Scope.ExcludeNamespaces...)
+		clone.Scope = &scope
+	}
+	if settings.Output != nil {
+		output := *settings.Output
+		output.Formats = append([]string(nil), settings.Output.Formats...)
+		clone.Output = &output
+	}
+	return &clone
+}

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -114,18 +114,19 @@ type PolicyIdentifier struct {
 }
 
 type ScanInfo struct {
-	UseExceptions             string      // Load file with exceptions configuration
-	AuditExceptions           bool        // Include exception usage audit in supported scan outputs
-	HonorInlineExceptions     BoolPtrFlag // Honor kubescape.io/skip-* annotations as inline exception policies
-	CustomRules               string      // Path to a directory of custom *.rego rules
-	ControlsInputs            string      // Load file with inputs for controls
-	AttackTracks              string      // Load file with attack tracks
-	UseFrom                   []string    // Load framework from local file (instead of download). Use when running offline
-	UseDefault                bool        // Load framework from cached file (instead of download). Use when running offline
-	UseArtifactsFrom          string      // Load artifacts from local path. Use when running offline
-	ControlsVersion           string      // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
-	VerboseMode               bool        // Display all the input resources and not only failed resources
-	Hide                      bool        // Hide sensitive identifiers (names, namespaces, images) in results
+	UseExceptions             string                                 // Load file with exceptions configuration
+	AuditExceptions           bool                                   // Include exception usage audit in supported scan outputs
+	HonorInlineExceptions     BoolPtrFlag                            // Honor kubescape.io/skip-* annotations as inline exception policies
+	CustomRules               string                                 // Path to a directory of custom *.rego rules
+	ControlsInputs            string                                 // Load file with inputs for controls
+	AttackTracks              string                                 // Load file with attack tracks
+	UseFrom                   []string                               // Load framework from local file (instead of download). Use when running offline
+	UseDefault                bool                                   // Load framework from cached file (instead of download). Use when running offline
+	UseArtifactsFrom          string                                 // Load artifacts from local path. Use when running offline
+	ControlsVersion           string                                 // Pin the regolibrary release used to download policies (e.g. "v2.0.301"). Empty uses the latest release
+	ScanContract              *reporthandlingv2.ScanContractMetadata // Selected repository scan contract provenance, populated only when --scan-contract is used
+	VerboseMode               bool                                   // Display all the input resources and not only failed resources
+	Hide                      bool                                   // Hide sensitive identifiers (names, namespaces, images) in results
 	EncryptionEnabled         bool
 	View                      string                       //
 	Format                    string                       // Format results (table, json, junit ...)
@@ -420,6 +421,7 @@ func scanInfoToScanMetadata(ctx context.Context, scanInfo *ScanInfo, policyIdent
 	metadata.ScanMetadata.HostScanner = scanInfo.HostSensorEnabled.GetBool()
 	metadata.ScanMetadata.VerboseMode = scanInfo.VerboseMode
 	metadata.ScanMetadata.ControlsInputs = scanInfo.ControlsInputs
+	metadata.ScanMetadata.ScanContract = finalizeScanContractMetadata(scanInfo, policyIdentifiers)
 
 	switch scanInfo.GetScanningContext() {
 	case ContextCluster:

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -98,6 +98,40 @@ func TestSetContextMetadata(t *testing.T) {
 	})
 }
 
+func TestScanContractProvenanceUsesFinalPolicySelection(t *testing.T) {
+	scanInfo := &ScanInfo{
+		ScanContract: &reporthandlingv2.ScanContractMetadata{
+			APIVersion:      "config.kubescape.io/v1alpha1",
+			Contract:        "ci",
+			DigestSchema:    "kubescape-scan-contract:v1",
+			ContractDigest:  "sha256:contract",
+			AllowedSections: []string{"policy"},
+			Effective: &reporthandlingv2.ScanContractEffectiveSettings{
+				Policy: &reporthandlingv2.ScanContractPolicy{
+					Frameworks: []string{"mitre"},
+				},
+			},
+		},
+	}
+
+	metadata := scanInfoToScanMetadata(context.Background(), scanInfo, []PolicyIdentifier{
+		{Identifier: "nsa", Kind: apisv1.KindFramework},
+		{Identifier: "C-0001", Kind: apisv1.KindControl},
+	})
+	provenance := metadata.ScanMetadata.ScanContract
+	require.NotNil(t, provenance)
+	require.NotNil(t, provenance.Effective)
+	require.NotNil(t, provenance.Effective.Policy)
+	assert.Equal(t, []string{"nsa"}, provenance.Effective.Policy.Frameworks)
+	assert.Equal(t, []string{"C-0001"}, provenance.Effective.Policy.Controls)
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, provenance.EffectiveRunDigest)
+	assert.Equal(t, []string{"mitre"}, scanInfo.ScanContract.Effective.Policy.Frameworks, "report finalization must not mutate the reusable scan input")
+
+	scanInfo.ControlsInputs = "runner-controls.json"
+	metadata = scanInfoToScanMetadata(context.Background(), scanInfo, nil)
+	assert.Empty(t, metadata.ScanMetadata.ScanContract.EffectiveRunDigest, "a later getter owns runner-file bytes, so no incomplete digest is emitted")
+}
+
 func TestResolveClusterContextNameRejectsInvalidSelection(t *testing.T) {
 	t.Run("missing override", func(t *testing.T) {
 		scanInfo := &ScanInfo{}

--- a/core/pkg/scancontract/v1alpha1/digest.go
+++ b/core/pkg/scancontract/v1alpha1/digest.go
@@ -9,6 +9,11 @@ import (
 	jsoncanonicalizer "github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 )
 
+// EffectiveRunDigestSchema identifies the canonical envelope used for the
+// resolved scan inputs. It is intentionally distinct from DigestSchema, which
+// covers only the selected repository contract.
+const EffectiveRunDigestSchema = "kubescape-effective-run:v1"
+
 type digestInput struct {
 	APIVersion              string   `json:"apiVersion"`
 	Kind                    string   `json:"kind"`
@@ -35,7 +40,27 @@ func Digest(selected *SelectedContract) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("canonicalize selected contract for digest: %w", err)
 	}
-	hashInput := append([]byte(DigestSchema+"\x00"), canonical...)
+	return digestCanonical(DigestSchema, canonical), nil
+}
+
+// DigestEffectiveRun produces a stable digest for the post-resolution scan
+// inputs. Callers provide a typed, JSON-serializable envelope so this package
+// can own the canonicalization and domain separation without depending on a
+// particular report schema.
+func DigestEffectiveRun(input any) (string, error) {
+	raw, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("marshal effective scan contract run for digest: %w", err)
+	}
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize effective scan contract run: %w", err)
+	}
+	return digestCanonical(EffectiveRunDigestSchema, canonical), nil
+}
+
+func digestCanonical(schema string, canonical []byte) string {
+	hashInput := append([]byte(schema+"\x00"), canonical...)
 	sum := sha256.Sum256(hashInput)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
+	return "sha256:" + hex.EncodeToString(sum[:])
 }

--- a/core/pkg/scancontract/v1alpha1/loader_test.go
+++ b/core/pkg/scancontract/v1alpha1/loader_test.go
@@ -156,6 +156,25 @@ func TestDigestPreservesExplicitEmptyValues(t *testing.T) {
 	assert.NotEqual(t, omitted.ContractDigest, explicit.ContractDigest)
 }
 
+func TestDigestEffectiveRunUsesSeparateStableDomain(t *testing.T) {
+	first, err := DigestEffectiveRun(struct {
+		Effective map[string]any `json:"effective"`
+	}{Effective: map[string]any{"coverageBelow": 95, "severityAtLeast": "high"}})
+	require.NoError(t, err)
+	second, err := DigestEffectiveRun(struct {
+		Effective map[string]any `json:"effective"`
+	}{Effective: map[string]any{"severityAtLeast": "high", "coverageBelow": 95}})
+	require.NoError(t, err)
+	changed, err := DigestEffectiveRun(struct {
+		Effective map[string]any `json:"effective"`
+	}{Effective: map[string]any{"coverageBelow": 90, "severityAtLeast": "high"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.NotEqual(t, first, changed)
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, first)
+}
+
 func TestLoadRejectsInvalidContractValues(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What this adds

This is the Kubescape half of Phase 3 from [the repository scan-contract proposal](https://github.com/kubescape/designs-and-proposals/pull/12), following the shared report schema in [kubescape/opa-utils#191](https://github.com/kubescape/opa-utils/pull/191).

A posture report now records an optional `metadata.scanMetadata.scanContract` block whenever `--scan-contract` is used. It includes:

- selected contract identity, API version, compatibility requirement, and canonical contract digest;
- a safe contract source label, never an absolute host path;
- the resolved policy, scope, evaluation, output, and failure settings;
- field-level contract, runner-floor, and effective values for each monotonic gate;
- normalized explicit CLI values that replaced ordinary contract settings;
- a separately domain-separated effective-run digest once the final policy selection is known.

The report finalizer uses the policy identifiers actually passed to the scanner, so a `scan framework` or `scan control` subcommand cannot leave provenance claiming the contract policy was executed when it was not.

## Deliberate boundary

This change does **not** pre-hash `--controls-config` or `--exceptions`. Those files are consumed later by their getters, and hashing them before reopening them would create a hash-then-load race. When either is present, the report intentionally omits `effectiveRunDigest` rather than presenting incomplete reproducibility data. A follow-up can add runner-file digests once the getters retain the exact bytes they consume.

## Validation

- `go test ./cmd/scan ./core/cautils ./core/pkg/scancontract/v1alpha1`
- `go vet ./cmd/scan ./core/cautils ./core/pkg/scancontract/v1alpha1`
- `go build ./cmd/scan ./core/cautils ./core/pkg/scancontract/v1alpha1`
- `go test ./...` was also run. The new and touched packages passed; the complete run still has an unrelated existing failure in `core/pkg/opaprocessor: TestProcessResourcesResult`. The v2 pretty-printer's temporary-file failure passes in isolation after cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scan results now include scan contract provenance when a contract is used.
  - View contract metadata, selected sections, effective scan settings, CLI overrides, and the policies ultimately executed.
  - Gate results now record contract thresholds, applied runner floors, and effective values.
  - Added stable digests for selected contracts and resolved scan inputs to support verification and comparison.
  - Contract sources are labeled safely as local or external without exposing sensitive paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->