### PR TITLE
feat(fixhandler): apply fixes to JSON manifests

### DIFF
--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -50,6 +50,9 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 
 	if len(resourcesToFix) == 0 && len(helmSuggestions) == 0 {
 		logger.L().Info(noResourcesToFix)
+		// Without this a report whose resources were all skipped reads as a
+		// clean bill of health rather than a set of findings nothing handled.
+		handler.PrintUnfixedControls(fixhandler.PhasePlanned)
 		return nil
 	}
 

--- a/core/pkg/fixhandler/datastructures.go
+++ b/core/pkg/fixhandler/datastructures.go
@@ -31,6 +31,13 @@ type ResourceFixInfo struct {
 	Resource        *reporthandling.Resource
 	FilePath        string
 	DocumentIndex   int
+
+	// failedControls and fixedCount let a resource be withdrawn after its
+	// controls have already been tallied: the entries are re-reported as
+	// unfixed and the count of fully fixed controls is given back.
+	failedControls []UnfixedControl
+	fixedCount     int
+	fileKey        string
 }
 
 // HelmFixSuggestion describes a fix for a Helm-rendered resource. We do not

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -236,6 +236,31 @@ func (h *FixHandler) resourceBasePath(resourceObj *reporthandling.Resource) stri
 	return sourcePath
 }
 
+// countResourcesPerFile tallies every resource the scan read from each manifest,
+// keyed by the file the report recorded it against.
+func (h *FixHandler) countResourcesPerFile(resources map[string]*reporthandling.Resource) map[string]int {
+	perFile := make(map[string]int, len(resources))
+	for _, resource := range resources {
+		if key := h.resourceFileKey(resource); key != "" {
+			perFile[key]++
+		}
+	}
+	return perFile
+}
+
+// resourceFileKey is the manifest a resource was read from, without the
+// document index the report appends to it.
+func (h *FixHandler) resourceFileKey(resource *reporthandling.Resource) string {
+	if resource == nil {
+		return ""
+	}
+	filePath, _, err := h.getFilePathAndIndex(h.getPathFromRawResource(resource.GetObject()))
+	if err != nil {
+		return ""
+	}
+	return filePath
+}
+
 func (h *FixHandler) buildResourcesMap() map[string]*reporthandling.Resource {
 	resourceIdToRawResource := make(map[string]*reporthandling.Resource)
 	for i := range h.reportObj.Resources {
@@ -276,6 +301,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 	resourceIdToResource := h.buildResourcesMap()
 
 	resourcesToFix := make([]ResourceFixInfo, 0)
+	resourcesPerFile := h.countResourcesPerFile(resourceIdToResource)
 	h.unfixedControls = h.unfixedControls[:0]
 	h.fixedControlsCount = 0
 
@@ -327,8 +353,8 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		skipReason := ""
 		if resourcePath == "" {
 			skipReason = "skipped: resource has no local file path"
-		} else if resourceObj.Source == nil || resourceObj.Source.FileType != reporthandling.SourceTypeYaml {
-			skipReason = "skipped: source is not a YAML file"
+		} else if resourceObj.Source == nil || !isFixableSourceType(resourceObj.Source.FileType) {
+			skipReason = "skipped: source is not a YAML or JSON file"
 		}
 
 		var absolutePath string
@@ -383,6 +409,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 
 		rfi := ResourceFixInfo{
 			FilePath:        absolutePath,
+			fileKey:         h.resourceFileKey(resourceObj),
 			Resource:        resourceObj,
 			YamlExpressions: make(map[string]armotypes.FixPath, 0),
 			DocumentIndex:   documentIndex,
@@ -405,9 +432,18 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 
 			added, skipped := rfi.addYamlExpressionsFromResourceAssociatedControl(documentIndex, ac, h.fixInfo.SkipUserValues)
 
+			rfi.failedControls = append(rfi.failedControls, UnfixedControl{
+				ControlID:    ac.GetID(),
+				ControlName:  ac.GetName(),
+				ResourceName: resourceObj.GetName(),
+				ResourceKind: resourceObj.GetKind(),
+				FilePath:     sanitizeForLog(absolutePath),
+			})
+
 			// Fully auto-remediated: every failed path produced an expression.
 			if added > 0 && len(skipped) == 0 {
 				h.fixedControlsCount++
+				rfi.fixedCount++
 				continue
 			}
 
@@ -444,6 +480,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		for _, pu := range tentativeUnfixed {
 			if len(plannedPaths) > 0 && controlIsCoveredByPlannedPaths(pu.ac, plannedPaths) {
 				h.fixedControlsCount++
+				rfi.fixedCount++
 				continue
 			}
 			h.unfixedControls = append(h.unfixedControls, pu.entry)
@@ -497,7 +534,52 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		}
 	}
 
-	return resourcesToFix
+	return h.dropWrappedResources(ctx, resourcesToFix, resourcesPerFile)
+}
+
+// dropWrappedResources removes resources whose fix paths would not resolve
+// against the document they were read from. A fix path is relative to its own
+// resource, but the expression is evaluated at the document root, so the two
+// only agree when the document is the resource. A manifest that wraps several
+// resources in one document, kind: List being the usual case, breaks that: the
+// paths are written to the wrapper and the file gains a spec block belonging to
+// none of them.
+//
+// A file yielding fewer documents than the resources read from it is wrapped.
+// The count comes from every resource the scan recorded, not from the failing
+// ones: a List whose other members passed is still a List.  Genuine
+// multi-document YAML has one document per resource and is untouched.
+func (h *FixHandler) dropWrappedResources(ctx context.Context, resourcesToFix []ResourceFixInfo, resourcesPerFile map[string]int) []ResourceFixInfo {
+	wrapped := make(map[string]bool, len(resourcesPerFile))
+	for i := range resourcesToFix {
+		filePath := resourcesToFix[i].FilePath
+		resources := resourcesPerFile[resourcesToFix[i].fileKey]
+		if _, checked := wrapped[filePath]; checked || resources < 2 {
+			continue
+		}
+		documents, err := countDocuments(ctx, filePath)
+		if err != nil {
+			// Leave it to the apply step, which reports the parse error itself.
+			continue
+		}
+		wrapped[filePath] = documents < resources
+	}
+
+	kept := make([]ResourceFixInfo, 0, len(resourcesToFix))
+	for i := range resourcesToFix {
+		rfi := resourcesToFix[i]
+		if !wrapped[rfi.FilePath] {
+			kept = append(kept, rfi)
+			continue
+		}
+
+		h.fixedControlsCount -= rfi.fixedCount
+		for _, unfixed := range rfi.failedControls {
+			unfixed.Reason = "skipped: the file declares several resources in one document"
+			h.unfixedControls = append(h.unfixedControls, unfixed)
+		}
+	}
+	return kept
 }
 
 // PrepareHelmSuggestions collects fix guidance for resources whose Source is a
@@ -704,14 +786,14 @@ func (h *FixHandler) ApplyChanges(ctx context.Context, resourcesToFix []Resource
 			continue
 		}
 
-		fixedYamlString, err := ApplyFixToContent(ctx, fileAsString, yamlExpression)
+		fixedContent, err := applyFixToFileContent(ctx, filepath, fileAsString, yamlExpression)
 
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to fix file %s: %w ", filepath, err))
 			continue
 		}
 
-		if err := writeFixesToFile(filepath, fixedYamlString); err != nil {
+		if err := writeFixesToFile(filepath, fixedContent); err != nil {
 			logger.L().Ctx(ctx).Warning(fmt.Sprintf("Failed to write fixes to file %s, %v", filepath, err.Error()))
 			errors = append(errors, err)
 			continue
@@ -813,6 +895,23 @@ func ApplyFixToContent(ctx context.Context, yamlAsString, yamlExpression string)
 	fixedString = revertSanitizeYaml(fixedString)
 
 	return fixedString, nil
+}
+
+// isFixableSourceType reports whether the scan parsed a file the fix engine can
+// rewrite. Helm-rendered resources carry their own type and are handled by
+// PrepareHelmSuggestions instead.
+func isFixableSourceType(fileType string) bool {
+	return fileType == reporthandling.SourceTypeYaml || fileType == reporthandling.SourceTypeJson
+}
+
+// applyFixToFileContent rewrites one file, keeping it in the format it was
+// written in. Emitting YAML into a .json manifest would break every tool that
+// reads it back.
+func applyFixToFileContent(ctx context.Context, filePath, content, yamlExpression string) (string, error) {
+	if isJSONSource(filePath) {
+		return applyFixToJSONContent(ctx, content, yamlExpression)
+	}
+	return ApplyFixToContent(ctx, content, yamlExpression)
 }
 
 func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) map[string]string {

--- a/core/pkg/fixhandler/jsonhandler.go
+++ b/core/pkg/fixhandler/jsonhandler.go
@@ -1,0 +1,95 @@
+package fixhandler
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+)
+
+const defaultJSONIndent = 2
+
+// applyFixToJSONContent evaluates the same expression the YAML path uses and
+// re-encodes the document. The YAML path splices the fixed lines back into the
+// original text to keep comments and layout; JSON carries neither, so
+// re-encoding loses nothing but the original whitespace.
+func applyFixToJSONContent(ctx context.Context, jsonAsString, yamlExpression string) (string, error) {
+	documents, err := readDocuments(ctx, strings.NewReader(jsonAsString), yqlib.NewJSONDecoder())
+	if err != nil {
+		return "", err
+	}
+
+	allDocuments := list.New()
+	allDocuments.PushBackList(documents)
+
+	fixedNodes, err := yqlib.NewAllAtOnceEvaluator().EvaluateCandidateNodes(yamlExpression, allDocuments)
+	if err != nil {
+		return "", fmt.Errorf("error fixing JSON, %w", err)
+	}
+
+	var fixed bytes.Buffer
+	printer := yqlib.NewPrinter(
+		yqlib.NewJSONEncoder(detectJSONIndent(jsonAsString), false),
+		yqlib.NewSinglePrinterWriter(&fixed),
+	)
+	if err := printer.PrintResults(fixedNodes); err != nil {
+		return "", fmt.Errorf("error encoding JSON, %w", err)
+	}
+
+	return fixed.String(), nil
+}
+
+// detectJSONIndent reads the indentation of the first nested line so a fixed
+// file keeps the spacing it was written with. A minified document has none, and
+// re-encoding it pretty-printed is preferable to emitting a single line the
+// user then has to read.
+func detectJSONIndent(jsonAsString string) int {
+	for _, line := range strings.Split(jsonAsString, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed == "" || len(trimmed) == len(line) {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "\t") {
+			return defaultJSONIndent
+		}
+		return len(line) - len(trimmed)
+	}
+	return defaultJSONIndent
+}
+
+// isJSONSource reports whether a scanned file is JSON rather than YAML. The
+// report records the type it parsed, and the extension is the fallback for a
+// caller that only has the path.
+func isJSONSource(filePath string) bool {
+	return strings.EqualFold(strings.TrimPrefix(pathExtension(filePath), "."), "json")
+}
+
+func pathExtension(filePath string) string {
+	if idx := strings.LastIndex(filePath, "."); idx != -1 {
+		return filePath[idx:]
+	}
+	return ""
+}
+
+// countDocuments reports how many documents a manifest holds. JSON is always a
+// single document; YAML separates them with ---.
+func countDocuments(ctx context.Context, filePath string) (int, error) {
+	content, err := GetFileString(filePath)
+	if err != nil {
+		return 0, err
+	}
+
+	decoder := yqlib.NewYamlDecoder(yqlib.ConfiguredYamlPreferences)
+	if isJSONSource(filePath) {
+		decoder = yqlib.NewJSONDecoder()
+	}
+
+	documents, err := readDocuments(ctx, strings.NewReader(content), decoder)
+	if err != nil {
+		return 0, err
+	}
+	return documents.Len(), nil
+}

--- a/core/pkg/fixhandler/jsonhandler_test.go
+++ b/core/pkg/fixhandler/jsonhandler_test.go
@@ -1,0 +1,129 @@
+package fixhandler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const jsonDeployment = `{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "api"
+  },
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "app",
+            "securityContext": {
+              "allowPrivilegeEscalation": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+`
+
+const privilegeEscalationFix = `select(di==0) | .spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation |= false`
+
+func TestApplyFixToJSONContentRewritesTheValue(t *testing.T) {
+	fixed, err := applyFixToJSONContent(context.Background(), jsonDeployment, privilegeEscalationFix)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(fixed), &decoded), "the fixed file must still parse as JSON")
+
+	containers := decoded["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
+	securityContext := containers[0].(map[string]any)["securityContext"].(map[string]any)
+	assert.Equal(t, false, securityContext["allowPrivilegeEscalation"])
+}
+
+func TestApplyFixToJSONContentAddsAMissingField(t *testing.T) {
+	fixed, err := applyFixToJSONContent(context.Background(), jsonDeployment,
+		`select(di==0) | .spec.template.spec.automountServiceAccountToken |= false`)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(fixed), &decoded))
+
+	podSpec := decoded["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+	assert.Equal(t, false, podSpec["automountServiceAccountToken"])
+	assert.Equal(t, "api", decoded["metadata"].(map[string]any)["name"], "untouched fields must survive the round trip")
+}
+
+func TestApplyFixToJSONContentKeepsTheOriginalIndent(t *testing.T) {
+	fourSpace := strings.ReplaceAll(jsonDeployment, "  ", "    ")
+
+	fixed, err := applyFixToJSONContent(context.Background(), fourSpace, privilegeEscalationFix)
+	require.NoError(t, err)
+
+	require.Contains(t, fixed, "\n    \"apiVersion\"")
+	assert.NotContains(t, fixed, "\n  \"apiVersion\"")
+}
+
+func TestApplyFixToJSONContentRejectsMalformedInput(t *testing.T) {
+	_, err := applyFixToJSONContent(context.Background(), `{"kind": `, privilegeEscalationFix)
+	assert.Error(t, err)
+}
+
+func TestDetectJSONIndent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "two spaces", in: "{\n  \"a\": 1\n}", want: 2},
+		{name: "four spaces", in: "{\n    \"a\": 1\n}", want: 4},
+		{name: "tabs fall back to the default", in: "{\n\t\"a\": 1\n}", want: defaultJSONIndent},
+		{name: "minified falls back to the default", in: `{"a":1}`, want: defaultJSONIndent},
+		{name: "empty falls back to the default", in: "", want: defaultJSONIndent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, detectJSONIndent(tt.in))
+		})
+	}
+}
+
+func TestIsJSONSource(t *testing.T) {
+	assert.True(t, isJSONSource("/tmp/deploy.json"))
+	assert.True(t, isJSONSource("/tmp/Deploy.JSON"))
+	assert.False(t, isJSONSource("/tmp/deploy.yaml"))
+	assert.False(t, isJSONSource("/tmp/deploy.yml"))
+	assert.False(t, isJSONSource("/tmp/deploy"))
+	assert.False(t, isJSONSource("/tmp/json/deploy.yaml"))
+}
+
+func TestIsFixableSourceType(t *testing.T) {
+	assert.True(t, isFixableSourceType(reporthandling.SourceTypeYaml))
+	assert.True(t, isFixableSourceType(reporthandling.SourceTypeJson))
+	assert.False(t, isFixableSourceType(reporthandling.SourceTypeHelmChart))
+	assert.False(t, isFixableSourceType(""))
+}
+
+// TestApplyFixToFileContentPreservesTheSourceFormat is the reason the dispatch
+// exists: emitting YAML into a .json manifest would break every tool that reads
+// it back.
+func TestApplyFixToFileContentPreservesTheSourceFormat(t *testing.T) {
+	fixedJSON, err := applyFixToFileContent(context.Background(), "/tmp/deploy.json", jsonDeployment, privilegeEscalationFix)
+	require.NoError(t, err)
+	assert.NoError(t, json.Unmarshal([]byte(fixedJSON), &map[string]any{}))
+
+	yamlDeployment := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api\nspec:\n  template:\n    spec:\n      containers:\n        - name: app\n          securityContext:\n            allowPrivilegeEscalation: true\n"
+
+	fixedYAML, err := applyFixToFileContent(context.Background(), "/tmp/deploy.yaml", yamlDeployment, privilegeEscalationFix)
+	require.NoError(t, err)
+	assert.Contains(t, fixedYAML, "allowPrivilegeEscalation: false")
+	assert.Error(t, json.Unmarshal([]byte(fixedYAML), &map[string]any{}), "the YAML path must not emit JSON")
+}

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- helpers --------------------------------------------------------------
@@ -370,12 +371,12 @@ func TestPrepareResourcesToFix_UnresolvableResourceID(t *testing.T) {
 	}
 }
 
-func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
+func TestPrepareResourcesToFix_UnsupportedSource(t *testing.T) {
 	dir := t.TempDir()
-	manifest := writeManifest(t, dir, "deploy.json", "{}")
+	manifest := writeManifest(t, dir, "deploy.yaml", "{}")
 	rel, _ := filepath.Rel(dir, manifest)
 	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
-	res.Source.FileType = reporthandling.SourceTypeJson
+	res.Source.FileType = reporthandling.SourceTypeHelmChart
 
 	results := []resourcesresults.Result{
 		{
@@ -391,7 +392,7 @@ func TestPrepareResourcesToFix_NonYamlSource(t *testing.T) {
 	h := newHandlerForResources(dir, results, nil, false)
 	_ = h.PrepareResourcesToFix(context.Background())
 	if assert.Len(t, h.UnfixedControls(), 1) {
-		assert.Contains(t, h.UnfixedControls()[0].Reason, "not a YAML")
+		assert.Contains(t, h.UnfixedControls()[0].Reason, "not a YAML or JSON")
 	}
 }
 
@@ -1065,4 +1066,152 @@ func TestNewFixHandler_AcceptsValidReport(t *testing.T) {
 	h, err := NewFixHandler(&metav1.FixInfo{ReportFile: reportFile})
 	assert.NoError(t, err)
 	assert.NotNil(t, h)
+}
+
+// TestPrepareResourcesToFix_JsonSource covers the format the scan reads and
+// reports fix paths for, but the fix engine used to refuse: the resource is
+// prepared for fixing rather than listed as unfixed.
+func TestPrepareResourcesToFix_JsonSource(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.json", `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"demo"},"spec":{"privileged":true}}`)
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Pod", "demo", 0)
+	res.Source.FileType = reporthandling.SourceTypeJson
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged",
+					failedRuleWithFix("spec.privileged", "false"),
+				),
+			},
+		},
+	}
+
+	h := newHandlerForResources(dir, results, nil, false)
+	toFix := h.PrepareResourcesToFix(context.Background())
+
+	require.Len(t, toFix, 1)
+	assert.Equal(t, manifest, toFix[0].FilePath)
+	assert.Empty(t, h.UnfixedControls())
+}
+
+// TestPrepareResourcesToFix_JsonFileWithSeveralResources covers a JSON manifest
+// that wraps its resources, kind: List being the common case. A JSON file is a
+// single document, so every fix path in it resolves against the wrapper rather
+// than the resource it belongs to.
+func TestPrepareResourcesToFix_JsonFileWithSeveralResources(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "list.json", `{"apiVersion":"v1","kind":"List","items":[]}`)
+	rel, _ := filepath.Rel(dir, manifest)
+
+	results := make([]resourcesresults.Result, 0, 2)
+	for i, name := range []string{"api", "web"} {
+		res := buildResource(t, dir, rel, "Pod", name, i)
+		res.Source.FileType = reporthandling.SourceTypeJson
+		results = append(results, resourcesresults.Result{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged", failedRuleWithFix("spec.privileged", "false")),
+			},
+		})
+	}
+
+	h := newHandlerForResources(dir, results, nil, false)
+	toFix := h.PrepareResourcesToFix(context.Background())
+
+	assert.Empty(t, toFix, "a wrapped JSON manifest must not be rewritten")
+	require.NotEmpty(t, h.UnfixedControls())
+	assert.Contains(t, h.UnfixedControls()[0].Reason, "several resources in one document")
+}
+
+// TestPrepareResourcesToFix_MultiDocumentYamlIsUnaffected keeps the guard from
+// over-reaching: each YAML document is a resource in its own right.
+func TestPrepareResourcesToFix_MultiDocumentYamlIsUnaffected(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "multi.yaml", "kind: Pod\n---\nkind: Pod\n")
+	rel, _ := filepath.Rel(dir, manifest)
+
+	results := make([]resourcesresults.Result, 0, 2)
+	for i, name := range []string{"api", "web"} {
+		res := buildResource(t, dir, rel, "Pod", name, i)
+		res.Source.FileType = reporthandling.SourceTypeYaml
+		results = append(results, resourcesresults.Result{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged", failedRuleWithFix("spec.privileged", "false")),
+			},
+		})
+	}
+
+	h := newHandlerForResources(dir, results, nil, false)
+
+	assert.Len(t, h.PrepareResourcesToFix(context.Background()), 2)
+}
+
+// TestPrepareResourcesToFix_YamlListIsNotRewritten covers the same wrapper in
+// YAML. One document, several resources: their fix paths resolve against the
+// List rather than the workloads, so the file is left alone.
+func TestPrepareResourcesToFix_YamlListIsNotRewritten(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "list.yaml", "apiVersion: v1\nkind: List\nitems:\n  - kind: Pod\n  - kind: Pod\n")
+	rel, _ := filepath.Rel(dir, manifest)
+
+	results := make([]resourcesresults.Result, 0, 2)
+	for i, name := range []string{"api", "web"} {
+		res := buildResource(t, dir, rel, "Pod", name, i)
+		res.Source.FileType = reporthandling.SourceTypeYaml
+		results = append(results, resourcesresults.Result{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged", failedRuleWithFix("spec.privileged", "false")),
+			},
+		})
+	}
+
+	h := newHandlerForResources(dir, results, nil, false)
+	toFix := h.PrepareResourcesToFix(context.Background())
+
+	assert.Empty(t, toFix)
+	require.NotEmpty(t, h.UnfixedControls())
+	assert.Contains(t, h.UnfixedControls()[0].Reason, "several resources in one document")
+}
+
+// TestPrepareResourcesToFix_ListWithOneFixableChild covers a wrapper whose other
+// members produced no fixes. Counting only the fixable resources would see one
+// resource, miss the wrapper and write its fix paths to the List.
+func TestPrepareResourcesToFix_ListWithOneFixableChild(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "list.json", `{"apiVersion":"v1","kind":"List","items":[]}`)
+	rel, _ := filepath.Rel(dir, manifest)
+
+	failing := buildResource(t, dir, rel, "Pod", "bad", 0)
+	failing.Source.FileType = reporthandling.SourceTypeJson
+	passing := buildResource(t, dir, rel, "ConfigMap", "cfg", 1)
+	passing.Source.FileType = reporthandling.SourceTypeJson
+
+	h := newHandlerForResources(dir, []resourcesresults.Result{
+		{
+			ResourceID:  failing.GetID(),
+			RawResource: failing,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged", failedRuleWithFix("spec.privileged", "false")),
+			},
+		},
+	}, nil, false)
+	h.reportObj.Resources = append(h.reportObj.Resources, *failing, *passing)
+
+	toFix := h.PrepareResourcesToFix(context.Background())
+
+	assert.Empty(t, toFix, "the wrapper must be detected from every scanned resource, not only the fixable ones")
+	assert.Zero(t, h.FixedControlsCount(), "a withdrawn resource must give back its fixed tally")
+	require.NotEmpty(t, h.UnfixedControls())
+	assert.Equal(t, "C-0057", h.UnfixedControls()[0].ControlID)
+	assert.Equal(t, "Privileged", h.UnfixedControls()[0].ControlName)
+	assert.Contains(t, h.UnfixedControls()[0].Reason, "several resources in one document")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -518,6 +518,22 @@ Auto-fix misconfigurations in Kubernetes manifest files.
 kubescape fix <report-file> [flags]
 ```
 
+### Supported manifest formats
+
+YAML and JSON manifests are both fixed in place, in the format they were written
+in. A YAML file keeps its comments and layout, since only the changed lines are
+rewritten; a JSON file is re-encoded at the indentation it already used, JSON
+having no comments to preserve.
+
+A manifest that wraps several resources in one document, `kind: List` being the
+usual case, is left alone in either format: the fix paths would resolve against
+the wrapper rather than the resources they belong to. Multi-document YAML is
+fixed normally, each document there being a resource in its own right.
+
+Helm charts are reported as suggestions rather than edited, because a rendered
+resource's fix path does not map reliably back to a template line. Resources
+from any other source are listed as unfixed with the reason.
+
 ### Flags
 
 | Flag | Description | Default |


### PR DESCRIPTION
## Summary

`kubescape scan` reads JSON manifests fine, but `kubescape fix` only accepts YAML sources, so it prints "No issues to fix." and does nothing, the same Deployment in YAML gets 6 of 23 flagged controls fixed. This wires up JSON, writing each file back in its own format (YAML keeps its comments via line splicing, JSON is re-encoded at the indent it already used).

While testing it I hit a pre-existing bug: on a `kind: List` manifest, fix reports "Fixed 12 of 46", changes nothing, and appends a bogus top-level `spec` to the file. Confirmed that on a clean master build. Since a fix path is relative to its resource but evaluated at the document root, any file with fewer documents than resources is now skipped with a reason instead of rewritten - that covers both formats, and plain multi-doc YAML is unaffected. Reports where nothing was fixable also print the skip reasons now, which is why the JSON gap looked clean in the first place.

Tested with `TestApplyFixToJSONContentRewritesTheValue`, `TestPrepareResourcesToFix_JsonSource`, `TestPrepareResourcesToFix_YamlListIsNotRewritten` and `TestPrepareResourcesToFix_MultiDocumentYamlIsUnaffected`, plus manual runs across single/List/multi-doc in both formats. No new dependencies.

**Which issue(s) this PR fixes:**

None, found by comparing the formats `scan` reads against the ones `fix` writes.

**Special notes for your reviewer:**

The `kind: List` guard changes YAML behaviour too. That's deliberate rather than scope creep: without it this PR would extend an existing corruption to a new format. My first attempt keyed on `(file, documentIndex)` and silently didn't fire, since List items get distinct indices despite sharing one document — comparing document count to resource count is the rule that actually holds.

**Does this PR introduce a user-facing change?**

Yes `kubescape fix` now fixes JSON manifests, and `kind: List` files in either format are reported as unfixed instead of being rewritten incorrectly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for applying fixes directly to JSON manifests while preserving their formatting.
  - Multi-document YAML files continue to be processed.
  - Reports now surface findings when all resources were skipped.

- **Bug Fixes**
  - Prevented edits to wrapper manifests containing multiple resources; these are reported as unfixed instead.
  - Unsupported sources are clearly reported as not fixable.

- **Documentation**
  - Updated CLI reference with supported formats and fix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->