### PR TITLE
fix(resourcehandler): do not report a kind's other served versions as unexamined

### DIFF
--- a/core/cautils/scancoverage.go
+++ b/core/cautils/scancoverage.go
@@ -58,6 +58,11 @@ type ScanCoverage struct {
 
 // UnexaminedKind is a listable resource kind the cluster serves that no rule
 // in the scanned policy set matched, so it was never collected or evaluated.
+//
+// One entry per kind, not per served version: a rule naming any one version of
+// a kind reaches all of its objects, so a kind is listed only when no rule
+// named it at any version, and GroupVersionResource then carries the version
+// the API server ranks highest.
 type UnexaminedKind struct {
 	GroupVersionResource string `json:"groupVersionResource"`
 	Kind                 string `json:"kind"`

--- a/core/pkg/resourcehandler/unexaminedkinds.go
+++ b/core/pkg/resourcehandler/unexaminedkinds.go
@@ -7,23 +7,54 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 )
 
+// examinedResourceKey is one side of the unexamined-kinds diff. The query set is
+// keyed by formatted triplets and discovery hands back a GroupVersionResource,
+// so both are parsed into this before being compared, rather than one side
+// being re-formatted into the other's spelling.
+type examinedResourceKey struct {
+	group    string
+	version  string
+	resource string
+}
+
+// queriedResourceKeys parses the query set's triplet keys. A key that is
+// not a triplet cannot name a discovered resource, so it is dropped rather than
+// kept as a partly-empty identity that could match one.
+func queriedResourceKeys(queryable QueryableResources) map[examinedResourceKey]struct{} {
+	queried := make(map[examinedResourceKey]struct{}, len(queryable))
+	for triplet := range queryable {
+		group, version, resource := k8sinterface.StringToResourceGroup(triplet)
+		if resource == "" {
+			continue
+		}
+		queried[examinedResourceKey{group: group, version: version, resource: resource}] = struct{}{}
+	}
+	return queried
+}
+
 // computeUnexaminedKinds returns the listable resource kinds discovery
 // reported that queryable does not include, sorted by GVR triplet. discovered
 // only ever contains real API-server-served kinds (see collectDiscoveredResources),
 // so Kubescape's own virtual/external resources (host sensor, cloud, RBAC)
 // never appear here and need no filtering.
 func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable QueryableResources) []cautils.UnexaminedKind {
+	queried := queriedResourceKeys(queryable)
+
 	var unexamined []cautils.UnexaminedKind
 	for _, candidate := range discovered {
 		if !candidate.listable {
 			continue
 		}
-		triplet := k8sinterface.GroupVersionResourceToString(&candidate.gvr)
-		if _, queried := queryable[triplet]; queried {
+		identity := examinedResourceKey{
+			group:    candidate.gvr.Group,
+			version:  candidate.gvr.Version,
+			resource: candidate.gvr.Resource,
+		}
+		if _, examined := queried[identity]; examined {
 			continue
 		}
 		unexamined = append(unexamined, cautils.UnexaminedKind{
-			GroupVersionResource: triplet,
+			GroupVersionResource: k8sinterface.GroupVersionResourceToString(&candidate.gvr),
 			Kind:                 candidate.kind,
 		})
 	}

--- a/core/pkg/resourcehandler/unexaminedkinds.go
+++ b/core/pkg/resourcehandler/unexaminedkinds.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 // examinedResourceKey is one side of the unexamined-kinds diff. The query set is
@@ -39,14 +40,17 @@ func queriedResourceKeys(queryable QueryableResources) map[examinedResourceKey]s
 }
 
 // computeUnexaminedKinds returns the listable resource kinds discovery
-// reported that queryable does not include, sorted by GVR triplet. discovered
-// only ever contains real API-server-served kinds (see collectDiscoveredResources),
-// so Kubescape's own virtual/external resources (host sensor, cloud, RBAC)
-// never appear here and need no filtering.
+// reported that queryable does not include, one entry per kind, sorted by GVR
+// triplet. discovered only ever contains real API-server-served kinds (see
+// collectDiscoveredResources), so Kubescape's own virtual/external resources
+// (host sensor, cloud, RBAC) never appear here and need no filtering.
+//
+// A kind served at several versions is one coverage gap, not one per version,
+// so it is reported at the version an apiserver itself would prefer.
 func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable QueryableResources) []cautils.UnexaminedKind {
 	queried := queriedResourceKeys(queryable)
 
-	var unexamined []cautils.UnexaminedKind
+	gaps := make(map[examinedResourceKey]discoveredAPIResource, len(discovered))
 	for _, candidate := range discovered {
 		if !candidate.listable {
 			continue
@@ -55,6 +59,14 @@ func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable Querya
 		if _, examined := queried[key]; examined {
 			continue
 		}
+		if reported, seen := gaps[key]; seen && !outranksVersion(candidate.gvr.Version, reported.gvr.Version) {
+			continue
+		}
+		gaps[key] = candidate
+	}
+
+	var unexamined []cautils.UnexaminedKind
+	for _, candidate := range gaps {
 		unexamined = append(unexamined, cautils.UnexaminedKind{
 			GroupVersionResource: k8sinterface.GroupVersionResourceToString(&candidate.gvr),
 			Kind:                 candidate.kind,
@@ -64,4 +76,13 @@ func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable Querya
 		return unexamined[i].GroupVersionResource < unexamined[j].GroupVersionResource
 	})
 	return unexamined
+}
+
+// outranksVersion reports whether candidate is the version an apiserver would
+// prefer over reported, using its own ordering: GA over beta over alpha, then
+// by number. The comparison is total even for versions that ordering cannot
+// parse, so which of a resource's versions gets reported never depends on the
+// order discovery listed them in.
+func outranksVersion(candidate, reported string) bool {
+	return version.CompareKubeAwareVersionStrings(candidate, reported) > 0
 }

--- a/core/pkg/resourcehandler/unexaminedkinds.go
+++ b/core/pkg/resourcehandler/unexaminedkinds.go
@@ -11,9 +11,15 @@ import (
 // keyed by formatted triplets and discovery hands back a GroupVersionResource,
 // so both are parsed into this before being compared, rather than one side
 // being re-formatted into the other's spelling.
+//
+// The served version is deliberately not part of it. Every version a group
+// serves a resource at is a view of the same stored objects, so a LIST at one
+// of them returns the whole set and examines the kind outright. Keying on the
+// version reported a second served version as a coverage gap that does not
+// exist, which any multi-version CRD and several built-in groups (autoscaling,
+// admissionregistration.k8s.io) hit on an ordinary cluster.
 type examinedResourceKey struct {
 	group    string
-	version  string
 	resource string
 }
 
@@ -23,11 +29,11 @@ type examinedResourceKey struct {
 func queriedResourceKeys(queryable QueryableResources) map[examinedResourceKey]struct{} {
 	queried := make(map[examinedResourceKey]struct{}, len(queryable))
 	for triplet := range queryable {
-		group, version, resource := k8sinterface.StringToResourceGroup(triplet)
+		group, _, resource := k8sinterface.StringToResourceGroup(triplet)
 		if resource == "" {
 			continue
 		}
-		queried[examinedResourceKey{group: group, version: version, resource: resource}] = struct{}{}
+		queried[examinedResourceKey{group: group, resource: resource}] = struct{}{}
 	}
 	return queried
 }
@@ -45,12 +51,8 @@ func computeUnexaminedKinds(discovered []discoveredAPIResource, queryable Querya
 		if !candidate.listable {
 			continue
 		}
-		identity := examinedResourceKey{
-			group:    candidate.gvr.Group,
-			version:  candidate.gvr.Version,
-			resource: candidate.gvr.Resource,
-		}
-		if _, examined := queried[identity]; examined {
+		key := examinedResourceKey{group: candidate.gvr.Group, resource: candidate.gvr.Resource}
+		if _, examined := queried[key]; examined {
 			continue
 		}
 		unexamined = append(unexamined, cautils.UnexaminedKind{

--- a/core/pkg/resourcehandler/unexaminedkinds_test.go
+++ b/core/pkg/resourcehandler/unexaminedkinds_test.go
@@ -2,6 +2,7 @@ package resourcehandler
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -243,4 +244,161 @@ func TestStreamResourcesBatches_PopulatesUnexaminedKinds(t *testing.T) {
 	}
 	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/httproutes")
 	assert.Contains(t, triplets, "gateway.networking.k8s.io/v1/gateways")
+}
+
+// clusterWithMultiVersionDiscovery serves two kinds at two versions each: a
+// CRD the way Agent Sandbox registers one (v1alpha1 alongside v1beta1), and a
+// built-in group an ordinary cluster already has (autoscaling v1 and v2).
+func clusterWithMultiVersionDiscovery() *discoveryfake.FakeDiscovery {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "agents.x-k8s.io/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{Name: "sandboxes", Kind: "Sandbox", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: "agents.x-k8s.io/v1beta1",
+			APIResources: []metav1.APIResource{
+				{Name: "sandboxes", Kind: "Sandbox", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: "autoscaling/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "horizontalpodautoscalers", Kind: "HorizontalPodAutoscaler", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: "autoscaling/v2",
+			APIResources: []metav1.APIResource{
+				{Name: "horizontalpodautoscalers", Kind: "HorizontalPodAutoscaler", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	return client
+}
+
+func queryableFrom(triplets ...string) QueryableResources {
+	queryable := QueryableResources{}
+	for _, triplet := range triplets {
+		queryable[triplet] = QueryableResource{GroupVersionResourceTriplet: triplet}
+	}
+	return queryable
+}
+
+func unexaminedTriplets(kinds []cautils.UnexaminedKind) []string {
+	var triplets []string
+	for _, kind := range kinds {
+		triplets = append(triplets, kind.GroupVersionResource)
+	}
+	return triplets
+}
+
+// TestComputeUnexaminedKinds_QueriedVersionExaminesEveryServedVersion pins the
+// core of the fix: a LIST at one served version returns every object of that
+// kind, so the versions the rule did not name are not coverage gaps.
+func TestComputeUnexaminedKinds_QueriedVersionExaminesEveryServedVersion(t *testing.T) {
+	_, _, discovered := newDiscoveryResourceResolverWithKinds(clusterWithMultiVersionDiscovery())
+	require.Len(t, discovered, 4)
+
+	queryable := queryableFrom(
+		"agents.x-k8s.io/v1beta1/sandboxes",
+		"autoscaling/v2/horizontalpodautoscalers",
+	)
+
+	assert.Empty(t, computeUnexaminedKinds(discovered, queryable),
+		"every Sandbox and HorizontalPodAutoscaler was examined; the other served version of each is the same objects")
+}
+
+// TestComputeUnexaminedKinds_ResourceNameInAnotherGroupIsStillAGap is the
+// regression risk of dropping the version from the comparison: only the
+// version may be ignored. Two groups serving the same resource name are
+// distinct resources backed by distinct storage, so querying one must not
+// clear the other.
+func TestComputeUnexaminedKinds_ResourceNameInAnotherGroupIsStillAGap(t *testing.T) {
+	client := &discoveryfake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	client.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "extensions/v1beta1",
+			APIResources: []metav1.APIResource{
+				{Name: "ingresses", Kind: "Ingress", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: "networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "ingresses", Kind: "Ingress", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	_, _, discovered := newDiscoveryResourceResolverWithKinds(client)
+
+	unexamined := computeUnexaminedKinds(discovered, queryableFrom("extensions/v1beta1/ingresses"))
+
+	assert.Equal(t, []string{"networking.k8s.io/v1/ingresses"}, unexaminedTriplets(unexamined))
+}
+
+// TestComputeUnexaminedKinds_MultiVersionGapReportedOnce covers a kind no rule
+// examined at any version: that is one coverage gap, reported at the version an
+// apiserver ranks highest, not one row per served version.
+func TestComputeUnexaminedKinds_MultiVersionGapReportedOnce(t *testing.T) {
+	_, _, discovered := newDiscoveryResourceResolverWithKinds(clusterWithMultiVersionDiscovery())
+
+	unexamined := computeUnexaminedKinds(discovered, QueryableResources{})
+
+	assert.Equal(t, []string{
+		"agents.x-k8s.io/v1beta1/sandboxes",
+		"autoscaling/v2/horizontalpodautoscalers",
+	}, unexaminedTriplets(unexamined))
+}
+
+// TestComputeUnexaminedKinds_ReportedVersionIgnoresDiscoveryOrder pins that
+// the version a gap is reported at comes from the apiserver's own version
+// ranking rather than from whichever group discovery happened to list first.
+func TestComputeUnexaminedKinds_ReportedVersionIgnoresDiscoveryOrder(t *testing.T) {
+	client := clusterWithMultiVersionDiscovery()
+	slices.Reverse(client.Resources)
+	_, _, discovered := newDiscoveryResourceResolverWithKinds(client)
+
+	unexamined := computeUnexaminedKinds(discovered, QueryableResources{})
+
+	assert.Equal(t, []string{
+		"agents.x-k8s.io/v1beta1/sandboxes",
+		"autoscaling/v2/horizontalpodautoscalers",
+	}, unexaminedTriplets(unexamined))
+}
+
+// TestGetResources_MultiVersionCRDQueriedAtOneVersionIsNoGap drives the same
+// case through the real collection path: a control naming the CRD at one of
+// the two versions the cluster serves it at leaves no coverage gap behind.
+func TestGetResources_MultiVersionCRDQueriedAtOneVersionIsNoGap(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	handler := getResourceHandlerMock()
+	handler.k8s.DiscoveryClient = clusterWithMultiVersionDiscovery()
+	handler.k8s.DynamicClient = &mockDynamicClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{}, nil
+		},
+	}
+
+	match := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{"agents.x-k8s.io"},
+		APIVersions: []string{"v1beta1"},
+		Resources:   []string{"Sandbox"},
+	}
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{match}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, _, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+	require.NoError(t, err)
+
+	assert.NotContains(t, unexaminedTriplets(sessionObj.UnexaminedKinds), "agents.x-k8s.io/v1alpha1/sandboxes",
+		"the control examines Sandbox; the version it did not name is not a coverage gap")
 }


### PR DESCRIPTION
`ScanCoverage.UnexaminedKinds` (added in #3588) reports the resource kinds a cluster serves that no control in the selected policy set queried. It works out that set by diffing discovery against the query set on the full group/version/resource triplet, which is one field too many. A kind is served at every version its group declares, and those versions are all views of the same stored objects, so a LIST at any one of them returns the whole set.

The result is that a control naming a kind at one version leaves every other served version of that same kind sitting in the report as a coverage gap, even though every object of that kind really was collected and evaluated. That is not an unusual shape to hit. Any CRD that has moved past its first version has it, and so do built in groups an ordinary cluster already has: autoscaling serves horizontalpodautoscalers at v1 and v2, and admissionregistration.k8s.io serves its policy types at more than one version as well. A cluster running the Agent Sandbox CRDs, which register sandboxes at v1alpha1 alongside v1beta1, gets it for those too.

The diff now compares group and resource only, so naming a kind at any one served version counts as examining it everywhere. There is a second, smaller thing that falls out of the same place: where a kind genuinely was not examined at any version, it used to emit one row per served version for what is really a single gap. It now emits one row, carrying the version the API server itself ranks highest (GA over beta over alpha, then by number), so the row names the version a reader would actually go and look at. That ranking is total even for versions it cannot parse, so the choice never depends on the order discovery happened to list the groups in.

The detail most likely to regress is that only the version may be dropped from the comparison, never the group. Two groups can serve the same resource name while being entirely distinct resources with distinct storage, ingresses under extensions and under networking.k8s.io being the familiar case, and querying one of those must not clear the other. There is a test pinning exactly that, and it is the one test here that passes both before and after the change, on purpose.

The first commit is plumbing only: both sides of the diff get parsed into one comparable key rather than one side being formatted into the other's string spelling. The two behaviour changes sit on top of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource coverage reporting for APIs served across multiple versions.
  - Querying one version of a resource now correctly accounts for that resource kind across all served versions.
  - Prevented duplicate reporting of the same resource kind when multiple API versions are available.
  - Reports the preferred API version consistently, regardless of discovery order.
  - Preserved distinct handling for resources with the same name in different API groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->