### PR TITLE
fix(anonymizer): hide scan path, host and cluster identity under --hide and --encrypt

### DIFF
--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -158,11 +158,39 @@ func transformSession(session *cautils.OPASessionObj, _ *Mapping, transformer Tr
 		if err := transformRepoContextMetadata(session.Metadata.ContextMetadata.RepoContextMetadata, transformer); err != nil {
 			return err
 		}
+		if err := transformDirectoryContextMetadata(session.Metadata.ContextMetadata.DirectoryContextMetadata, transformer); err != nil {
+			return err
+		}
+		if err := transformFileContextMetadata(session.Metadata.ContextMetadata.FileContextMetadata, transformer); err != nil {
+			return err
+		}
+		if err := transformClusterMetadata(session.Metadata.ContextMetadata.ClusterContextMetadata, transformer); err != nil {
+			return err
+		}
+		if err := transformClusterMetadata(&session.Metadata.ClusterMetadata, transformer); err != nil {
+			return err
+		}
 	}
 
 	if session.Report != nil {
 
 		if err := transformRepoContextMetadata(session.Report.Metadata.ContextMetadata.RepoContextMetadata, transformer); err != nil {
+			return err
+		}
+
+		if err := transformDirectoryContextMetadata(session.Report.Metadata.ContextMetadata.DirectoryContextMetadata, transformer); err != nil {
+			return err
+		}
+
+		if err := transformFileContextMetadata(session.Report.Metadata.ContextMetadata.FileContextMetadata, transformer); err != nil {
+			return err
+		}
+
+		if err := transformClusterMetadata(session.Report.Metadata.ContextMetadata.ClusterContextMetadata, transformer); err != nil {
+			return err
+		}
+
+		if err := transformClusterMetadata(&session.Report.Metadata.ClusterMetadata, transformer); err != nil {
 			return err
 		}
 
@@ -525,6 +553,129 @@ func transformRepoContextMetadata(repo *reporthandlingv2.RepoContextMetadata, tr
 	}
 
 	*repo = repoCopy
+
+	return nil
+}
+
+// transformClusterMetadata hides which cluster a report came from. The context
+// name is the entry the user selected in their kubeconfig, and the cloud names
+// are parsed straight out of it: for a GKE cluster "gke_project_zone_name" the
+// prefix is "gke_project_zone", so PrefixName and FullName carry the project
+// and, on EKS, the account ID out of the ARN. The provider and worker count
+// stay in cleartext - they describe the shape of the environment rather than
+// name it, and are what a shared report is usually read for.
+//
+// Namespace keys use the "ns" prefix so that under --hide they come out
+// string-identical to the namespaces transformResourceMetadata writes onto the
+// resources themselves; the per-namespace counts are only worth keeping if they
+// still join. Under --encrypt the two sides are separate ciphertexts, as every
+// repeated value in a report is, and the join reappears once both are
+// decrypted.
+func transformClusterMetadata(cluster *reporthandlingv2.ClusterMetadata, transformer Transformer) error {
+	if cluster == nil {
+		return nil
+	}
+
+	clusterCopy := *cluster
+
+	var err error
+
+	clusterCopy.ContextName, err = transformValue(transformer, "cluster", clusterCopy.ContextName)
+	if err != nil {
+		return err
+	}
+
+	if clusterCopy.CloudMetadata != nil {
+		cloudCopy := *clusterCopy.CloudMetadata
+
+		cloudCopy.FullName, err = transformValue(transformer, "cluster", cloudCopy.FullName)
+		if err != nil {
+			return err
+		}
+
+		cloudCopy.ShortName, err = transformValue(transformer, "cluster", cloudCopy.ShortName)
+		if err != nil {
+			return err
+		}
+
+		cloudCopy.PrefixName, err = transformValue(transformer, "cluster", cloudCopy.PrefixName)
+		if err != nil {
+			return err
+		}
+
+		clusterCopy.CloudMetadata = &cloudCopy
+	}
+
+	if clusterCopy.MapNamespaceToNumberOfResources != nil {
+		namespaceCounts := make(map[string]int, len(clusterCopy.MapNamespaceToNumberOfResources))
+
+		for namespace, count := range clusterCopy.MapNamespaceToNumberOfResources {
+			namespace, err = transformValue(transformer, "ns", namespace)
+			if err != nil {
+				return err
+			}
+
+			namespaceCounts[namespace] += count
+		}
+
+		clusterCopy.MapNamespaceToNumberOfResources = namespaceCounts
+	}
+
+	*cluster = clusterCopy
+
+	return nil
+}
+
+// transformDirectoryContextMetadata and transformFileContextMetadata hide where
+// the scan ran: the absolute path the user pointed at, which on most machines
+// carries their account name, and the machine itself. A directory scan records
+// the one, a single-file scan the other, and both survive into a report whose
+// whole purpose is to be shareable. The host uses a shared prefix so the same
+// machine reads as the same pseudonym either way.
+func transformDirectoryContextMetadata(directory *reporthandlingv2.DirectoryContextMetadata, transformer Transformer) error {
+	if directory == nil {
+		return nil
+	}
+
+	directoryCopy := *directory
+
+	var err error
+
+	directoryCopy.BasePath, err = transformValue(transformer, "dir", directoryCopy.BasePath)
+	if err != nil {
+		return err
+	}
+
+	directoryCopy.HostName, err = transformValue(transformer, "host", directoryCopy.HostName)
+	if err != nil {
+		return err
+	}
+
+	*directory = directoryCopy
+
+	return nil
+}
+
+func transformFileContextMetadata(file *reporthandlingv2.FileContextMetadata, transformer Transformer) error {
+	if file == nil {
+		return nil
+	}
+
+	fileCopy := *file
+
+	var err error
+
+	fileCopy.FilePath, err = transformValue(transformer, "file", fileCopy.FilePath)
+	if err != nil {
+		return err
+	}
+
+	fileCopy.HostName, err = transformValue(transformer, "host", fileCopy.HostName)
+	if err != nil {
+		return err
+	}
+
+	*file = fileCopy
 
 	return nil
 }

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -1362,3 +1362,325 @@ func TestTransformSourcePath_WindowsDriveLetterWithLineSuffix(t *testing.T) {
 
 	assert.Equal(t, `C:\Users\alice\manifests\payment.yaml`, decryptedPath)
 }
+
+func TestTransformSession_DirectoryContextMetadata(t *testing.T) {
+	const (
+		basePath = "/home/devjijo/work/internal-platform"
+		hostName = "build-agent-07.corp.internal"
+	)
+
+	directoryContext := func() *reporthandlingv2.DirectoryContextMetadata {
+		return &reporthandlingv2.DirectoryContextMetadata{BasePath: basePath, HostName: hostName}
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{DirectoryContextMetadata: directoryContext()},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			Metadata: reporthandlingv2.Metadata{
+				ContextMetadata: reporthandlingv2.ContextMetadata{DirectoryContextMetadata: directoryContext()},
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	for _, directory := range []*reporthandlingv2.DirectoryContextMetadata{
+		session.Metadata.ContextMetadata.DirectoryContextMetadata,
+		session.Report.Metadata.ContextMetadata.DirectoryContextMetadata,
+	} {
+		require.NotNil(t, directory)
+		assert.NotEqual(t, basePath, directory.BasePath, "the scanned directory names the account it ran under")
+		assert.NotEqual(t, hostName, directory.HostName, "the host names the machine the scan ran on")
+		assert.NotEmpty(t, directory.BasePath)
+		assert.NotEmpty(t, directory.HostName)
+	}
+
+	assert.Equal(t,
+		session.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath,
+		session.Report.Metadata.ContextMetadata.DirectoryContextMetadata.BasePath,
+		"both copies must map to the same pseudonym")
+}
+
+func TestTransformSession_FileContextMetadata(t *testing.T) {
+	const (
+		filePath = "/home/devjijo/work/internal-platform/deploy.yaml"
+		hostName = "build-agent-07.corp.internal"
+	)
+
+	fileContext := func() *reporthandlingv2.FileContextMetadata {
+		return &reporthandlingv2.FileContextMetadata{FilePath: filePath, HostName: hostName}
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{FileContextMetadata: fileContext()},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			Metadata: reporthandlingv2.Metadata{
+				ContextMetadata: reporthandlingv2.ContextMetadata{FileContextMetadata: fileContext()},
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	for _, file := range []*reporthandlingv2.FileContextMetadata{
+		session.Metadata.ContextMetadata.FileContextMetadata,
+		session.Report.Metadata.ContextMetadata.FileContextMetadata,
+	} {
+		require.NotNil(t, file)
+		assert.NotEqual(t, filePath, file.FilePath, "the scanned file names the account it ran under")
+		assert.NotEqual(t, hostName, file.HostName)
+		assert.NotEmpty(t, file.FilePath)
+		assert.NotEmpty(t, file.HostName)
+	}
+}
+
+// TestTransformSession_HostNameSharedAcrossContexts keeps the pseudonym stable:
+// a directory scan and a file scan of the same machine must read alike.
+func TestTransformSession_HostNameSharedAcrossContexts(t *testing.T) {
+	const hostName = "build-agent-07.corp.internal"
+
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{BasePath: "/tmp/a", HostName: hostName},
+				FileContextMetadata:      &reporthandlingv2.FileContextMetadata{FilePath: "/tmp/a/deploy.yaml", HostName: hostName},
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	assert.Equal(t,
+		session.Metadata.ContextMetadata.DirectoryContextMetadata.HostName,
+		session.Metadata.ContextMetadata.FileContextMetadata.HostName)
+}
+
+func TestTransformSession_NoDirectoryContextMetadata(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		Metadata:             &reporthandlingv2.Metadata{},
+		Report:               &reporthandlingv2.PostureReport{},
+	}
+
+	assert.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+}
+
+func TestTransformSession_ClusterContextMetadata(t *testing.T) {
+	const (
+		contextName = "gke_acme-prod-1234_us-central1_payments"
+		fullName    = "gke_acme-prod-1234_us-central1_payments"
+		shortName   = "payments"
+		prefixName  = "gke_acme-prod-1234_us-central1"
+	)
+
+	clusterContext := func() *reporthandlingv2.ClusterMetadata {
+		return &reporthandlingv2.ClusterMetadata{
+			ContextName:         contextName,
+			NumberOfWorkerNodes: 12,
+			CloudProvider:       "gke",
+			CloudMetadata: &reporthandlingv2.CloudMetadata{
+				CloudProvider: "gke",
+				FullName:      fullName,
+				ShortName:     shortName,
+				PrefixName:    prefixName,
+			},
+			MapNamespaceToNumberOfResources: map[string]int{
+				"kube-system":   41,
+				"acme-payments": 17,
+				"":              3,
+			},
+		}
+	}
+
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{ClusterContextMetadata: clusterContext()},
+			ClusterMetadata: *clusterContext(),
+		},
+		Report: &reporthandlingv2.PostureReport{
+			Metadata: reporthandlingv2.Metadata{
+				ContextMetadata: reporthandlingv2.ContextMetadata{ClusterContextMetadata: clusterContext()},
+				ClusterMetadata: *clusterContext(),
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	for _, cluster := range []*reporthandlingv2.ClusterMetadata{
+		session.Metadata.ContextMetadata.ClusterContextMetadata,
+		&session.Metadata.ClusterMetadata,
+		session.Report.Metadata.ContextMetadata.ClusterContextMetadata,
+		&session.Report.Metadata.ClusterMetadata,
+	} {
+		require.NotEqual(t, contextName, cluster.ContextName)
+		require.True(t, strings.HasPrefix(cluster.ContextName, "cluster-"))
+
+		require.NotEqual(t, fullName, cluster.CloudMetadata.FullName)
+		require.NotEqual(t, shortName, cluster.CloudMetadata.ShortName)
+		require.NotEqual(t, prefixName, cluster.CloudMetadata.PrefixName)
+
+		require.Equal(t, "gke", string(cluster.CloudMetadata.CloudProvider))
+		require.Equal(t, "gke", cluster.CloudProvider)
+		require.Equal(t, 12, cluster.NumberOfWorkerNodes)
+
+		require.Len(t, cluster.MapNamespaceToNumberOfResources, 3)
+		require.NotContains(t, cluster.MapNamespaceToNumberOfResources, "kube-system")
+		require.NotContains(t, cluster.MapNamespaceToNumberOfResources, "acme-payments")
+
+		total := 0
+		for namespace, count := range cluster.MapNamespaceToNumberOfResources {
+			if namespace != "" {
+				require.True(t, strings.HasPrefix(namespace, "ns-"))
+			}
+			total += count
+		}
+		require.Equal(t, 61, total)
+	}
+}
+
+func TestTransformSession_ClusterNamespaceCountsStayJoinable(t *testing.T) {
+	const namespace = "acme-payments"
+
+	resource := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "api", "namespace": namespace},
+	})
+
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{resource.GetID(): resource},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: &reporthandlingv2.ClusterMetadata{
+					MapNamespaceToNumberOfResources: map[string]int{namespace: 1},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+
+	var transformedNamespace string
+	for _, transformed := range session.AllResources {
+		transformedNamespace = transformed.GetNamespace()
+	}
+
+	require.NotEqual(t, namespace, transformedNamespace)
+	require.Contains(
+		t,
+		session.Metadata.ContextMetadata.ClusterContextMetadata.MapNamespaceToNumberOfResources,
+		transformedNamespace,
+	)
+}
+
+func TestTransformSession_NoClusterContextMetadata(t *testing.T) {
+	session := &cautils.OPASessionObj{
+		AllResources:         make(map[string]workloadinterface.IMetadata),
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{},
+		Report:   &reporthandlingv2.PostureReport{},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
+	require.Nil(t, session.Metadata.ContextMetadata.ClusterContextMetadata)
+	require.Nil(t, session.Metadata.ClusterMetadata.MapNamespaceToNumberOfResources)
+	require.Nil(t, session.Metadata.ClusterMetadata.CloudMetadata)
+}
+
+func TestTransformSession_ClusterNamespaceCountsJoinAfterDecryption(t *testing.T) {
+	const namespace = "acme-payments"
+
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	reportKey := reportcrypto.UnboundReportKey(dek)
+
+	resource := workloadinterface.NewWorkloadObj(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "api", "namespace": namespace},
+	})
+
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{resource.GetID(): resource},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+
+		Metadata: &reporthandlingv2.Metadata{
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: &reporthandlingv2.ClusterMetadata{
+					MapNamespaceToNumberOfResources: map[string]int{namespace: 1},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, transformSession(session, NewMapping(), NewEncryptionTransformer(reportKey)))
+
+	clusterMetadata := session.Metadata.ContextMetadata.ClusterContextMetadata
+	require.NotContains(t, clusterMetadata.MapNamespaceToNumberOfResources, namespace)
+
+	var transformedNamespace string
+	for _, transformed := range session.AllResources {
+		transformedNamespace = transformed.GetNamespace()
+		require.NoError(t, reportcrypto.DecryptResourceMetadata(transformed, reportKey))
+	}
+
+	require.NotContains(t, clusterMetadata.MapNamespaceToNumberOfResources, transformedNamespace)
+
+	decryptedCounts := make(map[string]int, len(clusterMetadata.MapNamespaceToNumberOfResources))
+	for encryptedNamespace, count := range clusterMetadata.MapNamespaceToNumberOfResources {
+		decryptedNamespace, decryptErr := reportKey.DecryptString(encryptedNamespace)
+		require.NoError(t, decryptErr)
+		decryptedCounts[decryptedNamespace] += count
+	}
+
+	for _, decrypted := range session.AllResources {
+		require.Equal(t, namespace, decrypted.GetNamespace())
+		require.Contains(t, decryptedCounts, decrypted.GetNamespace())
+	}
+}

--- a/core/pkg/reportcrypto/decrypt.go
+++ b/core/pkg/reportcrypto/decrypt.go
@@ -79,6 +79,139 @@ func DecryptRepoContextMetadata(
 	return decryptRepoContextMetadata(metadata, dek)
 }
 
+// decryptDirectoryContextMetadata and decryptFileContextMetadata restore the
+// scan location the anonymizer encrypted.
+func decryptDirectoryContextMetadata(metadata *reporthandlingv2.Metadata, dek *ReportKey) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata is nil")
+	}
+
+	directoryMetadata := metadata.ContextMetadata.DirectoryContextMetadata
+	if directoryMetadata == nil {
+		return nil
+	}
+
+	var err error
+
+	if directoryMetadata.BasePath != "" {
+		directoryMetadata.BasePath, err = decryptIfEncrypted(directoryMetadata.BasePath, dek)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt basePath: %w", err)
+		}
+	}
+
+	if directoryMetadata.HostName != "" {
+		directoryMetadata.HostName, err = decryptIfEncrypted(directoryMetadata.HostName, dek)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt hostName: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func decryptFileContextMetadata(metadata *reporthandlingv2.Metadata, dek *ReportKey) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata is nil")
+	}
+
+	fileMetadata := metadata.ContextMetadata.FileContextMetadata
+	if fileMetadata == nil {
+		return nil
+	}
+
+	var err error
+
+	if fileMetadata.FilePath != "" {
+		fileMetadata.FilePath, err = decryptIfEncrypted(fileMetadata.FilePath, dek)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt filePath: %w", err)
+		}
+	}
+
+	if fileMetadata.HostName != "" {
+		fileMetadata.HostName, err = decryptIfEncrypted(fileMetadata.HostName, dek)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt hostName: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// decryptClusterMetadata restores the cluster identity encrypted by the
+// anonymizer, in both places a report carries it: the target metadata and the
+// deprecated top-level copy. Namespace counts are re-keyed into a fresh map
+// because the keys themselves are ciphertext.
+func decryptClusterMetadata(metadata *reporthandlingv2.Metadata, dek *ReportKey) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata is nil")
+	}
+
+	for _, clusterMetadata := range []*reporthandlingv2.ClusterMetadata{
+		metadata.ContextMetadata.ClusterContextMetadata,
+		&metadata.ClusterMetadata,
+	} {
+		if clusterMetadata == nil {
+			continue
+		}
+
+		if err := decryptClusterMetadataFields(clusterMetadata, dek); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decryptClusterMetadataFields(clusterMetadata *reporthandlingv2.ClusterMetadata, dek *ReportKey) error {
+	var err error
+
+	if clusterMetadata.ContextName != "" {
+		clusterMetadata.ContextName, err = decryptIfEncrypted(clusterMetadata.ContextName, dek)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt contextName: %w", err)
+		}
+	}
+
+	if cloudMetadata := clusterMetadata.CloudMetadata; cloudMetadata != nil {
+		for name, field := range map[string]*string{
+			"fullName":   &cloudMetadata.FullName,
+			"shortName":  &cloudMetadata.ShortName,
+			"prefixName": &cloudMetadata.PrefixName,
+		} {
+			if *field == "" {
+				continue
+			}
+
+			if *field, err = decryptIfEncrypted(*field, dek); err != nil {
+				return fmt.Errorf("failed to decrypt %s: %w", name, err)
+			}
+		}
+	}
+
+	if clusterMetadata.MapNamespaceToNumberOfResources == nil {
+		return nil
+	}
+
+	namespaceCounts := make(map[string]int, len(clusterMetadata.MapNamespaceToNumberOfResources))
+
+	for namespace, count := range clusterMetadata.MapNamespaceToNumberOfResources {
+		if namespace != "" {
+			namespace, err = decryptIfEncrypted(namespace, dek)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt namespace: %w", err)
+			}
+		}
+
+		namespaceCounts[namespace] += count
+	}
+
+	clusterMetadata.MapNamespaceToNumberOfResources = namespaceCounts
+
+	return nil
+}
+
 // decryptRepoContextMetadata performs the repository metadata portion
 // of report decryption with an already unwrapped data-encryption key. Keeping
 // this internal avoids unwrapping the same key twice during whole-report

--- a/core/pkg/reportcrypto/decrypt_test.go
+++ b/core/pkg/reportcrypto/decrypt_test.go
@@ -771,3 +771,191 @@ func TestDecryptResourceAnnotations_PreservesPlaintextValue(t *testing.T) {
 	annotations := metadata["annotations"].(map[string]any)
 	assert.Equal(t, lastApplied, annotations["kubectl.kubernetes.io/last-applied-configuration"])
 }
+
+func TestDecryptDirectoryContextMetadata_RoundTrip(t *testing.T) {
+	const (
+		basePath = "/home/devjijo/work/internal-platform"
+		hostName = "build-agent-07.corp.internal"
+	)
+
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	reportKey, err := UnwrapReportKey(wrappedDEK, masterKey)
+	require.NoError(t, err)
+
+	encryptedBasePath, err := EncryptString(basePath, dek)
+	require.NoError(t, err)
+
+	encryptedHostName, err := EncryptString(hostName, dek)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			DirectoryContextMetadata: &reporthandlingv2.DirectoryContextMetadata{
+				BasePath: encryptedBasePath,
+				HostName: encryptedHostName,
+			},
+		},
+	}
+
+	require.NoError(t, decryptDirectoryContextMetadata(metadata, reportKey))
+
+	directory := metadata.ContextMetadata.DirectoryContextMetadata
+	assert.Equal(t, basePath, directory.BasePath)
+	assert.Equal(t, hostName, directory.HostName)
+}
+
+func TestDecryptFileContextMetadata_RoundTrip(t *testing.T) {
+	const (
+		filePath = "/home/devjijo/work/internal-platform/deploy.yaml"
+		hostName = "build-agent-07.corp.internal"
+	)
+
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	reportKey, err := UnwrapReportKey(wrappedDEK, masterKey)
+	require.NoError(t, err)
+
+	encryptedFilePath, err := EncryptString(filePath, dek)
+	require.NoError(t, err)
+
+	encryptedHostName, err := EncryptString(hostName, dek)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			FileContextMetadata: &reporthandlingv2.FileContextMetadata{
+				FilePath: encryptedFilePath,
+				HostName: encryptedHostName,
+			},
+		},
+	}
+
+	require.NoError(t, decryptFileContextMetadata(metadata, reportKey))
+
+	file := metadata.ContextMetadata.FileContextMetadata
+	assert.Equal(t, filePath, file.FilePath)
+	assert.Equal(t, hostName, file.HostName)
+}
+
+func TestDecryptDirectoryContextMetadata_NoDirectoryMetadata(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	reportKey, err := UnwrapReportKey(wrappedDEK, masterKey)
+	require.NoError(t, err)
+
+	assert.NoError(t, decryptDirectoryContextMetadata(&reporthandlingv2.Metadata{}, reportKey))
+}
+
+func TestDecryptClusterMetadata_RoundTrip(t *testing.T) {
+	const (
+		contextName = "gke_acme-prod-1234_us-central1_payments"
+		prefixName  = "gke_acme-prod-1234_us-central1"
+		shortName   = "payments"
+		namespace   = "acme-payments"
+	)
+
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	reportKey, err := UnwrapReportKey(wrappedDEK, masterKey)
+	require.NoError(t, err)
+
+	encrypt := func(value string) string {
+		encrypted, encryptErr := EncryptString(value, dek)
+		require.NoError(t, encryptErr)
+		return encrypted
+	}
+
+	clusterMetadata := func() reporthandlingv2.ClusterMetadata {
+		return reporthandlingv2.ClusterMetadata{
+			ContextName:         encrypt(contextName),
+			CloudProvider:       "gke",
+			NumberOfWorkerNodes: 12,
+			CloudMetadata: &reporthandlingv2.CloudMetadata{
+				CloudProvider: "gke",
+				FullName:      encrypt(contextName),
+				ShortName:     encrypt(shortName),
+				PrefixName:    encrypt(prefixName),
+			},
+			MapNamespaceToNumberOfResources: map[string]int{
+				encrypt(namespace): 17,
+				"":                 3,
+			},
+		}
+	}
+
+	contextCluster := clusterMetadata()
+	metadata := &reporthandlingv2.Metadata{
+		ContextMetadata: reporthandlingv2.ContextMetadata{ClusterContextMetadata: &contextCluster},
+		ClusterMetadata: clusterMetadata(),
+	}
+
+	require.NoError(t, decryptClusterMetadata(metadata, reportKey))
+
+	for _, cluster := range []*reporthandlingv2.ClusterMetadata{
+		metadata.ContextMetadata.ClusterContextMetadata,
+		&metadata.ClusterMetadata,
+	} {
+		require.Equal(t, contextName, cluster.ContextName)
+		require.Equal(t, contextName, cluster.CloudMetadata.FullName)
+		require.Equal(t, shortName, cluster.CloudMetadata.ShortName)
+		require.Equal(t, prefixName, cluster.CloudMetadata.PrefixName)
+		require.Equal(t, "gke", cluster.CloudProvider)
+		require.Equal(t, 12, cluster.NumberOfWorkerNodes)
+		require.Equal(
+			t,
+			map[string]int{namespace: 17, "": 3},
+			cluster.MapNamespaceToNumberOfResources,
+		)
+	}
+}
+
+func TestDecryptClusterMetadata_NoClusterMetadata(t *testing.T) {
+	dek, err := GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := GenerateDEK()
+	require.NoError(t, err)
+
+	wrappedDEK, err := WrapDEK(dek, masterKey)
+	require.NoError(t, err)
+
+	reportKey, err := UnwrapReportKey(wrappedDEK, masterKey)
+	require.NoError(t, err)
+
+	metadata := &reporthandlingv2.Metadata{}
+
+	require.NoError(t, decryptClusterMetadata(metadata, reportKey))
+	require.Nil(t, metadata.ContextMetadata.ClusterContextMetadata)
+	require.Nil(t, metadata.ClusterMetadata.MapNamespaceToNumberOfResources)
+
+	require.Error(t, decryptClusterMetadata(nil, reportKey))
+}

--- a/core/pkg/reportcrypto/report.go
+++ b/core/pkg/reportcrypto/report.go
@@ -117,6 +117,18 @@ func (d *reportDecryptor) decryptMetadata() error {
 		return fmt.Errorf("failed to decrypt report metadata: %w", err)
 	}
 
+	if err := decryptDirectoryContextMetadata(&metadata, d.dek); err != nil {
+		return fmt.Errorf("failed to decrypt report metadata: %w", err)
+	}
+
+	if err := decryptFileContextMetadata(&metadata, d.dek); err != nil {
+		return fmt.Errorf("failed to decrypt report metadata: %w", err)
+	}
+
+	if err := decryptClusterMetadata(&metadata, d.dek); err != nil {
+		return fmt.Errorf("failed to decrypt report metadata: %w", err)
+	}
+
 	// Marshal the known metadata shape, then recursively merge it into the
 	// original raw object. This updates decrypted values while retaining fields
 	// from future report schemas, including unknown fields inside lastCommit.


### PR DESCRIPTION
## Summary

- `transformSession` only covered repo metadata, so three of the five `ContextMetadata` sub-structs went into reports untouched.
- Directory and file scans leaked the absolute scan path (usually containing the account name) and the machine hostname.
- Cluster scans leaked the kubeconfig context name and, via `CloudMetadata`, the GCP project or EKS account ID parsed out of it.
- `MapNamespaceToNumberOfResources` kept every namespace in cleartext as map keys, even though resource namespaces were already anonymized - a full namespace inventory next to pseudonymized workloads.
- Adds transformers for the directory, file and cluster metadata, plus the matching decrypt paths so `--encrypt` still round-trips.
- Namespace keys reuse the `ns` prefix so the per-namespace counts stay joinable against the anonymized resources; `cloudProvider` and worker count stay in cleartext.
- Covered by `TestTransformSession_ClusterContextMetadata`, `TestTransformSession_ClusterNamespaceCountsStayJoinable`, `TestTransformSession_DirectoryContextMetadata`, `TestTransformSession_FileContextMetadata` and `TestDecryptClusterMetadata_RoundTrip`.

**Which issue(s) this PR fixes:**
None, found while reading `core/pkg/anonymizer`.

**Special notes for your reviewer:**
The cluster fields are covered by unit and round-trip tests only — I don't have a cluster to verify end-to-end, so the population sites (`scaninfo.go`, `k8sresources.go`) were confirmed by reading. I left `ClusterMetadata.CloudProvider` and `NumberOfWorkerNodes` alone since they describe the environment's shape without naming it, but happy to anonymize those too if you'd rather.

**Does this PR introduce a user-facing change?**
Yes `--hide` and `--encrypt` reports no longer contain the scan path, hostname, cluster context name, cloud account/project identifiers, or plaintext namespace names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy**
  - Expanded anonymization to directory, file, and cluster metadata, including paths, host names, cloud details, and namespace identifiers.
  - Preserved consistent pseudonyms across related report fields while retaining resource counts and other non-sensitive values.

- **Data Recovery**
  - Added decryption support for protected directory, file, and cluster metadata fields.
  - Preserved metadata integrity across encrypted and decrypted reports, including namespace-to-resource mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->