### PR TITLE
refactor(resourcehandler): partition streaming collector items as the pager yields them

### DIFF
--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -364,13 +364,18 @@ func streamingKubernetesResourceCount(resident *cautils.ResourceBatch, namespace
 // resulting in O(L × N) API-server LIST calls on large clusters.
 //
 // What this bounds is the evaluation input, not the collection peak: every GVR
-// is pulled and partitioned before the first batch is sent, so the whole
-// cluster is resident in this function at that point. The consumer
+// is traversed and partitioned before the first batch is sent, so the whole
+// cluster is still resident in this function at that point. The consumer
 // (OPAProcessor.ProcessWithStreaming) evaluates one namespace batch at a time,
 // so only the resident batch plus one namespace batch are in the evaluation
-// input at any moment. Bounding the collection peak itself would require paged
-// LISTs (metav1.ListOptions{Limit, Continue}) per GVR — a larger change than
-// this one.
+// input at any moment.
+//
+// Objects are partitioned as the pager yields them, so the collector no longer
+// materializes a whole-GVR slice on top of the batches that retain the objects
+// anyway. What still grows with the cluster is the batches themselves: every
+// namespace partition is held on the Go heap until its turn to be emitted.
+// Bounding that needs a partition store the collector can spill to, which is a
+// larger change than this one.
 func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Context, queryableResources QueryableResources, globalFieldSelectors IFieldSelector, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo, ksResourceMap cautils.ExternalResources, batchChan chan<- *cautils.ResourceBatch, resolver resourceResolver) error {
 	resident := cautils.NewResourceBatch(cautils.ClusterScope)
 	namespaceBatches := make(map[string]*cautils.ResourceBatch)
@@ -384,37 +389,50 @@ func (k8sHandler *K8sResourceHandler) collectAndStreamBatches(ctx context.Contex
 		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
 
-		result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, scanInfo.LabelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced)
+		// Partition each object as the pager yields it, so the collector never
+		// holds a whole-GVR []unstructured.Unstructured — nor the two
+		// same-length slices the map/meta conversion built from it — on top of
+		// the batches that retain the objects anyway. The partition is the only
+		// thing that keeps an object alive past the callback, and it keeps
+		// obj.Object rather than the pointer into the pager's page.
+		var firstResourceID string
+		collectedFromGVR := false
+		selectorErrs := k8sHandler.pullSingleResourceInto(ctx, &gvr, scanInfo.LabelSelector, qr.FieldSelectors, globalFieldSelectors, qr.Namespaced, func(obj *unstructured.Unstructured) error {
+			metaObj := objectsenvelopes.NewObject(obj.Object)
+			if metaObj == nil {
+				// Same drop as ConvertMapListToMeta: an object no envelope
+				// recognizes is not a scannable resource.
+				return nil
+			}
+			if !collectedFromGVR {
+				firstResourceID = metaObj.GetID()
+				collectedFromGVR = true
+			}
+
+			scope := streamingResourceScope(metaObj, qr.Namespaced)
+			batch := resident
+			if scope != cautils.ClusterScope {
+				existing, ok := namespaceBatches[scope]
+				if !ok {
+					existing = cautils.NewResourceBatch(scope)
+					namespaceBatches[scope] = existing
+				}
+				batch = existing
+			}
+			batch.K8SResources[qr.GroupVersionResourceTriplet] = append(batch.K8SResources[qr.GroupVersionResourceTriplet], metaObj.GetID())
+			batch.AllResources[metaObj.GetID()] = metaObj
+			return nil
+		})
 		for k, v := range classifySelectorFailures(qr.GroupVersionResourceTriplet, selectorErrs) {
 			failedQueries[k] = v
 		}
-		if len(result) == 0 && len(selectorErrs) > 0 {
-			continue
-		}
 
-		metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
-		if len(metaObjs) > 0 {
+		if collectedFromGVR {
 			// recordFailedQueryStatuses only distinguishes an empty GVR from a
 			// non-empty one. Keep one representative ID instead of duplicating
 			// every ID already retained in the streaming batches.
-			collectedK8sResources[qr.GroupVersionResourceTriplet] = []string{metaObjs[0].GetID()}
+			collectedK8sResources[qr.GroupVersionResourceTriplet] = []string{firstResourceID}
 			collectedAnyResource = true
-		}
-
-		for _, metaObj := range metaObjs {
-			scope := streamingResourceScope(metaObj, qr.Namespaced)
-			if scope == cautils.ClusterScope {
-				resident.K8SResources[qr.GroupVersionResourceTriplet] = append(resident.K8SResources[qr.GroupVersionResourceTriplet], metaObj.GetID())
-				resident.AllResources[metaObj.GetID()] = metaObj
-			} else {
-				batch, ok := namespaceBatches[scope]
-				if !ok {
-					batch = cautils.NewResourceBatch(scope)
-					namespaceBatches[scope] = batch
-				}
-				batch.K8SResources[qr.GroupVersionResourceTriplet] = append(batch.K8SResources[qr.GroupVersionResourceTriplet], metaObj.GetID())
-				batch.AllResources[metaObj.GetID()] = metaObj
-			}
 		}
 	}
 
@@ -1021,8 +1039,47 @@ func recordFailedQueryStatuses(failedQueries map[string]queryFailure, k8sResourc
 	return partials
 }
 
+// resourceSink receives every object a paginated LIST traversal yields, in
+// page order, before any per-GVR slice is built. The pointer handed to a sink
+// aims into the page the pager is currently holding and is only valid for the
+// duration of the call: a sink that needs to keep an object must keep
+// obj.Object (which the page's backing array does not own) or a copy, never
+// obj itself. Returning an error abandons the traversal of the selector being
+// walked; see pullSingleResourceInto.
+type resourceSink func(obj *unstructured.Unstructured) error
+
+// pullSingleResource walks every field-selector query for a resource and
+// returns the objects that survive parent filtering, together with the
+// per-selector failures. It is the eager collector's entry point; the
+// streaming collector uses pullSingleResourceInto so it never materializes
+// this slice.
 func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, resource *schema.GroupVersionResource, labelSelector string, fields string, fieldSelector IFieldSelector, namespaced *bool) ([]unstructured.Unstructured, []selectorFailure) {
 	var resourceList []unstructured.Unstructured
+	selectorErrs := k8sHandler.pullSingleResourceInto(ctx, resource, labelSelector, fields, fieldSelector, namespaced, func(obj *unstructured.Unstructured) error {
+		resourceList = append(resourceList, *obj)
+		return nil
+	})
+	return resourceList, selectorErrs
+}
+
+// pullSingleResourceInto is the collection core shared by both collectors: it
+// runs one paginated LIST traversal per field selector and hands each object
+// that survives parent filtering to sink as it arrives.
+//
+// The traversal contract the callers depend on is unchanged from when this
+// function accumulated a slice itself:
+//
+//   - client-go's pager.EachListItem does not retry an expired continuation
+//     token (only pager.List falls back to a full re-list), so a selector's
+//     objects are always one API-server snapshot and a sink never sees the
+//     same page twice.
+//   - A selector that fails part-way keeps the objects it already yielded and
+//     records a selectorFailure, which the callers surface as partial coverage
+//     rather than as a missing GVR. Remaining selectors are still walked.
+//   - A sink error stops the current selector the same way a LIST error does,
+//     so a caller whose per-object work can fail reports it as that selector's
+//     failure.
+func (k8sHandler *K8sResourceHandler) pullSingleResourceInto(ctx context.Context, resource *schema.GroupVersionResource, labelSelector string, fields string, fieldSelector IFieldSelector, namespaced *bool, sink resourceSink) []selectorFailure {
 	var selectorErrs []selectorFailure
 
 	fieldSelectors := fieldSelector.GetNamespacesSelectors(resource, namespaced)
@@ -1044,7 +1101,7 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 
 		clientResource := k8sHandler.k8s.DynamicClient.Resource(*resource)
 
-		lenBefore := len(resourceList)
+		collected := 0
 
 		if err := pager.New(func(pCtx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return clientResource.List(pCtx, opts)
@@ -1065,7 +1122,10 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 				return nil
 			}
 
-			resourceList = append(resourceList, *obj.(*unstructured.Unstructured))
+			if err := sink(uObject); err != nil {
+				return err
+			}
+			collected++
 			return nil
 
 		}); err != nil {
@@ -1085,11 +1145,11 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 			helpers.String("resource", resource.String()),
 			helpers.String("fieldSelector", listOptions.FieldSelector),
 			helpers.String("labelSelector", listOptions.LabelSelector),
-			helpers.Int("count", len(resourceList)-lenBefore),
+			helpers.Int("count", collected),
 		)
 	}
 
-	return resourceList, selectorErrs
+	return selectorErrs
 }
 func ConvertMapListToMeta(resourceMap []map[string]any) []workloadinterface.IMetadata {
 	var workloads []workloadinterface.IMetadata

--- a/core/pkg/resourcehandler/k8sresources_pull_sink_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_sink_test.go
@@ -1,0 +1,339 @@
+package resourcehandler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+// pagedLister answers LIST the way a paginating API server does: every call
+// returns at most pageSize items starting at the offset encoded in
+// opts.Continue, and sets a continue token whenever items remain. Per-selector
+// behaviour is keyed by field selector so a test can fail one query and leave
+// the others intact.
+//
+// The pager fetches pages on a background goroutine while the caller's sink
+// runs on the test goroutine, so every field is guarded.
+type pagedLister struct {
+	mu       sync.Mutex
+	pageSize int
+	// items holds the objects each field selector serves.
+	items map[string][]unstructured.Unstructured
+	// failAfterPage makes the (n+1)-th call for a selector fail once n pages
+	// have been served for it.
+	failAfterPage map[string]int
+	failWith      map[string]error
+	calls         []metav1.ListOptions
+}
+
+func newPagedLister(pageSize int) *pagedLister {
+	return &pagedLister{
+		pageSize:      pageSize,
+		items:         map[string][]unstructured.Unstructured{},
+		failAfterPage: map[string]int{},
+		failWith:      map[string]error{},
+	}
+}
+
+func (p *pagedLister) serve(selector string, items ...unstructured.Unstructured) *pagedLister {
+	p.items[selector] = items
+	return p
+}
+
+func (p *pagedLister) failSelectorAfterPage(selector string, pages int, err error) *pagedLister {
+	p.failAfterPage[selector] = pages
+	p.failWith[selector] = err
+	return p
+}
+
+func (p *pagedLister) list(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, opts)
+
+	offset := 0
+	if opts.Continue != "" {
+		parsed, err := strconv.Atoi(opts.Continue)
+		if err != nil {
+			return nil, fmt.Errorf("malformed continue token %q", opts.Continue)
+		}
+		offset = parsed
+	}
+
+	if pages, failing := p.failAfterPage[opts.FieldSelector]; failing && offset >= pages*p.pageSize {
+		return nil, p.failWith[opts.FieldSelector]
+	}
+
+	items := p.items[opts.FieldSelector]
+	end := min(offset+p.pageSize, len(items))
+	list := &unstructured.UnstructuredList{
+		Object: map[string]any{"apiVersion": "v1", "kind": "PodList"},
+		Items:  items[offset:end],
+	}
+	if end < len(items) {
+		list.SetContinue(strconv.Itoa(end))
+	}
+	return list, nil
+}
+
+func (p *pagedLister) recordedCalls() []metav1.ListOptions {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]metav1.ListOptions(nil), p.calls...)
+}
+
+func (p *pagedLister) handler() *K8sResourceHandler {
+	return &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		KubernetesClient: fakeclientset.NewClientset(),
+		DynamicClient:    &mockDynamicClient{listFunc: p.list},
+	}}
+}
+
+func sinkTestPod(name, namespace string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}}
+}
+
+func sinkTestPods(namespace string, count int) []unstructured.Unstructured {
+	pods := make([]unstructured.Unstructured, 0, count)
+	for i := range count {
+		pods = append(pods, sinkTestPod(fmt.Sprintf("pod-%d", i), namespace))
+	}
+	return pods
+}
+
+func collectNames(objs []*unstructured.Unstructured) []string {
+	names := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		names = append(names, obj.GetName())
+	}
+	return names
+}
+
+var sinkTestGVR = &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// A sink sees every object of a paginated traversal exactly once and in page
+// order, and the slice-returning wrapper the eager collector still uses agrees
+// with it object for object.
+func TestPullSingleResourceInto_YieldsEveryPagedObjectOnce(t *testing.T) {
+	lister := newPagedLister(3).serve("", sinkTestPods("default", 7)...)
+	handler := lister.handler()
+
+	var seen []*unstructured.Unstructured
+	selectorErrs := handler.pullSingleResourceInto(context.Background(), sinkTestGVR, "", "", &EmptySelector{}, nil, func(obj *unstructured.Unstructured) error {
+		// Copy: obj aims into the page the pager still owns.
+		seen = append(seen, obj.DeepCopy())
+		return nil
+	})
+
+	require.Empty(t, selectorErrs)
+	assert.Equal(t,
+		[]string{"pod-0", "pod-1", "pod-2", "pod-3", "pod-4", "pod-5", "pod-6"},
+		collectNames(seen),
+		"the sink must see each paged object once, in page order")
+
+	calls := lister.recordedCalls()
+	require.Len(t, calls, 3, "7 objects at 3 per page is three LIST calls")
+	assert.Empty(t, calls[0].Continue, "the first page must not carry a continue token")
+	assert.Equal(t, []string{"3", "6"}, []string{calls[1].Continue, calls[2].Continue})
+
+	// The eager collector's API is unchanged by the sink refactor.
+	eager := newPagedLister(3).serve("", sinkTestPods("default", 7)...)
+	slice, sliceErrs := eager.handler().pullSingleResource(context.Background(), sinkTestGVR, "", "", &EmptySelector{}, nil)
+	require.Empty(t, sliceErrs)
+	require.Len(t, slice, 7)
+	for i := range slice {
+		assert.Equal(t, seen[i].GetName(), slice[i].GetName())
+	}
+}
+
+// An expired continuation token must surface as a failure for the selector
+// being walked, not restart it: pager.EachListItem has no full-relist
+// fallback, so the objects already handed to the sink stay put and none of
+// them is replayed. This is what lets a sink store objects as they arrive
+// without needing to deduplicate a re-listed GVR.
+func TestPullSingleResourceInto_ExpiredContinuationTokenIsNotReplayed(t *testing.T) {
+	expired := apierrors.NewResourceExpired("continue token 2 expired")
+	lister := newPagedLister(2).
+		serve("", sinkTestPods("default", 6)...).
+		failSelectorAfterPage("", 1, expired)
+
+	var seen []*unstructured.Unstructured
+	selectorErrs := lister.handler().pullSingleResourceInto(context.Background(), sinkTestGVR, "", "", &EmptySelector{}, nil, func(obj *unstructured.Unstructured) error {
+		seen = append(seen, obj.DeepCopy())
+		return nil
+	})
+
+	assert.Equal(t, []string{"pod-0", "pod-1"}, collectNames(seen),
+		"the objects served before the token expired must be kept, and only once")
+
+	require.Len(t, selectorErrs, 1)
+	assert.True(t, apierrors.IsResourceExpired(errors.Unwrap(selectorErrs[0].err)),
+		"the expired status must reach the caller as the selector's failure")
+
+	calls := lister.recordedCalls()
+	require.Len(t, calls, 2, "the traversal must stop at the expired page")
+	for _, call := range calls[1:] {
+		assert.NotEmpty(t, call.Continue,
+			"a call without a continue token after page 1 would be a full re-list, which would replay page 1 into the sink")
+	}
+}
+
+// One selector failing part-way keeps what it already yielded and does not
+// abandon the remaining selectors. Callers rely on this to report partial
+// coverage for a GVR rather than dropping it.
+func TestPullSingleResourceInto_PartialSelectorFailureKeepsWalkingRemainingSelectors(t *testing.T) {
+	lister := newPagedLister(2).
+		serve("metadata.namespace=broken", sinkTestPods("broken", 6)...).
+		serve("metadata.namespace=healthy", sinkTestPods("healthy", 3)...).
+		failSelectorAfterPage("metadata.namespace=broken", 1, errors.New("etcd unavailable"))
+
+	selectors := &staticFieldSelector{selectors: []string{"metadata.namespace=broken", "metadata.namespace=healthy"}}
+
+	var seen []*unstructured.Unstructured
+	selectorErrs := lister.handler().pullSingleResourceInto(context.Background(), sinkTestGVR, "", "", selectors, nil, func(obj *unstructured.Unstructured) error {
+		seen = append(seen, obj.DeepCopy())
+		return nil
+	})
+
+	require.Len(t, seen, 5, "page 1 of the failed selector plus every object of the healthy one")
+	assert.Equal(t, []string{"broken", "broken", "healthy", "healthy", "healthy"},
+		[]string{seen[0].GetNamespace(), seen[1].GetNamespace(), seen[2].GetNamespace(), seen[3].GetNamespace(), seen[4].GetNamespace()})
+
+	require.Len(t, selectorErrs, 1)
+	assert.Equal(t, "metadata.namespace=broken", selectorErrs[0].selector)
+	assert.ErrorContains(t, selectorErrs[0].err, "etcd unavailable")
+}
+
+// A sink whose per-object work fails stops the selector it is walking the same
+// way a LIST error does, and the caller learns which selector it was.
+func TestPullSingleResourceInto_SinkErrorStopsTheSelectorAndIsReported(t *testing.T) {
+	sinkErr := errors.New("partition store is full")
+	lister := newPagedLister(2).serve("", sinkTestPods("default", 6)...)
+
+	handed := 0
+	selectorErrs := lister.handler().pullSingleResourceInto(context.Background(), sinkTestGVR, "", "", &EmptySelector{}, nil, func(*unstructured.Unstructured) error {
+		handed++
+		if handed == 3 {
+			return sinkErr
+		}
+		return nil
+	})
+
+	assert.Equal(t, 3, handed, "the traversal must stop at the failing object")
+	require.Len(t, selectorErrs, 1)
+	assert.ErrorIs(t, selectorErrs[0].err, sinkErr)
+}
+
+// Parent filtering happens before the sink, so a sink never stores an object
+// the eager collector would have dropped.
+func TestPullSingleResourceInto_FiltersOwnedWorkloadsBeforeTheSink(t *testing.T) {
+	owned := sinkTestPod("owned-pod", "default")
+	owned.SetOwnerReferences([]metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs", UID: "1"}})
+
+	lister := newPagedLister(2).serve("", sinkTestPod("bare-pod", "default"), owned)
+
+	var seen []*unstructured.Unstructured
+	selectorErrs := lister.handler().pullSingleResourceInto(context.Background(), sinkTestGVR, "", "", &EmptySelector{}, nil, func(obj *unstructured.Unstructured) error {
+		seen = append(seen, obj.DeepCopy())
+		return nil
+	})
+
+	require.Empty(t, selectorErrs)
+	assert.Equal(t, []string{"bare-pod"}, collectNames(seen))
+}
+
+// A cancelled scan reaches no sink at all: cancellation must not leave a
+// half-ingested GVR behind for a caller that stores objects as they arrive.
+func TestPullSingleResourceInto_CancelledContextNeverReachesTheSink(t *testing.T) {
+	lister := newPagedLister(2).serve("", sinkTestPods("default", 6)...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	handed := 0
+	selectorErrs := lister.handler().pullSingleResourceInto(ctx, sinkTestGVR, "", "", &EmptySelector{}, nil, func(*unstructured.Unstructured) error {
+		handed++
+		return nil
+	})
+
+	assert.Zero(t, handed)
+	assert.Empty(t, lister.recordedCalls())
+	require.Len(t, selectorErrs, 1)
+	assert.ErrorIs(t, selectorErrs[0].err, context.Canceled)
+}
+
+// The streaming collector partitions objects as the pager yields them, so a
+// GVR whose objects span several pages and several namespaces still lands in
+// the right batches, each object exactly once.
+func TestCollectAndStreamBatches_PartitionsObjectsAcrossPages(t *testing.T) {
+	var pods []unstructured.Unstructured
+	for _, namespace := range []string{"ns-a", "ns-b", "ns-c"} {
+		for i := range 3 {
+			pods = append(pods, sinkTestPod(fmt.Sprintf("%s-pod-%d", namespace, i), namespace))
+		}
+	}
+	// Two per page, so every namespace is split across a page boundary.
+	lister := newPagedLister(2).serve("", pods...)
+	handler := lister.handler()
+
+	namespaced := true
+	queryable := QueryableResources{
+		"/v1/pods": {GroupVersionResourceTriplet: "/v1/pods", Namespaced: &namespaced},
+	}
+
+	ctx := context.Background()
+	scanInfo, session := streamingTestSession(ctx)
+	batches := make(chan *cautils.ResourceBatch, 8)
+
+	require.NoError(t, handler.collectAndStreamBatches(ctx, queryable, &EmptySelector{}, session, scanInfo, cautils.ExternalResources{}, batches, nil))
+	close(batches)
+
+	resident := <-batches
+	assert.Empty(t, resident.AllResources, "no pod in this GVR is cluster-scoped")
+
+	perNamespace := map[string][]string{}
+	for batch := range batches {
+		perNamespace[batch.Scope] = collectMetadataNames(batch.AllResources)
+		assert.Len(t, batch.K8SResources["/v1/pods"], 3,
+			"the GVR bucket must list every object of the namespace exactly once")
+	}
+
+	assert.Equal(t, map[string][]string{
+		"ns-a": {"ns-a-pod-0", "ns-a-pod-1", "ns-a-pod-2"},
+		"ns-b": {"ns-b-pod-0", "ns-b-pod-1", "ns-b-pod-2"},
+		"ns-c": {"ns-c-pod-0", "ns-c-pod-1", "ns-c-pod-2"},
+	}, perNamespace)
+
+	require.Len(t, lister.recordedCalls(), 5, "9 pods at 2 per page is a single paginated traversal, not a LIST per namespace")
+}
+
+func collectMetadataNames(resources map[string]workloadinterface.IMetadata) []string {
+	names := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		names = append(names, resource.GetName())
+	}
+	sort.Strings(names)
+	return names
+}

--- a/docs/STREAMING_IMPLEMENTATION.md
+++ b/docs/STREAMING_IMPLEMENTATION.md
@@ -4,7 +4,9 @@
 
 This implementation addresses the API-server load issue described in A1 of `issues.md` and Phase 5 of `docs/optimization-plan.md`. The solution introduces resource streaming so the OPA evaluation never holds the whole cluster as its input: resources are partitioned by scope and the processor evaluates the resident (cluster-scoped) batch plus one namespace batch at a time, while the collection phase replaces the previous O(L × N) per-GVR-per-namespace LIST calls with a single LIST per GVR (O(L)).
 
-Note what streaming does *not* do: it does not reduce total retained memory. The collector still pulls every GVR and holds the full cluster until the first batch is sent, and the processor retains all resources in `AllResources` for downstream stages (exceptions, printers, image scanning). Streaming bounds the *evaluation input* and the number of API-server calls, not the process high-water mark.
+Note what streaming does *not* do: it does not reduce total retained memory. The collector traverses every GVR and holds the full cluster until the first batch is sent, and the processor retains all resources in `AllResources` for downstream stages (exceptions, printers, image scanning). Streaming bounds the *evaluation input* and the number of API-server calls, not the process high-water mark.
+
+Collection is paginated end to end: each GVR is walked once with `pager.EachListItem`, and objects are partitioned into their batch as the pager yields them rather than accumulated into a per-GVR slice first. What is still unbounded is the set of namespace batches, which is held on the heap until each batch is emitted.
 
 ## Problem Statement
 
@@ -101,7 +103,9 @@ The implementation reduces peak evaluation memory by:
 - Keeping only cluster-scoped resources (~10-20% of total) plus a single namespace batch in the evaluation input at any time
 - Processing controls scope-by-scope (resident + one namespace at a time)
 
-The collection peak is not reduced: all resources are pulled and partitioned before the first batch is sent, and the processor retains resources in `AllResources` for downstream stages. The real win over the previous approach is the API-server load — one LIST per GVR instead of one per GVR per namespace — and a bounded evaluation input.
+The collection peak is not reduced: all resources are traversed and partitioned before the first batch is sent, and the processor retains resources in `AllResources` for downstream stages. The real win over the previous approach is the API-server load — one paginated LIST traversal per GVR instead of one per GVR per namespace — and a bounded evaluation input.
+
+Within collection, the only whole-cluster containers left are the batches themselves. Neither the pager's pages nor any per-GVR slice adds to the peak: `pullSingleResourceInto` hands each object straight to the collector, which stores it in its namespace or resident batch and drops the pager's copy.
 
 ### Related-Object Resolution
 


### PR DESCRIPTION
## Overview

- **Current Behavior:** `pullSingleResource` accumulated full `[]unstructured.Unstructured` slices per GVR and converted them multiple times (`ConvertUnstructuredSliceToMap`, `ConvertMapListToMeta`) before batch partitioning, holding three duplicate representations in memory at peak.
- **Future Behavior:** Implements Phase 1 of #3235 by introducing `pullSingleResourceInto` with an incremental `resourceSink`, allowing `collectAndStreamBatches` to stream paged items directly into batches without building intermediate whole-GVR slices.

## Additional Information

- **Incremental Processing:** `pullSingleResourceInto(..., sink resourceSink)` handles paginated traversal per field selector and delivers items directly to the sink after parent filtering.
- **Backward Compatibility:** `pullSingleResource` remains as a thin wrapper that accumulates items into a slice, keeping the eager collector (`pullResources`) unchanged.
- **No-Replay Guarantee:** `pager.EachListItem` guarantees no full-relist fallback on expired continuation tokens, ensuring pages are never replayed and making direct sink ingestion safe without cross-page deduplication.
- **Scope:** Eliminates transient per-GVR slice allocations and establishes the interface seam for a bounded partition store (Phase 2). Documentation updated in `docs/STREAMING_IMPLEMENTATION.md`.

## How to Test

Run the new unit and regression tests in `core/pkg/resourcehandler`:

```bash
go test -v ./core/pkg/resourcehandler -run "TestPullSingleResourceInto|TestCollectAndStreamBatches"
go test ./core/...
```

*Test cases covered in `k8sresources_pull_sink_test.go`:*
- `TestPullSingleResourceInto_YieldsEveryPagedObjectOnce` (pagination & slice parity)
- `TestPullSingleResourceInto_ExpiredContinuationTokenIsNotReplayed` (token expiry safety)
- `TestPullSingleResourceInto_PartialSelectorFailureKeepsWalkingRemainingSelectors`
- `TestPullSingleResourceInto_SinkErrorStopsTheSelectorAndIsReported`
- `TestPullSingleResourceInto_FiltersOwnedWorkloadsBeforeTheSink`
- `TestPullSingleResourceInto_CancelledContextNeverReachesTheSink`
- `TestCollectAndStreamBatches_PartitionsObjectsAcrossPages`

## Examples/Screenshots

N/A (Backend refactoring & streaming collector optimization)

## Related issues/PRs:

* Part of #3235

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved large-scale resource collection by processing paginated results incrementally, reducing temporary memory usage.
  * Preserved object ordering and batch partitioning while streaming results.

* **Reliability**
  * Improved handling of cancellations, expired continuation tokens, selector failures, sink errors, and workload ownership filtering.

* **Documentation**
  * Updated streaming and memory-management documentation to describe paginated processing and batch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->