### PR TITLE
[LFX 2026] chore(deps): bump opa-utils to v0.0.312 for alertOnly exception semantics

### DIFF
--- a/core/mocks/loadmocks.go
+++ b/core/mocks/loadmocks.go
@@ -85,7 +85,7 @@ func MockDevelopmentWithHostpath() workloadinterface.IMetadata {
 func MockExceptionAllKinds(policy *armotypes.PosturePolicy) *armotypes.PostureExceptionPolicy {
 	return &armotypes.PostureExceptionPolicy{
 		PosturePolicies: []armotypes.PosturePolicy{*policy},
-		Actions:         []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
+		Actions:         []armotypes.PostureExceptionPolicyActions{armotypes.Disable},
 		Resources: []identifiers.PortalDesignator{
 			{
 				DesignatorType: identifiers.DesignatorAttributes,

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/kubescape/go-git-url v0.0.33
 	github.com/kubescape/go-logger v0.0.28
 	github.com/kubescape/k8s-interface v0.0.209
-	github.com/kubescape/opa-utils v0.0.309
+	github.com/kubescape/opa-utils v0.0.312
 	github.com/kubescape/rbac-utils v0.0.21
 	github.com/kubescape/regolibrary/v2 v2.0.1
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73

--- a/go.sum
+++ b/go.sum
@@ -1222,6 +1222,8 @@ github.com/kubescape/kubescape/v3 v3.0.4 h1:gZ5d8QMxLYZQ6Yz9wRvGcDQlBUIV+v/Y/41g
 github.com/kubescape/kubescape/v3 v3.0.4/go.mod h1:upPCVTCRT3+LuZ1bawGtjreRmr/Xa+LT0fHtPzlylRU=
 github.com/kubescape/opa-utils v0.0.309 h1:jc756tYiPPsFgaG5PmVuuHAwnb8R8N9wxbrFJ0ZnN9U=
 github.com/kubescape/opa-utils v0.0.309/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
+github.com/kubescape/opa-utils v0.0.312 h1:zCT3LbtvhOwxhVXRWHAdZv7F0JvnAiWSEMd0LAWK/Ho=
+github.com/kubescape/opa-utils v0.0.312/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
 github.com/kubescape/rbac-utils v0.0.21 h1:iRaGX8WKBd94dg31vpX10LHWoQZ/QKO5AMLzQf3kEkc=
 github.com/kubescape/rbac-utils v0.0.21/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.317-0.20240320124840-1d84ac7186ea h1:hLUe+1bdhiBD7xM/jliQozVd1NLYn1afQLxl5trQdPk=

--- a/httphandler/go.mod
+++ b/httphandler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/go-logger v0.0.34
 	github.com/kubescape/k8s-interface v0.0.218
 	github.com/kubescape/kubescape/v4 v4.0.12
-	github.com/kubescape/opa-utils v0.0.310
+	github.com/kubescape/opa-utils v0.0.312
 	github.com/kubescape/storage v0.0.258
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1

--- a/httphandler/go.sum
+++ b/httphandler/go.sum
@@ -1230,6 +1230,8 @@ github.com/kubescape/kubescape/v3 v3.0.48 h1:h41+i5Rmmjra80YOkusuevXcN+tjqdt10Pf
 github.com/kubescape/kubescape/v3 v3.0.48/go.mod h1:yByvOFYdzgQYGblg5lkAOIObhYMgxnlJyzBBJ1Q64PA=
 github.com/kubescape/opa-utils v0.0.310 h1:mFC7X1zDQmaH2SG6C2yxdjVc122n3b6dz3IJt8Cva+Q=
 github.com/kubescape/opa-utils v0.0.310/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
+github.com/kubescape/opa-utils v0.0.312 h1:zCT3LbtvhOwxhVXRWHAdZv7F0JvnAiWSEMd0LAWK/Ho=
+github.com/kubescape/opa-utils v0.0.312/go.mod h1:dWNcjmiTwGYlNmclXvDvgH7UlLdpDvmEc9T7ACTqLo0=
 github.com/kubescape/rbac-utils v0.0.21 h1:iRaGX8WKBd94dg31vpX10LHWoQZ/QKO5AMLzQf3kEkc=
 github.com/kubescape/rbac-utils v0.0.21/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=


### PR DESCRIPTION
## What

Bumps `opa-utils` to **v0.0.312** in both modules so the CLI picks up kubescape/opa-utils#190, which makes an `alertOnly` exception acknowledge a finding instead of suppressing it.

| module | before | after |
|---|---|---|
| `go.mod` | v0.0.309 | v0.0.312 |
| `httphandler/go.mod` | v0.0.310 | v0.0.312 |

Both need it. The fix landed in opa-utils commit `d93b556`, and `git tag --contains` puts it in **v0.0.311** and v0.0.312 only — so the existing `httphandler` pin at v0.0.310 predates it. Bumping only the root module would leave the in-cluster HTTP scan path on the old behaviour.

## Why this is not a routine dependency bump

opa-utils#190 is a deliberate behavioural change, and this is the PR where it reaches users.

Before, `alertOnly` and `disable` produced byte-for-byte identical results: both removed the resource from the failed count and lifted the compliance score by the same amount. Three places in the tree said they were meant to differ — the SecurityException design doc, the long-standing `IsDisable()`/`IsAlertOnly()` predicates in `armotypes`, and the legacy v1 report path, which already honoured them. The v2 results path never implemented it.

After this bump, a resource matched only by `alertOnly` exceptions reports `failed (w/exceptions)` and keeps counting against the score, while `disable` is unchanged.

**This lowers compliance scores for anyone currently using `alertOnly`.** That is the documented intent, but it is user-visible: a `--compliance-threshold` gate in CI can flip from pass to fail on an unchanged cluster. Worth calling out in the release notes.

## The test change

`core/mocks/loadmocks.go` — `MockExceptionAllKinds` pinned from `AlertOnly` to `Disable`.

This is required, not cosmetic. Without it `TestProcessResourcesResult` fails at `processorhandler_test.go:343-345`:

```
Error: Not equal:  expected: 2  actual: 1     (res.ListControlsIDs(nil).Passed())
Error: Should be true                          (res.GetStatus(nil).IsPassed())
Error: Should be false                         (res.GetStatus(nil).IsFailed())
```

The mock's fixture used `AlertOnly` while the assertions expect the exception to suppress the finding, so it encoded the old behaviour. The test is really about *which* exceptions match rather than *what the action does*, so pinning it to `Disable` preserves what it is actually testing. This mirrors how opa-utils#190 handled the same problem in `TestSetExceptions` upstream.

The mock's only other consumer, `core/pkg/policyhandler`, uses it as a cached-exceptions payload for getter plumbing and passes either way.

## Verification

Ran against this branch:

- `go test ./core/...` — **all green**, no failures
- `go test ./httphandler/...` — **all green** (5 packages)

`opaprocessor` was the only package that broke on the raw bump, and only through that one mock.

No printer changes were needed. `prettyprinter.go:224` already appends a non-unknown sub status, so `failed (w/exceptions)` renders on the control line as-is, and every test under `core/pkg/resultshandling/...` passes untouched.

## Follow-ups, not in this PR

- `core/pkg/opaprocessor/processorhandlerutils.go:156` sets manual controls to `StatusPassed` + `SubStatusException` without consulting the action. It should learn the same `alertOnly` distinction.
- opa-utils#190 added an `acknowledgedResources` sub counter alongside `ignoredResources`, but kubescape has no references to `ISubCounters` / `Ignored()` / `Acknowledged()` anywhere, so the suppressed-vs-acknowledged split is populated in JSON and never surfaced by the printers.
- The kubescape.io docs currently describe the old behaviour, since they were written to match what the code did. `docs/docs/accepting-risk.md` needs updating in the same release.

## Related

- Depends on kubescape/opa-utils#190
- Related to #1982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exception policy handling so affected controls are disabled instead of generating alerts only.
  * Improved consistency in policy behavior across supported components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->