### PR TITLE
feat: support --format json for the update command

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -5,6 +5,7 @@ package update
 //          kubescape update
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,12 @@ var updateCmdExamples = fmt.Sprintf(`
   %[1]s update
 `, cautils.ExecName())
 
+type UpdateInfo struct {
+	LatestVersion    string `json:"latestVersion,omitempty"`
+	InstallationLink string `json:"installationLink,omitempty"`
+	Message          string `json:"message,omitempty"`
+}
+
 // newVersionCheckHandler is the seam used by GetUpdateCmd so unit tests can
 // substitute a mock without changing runtime behaviour. The update command
 // intentionally does NOT use versioncheck.NewIVersionCheckHandler: that
@@ -37,15 +44,40 @@ var newVersionCheckHandler = func() versioncheck.IVersionCheckHandler {
 }
 
 func GetUpdateCmd(ks meta.IKubescape) *cobra.Command {
+	var updateFormat string
 	updateCmd := &cobra.Command{
 		Use:     "update",
 		Short:   "Update to latest release version",
 		Long:    ``,
 		Example: updateCmdExamples,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if updateFormat != "text" && updateFormat != "json" {
+				return fmt.Errorf("unsupported format %q, supported: text, json", updateFormat)
+			}
+
 			v := newVersionCheckHandler()
 			versionCheckRequest := versioncheck.NewVersionCheckRequest("", versioncheck.BuildNumber, "", "", "update", nil)
 			if err := v.CheckLatestVersion(ks.Context(), versionCheckRequest); err != nil {
+				return err
+			}
+
+			if updateFormat == "json" {
+				info := UpdateInfo{}
+				if versioncheck.BuildNumber == "" || strings.Contains(versioncheck.BuildNumber, "rc") {
+					info.Message = "Nothing to update: you are running the development version"
+				} else if versioncheck.LatestReleaseVersion == "" {
+					info.Message = "Failed to check for updates"
+				} else if versioncheck.BuildNumber == versioncheck.LatestReleaseVersion {
+					info.Message = "Nothing to update: you are running the latest version"
+				} else {
+					info.LatestVersion = versioncheck.LatestReleaseVersion
+					info.InstallationLink = installationLink
+				}
+				b, err := json.Marshal(info)
+				if err != nil {
+					return fmt.Errorf("failed to marshal update info: %w", err)
+				}
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(b))
 				return err
 			}
 
@@ -65,5 +97,6 @@ func GetUpdateCmd(ks meta.IKubescape) *cobra.Command {
 			return nil
 		},
 	}
+	updateCmd.Flags().StringVarP(&updateFormat, "format", "f", "text", "Output format. Supported formats: text, json")
 	return updateCmd
 }

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -135,6 +135,72 @@ func TestGetUpdateCmd_ReportsAvailableUpdate(t *testing.T) {
 	assert.Contains(t, string(out), "Version v3.1.0 is available.")
 }
 
+func TestGetUpdateCmd_UnsupportedFormat(t *testing.T) {
+	withVersionCheckHandler(t, versioncheck.NewVersionCheckHandlerMock())
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
+
+	err := cmd.Flags().Set("format", "yaml")
+	require.NoError(t, err)
+
+	err = cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format \"yaml\"")
+}
+
+func TestGetUpdateCmd_JSON_ReportsAvailableUpdate(t *testing.T) {
+	withVersionCheckHandler(t, &stubVersionCheckHandler{latest: "v3.1.0"})
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
+
+	err := cmd.Flags().Set("format", "json")
+	require.NoError(t, err)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	assert.NoError(t, cmd.RunE(cmd, []string{}))
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v3.1.0", versioncheck.LatestReleaseVersion)
+	assert.Contains(t, string(out), `"latestVersion":"v3.1.0"`)
+	assert.Contains(t, string(out), `"installationLink":"https://kubescape.io/docs/install-cli/"`)
+}
+
+func TestGetUpdateCmd_JSON_NothingToUpdate(t *testing.T) {
+	withVersionCheckHandler(t, &stubVersionCheckHandler{latest: "v3.0.0"})
+	withVersionGlobals(t, "v3.0.0", "")
+
+	cmd := GetUpdateCmd(&stubKubescape{ctx: context.Background()})
+	require.NotNil(t, cmd)
+
+	err := cmd.Flags().Set("format", "json")
+	require.NoError(t, err)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	assert.NoError(t, cmd.RunE(cmd, []string{}))
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v3.0.0", versioncheck.LatestReleaseVersion)
+	assert.Contains(t, string(out), `"message":"Nothing to update: you are running the latest version"`)
+}
+
 func TestUpdateCommandDoesNotHonorSkipUpdateCheckEnv(t *testing.T) {
 	// KS_SKIP_UPDATE_CHECK must not turn the update command into a no-op.
 	// NewIVersionCheckHandler would return VersionCheckHandlerMock here; the


### PR DESCRIPTION
## Overview
Added the `--format` flag to the `kubescape update` command to support JSON output. 

## Related issues/PRs:
Resolved #3616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output support to the update command through the `--format`/`-f` option.
  * JSON responses include the latest version, installation link, and status message.

* **Bug Fixes**
  * Configuration now rejects invalid cloud API and reporting URLs, including unsupported schemes and missing hosts.
  * Configuration errors are now reported instead of being silently ignored.

* **Validation**
  * Unsupported update output formats now return a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->