### PR TITLE
fix(anonymizer): anonymize Secret/ConfigMap names referenced via spec.volumes

### DIFF
--- a/core/pkg/anonymizer/container.go
+++ b/core/pkg/anonymizer/container.go
@@ -161,6 +161,13 @@ func transformPodSpecs(node any, knownRefNames map[string]map[string]struct{}, t
 			return err
 		}
 
+		if err := transformVolumes(
+			v,
+			transformer,
+		); err != nil {
+			return err
+		}
+
 		for _, child := range v {
 			if err := transformPodSpecs(
 				child,
@@ -721,5 +728,164 @@ func transformServiceAccountName(obj map[string]any, transformer Transformer) er
 		obj[key] = name
 	}
 
+	return nil
+}
+
+// transformVolumes applies the supplied Transformer to Secret/ConfigMap/PVC
+// names referenced by a pod's volumes, across both typed and unstructured
+// workload representations.
+//
+// A Secret/ConfigMap name referenced only here (not via envFrom or
+// imagePullSecrets) previously stayed in cleartext even with --hide/--encrypt
+// enabled. Per Mapping.GetOrCreate's doc comment (mapping.go), that is worse
+// than a field-local leak: because a pseudonym's suffix is derived from the
+// raw value alone, one cleartext occurrence anywhere in the report
+// de-anonymizes every pseudonym sharing that value's suffix, not just the
+// field it leaked from.
+func transformVolumes(obj map[string]any, transformer Transformer) error {
+	rawVolumes, ok := obj["volumes"]
+	if !ok || rawVolumes == nil {
+		return nil
+	}
+
+	switch volumes := rawVolumes.(type) {
+	case []corev1.Volume:
+		if err := transformTypedVolumes(volumes, transformer); err != nil {
+			return err
+		}
+	case []any:
+		for _, item := range volumes {
+			volume, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if err := transformUnstructuredVolume(volume, transformer); err != nil {
+				return err
+			}
+		}
+		obj["volumes"] = volumes
+	}
+
+	return nil
+}
+
+// transformTypedVolumes covers every volume source that names a Secret,
+// ConfigMap, or PersistentVolumeClaim: the direct secret/configMap volume
+// sources, a projected volume's secret/configMap sources, a CSI volume's
+// nodePublishSecretRef, and a PVC volume's claimName.
+func transformTypedVolumes(volumes []corev1.Volume, transformer Transformer) error {
+	var err error
+
+	for i := range volumes {
+		v := &volumes[i]
+
+		if v.Secret != nil && v.Secret.SecretName != "" {
+			v.Secret.SecretName, err = transformValue(transformer, "ref", v.Secret.SecretName)
+			if err != nil {
+				return err
+			}
+		}
+		if v.ConfigMap != nil && v.ConfigMap.Name != "" {
+			v.ConfigMap.Name, err = transformValue(transformer, "ref", v.ConfigMap.Name)
+			if err != nil {
+				return err
+			}
+		}
+		if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName != "" {
+			v.PersistentVolumeClaim.ClaimName, err = transformValue(transformer, "ref", v.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				return err
+			}
+		}
+		if v.CSI != nil && v.CSI.NodePublishSecretRef != nil && v.CSI.NodePublishSecretRef.Name != "" {
+			v.CSI.NodePublishSecretRef.Name, err = transformValue(transformer, "ref", v.CSI.NodePublishSecretRef.Name)
+			if err != nil {
+				return err
+			}
+		}
+		if v.Projected != nil {
+			for j := range v.Projected.Sources {
+				src := &v.Projected.Sources[j]
+				if src.Secret != nil && src.Secret.Name != "" {
+					src.Secret.Name, err = transformValue(transformer, "ref", src.Secret.Name)
+					if err != nil {
+						return err
+					}
+				}
+				if src.ConfigMap != nil && src.ConfigMap.Name != "" {
+					src.ConfigMap.Name, err = transformValue(transformer, "ref", src.ConfigMap.Name)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// transformUnstructuredVolume mirrors transformTypedVolumes for one volume
+// represented as a map[string]any.
+func transformUnstructuredVolume(volume map[string]any, transformer Transformer) error {
+	if secret, ok := volume["secret"].(map[string]any); ok {
+		if err := transformUnstructuredNamedField(secret, "secretName", transformer); err != nil {
+			return err
+		}
+	}
+
+	if err := transformUnstructuredReference(volume, "configMap", transformer); err != nil {
+		return err
+	}
+
+	if pvc, ok := volume["persistentVolumeClaim"].(map[string]any); ok {
+		if err := transformUnstructuredNamedField(pvc, "claimName", transformer); err != nil {
+			return err
+		}
+	}
+
+	if csi, ok := volume["csi"].(map[string]any); ok {
+		if err := transformUnstructuredReference(csi, "nodePublishSecretRef", transformer); err != nil {
+			return err
+		}
+	}
+
+	if projected, ok := volume["projected"].(map[string]any); ok {
+		if sources, ok := projected["sources"].([]any); ok {
+			for _, item := range sources {
+				source, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := transformUnstructuredReference(source, "secret", transformer); err != nil {
+					return err
+				}
+				if err := transformUnstructuredReference(source, "configMap", transformer); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// transformUnstructuredNamedField applies the supplied Transformer to one
+// string field on an unstructured object. Unlike transformUnstructuredReference
+// (which always reads the "name" field of a reference object), the
+// volume-level Secret/PersistentVolumeClaim sources this covers use their own
+// field name (secretName/claimName) directly on the volume source itself.
+func transformUnstructuredNamedField(obj map[string]any, field string, transformer Transformer) error {
+	value, ok := obj[field].(string)
+	if !ok || value == "" {
+		return nil
+	}
+
+	transformed, err := transformValue(transformer, "ref", value)
+	if err != nil {
+		return err
+	}
+
+	obj[field] = transformed
 	return nil
 }

--- a/core/pkg/anonymizer/container_test.go
+++ b/core/pkg/anonymizer/container_test.go
@@ -1163,3 +1163,156 @@ func TestTransformPodSpecs_TypedContainersFromScanPipeline(t *testing.T) {
 	assert.NotContains(t, containers[0].Image, "registry.internal.corp")
 	assert.NotContains(t, initContainers[0].Image, "registry.internal.corp")
 }
+
+func TestTransformVolumes_TypedSecretConfigMapPVCCSIProjected(t *testing.T) {
+	obj := map[string]any{
+		"volumes": []corev1.Volume{
+			{
+				Name: "creds",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "db-creds"},
+				},
+			},
+			{
+				Name: "config",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"},
+					},
+				},
+			},
+			{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"},
+				},
+			},
+			{
+				Name: "csi-secret",
+				VolumeSource: corev1.VolumeSource{
+					CSI: &corev1.CSIVolumeSource{
+						Driver:               "csi.example.com",
+						NodePublishSecretRef: &corev1.LocalObjectReference{Name: "csi-creds"},
+					},
+				},
+			},
+			{
+				Name: "projected",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "proj-secret"}}},
+							{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "proj-config"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, transformVolumes(obj, NewMappingTransformer()))
+
+	volumes := obj["volumes"].([]corev1.Volume)
+	assert.NotEqual(t, "db-creds", volumes[0].Secret.SecretName)
+	assert.NotEqual(t, "app-config", volumes[1].ConfigMap.Name)
+	assert.NotEqual(t, "data-pvc", volumes[2].PersistentVolumeClaim.ClaimName)
+	assert.NotEqual(t, "csi-creds", volumes[3].CSI.NodePublishSecretRef.Name)
+	assert.NotEqual(t, "proj-secret", volumes[4].Projected.Sources[0].Secret.Name)
+	assert.NotEqual(t, "proj-config", volumes[4].Projected.Sources[1].ConfigMap.Name)
+}
+
+func TestTransformVolumes_UnstructuredSecretConfigMapPVCCSIProjected(t *testing.T) {
+	obj := map[string]any{
+		"volumes": []any{
+			map[string]any{
+				"name":   "creds",
+				"secret": map[string]any{"secretName": "db-creds"},
+			},
+			map[string]any{
+				"name":      "config",
+				"configMap": map[string]any{"name": "app-config"},
+			},
+			map[string]any{
+				"name":                  "data",
+				"persistentVolumeClaim": map[string]any{"claimName": "data-pvc"},
+			},
+			map[string]any{
+				"name": "csi-secret",
+				"csi": map[string]any{
+					"driver":               "csi.example.com",
+					"nodePublishSecretRef": map[string]any{"name": "csi-creds"},
+				},
+			},
+			map[string]any{
+				"name": "projected",
+				"projected": map[string]any{
+					"sources": []any{
+						map[string]any{"secret": map[string]any{"name": "proj-secret"}},
+						map[string]any{"configMap": map[string]any{"name": "proj-config"}},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, transformVolumes(obj, NewMappingTransformer()))
+
+	volumes := obj["volumes"].([]any)
+	v0 := volumes[0].(map[string]any)
+	assert.NotEqual(t, "db-creds", v0["secret"].(map[string]any)["secretName"])
+
+	v1 := volumes[1].(map[string]any)
+	assert.NotEqual(t, "app-config", v1["configMap"].(map[string]any)["name"])
+
+	v2 := volumes[2].(map[string]any)
+	assert.NotEqual(t, "data-pvc", v2["persistentVolumeClaim"].(map[string]any)["claimName"])
+
+	v3 := volumes[3].(map[string]any)
+	assert.NotEqual(t, "csi-creds", v3["csi"].(map[string]any)["nodePublishSecretRef"].(map[string]any)["name"])
+
+	v4 := volumes[4].(map[string]any)
+	sources := v4["projected"].(map[string]any)["sources"].([]any)
+	assert.NotEqual(t, "proj-secret", sources[0].(map[string]any)["secret"].(map[string]any)["name"])
+	assert.NotEqual(t, "proj-config", sources[1].(map[string]any)["configMap"].(map[string]any)["name"])
+}
+
+func TestTransformVolumes_MissingOrEmptyIsSafe(t *testing.T) {
+	assert.NoError(t, transformVolumes(map[string]any{}, NewMappingTransformer()))
+	assert.NoError(t, transformVolumes(map[string]any{"volumes": nil}, NewMappingTransformer()))
+	assert.NoError(t, transformVolumes(map[string]any{"volumes": []any{"not-a-map"}}, NewMappingTransformer()))
+}
+
+// TestTransformPodSpecs_VolumeSecretNameMatchesEnvFromRefPseudonym is the
+// direct regression test for the leak this fixes: a Secret referenced both
+// via a volume and via envFrom must be pseudonymized to the SAME value in
+// both places (Mapping.GetOrCreate's cross-prefix suffix sharing), and
+// neither occurrence may leave it in cleartext.
+func TestTransformPodSpecs_VolumeSecretNameMatchesEnvFromRefPseudonym(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"volumes": []any{
+				map[string]any{
+					"name":   "creds-volume",
+					"secret": map[string]any{"secretName": "db-creds"},
+				},
+			},
+			"containers": []any{
+				map[string]any{
+					"name": "app",
+					"envFrom": []any{
+						map[string]any{"secretRef": map[string]any{"name": "db-creds"}},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, transformPodSpecs(obj, nil, NewMappingTransformer()))
+
+	spec := obj["spec"].(map[string]any)
+	volumeSecretName := spec["volumes"].([]any)[0].(map[string]any)["secret"].(map[string]any)["secretName"]
+	containerSecretName := spec["containers"].([]any)[0].(map[string]any)["envFrom"].([]any)[0].(map[string]any)["secretRef"].(map[string]any)["name"]
+
+	assert.NotEqual(t, "db-creds", volumeSecretName, "the volume's secretName must not stay in cleartext")
+	assert.Equal(t, containerSecretName, volumeSecretName, "the same Secret name referenced two ways must produce the same pseudonym")
+}


### PR DESCRIPTION
## Summary

Closes #3618.

`--hide`/`--encrypt` only ever anonymized Secret/ConfigMap references reached through `containers[].env[].valueFrom`, `containers[].envFrom`, and `imagePullSecrets`. A name referenced via `spec.volumes` (`secret.secretName`, `configMap.name`, `persistentVolumeClaim.claimName`, a projected volume's `secret`/`configMap` sources, `csi.nodePublishSecretRef.name`) stayed in cleartext in an otherwise-anonymized report -- already flagged as a known, disclosed gap in `mapping.go`'s doc comment (from #2687), but never turned into a tracked fix.

This matters more than an isolated field gap: `Mapping.GetOrCreate`'s pseudonym suffix is derived from the raw value alone (by design, so the same Secret name stays recognizable as the same pseudonym across different reference kinds in one report). That means one cleartext leak anywhere de-anonymizes every other pseudonym sharing that value's suffix throughout the whole report, not just the field it leaked from -- e.g. a Secret mounted via a volume and also referenced via `envFrom` in the same pod would leave the volume's `secretName` in the clear, revealing what the `envFrom` reference's pseudonym actually is.

## Change

Adds `transformVolumes` to `core/pkg/anonymizer/container.go`, wired into `transformPodSpecs` alongside the existing `transformImagePullSecrets`/`transformServiceAccountName` calls. Covers both typed (`[]corev1.Volume`) and unstructured (`[]any`) representations, matching the existing dual-path pattern already used throughout this file for containers/env vars.

## Test plan

- Unit tests for `transformVolumes` covering every source type (Secret, ConfigMap, PersistentVolumeClaim, CSI `nodePublishSecretRef`, and a projected volume's `secret`/`configMap` sources), both typed and unstructured, plus a missing/empty/malformed-input safety test.
- A direct regression test (`TestTransformPodSpecs_VolumeSecretNameMatchesEnvFromRefPseudonym`) reproducing the exact leak this fixes: a Secret referenced both via a volume and via `envFrom` in the same pod now produces the same pseudonym in both places, and neither occurrence is left in cleartext.
- Existing `anonymizer` package tests and the `opaprocessor` anonymizer integration tests (`TestUpdateResults_ThenAnonymizerApply_*`) all still pass unchanged.
- `go build ./...`, `go vet ./...`, `go test ./core/pkg/anonymizer/... -race`, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret, ConfigMap, and persistent volume claim names referenced by pod volumes are now anonymized.
  * Anonymization now covers projected volumes, CSI secret references, and both typed and unstructured pod definitions.
  * References to the same secret remain consistent across volumes and environment settings.
* **Tests**
  * Added coverage for supported volume types and safe handling of missing, empty, or invalid volume data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->