### PR TITLE
feat(scan): add SARIF contract validation output

### DIFF
--- a/cmd/scan/validate_contract.go
+++ b/cmd/scan/validate_contract.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -12,6 +13,12 @@ import (
 	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
 	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/spf13/cobra"
+)
+
+const (
+	validateContractFormatText  = "text"
+	validateContractFormatJSON  = "json"
+	validateContractFormatSARIF = "sarif"
 )
 
 func getValidateContractCmd(scanInfo *cautils.ScanInfo) *cobra.Command {
@@ -23,46 +30,233 @@ func getValidateContractCmd(scanInfo *cautils.ScanInfo) *cobra.Command {
 		Short: "Validate and select a repository scan contract without running a scan",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			selected, err := contractv1alpha1.LoadFile(args[0], contractv1alpha1.LoadOptions{
+			selected, validationErr := contractv1alpha1.LoadFile(args[0], contractv1alpha1.LoadOptions{
 				ContractName:        contractName,
 				RunningVersion:      versioncheck.BuildNumber,
 				SupportedFormats:    shared.ScanFormats,
 				SupportedSeverities: reporthandlingapis.GetSupportedSeverities(),
 			})
-			if err != nil {
-				return err
+			if validationErr != nil && outputFormat != validateContractFormatSARIF {
+				return validationErr
 			}
 
 			var output []byte
+			var err error
 			switch outputFormat {
-			case "text":
+			case validateContractFormatText:
 				output = []byte(fmt.Sprintf("Scan contract %q is valid\nSelected contract: %s\nContract digest: %s\n", selected.Metadata.Name, selected.ContractName, selected.ContractDigest))
-			case "json":
+			case validateContractFormatJSON:
 				output, err = json.MarshalIndent(selected, "", "  ")
 				if err != nil {
 					return fmt.Errorf("encode validated contract: %w", err)
 				}
 				output = append(output, '\n')
+			case validateContractFormatSARIF:
+				output, err = validateContractSARIF(args[0], selected, validationErr)
+				if err != nil {
+					return err
+				}
 			default:
-				return fmt.Errorf("unsupported format %q, supported: text, json", outputFormat)
+				return fmt.Errorf("unsupported format %q, supported: text, json, sarif", outputFormat)
 			}
 
 			if scanInfo.Output != "" {
 				if err := os.WriteFile(scanInfo.Output, output, 0o600); err != nil {
 					return fmt.Errorf("write validation output: %w", err)
 				}
+				if outputFormat == validateContractFormatSARIF && validationErr != nil {
+					cmd.SilenceUsage = true
+					cmd.SilenceErrors = true
+					return validationErr
+				}
 				return nil
 			}
-			_, err = cmd.OutOrStdout().Write(output)
-			return err
+			if _, err = cmd.OutOrStdout().Write(output); err != nil {
+				return err
+			}
+			if outputFormat == validateContractFormatSARIF && validationErr != nil {
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
+				return validationErr
+			}
+			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&contractName, "contract", "", "Named contract to validate; defaults to spec.defaultContract")
-	cmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json"`)
+	cmd.Flags().StringVarP(&outputFormat, "format", "f", "text", `Output format. Supported: "text", "json", "sarif"`)
 	cmd.Example = strings.Join([]string{
 		"  kubescape scan validate-contract kubescape.yaml",
 		"  kubescape scan validate-contract kubescape.yaml --contract ci --format json",
+		"  kubescape scan validate-contract kubescape.yaml --format sarif",
 	}, "\n")
 	return cmd
+}
+
+type validateContractSARIFReport struct {
+	Version string                     `json:"version"`
+	Schema  string                     `json:"$schema"`
+	Runs    []validateContractSARIFRun `json:"runs"`
+}
+
+type validateContractSARIFRun struct {
+	Tool        validateContractSARIFTool         `json:"tool"`
+	Invocations []validateContractSARIFInvocation `json:"invocations"`
+	Artifacts   []validateContractSARIFArtifact   `json:"artifacts,omitempty"`
+	Results     []validateContractSARIFResult     `json:"results"`
+}
+
+type validateContractSARIFTool struct {
+	Driver validateContractSARIFDriver `json:"driver"`
+}
+
+type validateContractSARIFDriver struct {
+	Name            string                      `json:"name"`
+	InformationURI  string                      `json:"informationUri,omitempty"`
+	SemanticVersion string                      `json:"semanticVersion,omitempty"`
+	Rules           []validateContractSARIFRule `json:"rules"`
+}
+
+type validateContractSARIFRule struct {
+	ID               string                       `json:"id"`
+	Name             string                       `json:"name"`
+	ShortDescription validateContractSARIFMessage `json:"shortDescription"`
+	FullDescription  validateContractSARIFMessage `json:"fullDescription"`
+	HelpURI          string                       `json:"helpUri,omitempty"`
+}
+
+type validateContractSARIFInvocation struct {
+	ExecutionSuccessful bool `json:"executionSuccessful"`
+	ExitCode            int  `json:"exitCode"`
+}
+
+type validateContractSARIFArtifact struct {
+	Location validateContractSARIFArtifactLocation `json:"location"`
+}
+
+type validateContractSARIFArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type validateContractSARIFResult struct {
+	RuleID    string                          `json:"ruleId"`
+	Level     string                          `json:"level"`
+	Message   validateContractSARIFMessage    `json:"message"`
+	Locations []validateContractSARIFLocation `json:"locations,omitempty"`
+}
+
+type validateContractSARIFLocation struct {
+	PhysicalLocation validateContractSARIFPhysicalLocation `json:"physicalLocation"`
+}
+
+type validateContractSARIFPhysicalLocation struct {
+	ArtifactLocation validateContractSARIFArtifactLocation `json:"artifactLocation"`
+	Region           validateContractSARIFRegion           `json:"region,omitempty"`
+}
+
+type validateContractSARIFRegion struct {
+	StartLine int `json:"startLine,omitempty"`
+}
+
+type validateContractSARIFMessage struct {
+	Text string `json:"text"`
+}
+
+func validateContractSARIF(path string, selected *contractv1alpha1.SelectedContract, validationErr error) ([]byte, error) {
+	report := validateContractSARIFReport{
+		Version: "2.1.0",
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Runs: []validateContractSARIFRun{
+			{
+				Tool: validateContractSARIFTool{
+					Driver: validateContractSARIFDriver{
+						Name:           "Kubescape",
+						InformationURI: "https://kubescape.io",
+						Rules:          validateContractSARIFRules(),
+					},
+				},
+				Invocations: []validateContractSARIFInvocation{
+					{
+						ExecutionSuccessful: validationErr == nil,
+						ExitCode:            validateContractSARIFExitCode(validationErr),
+					},
+				},
+				Artifacts: []validateContractSARIFArtifact{
+					{Location: validateContractSARIFArtifactLocation{URI: validateContractArtifactURI(path)}},
+				},
+				Results: validateContractSARIFResults(path, validationErr),
+			},
+		},
+	}
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode validate-contract SARIF: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+func validateContractSARIFRules() []validateContractSARIFRule {
+	return []validateContractSARIFRule{
+		{
+			ID:               "kubescape.scan-contract.valid",
+			Name:             "Scan contract validation",
+			ShortDescription: validateContractSARIFMessage{Text: "Validate a Kubescape scan contract"},
+			FullDescription:  validateContractSARIFMessage{Text: "Checks that a repository scan contract is syntactically valid and compatible with this Kubescape version."},
+		},
+	}
+}
+
+func validateContractSARIFResults(path string, validationErr error) []validateContractSARIFResult {
+	if validationErr != nil {
+		return []validateContractSARIFResult{
+			{
+				RuleID:  "kubescape.scan-contract.valid",
+				Level:   "error",
+				Message: validateContractSARIFMessage{Text: validationErr.Error()},
+				Locations: []validateContractSARIFLocation{
+					{
+						PhysicalLocation: validateContractSARIFPhysicalLocation{
+							ArtifactLocation: validateContractSARIFArtifactLocation{URI: validateContractArtifactURI(path)},
+							Region:           validateContractSARIFRegion{StartLine: 1},
+						},
+					},
+				},
+			},
+		}
+	}
+	return []validateContractSARIFResult{}
+}
+
+func validateContractSARIFExitCode(validationErr error) int {
+	if validationErr != nil {
+		return 1
+	}
+	return 0
+}
+
+func validateContractArtifactURI(path string) string {
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		cwd, cwdErr := os.Getwd()
+		if cwdErr == nil {
+			base := validateContractCleanPath(cwd)
+			target := validateContractCleanPath(path)
+			relative, err := filepath.Rel(base, target)
+			if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+				return filepath.ToSlash(relative)
+			}
+		}
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	return cleaned
+}
+
+func validateContractCleanPath(path string) string {
+	cleaned := filepath.Clean(path)
+	if evaluated, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return evaluated
+	}
+	return cleaned
 }

--- a/cmd/scan/validate_contract_test.go
+++ b/cmd/scan/validate_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,4 +110,154 @@ func TestValidateContractCommandReportsStrictErrors(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "field frameworkz not found")
+}
+
+func TestValidateContractCommandSARIFValidContract(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	require.NoError(t, os.WriteFile(contractPath, []byte(commandContract), 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "sarif"})
+	require.NoError(t, cmd.Execute())
+
+	report := decodeValidateContractSARIF(t, output.Bytes())
+	assert.Equal(t, "2.1.0", report["version"])
+	runs := report["runs"].([]any)
+	require.Len(t, runs, 1)
+	run := runs[0].(map[string]any)
+	assert.Empty(t, run["results"].([]any))
+
+	invocations := run["invocations"].([]any)
+	require.Len(t, invocations, 1)
+	invocation := invocations[0].(map[string]any)
+	assert.Equal(t, true, invocation["executionSuccessful"])
+	assert.Equal(t, float64(0), invocation["exitCode"])
+
+	tool := run["tool"].(map[string]any)
+	driver := tool["driver"].(map[string]any)
+	assert.Equal(t, "Kubescape", driver["name"])
+	rules := driver["rules"].([]any)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "kubescape.scan-contract.valid", rules[0].(map[string]any)["id"])
+}
+
+func TestValidateContractCommandSARIFInvalidContract(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	invalid := bytes.Replace([]byte(commandContract), []byte("frameworks"), []byte("frameworkz"), 1)
+	require.NoError(t, os.WriteFile(contractPath, invalid, 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "sarif"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field frameworkz not found")
+
+	report := decodeValidateContractSARIF(t, output.Bytes())
+	run := report["runs"].([]any)[0].(map[string]any)
+	results := run["results"].([]any)
+	require.Len(t, results, 1)
+	result := results[0].(map[string]any)
+	assert.Equal(t, "kubescape.scan-contract.valid", result["ruleId"])
+	assert.Equal(t, "error", result["level"])
+	assert.Contains(t, result["message"].(map[string]any)["text"], "field frameworkz not found")
+
+	invocation := run["invocations"].([]any)[0].(map[string]any)
+	assert.Equal(t, false, invocation["executionSuccessful"])
+	assert.Equal(t, float64(1), invocation["exitCode"])
+}
+
+func TestValidateContractCommandSARIFRelativizesAbsoluteContractPath(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	workspace := t.TempDir()
+	contractPath := filepath.Join(workspace, "configs", "kubescape.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(contractPath), 0o700))
+	invalid := bytes.Replace([]byte(commandContract), []byte("frameworks"), []byte("frameworkz"), 1)
+	require.NoError(t, os.WriteFile(contractPath, invalid, 0o600))
+
+	originalWorkingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workspace))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDirectory))
+	})
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "sarif"})
+	err = cmd.Execute()
+	require.Error(t, err)
+
+	report := decodeValidateContractSARIF(t, output.Bytes())
+	run := report["runs"].([]any)[0].(map[string]any)
+	artifacts := run["artifacts"].([]any)
+	require.Len(t, artifacts, 1)
+	artifactLocation := artifacts[0].(map[string]any)["location"].(map[string]any)
+	assert.Equal(t, "configs/kubescape.yaml", artifactLocation["uri"])
+
+	results := run["results"].([]any)
+	require.Len(t, results, 1)
+	locations := results[0].(map[string]any)["locations"].([]any)
+	physicalLocation := locations[0].(map[string]any)["physicalLocation"].(map[string]any)
+	resultArtifactLocation := physicalLocation["artifactLocation"].(map[string]any)
+	assert.Equal(t, "configs/kubescape.yaml", resultArtifactLocation["uri"])
+}
+
+func TestValidateContractCommandSARIFWritesOutputFileOnError(t *testing.T) {
+	originalBuildNumber := versioncheck.BuildNumber
+	versioncheck.BuildNumber = "v4.1.0"
+	t.Cleanup(func() { versioncheck.BuildNumber = originalBuildNumber })
+
+	temporaryDirectory := t.TempDir()
+	contractPath := filepath.Join(temporaryDirectory, "kubescape.yaml")
+	outputPath := filepath.Join(temporaryDirectory, "contract.sarif")
+	invalid := bytes.Replace([]byte(commandContract), []byte("frameworks"), []byte("frameworkz"), 1)
+	require.NoError(t, os.WriteFile(contractPath, invalid, 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "sarif", "--output", outputPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	contents, readErr := os.ReadFile(outputPath)
+	require.NoError(t, readErr)
+	report := decodeValidateContractSARIF(t, contents)
+	run := report["runs"].([]any)[0].(map[string]any)
+	assert.Len(t, run["results"].([]any), 1)
+}
+
+func TestValidateContractCommandUnsupportedFormatMentionsSARIF(t *testing.T) {
+	contractPath := filepath.Join(t.TempDir(), "kubescape.yaml")
+	require.NoError(t, os.WriteFile(contractPath, []byte(commandContract), 0o600))
+
+	cmd := GetScanCommand(core.NewKubescape(context.Background()))
+	cmd.SetArgs([]string{"validate-contract", contractPath, "--format", "xml"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.EqualError(t, err, `unsupported format "xml", supported: text, json, sarif`)
+}
+
+func decodeValidateContractSARIF(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var report map[string]any
+	require.NoError(t, json.Unmarshal(data, &report))
+	return report
 }


### PR DESCRIPTION
## Summary
- add `--format sarif` to `kubescape scan validate-contract`
- emit SARIF for both valid and invalid scan contracts
- keep SARIF stdout/file output machine-readable while preserving non-zero exits for validation failures

Closes #3621

## Testing
- go test ./cmd/scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SARIF 2.1.0 output support to the `validate-contract` command.
  * SARIF reports include validation results, rule metadata, invocation status, and exit information.
  * Added support for writing SARIF reports to an output file, including when validation fails.

* **Documentation**
  * Updated command help text and examples to include the SARIF format.

* **Bug Fixes**
  * Validation failures can now be reported in SARIF format without being replaced by command error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->