### PR TITLE
feat(list): filter controls by framework and search

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -23,6 +23,9 @@ var (
   # List all supported controls names with ids
   %[1]s list controls
 
+  # List controls in a framework, optionally narrowed by text
+  %[1]s list controls --framework NSA --search container
+
   # Show the configurable inputs a scan evaluates controls against
   %[1]s list controls-config
 
@@ -60,6 +63,9 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 			}
 
 			listPolicies.Target = args[0]
+			if err := validateControlListFilters(listPolicies.Target, listPolicies.ControlFilters); err != nil {
+				return err
+			}
 
 			result, err := ks.List(&listPolicies)
 			if err != nil {
@@ -75,6 +81,8 @@ func GetListCmd(ks meta.IKubescape) *cobra.Command {
 	listCmd.PersistentFlags().StringVarP(&listPolicies.AccessKey, "access-key", "", "", "Kubescape SaaS access key. Default will load access key from cache")
 	listCmd.PersistentFlags().StringVarP(&listPolicies.Format, "format", "f", "pretty-print", "output format. supported: 'pretty-print'/'json'/'yaml'/'csv'")
 	listCmd.PersistentFlags().StringVar(&listPolicies.ControlsInputs, "controls-config", "", "Path to a controls-config file, to show the inputs a scan would use with it. Only applies to 'controls-config'")
+	listCmd.PersistentFlags().StringVar(&listPolicies.ControlFilters.Framework, "framework", "", "Only applies to 'controls'. Return controls that belong to this framework")
+	listCmd.PersistentFlags().StringVar(&listPolicies.ControlFilters.Search, "search", "", "Only applies to 'controls'. Case-insensitive match against control ID, name, or framework")
 
 	// Deprecated flags
 	var dummyID bool
@@ -90,4 +98,14 @@ func flagValidationList(listPolicies *v1.ListPolicies) error {
 
 	// Validate the user's credentials
 	return cautils.ValidateAccountID(listPolicies.AccountID)
+}
+
+func validateControlListFilters(target string, filters v1.ControlListFilters) error {
+	if strings.TrimSpace(filters.Framework) == "" && strings.TrimSpace(filters.Search) == "" {
+		return nil
+	}
+	if target != "controls" {
+		return fmt.Errorf("--framework and --search can only be used with 'list controls'")
+	}
+	return nil
 }

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -1,14 +1,33 @@
 package list
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/core"
+	"github.com/kubescape/kubescape/v4/core/meta"
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type recordingListKubescape struct {
+	meta.IKubescape
+	received *metav1.ListPolicies
+}
+
+func (r *recordingListKubescape) Context() context.Context {
+	return context.Background()
+}
+
+func (r *recordingListKubescape) List(listPolicies *metav1.ListPolicies) (*metav1.ListResult, error) {
+	copy := *listPolicies
+	r.received = &copy
+	return &metav1.ListResult{}, nil
+}
 
 func TestGetListCmd(t *testing.T) {
 	// Create a mock Kubescape interface
@@ -37,4 +56,42 @@ func TestGetListCmd(t *testing.T) {
 
 	err = listCmd.RunE(&cobra.Command{}, []string{"some-value"})
 	assert.ErrorContains(t, err, "invalid target")
+}
+
+func TestGetListCmd_ControlFilterFlags(t *testing.T) {
+	recorder := &recordingListKubescape{}
+	listCmd := GetListCmd(recorder)
+	listCmd.SetArgs([]string{"controls", "--framework", "NSA", "--search", "container", "--format", "json"})
+
+	require.NoError(t, listCmd.Execute())
+	require.NotNil(t, recorder.received)
+	assert.Equal(t, "controls", recorder.received.Target)
+	assert.Equal(t, "json", recorder.received.Format)
+	assert.Equal(t, "NSA", recorder.received.ControlFilters.Framework)
+	assert.Equal(t, "container", recorder.received.ControlFilters.Search)
+}
+
+func TestGetListCmd_ControlFilterFlagsRejectNonControlsTarget(t *testing.T) {
+	listCmd := GetListCmd(&recordingListKubescape{})
+	listCmd.SilenceUsage = true
+	listCmd.SilenceErrors = true
+	listCmd.SetArgs([]string{"frameworks", "--framework", "NSA"})
+
+	err := listCmd.Execute()
+	require.Error(t, err)
+	assert.EqualError(t, err, "--framework and --search can only be used with 'list controls'")
+}
+
+func TestGetListCmd_ControlFilterFlagMetadata(t *testing.T) {
+	listCmd := GetListCmd(&mocks.MockIKubescape{})
+
+	frameworkFlag := listCmd.PersistentFlags().Lookup("framework")
+	require.NotNil(t, frameworkFlag)
+	assert.Equal(t, "", frameworkFlag.DefValue)
+	assert.Contains(t, frameworkFlag.Usage, "Only applies to 'controls'")
+
+	searchFlag := listCmd.PersistentFlags().Lookup("search")
+	require.NotNil(t, searchFlag)
+	assert.Equal(t, "", searchFlag.DefValue)
+	assert.Contains(t, searchFlag.Usage, "Case-insensitive")
 }

--- a/core/core/list.go
+++ b/core/core/list.go
@@ -158,7 +158,7 @@ func listControls(ctx context.Context, listPolicies *metav1.ListPolicies) ([]met
 	for _, pipe := range pipes {
 		entries = append(entries, parseControlEntry(pipe))
 	}
-	return entries, nil
+	return filterControlEntries(entries, listPolicies.ControlFilters), nil
 }
 
 // parseControlEntry converts a pipe-delimited "id|name|fw1, fw2" string into a ControlListEntry.
@@ -192,6 +192,52 @@ func parseControlEntry(pipe string) metav1.ControlListEntry {
 		}
 	}
 	return entry
+}
+
+func filterControlEntries(entries []metav1.ControlListEntry, filters metav1.ControlListFilters) []metav1.ControlListEntry {
+	framework := strings.TrimSpace(filters.Framework)
+	search := strings.TrimSpace(filters.Search)
+	if framework == "" && search == "" {
+		return entries
+	}
+
+	filtered := make([]metav1.ControlListEntry, 0, len(entries))
+	for _, entry := range entries {
+		if framework != "" && !controlEntryHasFramework(entry, framework) {
+			continue
+		}
+		if search != "" && !controlEntryMatchesSearch(entry, search) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func controlEntryHasFramework(entry metav1.ControlListEntry, framework string) bool {
+	framework = strings.TrimSpace(framework)
+	for _, candidate := range entry.Frameworks {
+		if strings.EqualFold(strings.TrimSpace(candidate), framework) {
+			return true
+		}
+	}
+	return false
+}
+
+func controlEntryMatchesSearch(entry metav1.ControlListEntry, search string) bool {
+	search = strings.ToLower(search)
+	if strings.Contains(strings.ToLower(entry.ID), search) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Name), search) {
+		return true
+	}
+	for _, framework := range entry.Frameworks {
+		if strings.Contains(strings.ToLower(framework), search) {
+			return true
+		}
+	}
+	return false
 }
 
 func listExceptions(ctx context.Context, listPolicies *metav1.ListPolicies) ([]string, error) {

--- a/core/core/list_test.go
+++ b/core/core/list_test.go
@@ -261,6 +261,83 @@ func TestParseControlEntry(t *testing.T) {
 	}
 }
 
+func TestFilterControlEntries(t *testing.T) {
+	entries := []metav1.ControlListEntry{
+		{ID: "C-0001", Name: "Forbidden Container Registries", Frameworks: []string{"NSA", "MITRE"}},
+		{ID: "C-0002", Name: "Privileged Containers", Frameworks: []string{"AllControls", "NSA"}},
+		{ID: "C-0003", Name: "HostPath mount", Frameworks: []string{"MITRE"}},
+		{ID: "C-0100", Name: "API server flags", Frameworks: []string{}},
+	}
+
+	tests := []struct {
+		name    string
+		filters metav1.ControlListFilters
+		wantIDs []string
+	}{
+		{
+			name:    "no filters returns all entries",
+			filters: metav1.ControlListFilters{},
+			wantIDs: []string{"C-0001", "C-0002", "C-0003", "C-0100"},
+		},
+		{
+			name:    "framework filter is exact and case-insensitive",
+			filters: metav1.ControlListFilters{Framework: "nsa"},
+			wantIDs: []string{"C-0001", "C-0002"},
+		},
+		{
+			name:    "search matches control id",
+			filters: metav1.ControlListFilters{Search: "0100"},
+			wantIDs: []string{"C-0100"},
+		},
+		{
+			name:    "search matches control name",
+			filters: metav1.ControlListFilters{Search: "hostpath"},
+			wantIDs: []string{"C-0003"},
+		},
+		{
+			name:    "search matches frameworks",
+			filters: metav1.ControlListFilters{Search: "allcontrols"},
+			wantIDs: []string{"C-0002"},
+		},
+		{
+			name:    "framework and search compose",
+			filters: metav1.ControlListFilters{Framework: "NSA", Search: "registries"},
+			wantIDs: []string{"C-0001"},
+		},
+		{
+			name:    "framework without match returns empty",
+			filters: metav1.ControlListFilters{Framework: "PCI-DSS"},
+			wantIDs: []string{},
+		},
+		{
+			name:    "whitespace filters are ignored",
+			filters: metav1.ControlListFilters{Framework: " ", Search: "\t"},
+			wantIDs: []string{"C-0001", "C-0002", "C-0003", "C-0100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterControlEntries(entries, tt.filters)
+			assert.Equal(t, tt.wantIDs, controlEntryIDs(got))
+		})
+	}
+}
+
+func TestControlEntryHasFrameworkTrimsCatalogValues(t *testing.T) {
+	entry := metav1.ControlListEntry{Frameworks: []string{" NSA ", "MITRE"}}
+	assert.True(t, controlEntryHasFramework(entry, "nsa"))
+	assert.True(t, controlEntryHasFramework(entry, "NSA "))
+}
+
+func controlEntryIDs(entries []metav1.ControlListEntry) []string {
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, entry.ID)
+	}
+	return ids
+}
+
 // Generates rows for each entry with ID, name, documentation link, and frameworks.
 func TestGenerateControlRowsWithAllFields(t *testing.T) {
 	entries := []metav1.ControlListEntry{

--- a/core/meta/datastructures/v1/listpolicies.go
+++ b/core/meta/datastructures/v1/listpolicies.go
@@ -6,6 +6,12 @@ type ListPolicies struct {
 	AccountID      string
 	AccessKey      string
 	ControlsInputs string
+	ControlFilters ControlListFilters
+}
+
+type ControlListFilters struct {
+	Framework string
+	Search    string
 }
 
 type ListResponse struct {


### PR DESCRIPTION
This pull request adds support for filtering the output of the `list controls` command by framework and by a case-insensitive search string. It introduces new flags (`--framework` and `--search`) to the CLI, implements the backend filtering logic, and provides comprehensive tests for these features. The flags are validated to ensure they are only used with the `controls` target.

**CLI Enhancements:**

* Added `--framework` and `--search` flags to the `list controls` command, allowing users to filter controls by framework and by a case-insensitive match against control ID, name, or framework. The help text and usage examples have been updated accordingly. [[1]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R26-R28) [[2]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R84-R85)
* Added validation to ensure that the new filter flags are only used with the `controls` target, returning an error otherwise. [[1]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R66-R68) [[2]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R102-R111)

**Backend Filtering Logic:**

* Implemented `ControlListFilters` in the data structures and applied filtering logic in the backend to return only matching controls based on the provided filters. [[1]](diffhunk://#diff-3db77ec55008456490f652c6aa2ab5fdf180eda51bb8e5a1df2cfaf504d2abfaR9-R14) [[2]](diffhunk://#diff-ca84ef8466b6c6ba6317e9a2acedbb449bc881d2bbeb2623620a3eb70115145aL161-R161) [[3]](diffhunk://#diff-ca84ef8466b6c6ba6317e9a2acedbb449bc881d2bbeb2623620a3eb70115145aR197-R242)

**Testing Improvements:**

* Added unit tests for the new filtering logic, including edge cases, and for CLI flag parsing and validation to ensure correct wiring and error handling. [[1]](diffhunk://#diff-ecbb765d0ce8d534a49555ba1aaadacc66fd491e1f9ce6158562a29845c7d925R4-R31) [[2]](diffhunk://#diff-ecbb765d0ce8d534a49555ba1aaadacc66fd491e1f9ce6158562a29845c7d925R60-R97) [[3]](diffhunk://#diff-2be97573b7116107627698d5c0c6dabc7dc0a9559a5a81f0973b7e505f77c611R264-R340)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added framework and text search filters to the `list controls` command.
  - Search matches control IDs, names, and frameworks without case sensitivity.
  - Framework and search filters can be combined for more precise results.
  - Added command usage examples and validation for supported targets.

- **Bug Fixes**
  - Control listings now correctly apply the selected filters, including whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->