### PR TITLE
fix: complete V2 to V1 remediation paths mapping and formalize failedPaths deprecation

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -2,6 +2,8 @@ package cautils
 
 import (
 	"maps"
+	"slices"
+	"strings"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -52,7 +54,6 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 		crv1.Score = crv2.GetScore()
 		crv1.Control_ID = controlID
 
-		// TODO - add fields
 		crv1.Description = crv2.Description
 		crv1.Remediation = crv2.Remediation
 
@@ -79,14 +80,25 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 						// rule response
 						ruleResponse := reporthandling.RuleResponse{}
 						ruleResponse.Rulename = rulev2.GetName()
+						var fixCommands []string
 						for i := range rulev2.Paths {
 							if rulev2.Paths[i].FailedPath != "" {
 								ruleResponse.FailedPaths = append(ruleResponse.FailedPaths, rulev2.Paths[i].FailedPath)
 							}
+							if rulev2.Paths[i].DeletePath != "" {
+								ruleResponse.DeletePaths = append(ruleResponse.DeletePaths, rulev2.Paths[i].DeletePath)
+							}
+							if rulev2.Paths[i].ReviewPath != "" {
+								ruleResponse.ReviewPaths = append(ruleResponse.ReviewPaths, rulev2.Paths[i].ReviewPath)
+							}
 							if rulev2.Paths[i].FixPath.Path != "" {
 								ruleResponse.FixPaths = append(ruleResponse.FixPaths, rulev2.Paths[i].FixPath)
 							}
+							if cmd := rulev2.Paths[i].FixCommand; cmd != "" && !slices.Contains(fixCommands, cmd) {
+								fixCommands = append(fixCommands, cmd)
+							}
 						}
+						ruleResponse.FixCommand = strings.Join(fixCommands, "\n")
 						ruleResponse.RuleStatus = string(status.Status())
 						if len(rulev2.Exception) > 0 {
 							ruleResponse.Exception = &rulev2.Exception[0]

--- a/core/cautils/reportv2tov1_test.go
+++ b/core/cautils/reportv2tov1_test.go
@@ -129,3 +129,82 @@ func TestReportV2ToV1_DoesNotMutateAllResources(t *testing.T) {
 	require.Len(t, alertObjects, 1)
 	assert.NotContains(t, alertObjects[0], "spec")
 }
+
+func TestReportV2ToV1_PreservesAllRemediationPathTypes(t *testing.T) {
+	resourceID := "apps/v1/ns/Deployment/remediation-test"
+	controlID := "C-002"
+
+	controlSummary := reportsummary.ControlSummary{
+		ControlID:   controlID,
+		Name:        "control remediation",
+		ScoreFactor: 3,
+		Description: "test description",
+		Remediation: "test remediation",
+	}
+	controlSummary.Append(helpersv1.NewStatus(apis.StatusFailed), resourceID)
+
+	session := &OPASessionObj{
+		AllResources: map[string]workloadinterface.IMetadata{
+			resourceID: workloadinterface.NewWorkloadObj(map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": "remediation-test", "namespace": "ns"},
+				"spec":       map[string]any{"privileged": true},
+			}),
+		},
+		ResourcesResult: map[string]resourcesresults.Result{
+			resourceID: {
+				ResourceID: resourceID,
+				AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+					{
+						ControlID: controlID,
+						ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+							{
+								Name:   "rule-remediation",
+								Status: apis.StatusFailed,
+								Paths: []armotypes.PosturePaths{
+									{
+										FailedPath: "spec.containers[0].securityContext.privileged",
+										DeletePath: "spec.containers[0].securityContext.privileged",
+										ReviewPath: "spec.containers[0].securityContext",
+										FixPath:    armotypes.FixPath{Path: "spec.containers[0].securityContext.allowPrivilegeEscalation", Value: "false"},
+										FixCommand: "kubectl patch deployment remediation-test",
+									},
+									{
+										FixCommand: "kubectl label deployment remediation-test env=prod",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{controlID: controlSummary},
+			},
+		},
+	}
+
+	got := ReportV2ToV1(session)
+
+	require.NotNil(t, got)
+	require.Len(t, got.FrameworkReports, 1)
+	require.Len(t, got.FrameworkReports[0].ControlReports, 1)
+
+	cr := got.FrameworkReports[0].ControlReports[0]
+	assert.Equal(t, "test description", cr.Description)
+	assert.Equal(t, "test remediation", cr.Remediation)
+	assert.Equal(t, controlID, cr.ControlID)
+
+	require.Len(t, cr.RuleReports, 1)
+	require.Len(t, cr.RuleReports[0].RuleResponses, 1)
+
+	resp := cr.RuleReports[0].RuleResponses[0]
+	assert.Equal(t, []string{"spec.containers[0].securityContext.privileged"}, resp.FailedPaths)
+	assert.Equal(t, []string{"spec.containers[0].securityContext.privileged"}, resp.DeletePaths)
+	assert.Equal(t, []string{"spec.containers[0].securityContext"}, resp.ReviewPaths)
+	assert.Equal(t, []armotypes.FixPath{{Path: "spec.containers[0].securityContext.allowPrivilegeEscalation", Value: "false"}}, resp.FixPaths)
+	assert.Equal(t, "kubectl patch deployment remediation-test\nkubectl label deployment remediation-test env=prod", resp.FixCommand)
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1262,9 +1262,10 @@ func (opap *OPAProcessor) markControlTimedOut(control *reporthandling.Control, t
 	opap.TimedOutControls[control.ControlID] = fmt.Sprintf("control evaluation timed out after %s", timeout)
 }
 
-// appendPaths appends the failedPaths, fixPaths and fixCommand to the paths slice with the resourceID
+// appendPaths appends failedPaths, deletePaths, reviewPaths, fixPaths and fixCommand to the paths slice with the resourceID.
 func appendPaths(paths []armotypes.PosturePaths, assistedRemediation reporthandling.AssistedRemediation, resourceID string) []armotypes.PosturePaths {
-	// TODO - deprecate failedPaths after all controls support reviewPaths and deletePaths
+	// Deprecated: FailedPaths is retained for backward compatibility with rules
+	// that have not yet migrated to ReviewPaths/DeletePaths.
 	for _, failedPath := range assistedRemediation.FailedPaths {
 		paths = append(paths, armotypes.PosturePaths{ResourceID: resourceID, FailedPath: failedPath})
 	}

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -189,7 +189,8 @@ func (a Matrix) Less(i, j int) bool {
 	return true
 }
 
-// TODO - deprecate once all controls support review/delete paths
+// Deprecated: failedPathsToString is retained for backward compatibility with rules
+// that have not yet migrated to reviewPaths/deletePaths.
 func failedPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
 	var paths []string
 
@@ -249,7 +250,7 @@ func reviewPathsToString(control *resourcesresults.ResourceAssociatedControl) []
 
 func AssistedRemediationPathsToString(control *resourcesresults.ResourceAssociatedControl) []string {
 	paths := append(fixPathsToString(control, false), append(deletePathsToString(control), reviewPathsToString(control)...)...)
-	// TODO - deprecate failedPaths once all controls support review/delete paths
+	// Retained for backward compatibility: fall back to failedPaths only when not already represented by fixPaths, deletePaths, or reviewPaths.
 	paths = appendFailedPathsIfNotInPaths(paths, failedPathsToString(control))
 	return paths
 }

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -91,12 +91,40 @@ func TestAssistedRemediationPathsToString(t *testing.T) {
 		},
 	}
 
+	control3 := &resourcesresults.ResourceAssociatedControl{
+		ControlID: "control-3",
+		Name:      "Control 3 - Mixed Migrated and Legacy Paths",
+		Status:    apis.StatusInfo{},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:      "Rule 3",
+				Status:    "failed",
+				SubStatus: "skipped",
+				Paths: []armotypes.PosturePaths{
+					{
+						FixPath:    armotypes.FixPath{Path: "spec.replicas", Value: "3"},
+						DeletePath: "spec.containers[0].securityContext.privileged",
+						ReviewPath: "spec.containers[0].securityContext",
+						FailedPath: "spec.containers[0].securityContext.privileged",
+					},
+					{
+						FailedPath: "spec.hostNetwork",
+					},
+				},
+			},
+		},
+	}
+
 	actualPaths := AssistedRemediationPathsToString(control1)
 	expectedPaths := []string{"some-path1", "random-path1"}
 	assert.Equal(t, expectedPaths, actualPaths)
 
 	actualPaths = AssistedRemediationPathsToString(control2)
 	expectedPaths = []string{"some-path2", "random-path2"}
+	assert.Equal(t, expectedPaths, actualPaths)
+
+	actualPaths = AssistedRemediationPathsToString(control3)
+	expectedPaths = []string{"spec.replicas=3", "spec.containers[0].securityContext.privileged", "spec.containers[0].securityContext", "spec.hostNetwork"}
 	assert.Equal(t, expectedPaths, actualPaths)
 }
 


### PR DESCRIPTION
### Summary
This PR completes the remediation-path mapping during V2-to-V1 report conversion and formalizes the deprecation status of legacy `failedPaths`.

### Changes

1. **`reportv2tov1.go`**:
   - Mapped `DeletePaths`, `ReviewPaths`, and `FixCommand` from `rulev2.Paths` into `RuleResponse`.
   - Used exact deduplication (`slices.Contains`) when aggregating multiple distinct `FixCommand` entries into newline-separated commands.
   - Removed the outdated `// TODO - add fields` placeholder.

2. **`processorhandler.go` & `resourcetable.go`**:
   - Updated documentation to follow standard Go `// Deprecated:` conventions for `FailedPaths` and `failedPathsToString`.
   - Explicitly clarified that `failedPaths` is retained as a backward-compatibility fallback so rules that have not yet migrated to `reviewPaths`/`deletePaths` continue to display remediation paths.

3. **Tests**:
   - Added `TestReportV2ToV1_PreservesAllRemediationPathTypes` in `reportv2tov1_test.go` verifying that all path types and multi-command fix strings are preserved during conversion.
   - Added precedence test case `control3` in `resourcetable_test.go` confirming that `failedPaths` is deduplicated when already represented by `deletePaths`/`reviewPaths`/`fixPaths`, and preserved when acting as an unmigrated standalone fallback.

---

### Open Question for Maintainers
There are currently 650+ Rego rules in `rules/` that still output `"failedPaths": finalpath`. 
- Does the team have an overarching plan/timeline to batch-migrate the rule producers to `reviewPaths`/`deletePaths`?
- Until that migration takes place, should the engine and table printer continue maintaining this backward-compatible fallback, or is there an intention to deprecate support across a specific major release boundary?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remediation details now preserve failed, delete, review, and fix paths when reports are converted.
  * Multiple fix commands are combined and displayed clearly.
  * Remediation paths retain a consistent order and formatting, including legacy paths.

* **Documentation**
  * Updated remediation path guidance and backward-compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->