### PR TITLE
fix(opaprocessor): evaluate rules against full input after enumeration

### DIFF
--- a/core/pkg/opaprocessor/enumerator_join_regression_test.go
+++ b/core/pkg/opaprocessor/enumerator_join_regression_test.go
@@ -480,3 +480,149 @@ hasSSHPorts(service) {
 	port.targetPort == 2222
 }
 `
+
+// TestNonEnumeratorRuleWithExternalObjectFailureIsReported guards the
+// maintainer-flagged regression: a rule with no ResourceEnumerator at all
+// that reports its failure through a synthesized AlertObject.ExternalObjects
+// (its own identity, not any literal input resource's), the shape
+// audit-policy-content (CIS 3.2.2) uses. enumeratedIDs must never restrict
+// reporting for such a rule - it only applies to rules that declare a
+// ResourceEnumerator.
+func TestNonEnumeratorRuleWithExternalObjectFailureIsReported(t *testing.T) {
+	node := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata":   map[string]any{"name": "control-plane"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{"/v1/nodes": {node.GetID()}}
+	sess.AllResources[node.GetID()] = node
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	rule := &reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+deny[msga] {
+	node := input[_]
+	node.kind == "Node"
+	vector := {"name": "audit-policy", "namespace": "", "kind": "AuditPolicy", "relatedObjects": node}
+	msga := {
+		"alertMessage": "audit policy content is invalid",
+		"packagename": "armo_builtins",
+		"alertScore": 5,
+		"failedPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": vector
+		}
+	}
+}
+`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{
+			{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Node"}},
+		},
+	}
+	rule.Name = "audit-policy-content"
+
+	got, err := opap.processRule(context.Background(), rule, nil, evaluationScope{}, &reporthandling.Control{})
+	require.NoError(t, err)
+
+	// The rule matches Node, so the real Node also appears in the results -
+	// passed, since the deny block never names the Node itself as failed.
+	// What matters here is that the synthesized ExternalObjects failure is
+	// not filtered out.
+	var sawFailure bool
+	for id, result := range got {
+		t.Logf("id=%q status=%q", id, result.GetStatus(nil).Status())
+		if result.GetStatus(nil).Status() == apis.StatusFailed {
+			sawFailure = true
+		}
+	}
+	require.True(t, sawFailure, "the synthesized ExternalObjects failure must be reported")
+}
+
+// TestEnumeratorMixedKubernetesAndVectorFailuresBothReported covers
+// CodeRabbit's finding: an enumerator that resolves to real K8sApiObjects for
+// one resource and a RegoResponseVectorObject for another (mixed output) must
+// not let the K8sApiObjects-derived scope swallow the vector failure. The
+// enumerator selects both a Pod (real object, enters enumeratedIDs) and
+// reports a Service exposure through ExternalObjects (a vector, whose ID by
+// construction is never in enumeratedIDs) - both must still be reportable.
+func TestEnumeratorMixedKubernetesAndVectorFailuresBothReported(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "insecure-pod", "namespace": "prod"},
+		"spec":       map[string]any{"hostNetwork": true},
+	})
+	service := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "exposed-svc", "namespace": "prod"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"/v1/pods":     {pod.GetID()},
+		"/v1/services": {service.GetID()},
+	}
+	sess.AllResources[pod.GetID()] = pod
+	sess.AllResources[service.GetID()] = service
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	rule := enumeratorRule(
+		"mixed-enumerator",
+		`package armo_builtins
+deny[msga] {
+	obj := input[_]
+	obj.kind == "Pod"
+	obj.spec.hostNetwork == true
+	msga := {"alertMessage": "hostNetwork pod", "packagename": "armo_builtins", "alertScore": 5, "failedPaths": [], "alertObject": {"k8sApiObjects": [obj]}}
+}
+deny[msga] {
+	obj := input[_]
+	obj.kind == "Service"
+	vector := {"name": obj.metadata.name, "namespace": obj.metadata.namespace, "kind": obj.kind, "relatedObjects": obj}
+	msga := {"alertMessage": "exposed service", "packagename": "armo_builtins", "alertScore": 5, "failedPaths": [], "alertObject": {"k8sApiObjects": [], "externalObjects": vector}}
+}
+`,
+		`package armo_builtins
+deny[msga] {
+	obj := input[_]
+	obj.kind == "Pod"
+	obj.spec.hostNetwork == true
+	msga := {"alertMessage": "hostNetwork pod", "packagename": "armo_builtins", "alertScore": 5, "failedPaths": [], "alertObject": {"k8sApiObjects": [obj]}}
+}
+deny[msga] {
+	obj := input[_]
+	obj.kind == "Service"
+	vector := {"name": obj.metadata.name, "namespace": obj.metadata.namespace, "kind": obj.kind, "relatedObjects": obj}
+	msga := {"alertMessage": "exposed service", "packagename": "armo_builtins", "alertScore": 5, "failedPaths": [], "alertObject": {"k8sApiObjects": [], "externalObjects": vector}}
+}
+`,
+		[]reporthandling.RuleMatchObjects{
+			{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}},
+			{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Service"}},
+		},
+	)
+
+	got, err := opap.processRule(context.Background(), rule, nil, evaluationScope{}, &reporthandling.Control{})
+	require.NoError(t, err)
+
+	podResult, ok := got[pod.GetID()]
+	require.True(t, ok, "the real Pod failure must be reported")
+	require.Equal(t, apis.StatusFailed, podResult.GetStatus(nil).Status())
+
+	var sawVectorFailure bool
+	for id, result := range got {
+		if id == pod.GetID() {
+			continue
+		}
+		t.Logf("vector-reported entry id=%q status=%q", id, result.GetStatus(nil).Status())
+		if result.GetStatus(nil).Status() == apis.StatusFailed {
+			sawVectorFailure = true
+		}
+	}
+	require.True(t, sawVectorFailure, "the vector-reported Service exposure must also be reported")
+}

--- a/core/pkg/opaprocessor/enumerator_join_regression_test.go
+++ b/core/pkg/opaprocessor/enumerator_join_regression_test.go
@@ -1,0 +1,482 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// Verbatim from the shipped C-0054 internal-networking rule (NSA and MITRE).
+// The enumerator emits Namespace objects only; the main rule needs the
+// NetworkPolicy objects in the same input to decide whether a namespace is
+// covered.
+const c0054Enumerator = `package armo_builtins
+
+deny[msga] {
+	namespaces := [namespace | namespace = input[_]; namespace.kind == "Namespace"]
+	namespace := namespaces[_]
+
+	msga := {
+		"alertMessage": sprintf("no policy is defined for namespace %v", [namespace.metadata.name]),
+		"alertScore": 9,
+		"packagename": "armo_builtins",
+		"failedPaths": [""],
+		"alertObject": {
+			"k8sApiObjects": [namespace]
+		}
+	}
+}
+`
+
+const c0054MainRule = `package armo_builtins
+
+deny[msga] {
+	namespaces := [namespace | namespace = input[_]; namespace.kind == "Namespace"]
+	namespace := namespaces[_]
+	policy_names := [policy.metadata.namespace | policy = input[_]; policy.kind == "NetworkPolicy"]
+	not list_contains(policy_names, namespace.metadata.name)
+
+	msga := {
+		"alertMessage": sprintf("no policy is defined for namespace %v", [namespace.metadata.name]),
+		"alertScore": 9,
+		"packagename": "armo_builtins",
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [namespace]
+		}
+	}
+}
+
+list_contains(list, element) {
+  some i
+  list[i] == element
+}
+`
+
+// Models the shipped C-0042 rule-can-ssh-to-pod-v1 shape: the enumerator
+// reports through externalObjects with an empty k8sApiObjects list, and the
+// main rule joins a Pod against a Service in the same namespace.
+const c0042Enumerator = `package armo_builtins
+
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	service := input[_]
+	service.kind == "Service"
+	service.metadata.namespace == pod.metadata.namespace
+
+	wlvector = {"name": pod.metadata.name,
+				"namespace": pod.metadata.namespace,
+				"kind": pod.kind,
+				"relatedObjects": service}
+
+	msga := {
+		"alertMessage": sprintf("pod %v exposed by service", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": ["metadata.labels"],
+		"alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+	}
+}
+`
+
+const c0042MainRule = `package armo_builtins
+
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	service := input[_]
+	service.kind == "Service"
+	service.metadata.namespace == pod.metadata.namespace
+	service.spec.ports[_].port == 22
+
+	msga := {
+		"alertMessage": sprintf("pod %v is exposed by an SSH service", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+`
+
+func enumeratorRule(name, mainRule, enumerator string, match []reporthandling.RuleMatchObjects) *reporthandling.PolicyRule {
+	rule := &reporthandling.PolicyRule{
+		Rule:               mainRule,
+		ResourceEnumerator: enumerator,
+		RuleLanguage:       reporthandling.RegoLanguage,
+		Match:              match,
+	}
+	rule.Name = name
+	return rule
+}
+
+// TestEnumeratorPreservesCrossKindJoinInput_FalsePositive drives the real
+// shipped C-0054 rego against a namespace that IS covered by a NetworkPolicy.
+// The control must not fail it. It fails only when the NetworkPolicy objects
+// the main rule joins against are missing from the evaluation input, which is
+// what happens when the enumerator's output replaces that input.
+func TestEnumeratorPreservesCrossKindJoinInput_FalsePositive(t *testing.T) {
+	namespace := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   map[string]any{"name": "prod"},
+	})
+	netpol := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": "default-deny", "namespace": "prod"},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"/v1/namespaces":                       {namespace.GetID()},
+		"networking.k8s.io/v1/networkpolicies": {netpol.GetID()},
+	}
+	sess.AllResources[namespace.GetID()] = namespace
+	sess.AllResources[netpol.GetID()] = netpol
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	rule := enumeratorRule("internal-networking", c0054MainRule, c0054Enumerator, []reporthandling.RuleMatchObjects{
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Namespace"}},
+		{APIGroups: []string{"networking.k8s.io"}, APIVersions: []string{"v1"}, Resources: []string{"NetworkPolicy"}},
+	})
+
+	got, err := opap.processRule(context.Background(), rule, nil, evaluationScope{}, &reporthandling.Control{})
+	require.NoError(t, err)
+
+	result, ok := got[namespace.GetID()]
+	require.True(t, ok, "the namespace must appear in the results")
+	t.Logf("namespace prod (covered by a NetworkPolicy) -> status=%q", result.GetStatus(nil).Status())
+
+	require.NotEqual(t, apis.StatusFailed, result.GetStatus(nil).Status(),
+		"namespace prod is covered by a NetworkPolicy; C-0054 must not fail it")
+}
+
+// TestEnumeratorPreservesCrossKindJoinInput_FalseNegative covers the opposite
+// direction on the C-0042 shape: an enumerator that reports through
+// externalObjects contributes no real Kubernetes objects, so replacing the
+// evaluation input with its output leaves the main rule nothing to evaluate
+// and the control reports clean on a genuinely exposed pod.
+func TestEnumeratorPreservesCrossKindJoinInput_FalseNegative(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "ssh-pod", "namespace": "prod", "labels": map[string]any{"app": "ssh"}},
+	})
+	service := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "ssh-svc", "namespace": "prod"},
+		"spec": map[string]any{
+			"selector": map[string]any{"app": "ssh"},
+			"ports":    []any{map[string]any{"port": 22}},
+		},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"/v1/pods":     {pod.GetID()},
+		"/v1/services": {service.GetID()},
+	}
+	sess.AllResources[pod.GetID()] = pod
+	sess.AllResources[service.GetID()] = service
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	rule := enumeratorRule("rule-can-ssh-to-pod-v1", c0042MainRule, c0042Enumerator, []reporthandling.RuleMatchObjects{
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}},
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Service"}},
+	})
+
+	got, err := opap.processRule(context.Background(), rule, nil, evaluationScope{}, &reporthandling.Control{})
+	require.NoError(t, err)
+
+	result, ok := got[pod.GetID()]
+	require.True(t, ok, "the pod must appear in the results")
+	t.Logf("pod ssh-pod (exposed on port 22) -> status=%q", result.GetStatus(nil).Status())
+
+	require.Equal(t, apis.StatusFailed, result.GetStatus(nil).Status(),
+		"pod ssh-pod is exposed by a service on port 22; the control must fail it")
+}
+
+// TestEnumeratorExternalObjectsRealC0042 drives the verbatim shipped C-0042
+// rule-can-ssh-to-pod-v1 rego (MITRE.json), where both the enumerator and the
+// main rule report exclusively through AlertObject.ExternalObjects. It
+// guards the refinement that scopes reporting only to K8sApiObjects-derived
+// IDs: a RegoResponseVectorObject's GetID is a composite of its own fields
+// and never equals the underlying resource's ID, so scoping by it would
+// silently drop every real failure this rule (and C-0053) reports.
+func TestEnumeratorExternalObjectsRealC0042(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "ssh-pod", "namespace": "prod", "labels": map[string]any{"app": "ssh"}},
+	})
+	service := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "ssh-svc", "namespace": "prod"},
+		"spec": map[string]any{
+			"selector": map[string]any{"app": "ssh"},
+			"ports":    []any{map[string]any{"port": 22}},
+		},
+	})
+
+	sess := cautils.NewOPASessionObjMock()
+	sess.K8SResources = cautils.K8SResources{
+		"/v1/pods":     {pod.GetID()},
+		"/v1/services": {service.GetID()},
+	}
+	sess.AllResources[pod.GetID()] = pod
+	sess.AllResources[service.GetID()] = service
+
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	rule := enumeratorRule("rule-can-ssh-to-pod-v1", c0042RealMainRule, c0042RealEnumerator, []reporthandling.RuleMatchObjects{
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Pod"}},
+		{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"Service"}},
+	})
+
+	got, err := opap.processRule(context.Background(), rule, nil, evaluationScope{}, &reporthandling.Control{})
+	require.NoError(t, err)
+
+	// This rule reports failures through AlertObject.ExternalObjects, so the
+	// result is keyed by the reported vector's own composite ID, not
+	// pod.GetID() (see RegoResponseVectorObject.GetID) - the same as it was
+	// before this fix. What matters here is that a real failure was found and
+	// reported at all.
+	require.Len(t, got, 1, "the exposed pod must be reported exactly once")
+	for _, result := range got {
+		t.Logf("real C-0042 rego -> status=%q", result.GetStatus(nil).Status())
+		require.Equal(t, apis.StatusFailed, result.GetStatus(nil).Status())
+	}
+}
+
+// c0042RealEnumerator and c0042RealMainRule are verbatim from
+// core/cautils/getter/testdata/MITRE.json, control C-0042, rule
+// rule-can-ssh-to-pod-v1.
+const c0042RealEnumerator = `package armo_builtins
+
+# input: pod
+# apiversion: v1
+# does:	returns the external facing services of that pod
+
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	podns := pod.metadata.namespace
+	podname := pod.metadata.name
+	labels := pod.metadata.labels
+	filtered_labels := json.remove(labels, ["pod-template-hash"])
+    path := "metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == podns
+	service.spec.selector == filtered_labels
+
+
+	wlvector = {"name": pod.metadata.name,
+				"namespace": pod.metadata.namespace,
+				"kind": pod.kind,
+				"relatedObjects": service}
+	msga := {
+		"alertMessage": sprintf("pod %v/%v exposed by SSH services: %v", [podns, podname, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+    }
+}
+
+deny[msga] {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+	labels := wl.spec.template.metadata.labels
+    path := "spec.template.metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == wl.metadata.namespace
+	service.spec.selector == labels
+
+
+	wlvector = {"name": wl.metadata.name,
+				"namespace": wl.metadata.namespace,
+				"kind": wl.kind,
+				"relatedObjects": service}
+
+	msga := {
+		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+     }
+}
+
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	labels := wl.spec.jobTemplate.spec.template.metadata.labels
+    path := "spec.jobTemplate.spec.template.metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == wl.metadata.namespace
+	service.spec.selector == labels
+
+
+	wlvector = {"name": wl.metadata.name,
+				"namespace": wl.metadata.namespace,
+				"kind": wl.kind,
+				"relatedObjects": service}
+
+	msga := {
+		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+     }
+}
+`
+
+const c0042RealMainRule = `package armo_builtins
+
+# input: pod
+# apiversion: v1
+# does:	returns the external facing services of that pod
+
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	podns := pod.metadata.namespace
+	podname := pod.metadata.name
+	labels := pod.metadata.labels
+	filtered_labels := json.remove(labels, ["pod-template-hash"])
+    path := "metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == podns
+	service.spec.selector == filtered_labels
+    
+	hasSSHPorts(service)
+
+	wlvector = {"name": pod.metadata.name,
+				"namespace": pod.metadata.namespace,
+				"kind": pod.kind,
+				"relatedObjects": service}
+	msga := {
+		"alertMessage": sprintf("pod %v/%v exposed by SSH services: %v", [podns, podname, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+		"fixPaths": [],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+    }
+}
+
+deny[msga] {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+	labels := wl.spec.template.metadata.labels
+    path := "spec.template.metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == wl.metadata.namespace
+	service.spec.selector == labels
+
+	hasSSHPorts(service)
+
+	wlvector = {"name": wl.metadata.name,
+				"namespace": wl.metadata.namespace,
+				"kind": wl.kind,
+				"relatedObjects": service}
+
+	msga := {
+		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+     }
+}
+
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	labels := wl.spec.jobTemplate.spec.template.metadata.labels
+    path := "spec.jobTemplate.spec.template.metadata.labels"
+	service := 	input[_]
+	service.kind == "Service"
+	service.metadata.namespace == wl.metadata.namespace
+	service.spec.selector == labels
+
+	hasSSHPorts(service)
+
+	wlvector = {"name": wl.metadata.name,
+				"namespace": wl.metadata.namespace,
+				"kind": wl.kind,
+				"relatedObjects": service}
+
+	msga := {
+		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+        "alertObject": {
+			"k8sApiObjects": [],
+			"externalObjects": wlvector
+		}
+     }
+}
+
+hasSSHPorts(service) {
+	port := service.spec.ports[_]
+	port.port == 22
+}
+
+
+hasSSHPorts(service) {
+	port := service.spec.ports[_]
+	port.port == 2222
+}
+
+hasSSHPorts(service) {
+	port := service.spec.ports[_]
+	port.targetPort == 22
+}
+
+
+hasSSHPorts(service) {
+	port := service.spec.ports[_]
+	port.targetPort == 2222
+}
+`

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1158,8 +1158,15 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 	// enumeratedIDs scopes which failed resources get reported, without
 	// scoping what the rule evaluates against below (that stays
 	// inputRawResources, the full aggregated input, so a rule that joins
-	// across kinds still sees every kind it matched). It is built only from
-	// the enumerator's real, stable-ID objects (K8sApiObjects), never from a
+	// across kinds still sees every kind it matched). It only applies to
+	// rules that actually declare a ResourceEnumerator: for every other rule,
+	// enumerateData returns inputRawResources unchanged, which is not a
+	// selection to scope reporting by, and a rule that reports through its
+	// own synthesized ExternalObjects (e.g. audit-policy-content) has an
+	// identity that was never going to appear in that unchanged set anyway.
+	//
+	// When a rule does declare one, enumeratedIDs is built only from its
+	// real, stable-ID objects (K8sApiObjects), never from a
 	// RegoResponseVectorObject: a vector's GetID is a composite of its own
 	// fields, not the underlying resource's ID, so it can never match the ID
 	// a k8sApiObjects-reporting rule fails with, and an enumerator that
@@ -1168,17 +1175,19 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 	// An enumerator that matched nothing at all yields an empty, non-nil set
 	// so nothing gets reported.
 	var enumeratedIDs map[string]struct{}
-	if len(enumeratedData) == 0 {
-		enumeratedIDs = map[string]struct{}{}
-	} else {
-		for _, r := range inputResources {
-			if objectsenvelopes.GetObjectType(r.GetObject()) == objectsenvelopes.TypeRegoResponseVectorObject {
-				continue
+	if ruleEnumeratorData(rule) != "" {
+		if len(enumeratedData) == 0 {
+			enumeratedIDs = map[string]struct{}{}
+		} else {
+			for _, r := range inputResources {
+				if objectsenvelopes.GetObjectType(r.GetObject()) == objectsenvelopes.TypeRegoResponseVectorObject {
+					continue
+				}
+				if enumeratedIDs == nil {
+					enumeratedIDs = make(map[string]struct{}, len(inputResources))
+				}
+				enumeratedIDs[r.GetID()] = struct{}{}
 			}
-			if enumeratedIDs == nil {
-				enumeratedIDs = make(map[string]struct{}, len(inputResources))
-			}
-			enumeratedIDs[r.GetID()] = struct{}{}
 		}
 	}
 
@@ -1229,10 +1238,8 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 				continue
 			}
 			id := failedResource.GetID()
-			if enumeratedIDs != nil {
-				if _, inScope := enumeratedIDs[id]; !inScope {
-					continue
-				}
+			if !inEnumeratedScope(enumeratedIDs, failedResource, id) {
+				continue
 			}
 			failedIDs[id] = struct{}{}
 			if _, exists := resources[id]; exists {
@@ -1276,10 +1283,8 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 			if opap.skipNamespace(failedResource.GetNamespace()) {
 				continue
 			}
-			if enumeratedIDs != nil {
-				if _, inScope := enumeratedIDs[failedResource.GetID()]; !inScope {
-					continue
-				}
+			if !inEnumeratedScope(enumeratedIDs, failedResource, failedResource.GetID()) {
+				continue
 			}
 			var ruleResult *resourcesresults.ResourceAssociatedRule
 			if r, found := resources[failedResource.GetID()]; found {

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1155,6 +1155,33 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 
 	inputResources = objectsenvelopes.ListMapToMeta(enumeratedData)
 
+	// enumeratedIDs scopes which failed resources get reported, without
+	// scoping what the rule evaluates against below (that stays
+	// inputRawResources, the full aggregated input, so a rule that joins
+	// across kinds still sees every kind it matched). It is built only from
+	// the enumerator's real, stable-ID objects (K8sApiObjects), never from a
+	// RegoResponseVectorObject: a vector's GetID is a composite of its own
+	// fields, not the underlying resource's ID, so it can never match the ID
+	// a k8sApiObjects-reporting rule fails with, and an enumerator that
+	// reports purely through ExternalObjects (e.g. C-0042, C-0053) is meant
+	// to leave reporting unrestricted, not restricted to nothing.
+	// An enumerator that matched nothing at all yields an empty, non-nil set
+	// so nothing gets reported.
+	var enumeratedIDs map[string]struct{}
+	if len(enumeratedData) == 0 {
+		enumeratedIDs = map[string]struct{}{}
+	} else {
+		for _, r := range inputResources {
+			if objectsenvelopes.GetObjectType(r.GetObject()) == objectsenvelopes.TypeRegoResponseVectorObject {
+				continue
+			}
+			if enumeratedIDs == nil {
+				enumeratedIDs = make(map[string]struct{}, len(inputResources))
+			}
+			enumeratedIDs[r.GetID()] = struct{}{}
+		}
+	}
+
 	var addedResources []workloadinterface.IMetadata
 	for _, inputResource := range inputResources {
 		if opap.skipNamespace(inputResource.GetNamespace()) {
@@ -1175,7 +1202,7 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		opap.mu.Unlock()
 	}
 
-	ruleResponses, celOut, err := opap.runOPAOnSingleRule(ctx, rule, enumeratedData, ruleData, ruleRegoDependenciesData, controlID)
+	ruleResponses, celOut, err := opap.runOPAOnSingleRule(ctx, rule, inputRawResources, ruleData, ruleRegoDependenciesData, controlID)
 	if err != nil {
 		opap.markResourcesSkipped(resources, rule, ruleRegoDependenciesData, inputResources, err)
 		return resources, fmt.Errorf("rego eval failed for namespace %q: %w", scope.name, err)
@@ -1202,6 +1229,11 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 				continue
 			}
 			id := failedResource.GetID()
+			if enumeratedIDs != nil {
+				if _, inScope := enumeratedIDs[id]; !inScope {
+					continue
+				}
+			}
 			failedIDs[id] = struct{}{}
 			if _, exists := resources[id]; exists {
 				continue
@@ -1243,6 +1275,11 @@ func (opap *OPAProcessor) processRuleOnScope(ctx context.Context, rule *reportha
 		for _, failedResource := range failedResources {
 			if opap.skipNamespace(failedResource.GetNamespace()) {
 				continue
+			}
+			if enumeratedIDs != nil {
+				if _, inScope := enumeratedIDs[failedResource.GetID()]; !inScope {
+					continue
+				}
 			}
 			var ruleResult *resourcesresults.ResourceAssociatedRule
 			if r, found := resources[failedResource.GetID()]; found {

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -737,6 +738,24 @@ func ruleData(rule *reporthandling.PolicyRule) string {
 
 func ruleEnumeratorData(rule *reporthandling.PolicyRule) string {
 	return rule.ResourceEnumerator
+}
+
+// inEnumeratedScope reports whether a failed resource may be reported, given
+// the enumerator's reporting-scope restriction built in processRuleOnScope. A
+// nil scope means unrestricted. A RegoResponseVectorObject is never checked
+// against it: its GetID is a composite of its own fields, not the underlying
+// resource's ID, so it can never legitimately match an enumeratedIDs entry
+// (which only ever holds real, stable-ID objects) - restricting it would just
+// drop every vector-reported failure, enumerator or not.
+func inEnumeratedScope(enumeratedIDs map[string]struct{}, failedResource workloadinterface.IMetadata, id string) bool {
+	if enumeratedIDs == nil {
+		return true
+	}
+	if objectsenvelopes.GetObjectType(failedResource.GetObject()) == objectsenvelopes.TypeRegoResponseVectorObject {
+		return true
+	}
+	_, inScope := enumeratedIDs[id]
+	return inScope
 }
 
 // errIncludeControlsNoMatch is returned when --include-controls is set but


### PR DESCRIPTION
I found that #3559 broke every rule that joins across kinds. It changed the rego evaluation input from the full aggregated resources to the enumerator's own output, on the reasoning that the enumerator narrows the input. That is true for single-kind rules, but a rule with a ResourceEnumerator can still declare a Match across several kinds and read all of them in its main deny block. Once the input is narrowed to only what the enumerator selected, every other kind the join needed is gone.

Six of the seven enumerator rules shipped in NSA and MITRE do exactly this. C-0054 internal-networking enumerates Namespaces but its main rule also needs NetworkPolicy objects to decide coverage, so every namespace fails regardless of whether it has a policy. C-0042, C-0053, C-0021 and C-0058 enumerate one kind (Pod, ServiceAccount, workloads) while reading Services, RoleBindings, ClusterRoles or Nodes in the same evaluation, and their reports come back empty since the enumerator's own output has nothing for the main rule to work with.

I reverted the evaluation input to the full aggregated resources, so a joining rule sees everything it matched again. That alone would have broken the narrowing behavior single-kind rules rely on, since a rule like C-0005 expects the enumerator's selection to also limit what gets reported. So I added a small scope check: which failures get written into the result map is restricted to the enumerator's real object selections, when it made any. An enumerator that reports through ExternalObjects rather than real Kubernetes objects, which C-0042 and C-0053 both do, leaves reporting unrestricted, since there is nothing meaningful to restrict it to.

I added four tests using the actual shipped rego for C-0054 and C-0042, plus a cross-kind case, and ran them together with the existing enumerator test suite added in #3559 to make sure both directions hold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy evaluation for rules involving multiple resource types by preserving relationships between resources during assessment.
  * Corrected reporting for enumerated resources so valid resources are not incorrectly marked as failed.
  * Fixed detection of exposed workloads, including findings reported through external resource details.
  * Ensured findings use the correct composite identifier for accurate result tracking.
  * Preserved synthesized and mixed resource findings during reporting.

* **Tests**
  * Added regression coverage for resource enumeration, cross-resource joins, external findings, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->