### PR TITLE
fix(cel): matchConditions short-circuit on false skips evaluating later conditions

### DIFF
--- a/core/pkg/opaprocessor/cel/matchconditions.go
+++ b/core/pkg/opaprocessor/cel/matchconditions.go
@@ -22,23 +22,34 @@ type MatchCondition struct {
 // skipped and none of its validations run, so offline we must do the same:
 // running a gated policy's validations emits violations admission never raises.
 //
+// Every condition is evaluated, even after one has already come back false.
+// The apiserver's matcher (webhook/matchconditions matcher.go, which the VAP
+// path reuses) works in two separate phases: ForInput first evaluates every
+// compiled condition unconditionally against one shared cost budget
+// (admission/plugin/cel/condition.go), and only once that finishes does
+// Match walk the completed results to pick a verdict, returning not-matched
+// at the first false it finds there. Stopping the evaluation loop itself the
+// moment a false is seen -- which this function used to do -- looks
+// equivalent (the two-condition, no-budget-pressure case indeed produces the
+// same verdict either way) but is not: it also stops charging the shared
+// budget for whatever conditions come after the false one. A false condition
+// followed by an expensive one that would have exhausted the budget is
+// exactly the case where the two diverge -- the apiserver still exhausts the
+// budget and denies the request under failurePolicy Fail, while stopping
+// early here would report a clean not-matched skip instead.
+//
 // A false condition outranks a condition that errored, whatever order the two
-// appear in. The apiserver's matcher evaluates every condition, collects the
-// errors, and still returns not-matched the moment it sees a false one; only a
-// gate of trues and errors reaches failurePolicy (webhook/matchconditions
-// matcher.go, which the VAP path reuses). So an error is retained rather than
-// returned, and a later false discards it. Returning on the first error instead
-// would deny an object under failurePolicy Fail that admission simply skips.
+// appear in: the apiserver's Match checks every result for EvalResult==False
+// before it even looks at the collected errors, so a false anywhere in the
+// gate produces not-matched regardless of what else errored. Only a gate of
+// trues and errors, with no false at all, reaches failurePolicy. So an error
+// is retained rather than returned immediately, and a false seen anywhere
+// (before or after it) discards it at the end.
 //
-// A false condition still short-circuits the conditions after it. Evaluating
-// them could only add errors that the false already outranks, and the gate's
-// budget is discarded either way, so the outcome is identical to the
-// apiserver's for less work.
-//
-// Cancellation and an exhausted budget are the exceptions: they are terminal,
-// because no later condition can still produce the false that would outrank
-// them. A compile error is not terminal, since the conditions after it are
-// unaffected and one of them may yet be false.
+// Cancellation and an exhausted budget are still terminal mid-loop: nothing
+// evaluated under an exhausted budget can be trusted, including a false that
+// might otherwise have outranked it, so both stop the loop outright rather
+// than being retained like a compile/eval error.
 //
 // The error return is the unknown case. Whether it denies the object or skips
 // the policy depends on failurePolicy, so the caller decides (see
@@ -69,9 +80,10 @@ func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchC
 	budget := newCostBudget(e.matchConditionsBudgetLimit())
 	activation := e.activationFor(ctx, obj, nil, params, variables, budget)
 
-	// The first error we can still recover from, held until a false outranks it
-	// or the gate runs out of conditions.
+	// The first error we can still recover from, held until the loop ends
+	// (whereupon a false condition seen anywhere outranks it).
 	var retained error
+	sawFalse := false
 
 	for _, condition := range conditions {
 		// cel-go only notices a cancelled context every InterruptCheckFrequency
@@ -100,10 +112,13 @@ func (e *Evaluator) matchConditionsHold(ctx context.Context, conditions []MatchC
 			continue
 		}
 		if !matched {
-			return false, nil
+			sawFalse = true
 		}
 	}
 
+	if sawFalse {
+		return false, nil
+	}
 	if retained != nil {
 		return false, retained
 	}

--- a/core/pkg/opaprocessor/cel/matchconditions_test.go
+++ b/core/pkg/opaprocessor/cel/matchconditions_test.go
@@ -59,9 +59,11 @@ func TestMatchConditionsHold(t *testing.T) {
 		},
 		{
 			// The second condition selects a field that is absent, which errors
-			// when evaluated. A clean not-matched verdict therefore proves the
-			// first false condition short-circuited it, as the apiserver does.
-			name: "a false condition short-circuits the ones after it",
+			// when evaluated. It is still evaluated -- see
+			// TestMatchConditionsHoldEvaluatesEveryConditionEvenAfterFalse for why
+			// that matters -- but a false condition outranks an error however they
+			// are ordered, so the verdict is a clean not-matched either way.
+			name: "a false condition outranks a later condition that errors",
 			conditions: []MatchCondition{
 				cond("is-kube-system", "object.metadata.namespace == 'kube-system'"),
 				cond("would-error", "object.spec.nodeName == 'node-1'"),
@@ -235,6 +237,33 @@ func TestMatchConditionsHoldCancellation(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, matched)
 	assert.False(t, IsExpressionError(err), "a cancelled scan is not a verdict failurePolicy governs")
+}
+
+// TestMatchConditionsHoldEvaluatesEveryConditionEvenAfterFalse is the direct
+// regression test for the divergence from the apiserver's real matcher: a
+// false condition must not stop the gate from evaluating (and charging the
+// shared budget for) the conditions after it, because the apiserver's own
+// ForInput evaluates every condition unconditionally before Match ever picks
+// a verdict from the results. A condition expensive enough to exhaust the
+// budget on its own, placed after an already-false condition, must still
+// exhaust it and produce the terminal budget error -- not a clean,
+// budget-untouched not-matched skip.
+func TestMatchConditionsHoldEvaluatesEveryConditionEvenAfterFalse(t *testing.T) {
+	// A single "object.metadata.namespace == '...'" condition costs 4 units
+	// (measured directly against this evaluator). A budget of 5 leaves the
+	// first condition just enough to succeed (remaining: 1), with too little
+	// left for the identical second condition to also complete.
+	e, err := NewEvaluator(WithCostBudget(5))
+	require.NoError(t, err)
+
+	isFalse := cond("is-kube-system", "object.metadata.namespace == 'kube-system'")
+	wouldExhaust := cond("is-prod", "object.metadata.namespace == 'prod'")
+
+	matched, err := e.matchConditionsHold(context.Background(), []MatchCondition{isFalse, wouldExhaust}, gatedPod(), nil, nil)
+
+	require.Error(t, err, "the second condition must still be evaluated and exhaust the budget, matching the apiserver's ForInput")
+	assert.False(t, matched)
+	assert.False(t, IsExpressionError(err), "budget exhaustion is terminal, not a retained expression error a false could outrank")
 }
 
 // TestMatchConditionsHoldOwnBudget proves the gate does not spend the budget the


### PR DESCRIPTION
## Summary

Closes #3629.

`matchConditionsHold` (`core/pkg/opaprocessor/cel/matchconditions.go`) returned as soon as a matchCondition evaluated to `false`, skipping -- and not charging the shared CEL cost budget for -- any conditions after it. Verified against the real vendored `k8s.io/apiserver@v0.35.4` source (same version this repo depends on):

- `pkg/admission/plugin/cel/condition.go:104-109` (`ForInput`): evaluates **every** compiled matchCondition unconditionally against one shared budget. It only stops early on budget/context exhaustion.
- `pkg/admission/plugin/webhook/matchconditions/matcher.go:103-122` (`Match`): only *after* `ForInput` finishes does this walk the completed results and pick `Matches:false` at the first `false` -- but by then every condition has already run.

The two diverge exactly when a condition after an already-false one would have exhausted the shared budget on its own: the real apiserver still evaluates it, exhausts the budget, and (under `failurePolicy: Fail`, the default) **denies the request**. The old short-circuit here reported a clean not-matched skip instead, since it never got that far -- a real admission-time deny silently reported as a clean pass offline.

## Fix

Evaluate every condition (still stopping immediately on budget/context exhaustion, which is genuinely terminal -- that part is unchanged), track whether any condition came back `false`, and decide the final verdict only once the loop completes. `false` still outranks a retained non-terminal error exactly as before -- only now that decision is made after every condition has actually run, matching the apiserver's two-phase evaluate-then-interpret structure.

## Test plan

- New regression test `TestMatchConditionsHoldEvaluatesEveryConditionEvenAfterFalse`, calibrated against the evaluator's real measured CEL cost for a simple equality condition (empirically measured at 4 units): a budget of 5 lets a first, false condition succeed (1 unit remaining) but leaves too little for an identical second condition, which must still be evaluated and exhaust the budget. **Verified this test fails against the pre-fix code and passes with the fix** (confirmed both directions locally before committing).
- Updated a pre-existing test's misleading name/comment ("a false condition short-circuits the ones after it") that described the old (incorrect) mental model; its assertion is unchanged since the two implementations happen to produce the same verdict in that specific no-budget-pressure case.
- All existing `matchconditions_test.go` tests pass unchanged (`TestMatchConditionsHoldFalseOutranksError`, `TestMatchConditionsHoldOwnBudget`, etc.) -- the false-outranks-error precedence and budget/context-exhaustion terminal handling are untouched.
- `go build ./...`, `go vet`, `go test -race` on the affected packages, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Match conditions now evaluate all applicable conditions instead of stopping after the first false result.
  * False results are correctly prioritized over later evaluation errors.
  * Budget exhaustion and cancellation continue to stop evaluation immediately.

* **Tests**
  * Added coverage for continued evaluation after false conditions.
  * Added regression coverage for budget exhaustion during subsequent condition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->