### PR TITLE
feat(networkpolicy,vulnexposure): correlate vulnerabilities with NetworkPolicy exposure

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -1330,6 +1330,7 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createNetworkScanningTools(ksServer)
 	createNetworkReachabilityTools(ksServer)
 	createMutatingAdmissionPolicyTools(ksServer)
+	createVulnerabilityExposureTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)

--- a/cmd/mcpserver/vulnerability_exposure.go
+++ b/cmd/mcpserver/vulnerability_exposure.go
@@ -1,0 +1,243 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/armosec/utils-k8s-go/wlid"
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/networkpolicy"
+	"github.com/kubescape/kubescape/v4/core/pkg/vulnexposure"
+	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// workloadKindGVRs maps the workload kinds this tool knows how to resolve a
+// pod template's labels for to their GVR. Kinds outside this map are
+// reported in the response's skipped_workloads rather than guessed at --
+// see resolvePodTemplateLabels.
+var workloadKindGVRs = map[string]schema.GroupVersionResource{
+	"Pod":         {Group: "", Version: "v1", Resource: "pods"},
+	"Deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
+	"StatefulSet": {Group: "apps", Version: "v1", Resource: "statefulsets"},
+	"DaemonSet":   {Group: "apps", Version: "v1", Resource: "daemonsets"},
+	"ReplicaSet":  {Group: "apps", Version: "v1", Resource: "replicasets"},
+	"Job":         {Group: "batch", Version: "v1", Resource: "jobs"},
+	"CronJob":     {Group: "batch", Version: "v1", Resource: "cronjobs"},
+}
+
+// createVulnerabilityExposureTools registers analyze_vulnerability_exposure,
+// which joins a cluster's already-scanned image vulnerabilities
+// (VulnerabilityManifest objects, produced by an in-cluster scanner) with
+// the NetworkPolicy ingress exposure model (core/pkg/networkpolicy) to
+// surface the question neither answers alone: which known CVEs sit on
+// workloads a NetworkPolicy actually leaves reachable, and from how wide a
+// source.
+func createVulnerabilityExposureTools(ksServer *KubescapeMcpserver) {
+	tool := mcp.NewTool(
+		"analyze_vulnerability_exposure",
+		mcp.WithDescription("Correlate known image vulnerabilities (from already-scanned VulnerabilityManifest objects) with each workload's NetworkPolicy ingress exposure, so findings can be prioritized by whether they are actually reachable -- and how widely -- rather than by severity alone. Reports each (workload, CVE) pair at or above min_severity together with the widest ingress source class some NetworkPolicy rule already admits (open/external-cidr/any-namespace/restricted)."),
+		mcp.WithString("namespace", mcp.Description("Restrict to one namespace (optional; omit for cluster-wide)")),
+		mcp.WithString("min_severity", mcp.Description("Minimum vulnerability severity to include: Critical, High, Medium, Low, Negligible (default High)")),
+	)
+
+	ksServer.s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok || args == nil {
+			args = map[string]any{}
+		}
+
+		namespace, _ := args["namespace"].(string)
+
+		minSeverity := vulnexposure.SeverityHigh
+		if raw, ok := args["min_severity"].(string); ok && raw != "" {
+			minSeverity = vulnexposure.ParseSeverity(raw)
+			if minSeverity == vulnexposure.SeverityUnknown {
+				return mcp.NewToolResultError(fmt.Sprintf("min_severity must be one of Critical, High, Medium, Low, Negligible (got %q)", raw)), nil
+			}
+		}
+
+		ksClient, ksErr := ksServer.getKsClient()
+		if ksErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubescape storage: %v", ksErr)), nil
+		}
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+		}
+
+		listNamespace := namespace
+		manifests, err := ksClient.VulnerabilityManifests(listNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list VulnerabilityManifest objects: %v", err)), nil
+		}
+
+		vulnsByWorkload := make(map[vulnexposure.Workload][]storagev1beta1.Vulnerability)
+		var imageLevelSkipped int
+		for i := range manifests.Items {
+			manifest := &manifests.Items[i]
+			w, ok := workloadFromManifest(manifest)
+			if !ok {
+				imageLevelSkipped++
+				continue
+			}
+			for _, match := range manifest.Spec.Payload.Matches {
+				vulnsByWorkload[w] = append(vulnsByWorkload[w], match.Vulnerability)
+			}
+		}
+
+		dynClient := k8sClient.DynamicClient
+		endpoints := make(map[vulnexposure.Workload]networkpolicy.Endpoint, len(vulnsByWorkload))
+		var unresolvedWorkloads []vulnexposure.Workload
+		for w := range vulnsByWorkload {
+			ep, resolveErr := resolveEndpoint(ctx, dynClient, w)
+			if resolveErr != nil {
+				unresolvedWorkloads = append(unresolvedWorkloads, w)
+				continue
+			}
+			endpoints[w] = ep
+		}
+
+		npGVR := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
+		npList, err := dynClient.Resource(npGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list NetworkPolicy objects: %v", err)), nil
+		}
+		nsList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+		}
+
+		resources := make(map[string]workloadinterface.IMetadata, len(npList.Items)+len(nsList.Items))
+		for i := range npList.Items {
+			w := workloadinterface.NewWorkloadObj(npList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+		for i := range nsList.Items {
+			w := workloadinterface.NewWorkloadObj(nsList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+		policies, namespaces, decodeErrs := networkpolicy.FromResources(resources)
+		idx, indexErrs := networkpolicy.NewIndex(policies, namespaces)
+
+		// endpoints only ever contains workloads resolveEndpoint succeeded
+		// for, so Correlate's own skipped return would just be
+		// unresolvedWorkloads again under a less specific message -- that
+		// warning is already produced below from unresolvedWorkloads
+		// directly, with the actual resolution failure reason.
+		findings, _ := vulnexposure.Correlate(idx, endpoints, vulnsByWorkload, minSeverity)
+
+		result := map[string]any{
+			"findings": buildFindingSummaries(findings),
+		}
+
+		var warnings []string
+		for _, e := range decodeErrs {
+			warnings = append(warnings, e.Error())
+		}
+		for _, e := range indexErrs {
+			warnings = append(warnings, e.Error())
+		}
+		if imageLevelSkipped > 0 {
+			warnings = append(warnings, fmt.Sprintf("%d image-level VulnerabilityManifest object(s) skipped: not attributable to a specific running workload", imageLevelSkipped))
+		}
+		for _, w := range unresolvedWorkloads {
+			warnings = append(warnings, fmt.Sprintf("workload %s/%s (%s): could not resolve its pod template live, excluded from correlation", w.Namespace, w.Kind, w.Name))
+		}
+		if len(warnings) > 0 {
+			result["warnings"] = warnings
+		}
+
+		resBytes, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(resBytes)), nil
+	})
+}
+
+// workloadFromManifest extracts the workload a VulnerabilityManifest was
+// produced for from its WLID annotation. An image-level manifest (no WLID:
+// grype scanned an image directly, not by way of a specific running
+// workload) returns ok=false rather than a guessed/empty Workload.
+func workloadFromManifest(manifest *storagev1beta1.VulnerabilityManifest) (vulnexposure.Workload, bool) {
+	wlidStr := manifest.Annotations[helpers.WlidMetadataKey]
+	if wlidStr == "" {
+		return vulnexposure.Workload{}, false
+	}
+	ns := wlid.GetNamespaceFromWlid(wlidStr)
+	kind := wlid.GetKindFromWlid(wlidStr)
+	name := wlid.GetNameFromWlid(wlidStr)
+	if ns == "" || kind == "" || name == "" {
+		return vulnexposure.Workload{}, false
+	}
+	return vulnexposure.Workload{Namespace: ns, Kind: kind, Name: name}, true
+}
+
+// resolveEndpoint fetches w's live object and extracts the labels a
+// NetworkPolicy actually selects on: a Pod's own labels, or a controller's
+// pod template labels. Only the kinds in workloadKindGVRs are resolved; any
+// other kind (a custom controller, or one this tool does not yet cover)
+// returns an error rather than a guessed selector.
+func resolveEndpoint(ctx context.Context, dynClient dynamic.Interface, w vulnexposure.Workload) (networkpolicy.Endpoint, error) {
+	gvr, known := workloadKindGVRs[w.Kind]
+	if !known {
+		return networkpolicy.Endpoint{}, fmt.Errorf("kind %q is not a resolvable workload kind", w.Kind)
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(w.Namespace).Get(ctx, w.Name, metav1.GetOptions{})
+	if err != nil {
+		return networkpolicy.Endpoint{}, fmt.Errorf("failed to get %s %s/%s: %w", w.Kind, w.Namespace, w.Name, err)
+	}
+
+	labels := podTemplateLabels(w.Kind, obj)
+	return networkpolicy.Endpoint{Namespace: w.Namespace, Name: w.Name, Labels: labels}, nil
+}
+
+// podTemplateLabels extracts the labels a NetworkPolicy's podSelector
+// matches against from a live workload object: a Pod's own metadata.labels,
+// or (for the controller kinds workloadKindGVRs knows) the pod template's
+// labels -- what a NetworkPolicy selects on is always the labels the actual
+// running Pod carries, not the controller object's own labels, which can
+// (and often do) differ.
+func podTemplateLabels(kind string, obj *unstructured.Unstructured) map[string]string {
+	if kind == "Pod" {
+		return obj.GetLabels()
+	}
+
+	path := []string{"spec", "template", "metadata", "labels"}
+	if kind == "CronJob" {
+		path = []string{"spec", "jobTemplate", "spec", "template", "metadata", "labels"}
+	}
+
+	raw, found, err := unstructured.NestedStringMap(obj.Object, path...)
+	if err != nil || !found {
+		return nil
+	}
+	return raw
+}
+
+func buildFindingSummaries(findings []vulnexposure.Finding) []map[string]any {
+	out := make([]map[string]any, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, map[string]any{
+			"namespace":       f.Workload.Namespace,
+			"workload_kind":   f.Workload.Kind,
+			"workload_name":   f.Workload.Name,
+			"cve_id":          f.Vulnerability.ID,
+			"severity":        f.Vulnerability.Severity,
+			"fix_available":   f.FixAvailable,
+			"description":     f.Vulnerability.Description,
+			"exposure":        f.Exposure.Level.String(),
+			"exposure_reason": f.Exposure.Reason,
+			"matched_policy":  f.Exposure.MatchedPolicy,
+		})
+	}
+	return out
+}

--- a/cmd/mcpserver/vulnerability_exposure_test.go
+++ b/cmd/mcpserver/vulnerability_exposure_test.go
@@ -1,0 +1,207 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	storagefake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	softwarecompositionv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+func newVulnExposureTestServer(t *testing.T, k8sObjects []runtime.Object, storageObjects ...runtime.Object) *KubescapeMcpserver {
+	t.Helper()
+
+	listKinds := map[schema.GroupVersionResource]string{
+		networkPolicyGVR: "NetworkPolicyList",
+		namespaceGVR:     "NamespaceList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+		{Group: "", Version: "v1", Resource: "pods"}:            "PodList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, k8sObjects...)
+
+	storageClientset := storagefake.NewClientset(storageObjects...)
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+		ksClientInit: func() (spdxv1beta1.SpdxV1beta1Interface, error) {
+			return storageClientset.SpdxV1beta1(), nil
+		},
+	}
+	createVulnerabilityExposureTools(ksServer)
+	return ksServer
+}
+
+func unstructuredDeployment(namespace, name string, podLabels map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"labels": podLabels,
+				},
+			},
+		},
+	}}
+}
+
+func vulnerabilityManifest(namespace, name, wlidStr string, matches ...softwarecompositionv1beta1.Match) *softwarecompositionv1beta1.VulnerabilityManifest {
+	return &softwarecompositionv1beta1.VulnerabilityManifest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{helpers.WlidMetadataKey: wlidStr},
+		},
+		Spec: softwarecompositionv1beta1.VulnerabilityManifestSpec{
+			Payload: softwarecompositionv1beta1.GrypeDocument{Matches: matches},
+		},
+	}
+}
+
+func criticalMatch(id string) softwarecompositionv1beta1.Match {
+	return softwarecompositionv1beta1.Match{
+		Vulnerability: softwarecompositionv1beta1.Vulnerability{
+			VulnerabilityMetadata: softwarecompositionv1beta1.VulnerabilityMetadata{ID: id, Severity: "Critical"},
+		},
+	}
+}
+
+func TestAnalyzeVulnerabilityExposure_OpenWorkloadWithCriticalCVEIsReported(t *testing.T) {
+	deploy := unstructuredDeployment("prod", "web", map[string]any{"app": "web"})
+	manifest := vulnerabilityManifest("prod", "web-manifest", "wlid://cluster-test/namespace-prod/deployment-web", criticalMatch("CVE-2024-1"))
+
+	ksServer := newVulnExposureTestServer(t, []runtime.Object{deploy}, manifest)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	findings, ok := parsed["findings"].([]any)
+	require.True(t, ok)
+	require.Len(t, findings, 1)
+	f := findings[0].(map[string]any)
+	require.Equal(t, "CVE-2024-1", f["cve_id"])
+	require.Equal(t, "open", f["exposure"])
+}
+
+func TestAnalyzeVulnerabilityExposure_RestrictedWorkloadStillReportedButLabeledRestricted(t *testing.T) {
+	deploy := unstructuredDeployment("prod", "web", map[string]any{"app": "web"})
+	np := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": "restrict-web", "namespace": "prod"},
+		"spec": map[string]any{
+			"podSelector": map[string]any{"matchLabels": map[string]any{"app": "web"}},
+			"policyTypes": []any{"Ingress"},
+			"ingress": []any{
+				map[string]any{
+					"from": []any{
+						map[string]any{"podSelector": map[string]any{"matchLabels": map[string]any{"app": "client"}}},
+					},
+				},
+			},
+		},
+	}}
+	manifest := vulnerabilityManifest("prod", "web-manifest", "wlid://cluster-test/namespace-prod/deployment-web", criticalMatch("CVE-2024-1"))
+
+	ksServer := newVulnExposureTestServer(t, []runtime.Object{deploy, np}, manifest)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	findings := parsed["findings"].([]any)
+	require.Len(t, findings, 1)
+	require.Equal(t, "restricted", findings[0].(map[string]any)["exposure"])
+}
+
+func TestAnalyzeVulnerabilityExposure_MinSeverityFiltersOutLowerFindings(t *testing.T) {
+	deploy := unstructuredDeployment("prod", "web", map[string]any{"app": "web"})
+	lowMatch := softwarecompositionv1beta1.Match{
+		Vulnerability: softwarecompositionv1beta1.Vulnerability{
+			VulnerabilityMetadata: softwarecompositionv1beta1.VulnerabilityMetadata{ID: "CVE-LOW", Severity: "Low"},
+		},
+	}
+	manifest := vulnerabilityManifest("prod", "web-manifest", "wlid://cluster-test/namespace-prod/deployment-web", lowMatch, criticalMatch("CVE-CRIT"))
+
+	ksServer := newVulnExposureTestServer(t, []runtime.Object{deploy}, manifest)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{
+		"min_severity": "Critical",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	findings := parsed["findings"].([]any)
+	require.Len(t, findings, 1)
+	require.Equal(t, "CVE-CRIT", findings[0].(map[string]any)["cve_id"])
+}
+
+func TestAnalyzeVulnerabilityExposure_InvalidMinSeverityReturnsError(t *testing.T) {
+	ksServer := newVulnExposureTestServer(t, nil)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{
+		"min_severity": "Catastrophic",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeVulnerabilityExposure_UnresolvableWorkloadIsSkippedWithWarning(t *testing.T) {
+	// No matching Deployment exists live, so this workload cannot be resolved
+	// to a pod template -- it must be excluded from findings, not guessed at.
+	manifest := vulnerabilityManifest("prod", "ghost-manifest", "wlid://cluster-test/namespace-prod/deployment-ghost", criticalMatch("CVE-2024-1"))
+
+	ksServer := newVulnExposureTestServer(t, nil, manifest)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Empty(t, parsed["findings"])
+	warnings, ok := parsed["warnings"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, warnings)
+}
+
+func TestAnalyzeVulnerabilityExposure_ImageLevelManifestIsSkippedNotFatal(t *testing.T) {
+	imageLevelManifest := &softwarecompositionv1beta1.VulnerabilityManifest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kubescape", Name: "image-manifest"},
+		Spec: softwarecompositionv1beta1.VulnerabilityManifestSpec{
+			Payload: softwarecompositionv1beta1.GrypeDocument{Matches: []softwarecompositionv1beta1.Match{criticalMatch("CVE-IMG")}},
+		},
+	}
+
+	ksServer := newVulnExposureTestServer(t, nil, imageLevelManifest)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_vulnerability_exposure", map[string]any{}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Empty(t, parsed["findings"])
+}

--- a/core/pkg/networkpolicy/exposure.go
+++ b/core/pkg/networkpolicy/exposure.go
@@ -1,0 +1,142 @@
+package networkpolicy
+
+import (
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ExposureLevel classifies how broadly an endpoint is reachable on ingress,
+// from most to least exposed. Unlike Verdict (which answers "can THIS
+// specific source reach THIS destination"), ExposureLevel answers "what is
+// the widest reasonable source class that some NetworkPolicy rule already
+// admits" -- a structural property of the rule's own shape (an empty
+// selector, an ipBlock, a missing From list), not a per-candidate match
+// test. That is what makes it always fully determinable: no case here needs
+// a specific candidate's IP or a namespace's actual labels the way Reaches
+// does, only the policy objects themselves.
+type ExposureLevel int
+
+const (
+	// ExposureRestricted means every ingress rule that selects this endpoint
+	// scopes its peers: a podSelector (always same-namespace-only, per
+	// NetworkPolicy's own semantics) or a namespaceSelector with actual
+	// matchLabels/matchExpressions.
+	ExposureRestricted ExposureLevel = iota
+	// ExposureAnyNamespace means some ingress rule's namespaceSelector is
+	// empty (matches every namespace, present and future), so the endpoint
+	// is reachable from any pod in the cluster regardless of which
+	// namespace it runs in.
+	ExposureAnyNamespace
+	// ExposureExternalCIDR means some ingress rule admits an ipBlock peer:
+	// reachable by IP address rather than by pod/namespace identity at all,
+	// which typically includes traffic from outside the cluster's own pod
+	// network.
+	ExposureExternalCIDR
+	// ExposureOpen means the endpoint is not ingress-isolated by any
+	// NetworkPolicy at all (default allow), or some rule has no From
+	// restriction whatsoever -- either way, reachable from literally
+	// anywhere.
+	ExposureOpen
+)
+
+func (l ExposureLevel) String() string {
+	switch l {
+	case ExposureOpen:
+		return "open"
+	case ExposureExternalCIDR:
+		return "external-cidr"
+	case ExposureAnyNamespace:
+		return "any-namespace"
+	default:
+		return "restricted"
+	}
+}
+
+// Exposure is the result of classifying one endpoint's ingress exposure.
+type Exposure struct {
+	Level ExposureLevel
+	// Reason explains what produced Level: which rule shape was found, or
+	// that no policy isolates the endpoint at all.
+	Reason string
+	// MatchedPolicy names the NetworkPolicy (namespace/name) responsible for
+	// Level, when a specific policy is what determined it. Empty when Level
+	// is ExposureOpen because nothing isolates the endpoint at all -- there
+	// is no specific policy to blame for that.
+	MatchedPolicy string
+}
+
+// IngressExposure classifies the widest ingress source class any
+// NetworkPolicy rule already admits for ep. It is a coarser question than
+// Reaches: not "can pod X reach this," but "what is the broadest class of
+// pod this endpoint is already open to, per its own NetworkPolicy rules."
+// This is the signal a vulnerability-prioritization consumer wants: a
+// critical CVE on a pod that is ExposureOpen or ExposureExternalCIDR is a
+// materially different risk than the same CVE on an ExposureRestricted pod.
+func (idx *Index) IngressExposure(ep Endpoint) Exposure {
+	if !idx.IsIsolated(ep, Ingress) {
+		return Exposure{Level: ExposureOpen, Reason: "no NetworkPolicy selects this endpoint for ingress; default allow"}
+	}
+
+	best := Exposure{Level: ExposureRestricted, Reason: "every ingress rule that matches restricts its peers"}
+	for _, cp := range idx.byNamespace[ep.Namespace] {
+		if !cp.hasIngress || !cp.podSelector.Matches(labels.Set(ep.Labels)) {
+			continue
+		}
+		for _, rule := range cp.policy.Spec.Ingress {
+			level, reason := classifyPeers(rule.From)
+			if level > best.Level {
+				best = Exposure{
+					Level:         level,
+					Reason:        reason,
+					MatchedPolicy: fmt.Sprintf("%s/%s", cp.policy.Namespace, cp.policy.Name),
+				}
+				if best.Level == ExposureOpen {
+					return best
+				}
+			}
+		}
+	}
+	return best
+}
+
+// classifyPeers reports the widest exposure level a single ingress rule's
+// From list admits. An empty/nil From list matches every peer, the same
+// "absent means unrestricted" semantics portVerdict/peerListVerdict already
+// apply elsewhere in this package.
+func classifyPeers(peers []networkingv1.NetworkPolicyPeer) (ExposureLevel, string) {
+	if len(peers) == 0 {
+		return ExposureOpen, "rule has no source restriction; matches every peer"
+	}
+
+	best := ExposureRestricted
+	reason := "matches only specific, scoped peers"
+	for _, peer := range peers {
+		level, r := classifyPeer(peer)
+		if level > best {
+			best, reason = level, r
+		}
+	}
+	return best, reason
+}
+
+// classifyPeer reports the exposure level a single networkingv1.NetworkPolicyPeer
+// contributes. A podSelector alone is always ExposureRestricted regardless
+// of how permissive its own label match is: per NetworkPolicy's own
+// semantics (see match.go's peerMatches), a podSelector with no
+// namespaceSelector only ever reaches pods in the policy's own namespace.
+func classifyPeer(peer networkingv1.NetworkPolicyPeer) (ExposureLevel, string) {
+	if peer.IPBlock != nil {
+		return ExposureExternalCIDR, fmt.Sprintf("ipBlock %s admits peers by IP, not pod/namespace identity", peer.IPBlock.CIDR)
+	}
+	if peer.NamespaceSelector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		if err == nil && sel.Empty() {
+			return ExposureAnyNamespace, "namespaceSelector is empty, matching every namespace"
+		}
+		return ExposureRestricted, "namespaceSelector scopes peers to specific namespaces"
+	}
+	return ExposureRestricted, "podSelector only ever matches pods in this endpoint's own namespace"
+}

--- a/core/pkg/networkpolicy/exposure.go
+++ b/core/pkg/networkpolicy/exposure.go
@@ -80,19 +80,37 @@ func (idx *Index) IngressExposure(ep Endpoint) Exposure {
 		return Exposure{Level: ExposureOpen, Reason: "no NetworkPolicy selects this endpoint for ingress; default allow"}
 	}
 
-	best := Exposure{Level: ExposureRestricted, Reason: "every ingress rule that matches restricts its peers"}
+	// haveBest tracks whether best has ever been assigned from a real
+	// matching policy, since ExposureRestricted is also ExposureLevel's zero
+	// value: a plain "level > best.Level" comparison starting from a
+	// zero-valued best would never fire for the common case where the
+	// widest level found really is Restricted, leaving MatchedPolicy empty
+	// even though a specific policy is responsible for it.
+	var best Exposure
+	haveBest := false
 	for _, cp := range idx.byNamespace[ep.Namespace] {
 		if !cp.hasIngress || !cp.podSelector.Matches(labels.Set(ep.Labels)) {
 			continue
 		}
+		policyName := fmt.Sprintf("%s/%s", cp.policy.Namespace, cp.policy.Name)
+
+		if len(cp.policy.Spec.Ingress) == 0 {
+			// hasIngress is true (Ingress is in this policy's policyTypes)
+			// but it declares no ingress rules at all: it isolates the
+			// endpoint and admits nothing. Still a real, attributable
+			// policy -- record it unless a wider level already applies.
+			if !haveBest {
+				best = Exposure{Level: ExposureRestricted, Reason: "isolated by a policy with no ingress rules; admits nothing", MatchedPolicy: policyName}
+				haveBest = true
+			}
+			continue
+		}
+
 		for _, rule := range cp.policy.Spec.Ingress {
 			level, reason := classifyPeers(rule.From)
-			if level > best.Level {
-				best = Exposure{
-					Level:         level,
-					Reason:        reason,
-					MatchedPolicy: fmt.Sprintf("%s/%s", cp.policy.Namespace, cp.policy.Name),
-				}
+			if !haveBest || level > best.Level {
+				best = Exposure{Level: level, Reason: reason, MatchedPolicy: policyName}
+				haveBest = true
 				if best.Level == ExposureOpen {
 					return best
 				}

--- a/core/pkg/networkpolicy/exposure_test.go
+++ b/core/pkg/networkpolicy/exposure_test.go
@@ -1,0 +1,167 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ingressRule(from ...networkingv1.NetworkPolicyPeer) networkingv1.NetworkPolicyIngressRule {
+	return networkingv1.NetworkPolicyIngressRule{From: from}
+}
+
+func podSelectorPeer(kv ...string) networkingv1.NetworkPolicyPeer {
+	s := selector(kv...)
+	return networkingv1.NetworkPolicyPeer{PodSelector: &s}
+}
+
+func namespaceSelectorPeer(kv ...string) networkingv1.NetworkPolicyPeer {
+	s := selector(kv...)
+	return networkingv1.NetworkPolicyPeer{NamespaceSelector: &s}
+}
+
+func emptyNamespaceSelectorPeer() networkingv1.NetworkPolicyPeer {
+	return networkingv1.NetworkPolicyPeer{NamespaceSelector: &metav1.LabelSelector{}}
+}
+
+func ipBlockPeer(cidr string) networkingv1.NetworkPolicyPeer {
+	return networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: cidr}}
+}
+
+func TestIngressExposure_NoPolicySelectsPodIsOpen(t *testing.T) {
+	idx, _ := NewIndex(nil, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureOpen {
+		t.Errorf("Level = %v, want ExposureOpen", exposure.Level)
+	}
+}
+
+func TestIngressExposure_EmptyFromListIsOpen(t *testing.T) {
+	p := policy("ns", "allow-all", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule()}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureOpen {
+		t.Errorf("Level = %v, want ExposureOpen", exposure.Level)
+	}
+}
+
+func TestIngressExposure_IPBlockPeerIsExternalCIDR(t *testing.T) {
+	p := policy("ns", "allow-cidr", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(ipBlockPeer("0.0.0.0/0"))}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureExternalCIDR {
+		t.Errorf("Level = %v, want ExposureExternalCIDR", exposure.Level)
+	}
+	if exposure.MatchedPolicy != "ns/allow-cidr" {
+		t.Errorf("MatchedPolicy = %q, want ns/allow-cidr", exposure.MatchedPolicy)
+	}
+}
+
+func TestIngressExposure_EmptyNamespaceSelectorIsAnyNamespace(t *testing.T) {
+	p := policy("ns", "allow-any-ns", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(emptyNamespaceSelectorPeer())}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureAnyNamespace {
+		t.Errorf("Level = %v, want ExposureAnyNamespace", exposure.Level)
+	}
+}
+
+func TestIngressExposure_PodSelectorOnlyIsRestricted(t *testing.T) {
+	p := policy("ns", "allow-client", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(podSelectorPeer("app", "client"))}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureRestricted {
+		t.Errorf("Level = %v, want ExposureRestricted (podSelector alone never crosses namespaces)", exposure.Level)
+	}
+}
+
+func TestIngressExposure_NonEmptyNamespaceSelectorIsRestricted(t *testing.T) {
+	p := policy("ns", "allow-labeled-ns", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(namespaceSelectorPeer("team", "payments"))}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureRestricted {
+		t.Errorf("Level = %v, want ExposureRestricted", exposure.Level)
+	}
+}
+
+func TestIngressExposure_WidestAcrossMultipleRulesWins(t *testing.T) {
+	p := policy("ns", "mixed", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{
+			ingressRule(podSelectorPeer("app", "client")),
+			ingressRule(ipBlockPeer("10.0.0.0/8")),
+		}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureExternalCIDR {
+		t.Errorf("Level = %v, want ExposureExternalCIDR (the wider of the two rules)", exposure.Level)
+	}
+}
+
+func TestIngressExposure_WidestAcrossMultiplePoliciesWins(t *testing.T) {
+	restrictive := policy("ns", "restrictive", selector("app", "web"), []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(podSelectorPeer("app", "client"))}, nil)
+	open := policy("ns", "open", selector("app", "web"), []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule()}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{restrictive, open}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureOpen {
+		t.Errorf("Level = %v, want ExposureOpen: multiple policies selecting the same pod combine via OR, so the more permissive one wins", exposure.Level)
+	}
+}
+
+func TestIngressExposure_PolicyInAnotherNamespaceDoesNotApply(t *testing.T) {
+	p := policy("other-ns", "open", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule()}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureOpen {
+		t.Errorf("Level = %v, want ExposureOpen: no policy in ep's own namespace isolates it, so it is not isolated at all (default allow), regardless of what a policy in a different namespace says", exposure.Level)
+	}
+}
+
+func TestExposureLevel_String(t *testing.T) {
+	cases := map[ExposureLevel]string{
+		ExposureRestricted:   "restricted",
+		ExposureAnyNamespace: "any-namespace",
+		ExposureExternalCIDR: "external-cidr",
+		ExposureOpen:         "open",
+	}
+	for level, want := range cases {
+		if got := level.String(); got != want {
+			t.Errorf("%v.String() = %q, want %q", int(level), got, want)
+		}
+	}
+}

--- a/core/pkg/networkpolicy/exposure_test.go
+++ b/core/pkg/networkpolicy/exposure_test.go
@@ -108,6 +108,47 @@ func TestIngressExposure_NonEmptyNamespaceSelectorIsRestricted(t *testing.T) {
 	}
 }
 
+// TestIngressExposure_RestrictedResultStillNamesMatchedPolicy is the direct
+// regression test for the bug this fixes: ExposureRestricted is also
+// ExposureLevel's zero value, so a naive "level > best.Level" comparison
+// starting from a zero-valued best never fires for the common case (a
+// well-scoped policy), leaving MatchedPolicy empty even though a specific
+// policy caused the classification.
+func TestIngressExposure_RestrictedResultStillNamesMatchedPolicy(t *testing.T) {
+	p := policy("ns", "allow-client", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		[]networkingv1.NetworkPolicyIngressRule{ingressRule(podSelectorPeer("app", "client"))}, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureRestricted {
+		t.Fatalf("Level = %v, want ExposureRestricted", exposure.Level)
+	}
+	if exposure.MatchedPolicy != "ns/allow-client" {
+		t.Errorf("MatchedPolicy = %q, want \"ns/allow-client\": the responsible policy must be named even when the result is Restricted", exposure.MatchedPolicy)
+	}
+}
+
+// TestIngressExposure_PolicyWithNoIngressRulesStillNamesMatchedPolicy covers
+// the related edge case the same bug produced: a policy that isolates the
+// endpoint (Ingress is in policyTypes) but declares zero ingress rules at
+// all never enters the rule loop, so it needs its own explicit attribution.
+func TestIngressExposure_PolicyWithNoIngressRulesStillNamesMatchedPolicy(t *testing.T) {
+	p := policy("ns", "deny-all-no-rules", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil)
+	idx, _ := NewIndex([]*networkingv1.NetworkPolicy{p}, nil)
+	ep := Endpoint{Namespace: "ns", Name: "app", Labels: map[string]string{"app": "web"}}
+
+	exposure := idx.IngressExposure(ep)
+
+	if exposure.Level != ExposureRestricted {
+		t.Fatalf("Level = %v, want ExposureRestricted", exposure.Level)
+	}
+	if exposure.MatchedPolicy != "ns/deny-all-no-rules" {
+		t.Errorf("MatchedPolicy = %q, want \"ns/deny-all-no-rules\"", exposure.MatchedPolicy)
+	}
+}
+
 func TestIngressExposure_WidestAcrossMultipleRulesWins(t *testing.T) {
 	p := policy("ns", "mixed", metav1.LabelSelector{}, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		[]networkingv1.NetworkPolicyIngressRule{

--- a/core/pkg/vulnexposure/correlate.go
+++ b/core/pkg/vulnexposure/correlate.go
@@ -1,0 +1,164 @@
+// Package vulnexposure joins two capabilities that otherwise never speak to
+// each other in this repo: image vulnerability data (a workload's known
+// CVEs, sourced from an already-running in-cluster scanner via
+// VulnerabilityManifest objects) and NetworkPolicy ingress exposure (core/pkg
+// /networkpolicy). Neither, on its own, answers the question that actually
+// matters for prioritization: a critical, fixable CVE on a workload wide
+// open to the whole cluster is a materially different risk than the same CVE
+// on a workload no NetworkPolicy lets anything reach.
+package vulnexposure
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/networkpolicy"
+	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+// Severity is a coarse, ordered vulnerability severity, so callers can
+// filter/sort by a threshold without depending on grype's exact severity
+// string spelling or casing.
+type Severity int
+
+const (
+	SeverityUnknown Severity = iota
+	SeverityNegligible
+	SeverityLow
+	SeverityMedium
+	SeverityHigh
+	SeverityCritical
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityCritical:
+		return "Critical"
+	case SeverityHigh:
+		return "High"
+	case SeverityMedium:
+		return "Medium"
+	case SeverityLow:
+		return "Low"
+	case SeverityNegligible:
+		return "Negligible"
+	default:
+		return "Unknown"
+	}
+}
+
+// ParseSeverity converts a grype-style severity string to Severity,
+// case-insensitively. An unrecognized string (including empty) is
+// SeverityUnknown, not an error: a manifest with a severity grype has not
+// classified should not be silently dropped by a naive string comparison,
+// but it also should not be promoted above a real severity by accident, so
+// it sorts below every known level.
+func ParseSeverity(s string) Severity {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "critical":
+		return SeverityCritical
+	case "high":
+		return SeverityHigh
+	case "medium":
+		return SeverityMedium
+	case "low":
+		return SeverityLow
+	case "negligible":
+		return SeverityNegligible
+	default:
+		return SeverityUnknown
+	}
+}
+
+// Workload identifies one workload a VulnerabilityManifest was produced for.
+type Workload struct {
+	Namespace string
+	Kind      string
+	Name      string
+}
+
+// Finding is one (workload, vulnerability) pair worth surfacing, joined with
+// how exposed that workload's ingress is.
+type Finding struct {
+	Workload      Workload
+	Vulnerability storagev1beta1.VulnerabilityMetadata
+	// FixAvailable is true when grype reports a fixed version exists --
+	// worth carrying alongside severity, since a fixable critical CVE on an
+	// exposed workload is the most actionable class of finding this
+	// produces.
+	FixAvailable bool
+	Exposure     networkpolicy.Exposure
+}
+
+// exposureRank orders Finding.Exposure.Level the same way
+// networkpolicy.ExposureLevel's own int values already do (higher is more
+// exposed), kept as a named function so Correlate's sort reads by intent
+// rather than by the underlying type's representation.
+func exposureRank(e networkpolicy.Exposure) int {
+	return int(e.Level)
+}
+
+// Correlate joins each workload's known vulnerabilities (at or above
+// minSeverity) with its ingress exposure. A workload with vulnerabilities
+// but no entry in endpoints is skipped, not guessed at: this package never
+// assumes an exposure level for a workload it was not given a resolved
+// Endpoint for (e.g. because its kind could not be mapped to a concrete pod
+// template, or the live Get failed) -- see the "skipped" return for exactly
+// which workloads that happened to.
+//
+// Results are sorted most-actionable first: widest exposure, then highest
+// severity, then a stable ID/name tiebreak, so a caller displaying only the
+// top N never has to sort them itself.
+func Correlate(idx *networkpolicy.Index, endpoints map[Workload]networkpolicy.Endpoint, vulnerabilitiesByWorkload map[Workload][]storagev1beta1.Vulnerability, minSeverity Severity) (findings []Finding, skipped []Workload) {
+	for workload, vulns := range vulnerabilitiesByWorkload {
+		ep, ok := endpoints[workload]
+		if !ok {
+			skipped = append(skipped, workload)
+			continue
+		}
+
+		exposure := idx.IngressExposure(ep)
+		for _, v := range vulns {
+			if ParseSeverity(v.Severity) < minSeverity {
+				continue
+			}
+			findings = append(findings, Finding{
+				Workload:      workload,
+				Vulnerability: v.VulnerabilityMetadata,
+				FixAvailable:  len(v.Fix.Versions) > 0 && v.Fix.State == "fixed",
+				Exposure:      exposure,
+			})
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if ra, rb := exposureRank(a.Exposure), exposureRank(b.Exposure); ra != rb {
+			return ra > rb
+		}
+		if sa, sb := ParseSeverity(a.Vulnerability.Severity), ParseSeverity(b.Vulnerability.Severity); sa != sb {
+			return sa > sb
+		}
+		if a.Workload != b.Workload {
+			if a.Workload.Namespace != b.Workload.Namespace {
+				return a.Workload.Namespace < b.Workload.Namespace
+			}
+			if a.Workload.Kind != b.Workload.Kind {
+				return a.Workload.Kind < b.Workload.Kind
+			}
+			return a.Workload.Name < b.Workload.Name
+		}
+		return a.Vulnerability.ID < b.Vulnerability.ID
+	})
+	sort.Slice(skipped, func(i, j int) bool {
+		if skipped[i].Namespace != skipped[j].Namespace {
+			return skipped[i].Namespace < skipped[j].Namespace
+		}
+		if skipped[i].Kind != skipped[j].Kind {
+			return skipped[i].Kind < skipped[j].Kind
+		}
+		return skipped[i].Name < skipped[j].Name
+	})
+
+	return findings, skipped
+}

--- a/core/pkg/vulnexposure/correlate_test.go
+++ b/core/pkg/vulnexposure/correlate_test.go
@@ -1,0 +1,167 @@
+package vulnexposure
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/networkpolicy"
+	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func vuln(id, severity string, fixed bool) storagev1beta1.Vulnerability {
+	v := storagev1beta1.Vulnerability{
+		VulnerabilityMetadata: storagev1beta1.VulnerabilityMetadata{ID: id, Severity: severity},
+	}
+	if fixed {
+		v.Fix = storagev1beta1.Fix{Versions: []string{"1.2.4"}, State: "fixed"}
+	}
+	return v
+}
+
+func TestParseSeverity(t *testing.T) {
+	cases := map[string]Severity{
+		"Critical":   SeverityCritical,
+		"CRITICAL":   SeverityCritical,
+		"high":       SeverityHigh,
+		"Medium":     SeverityMedium,
+		"low":        SeverityLow,
+		"Negligible": SeverityNegligible,
+		"":           SeverityUnknown,
+		"garbage":    SeverityUnknown,
+	}
+	for input, want := range cases {
+		if got := ParseSeverity(input); got != want {
+			t.Errorf("ParseSeverity(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestSeverityOrdering(t *testing.T) {
+	ordered := []Severity{SeverityUnknown, SeverityNegligible, SeverityLow, SeverityMedium, SeverityHigh, SeverityCritical}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i] <= ordered[i-1] {
+			t.Fatalf("severity levels must strictly increase: %v is not greater than %v", ordered[i], ordered[i-1])
+		}
+	}
+}
+
+func openIndex(t *testing.T) *networkpolicy.Index {
+	t.Helper()
+	idx, errs := networkpolicy.NewIndex(nil, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	return idx
+}
+
+func TestCorrelate_SkipsWorkloadWithoutResolvedEndpoint(t *testing.T) {
+	idx := openIndex(t)
+	w := Workload{Namespace: "prod", Kind: "Deployment", Name: "web"}
+
+	findings, skipped := Correlate(idx, nil, map[Workload][]storagev1beta1.Vulnerability{
+		w: {vuln("CVE-1", "Critical", true)},
+	}, SeverityLow)
+
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for an unresolved workload, got %d", len(findings))
+	}
+	if len(skipped) != 1 || skipped[0] != w {
+		t.Errorf("expected %v in skipped, got %v", w, skipped)
+	}
+}
+
+func TestCorrelate_FiltersBelowMinSeverity(t *testing.T) {
+	idx := openIndex(t)
+	w := Workload{Namespace: "prod", Kind: "Deployment", Name: "web"}
+	endpoints := map[Workload]networkpolicy.Endpoint{
+		w: {Namespace: "prod", Name: "web", Labels: map[string]string{"app": "web"}},
+	}
+
+	findings, _ := Correlate(idx, endpoints, map[Workload][]storagev1beta1.Vulnerability{
+		w: {vuln("CVE-LOW", "Low", false), vuln("CVE-CRIT", "Critical", true)},
+	}, SeverityHigh)
+
+	if len(findings) != 1 || findings[0].Vulnerability.ID != "CVE-CRIT" {
+		t.Errorf("expected only CVE-CRIT to survive the High threshold, got %+v", findings)
+	}
+}
+
+func TestCorrelate_CarriesFixAvailable(t *testing.T) {
+	idx := openIndex(t)
+	w := Workload{Namespace: "prod", Kind: "Deployment", Name: "web"}
+	endpoints := map[Workload]networkpolicy.Endpoint{
+		w: {Namespace: "prod", Name: "web", Labels: map[string]string{"app": "web"}},
+	}
+
+	findings, _ := Correlate(idx, endpoints, map[Workload][]storagev1beta1.Vulnerability{
+		w: {vuln("CVE-FIXED", "Critical", true), vuln("CVE-UNFIXED", "Critical", false)},
+	}, SeverityLow)
+
+	byID := map[string]bool{}
+	for _, f := range findings {
+		byID[f.Vulnerability.ID] = f.FixAvailable
+	}
+	if !byID["CVE-FIXED"] {
+		t.Error("CVE-FIXED must have FixAvailable = true")
+	}
+	if byID["CVE-UNFIXED"] {
+		t.Error("CVE-UNFIXED must have FixAvailable = false")
+	}
+}
+
+func TestCorrelate_ExposureIsAttachedFromTheIndex(t *testing.T) {
+	// No NetworkPolicy at all selects this workload, so it must come back
+	// ExposureOpen -- proves Correlate actually calls into the real
+	// reachability model rather than a stub.
+	idx := openIndex(t)
+	w := Workload{Namespace: "prod", Kind: "Deployment", Name: "web"}
+	endpoints := map[Workload]networkpolicy.Endpoint{
+		w: {Namespace: "prod", Name: "web", Labels: map[string]string{"app": "web"}},
+	}
+
+	findings, _ := Correlate(idx, endpoints, map[Workload][]storagev1beta1.Vulnerability{
+		w: {vuln("CVE-1", "Critical", true)},
+	}, SeverityLow)
+
+	if len(findings) != 1 || findings[0].Exposure.Level != networkpolicy.ExposureOpen {
+		t.Errorf("expected ExposureOpen (no policy selects this workload), got %+v", findings)
+	}
+}
+
+func TestCorrelate_SortsWidestExposureAndHighestSeverityFirst(t *testing.T) {
+	restrictiveSel := metav1.LabelSelector{MatchLabels: map[string]string{"app": "restricted"}}
+	restrictivePolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "restrict"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: restrictiveSel,
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "client"}}}},
+			}},
+		},
+	}
+	idx, errs := networkpolicy.NewIndex([]*networkingv1.NetworkPolicy{restrictivePolicy}, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	openWorkload := Workload{Namespace: "prod", Kind: "Deployment", Name: "open-app"}
+	restrictedWorkload := Workload{Namespace: "prod", Kind: "Deployment", Name: "restricted-app"}
+	endpoints := map[Workload]networkpolicy.Endpoint{
+		openWorkload:       {Namespace: "prod", Name: "open-app", Labels: map[string]string{"app": "open"}},
+		restrictedWorkload: {Namespace: "prod", Name: "restricted-app", Labels: map[string]string{"app": "restricted"}},
+	}
+
+	findings, _ := Correlate(idx, endpoints, map[Workload][]storagev1beta1.Vulnerability{
+		openWorkload:       {vuln("CVE-OPEN", "Critical", true)},
+		restrictedWorkload: {vuln("CVE-RESTRICTED", "Critical", true)},
+	}, SeverityLow)
+
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	if findings[0].Vulnerability.ID != "CVE-OPEN" {
+		t.Errorf("expected the ExposureOpen workload's finding first, got %+v", findings[0])
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3631.

Kubescape's image vulnerability scanning (`VulnerabilityManifest` objects, produced by an already-running in-cluster scanner) and its NetworkPolicy reachability model (`core/pkg/networkpolicy`) never talked to each other. A critical, fixable CVE on a workload wide open to the whole cluster was indistinguishable, in every existing report, from the same CVE on a workload no NetworkPolicy lets anything reach.

## Changes

- **`core/pkg/networkpolicy/exposure.go`** -- `Index.IngressExposure` classifies the widest ingress source class any NetworkPolicy rule already admits for an endpoint: `open` (not isolated at all, or a rule with no `From` restriction), `external-cidr` (an `ipBlock` peer), `any-namespace` (an empty `namespaceSelector`), or `restricted` (everything else scoped). Unlike `Reaches` (which needs a specific candidate's real IP or a namespace's real labels), this only inspects the *shape* of the policy's own rules, so it's always fully determinable -- no `Unknown` case is needed here.
- **`core/pkg/vulnexposure`** (new package) -- pure correlation logic: joins a workload's known CVEs (filtered by a minimum severity threshold) with its `IngressExposure`, sorted most-actionable first (widest exposure, then highest severity). A workload with vulnerabilities but no resolved endpoint is skipped, never guessed at.
- **`analyze_vulnerability_exposure`** (new MCP tool) -- lists live `VulnerabilityManifest` objects (the same live data source `list_vulnerabilities_in_manifest` already reads), resolves each workload's pod-template labels live via its WLID (Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob/Pod -- other kinds are reported as skipped with a warning, not guessed at), builds a live `NetworkPolicy`/`Namespace`-backed `Index`, and returns each (workload, CVE) pair joined with its exposure classification.

## Test plan

- Unit tests for `IngressExposure` (`core/pkg/networkpolicy/exposure_test.go`): no-policy-is-open, empty-From-is-open, ipBlock, empty vs. non-empty namespaceSelector, podSelector-only-never-crosses-namespaces, widest-across-multiple-rules/policies wins, a policy in another namespace not applying.
- Unit tests for `Correlate` (`core/pkg/vulnexposure/correlate_test.go`): severity parsing/ordering, skip-unresolved-workload, severity filtering, fix-available carrying, real exposure attachment (not a stub), sort ordering.
- MCP-level tests exercising the real MCP JSON-RPC dispatch path against a fake dynamic client *and* a fake kubescape storage clientset (`storagefake.NewClientset`): open workload reported, restricted workload still reported but correctly labeled, min_severity filtering, invalid min_severity rejected, an unresolvable workload skipped with a warning (not fatal), an image-level manifest (no WLID) skipped, not fatal.
- `go build ./...`, `go vet ./...`, `go test -race` on the affected packages, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vulnerability exposure analysis for workloads, correlating vulnerabilities with network accessibility.
  * Reports exposure from restricted to open, including the determining policy and reason.
  * Supports minimum-severity filtering and indicates whether fixes are available.
  * Added warnings for skipped image-only findings, unresolved workloads, and incomplete data.
* **Bug Fixes**
  * Improved handling of workload and network policy edge cases for more accurate exposure results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->