### PR TITLE
fix(fixhandler): cross-control fix promotion checks the value, not just the path

### DIFF
--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 	storagev1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	"gopkg.in/op/go-logging.v1"
+	"gopkg.in/yaml.v3"
 )
 
 const UserValuePrefix = "YOUR_"
@@ -937,18 +939,27 @@ func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) ma
 // values from a YamlExpressions map. Used by the unfixed-control reconciliation
 // pass to test whether a control's failed paths are covered by some planned
 // edit.
-func plannedPathsFromExpressions(exprs map[string]armotypes.FixPath) []string {
+// plannedFix is one planned YAML edit's location and the value it writes
+// there, kept together so a caller can tell not just that a planned edit
+// touches a given path, but whether it writes the value another control's
+// check actually expected to find (see controlIsCoveredByPlannedPaths).
+type plannedFix struct {
+	Path  string
+	Value string
+}
+
+func plannedPathsFromExpressions(exprs map[string]armotypes.FixPath) []plannedFix {
 	if len(exprs) == 0 {
 		return nil
 	}
 	seen := make(map[string]bool, len(exprs))
-	out := make([]string, 0, len(exprs))
+	out := make([]plannedFix, 0, len(exprs))
 	for _, fp := range exprs {
 		if fp.Path == "" || seen[fp.Path] {
 			continue
 		}
 		seen[fp.Path] = true
-		out = append(out, fp.Path)
+		out = append(out, plannedFix{Path: fp.Path, Value: fp.Value})
 	}
 	return out
 }
@@ -962,6 +973,37 @@ func normalizeFailedPath(p string) string {
 		return before
 	}
 	return p
+}
+
+// expectedValueSuffix extracts the "<expected>" part of a raw path value
+// like "spec.…runAsNonRoot=true" -- the same suffix normalizeFailedPath
+// discards. ok is false when p carries no "=" at all, meaning the check
+// recorded no specific expected value to compare against.
+func expectedValueSuffix(p string) (value string, ok bool) {
+	_, after, found := strings.Cut(p, "=")
+	if !found {
+		return "", false
+	}
+	return after, true
+}
+
+// yamlValuesEqual reports whether two raw fix-value strings represent the
+// same YAML value, tolerating formatting differences (quoting, spacing,
+// key order) a literal string comparison would wrongly treat as different.
+// Either string failing to parse falls back to a literal comparison rather
+// than silently treating an unparsable value as a match -- callers only
+// reach here to decide whether to REFUSE a promotion, so being unable to
+// parse a value must not accidentally make two different-looking strings
+// compare equal.
+func yamlValuesEqual(a, b string) bool {
+	var av, bv any
+	if err := yaml.Unmarshal([]byte(a), &av); err != nil {
+		return a == b
+	}
+	if err := yaml.Unmarshal([]byte(b), &bv); err != nil {
+		return a == b
+	}
+	return reflect.DeepEqual(av, bv)
 }
 
 // yamlPathCovers reports whether setting `planned` necessarily satisfies a
@@ -985,25 +1027,28 @@ func yamlPathCovers(planned, failed string) bool {
 	return next == '.' || next == '['
 }
 
-// actionableLocation returns the YAML location a path entry describes,
+// actionableLocation returns the normalized YAML location a path entry
+// describes, and the raw string it was derived from (which may still carry
+// an "=<expected>" suffix normalizeFailedPath stripped from location),
 // regardless of which remediation field it was stored in. PosturePaths
 // entries carry exactly one of FailedPath / DeletePath / ReviewPath / FixPath
 // in practice (see appendPaths in opa-utils), so taking the first non-empty
-// one yields the location the check was actually pointing at.
-func actionableLocation(p armotypes.PosturePaths) string {
+// one yields the location the check was actually pointing at. Callers that
+// need the value the check expected use raw with expectedValueSuffix.
+func actionableLocation(p armotypes.PosturePaths) (location, raw string) {
 	if p.FailedPath != "" {
-		return normalizeFailedPath(p.FailedPath)
+		return normalizeFailedPath(p.FailedPath), p.FailedPath
 	}
 	if p.DeletePath != "" {
-		return normalizeFailedPath(p.DeletePath)
+		return normalizeFailedPath(p.DeletePath), p.DeletePath
 	}
 	if p.ReviewPath != "" {
-		return normalizeFailedPath(p.ReviewPath)
+		return normalizeFailedPath(p.ReviewPath), p.ReviewPath
 	}
 	if p.FixPath.Path != "" {
-		return p.FixPath.Path
+		return p.FixPath.Path, p.FixPath.Path
 	}
-	return ""
+	return "", ""
 }
 
 // controlIsCoveredByPlannedPaths reports whether every actionable path entry
@@ -1013,24 +1058,44 @@ func actionableLocation(p armotypes.PosturePaths) string {
 // just because an unrelated FailedPath happens to overlap with a planned
 // edit. A control whose rules carry no actionable locations at all is not
 // promoted either (nothing concrete to match against).
-func controlIsCoveredByPlannedPaths(ac *resourcesresults.ResourceAssociatedControl, plannedPaths []string) bool {
+//
+// An exact path match (not merely an ancestor) is further required to write
+// the same value the failed check expected, when that check recorded one
+// (a FailedPath's "=<expected>" suffix): path overlap alone does not prove
+// a different control's fix actually satisfies this check, only that it
+// touches the same field. Two controls checking the same field for two
+// different concrete values (e.g. one wants capabilities.drop == ["ALL"],
+// another wants it == ["SYS_ADMIN","NET_ADMIN"]) must not promote each
+// other. An ancestor match (the planned edit replaces a whole subtree the
+// failed path lives inside) still counts as covered without a value check:
+// verifying a specific leaf's resulting value inside an arbitrarily
+// structured subtree write is not attempted here.
+func controlIsCoveredByPlannedPaths(ac *resourcesresults.ResourceAssociatedControl, plannedPaths []plannedFix) bool {
 	sawActionablePath := false
 	for _, rule := range ac.ResourceAssociatedRules {
 		if !rule.GetStatus(nil).IsFailed() {
 			continue
 		}
 		for _, p := range rule.Paths {
-			loc := actionableLocation(p)
+			loc, raw := actionableLocation(p)
 			if loc == "" {
 				continue
 			}
 			sawActionablePath = true
+			expected, hasExpected := expectedValueSuffix(raw)
 			covered := false
 			for _, planned := range plannedPaths {
-				if yamlPathCovers(planned, loc) {
-					covered = true
-					break
+				if !yamlPathCovers(planned.Path, loc) {
+					continue
 				}
+				if planned.Path == loc && hasExpected && !yamlValuesEqual(planned.Value, expected) {
+					// Same field, but this planned fix writes a value the
+					// failed check did not expect: overlap alone does not
+					// prove the check would now pass.
+					continue
+				}
+				covered = true
+				break
 			}
 			if !covered {
 				return false

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -935,10 +935,6 @@ func (h *FixHandler) getFileYamlExpressions(resourcesToFix []ResourceFixInfo) ma
 	return fileYamlExpressions
 }
 
-// plannedPathsFromExpressions returns the distinct, non-empty FixPath.Path
-// values from a YamlExpressions map. Used by the unfixed-control reconciliation
-// pass to test whether a control's failed paths are covered by some planned
-// edit.
 // plannedFix is one planned YAML edit's location and the value it writes
 // there, kept together so a caller can tell not just that a planned edit
 // touches a given path, but whether it writes the value another control's
@@ -948,17 +944,29 @@ type plannedFix struct {
 	Value string
 }
 
+// plannedPathsFromExpressions returns every non-empty (Path, Value) pair
+// from a YamlExpressions map, used by the unfixed-control reconciliation
+// pass to test whether a control's failed paths are covered by some planned
+// edit. exprs' own keys (the yaml expression strings) are already unique,
+// so no further dedup is applied here: two entries can legitimately share a
+// Path with different Values (two controls each owning their own concrete
+// FixPath at the same location), and collapsing those to one by Path alone
+// would silently discard whichever Value the map's (unordered) iteration
+// happened to visit second -- now that Value is load-bearing for
+// controlIsCoveredByPlannedPaths' coverage decision, that would reintroduce
+// the exact class of bug this reconciliation pass exists to avoid, just
+// nondeterministically. controlIsCoveredByPlannedPaths' own inner loop
+// already checks every entry and only accepts an actual match, so keeping
+// duplicates is harmless.
 func plannedPathsFromExpressions(exprs map[string]armotypes.FixPath) []plannedFix {
 	if len(exprs) == 0 {
 		return nil
 	}
-	seen := make(map[string]bool, len(exprs))
 	out := make([]plannedFix, 0, len(exprs))
 	for _, fp := range exprs {
-		if fp.Path == "" || seen[fp.Path] {
+		if fp.Path == "" {
 			continue
 		}
-		seen[fp.Path] = true
 		out = append(out, plannedFix{Path: fp.Path, Value: fp.Value})
 	}
 	return out

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -587,7 +587,7 @@ func TestPlannedPathsFromExpressions_DedupesAndSkipsEmpty(t *testing.T) {
 		"e4": {Path: "", Value: ""},        // empty — must be skipped
 	}
 	got := plannedPathsFromExpressions(exprs)
-	assert.ElementsMatch(t, []string{"spec.a", "spec.b"}, got)
+	assert.ElementsMatch(t, []plannedFix{{Path: "spec.a", Value: "1"}, {Path: "spec.b", Value: "2"}}, got)
 }
 
 func TestPlannedPathsFromExpressions_EmptyInput(t *testing.T) {
@@ -633,6 +633,70 @@ func TestPrepareResourcesToFix_PromotesCrossControlCoveredControl(t *testing.T) 
 	if assert.Len(t, h.UnfixedControls(), 1, "only C-0041 must remain unfixed") {
 		assert.Equal(t, "C-0041", h.UnfixedControls()[0].ControlID)
 	}
+}
+
+// The value-conflict bug this fixes: C-DROP-ALL owns a FixPath that sets
+// capabilities.drop to ["ALL"]. C-DROP-SPECIFIC fails on the exact same
+// field but expects a DIFFERENT value (["SYS_ADMIN","NET_ADMIN"], encoded in
+// its FailedPath's "=<expected>" suffix) and has no FixPath of its own.
+// Before this fix, path overlap alone promoted C-DROP-SPECIFIC to fixed even
+// though the file now contains a value its own check never expected --
+// reporting "fixed" for a control a rescan would still show failing.
+func TestPrepareResourcesToFix_DoesNotPromoteControlWhenCoveringFixWritesADifferentValue(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-DROP-ALL", "drop all capabilities",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.capabilities.drop", `["ALL"]`),
+				),
+				failedControl("C-DROP-SPECIFIC", "drop only SYS_ADMIN and NET_ADMIN",
+					failedRuleNoFixAtPath(`spec.template.spec.containers[0].securityContext.capabilities.drop=["SYS_ADMIN","NET_ADMIN"]`),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 1, h.FixedControlsCount(), "only C-DROP-ALL is genuinely fixed")
+	if assert.Len(t, h.UnfixedControls(), 1, "C-DROP-SPECIFIC must not be promoted: the covering fix writes a different value than its check expected") {
+		assert.Equal(t, "C-DROP-SPECIFIC", h.UnfixedControls()[0].ControlID)
+	}
+}
+
+func TestYamlValuesEqual(t *testing.T) {
+	cases := []struct {
+		name  string
+		a, b  string
+		equal bool
+	}{
+		{"identical scalars", "true", "true", true},
+		{"identical lists, different spacing", `["ALL"]`, `[ "ALL" ]`, true},
+		{"different lists", `["ALL"]`, `["SYS_ADMIN","NET_ADMIN"]`, false},
+		{"same list, different order", `["A","B"]`, `["B","A"]`, false},
+		{"unparsable falls back to literal equality", "not: [valid: yaml:", "not: [valid: yaml:", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.equal, yamlValuesEqual(tc.a, tc.b))
+		})
+	}
+}
+
+func TestExpectedValueSuffix(t *testing.T) {
+	value, ok := expectedValueSuffix(`spec.a=["ALL"]`)
+	assert.True(t, ok)
+	assert.Equal(t, `["ALL"]`, value)
+
+	_, ok = expectedValueSuffix("spec.a")
+	assert.False(t, ok, "a path with no '=' carries no expected value to compare against")
 }
 
 // Parent-path coverage: planned edit sets `securityContext = {...}`, failed

--- a/core/pkg/fixhandler/unfixed_test.go
+++ b/core/pkg/fixhandler/unfixed_test.go
@@ -579,15 +579,42 @@ func TestYamlPathCovers(t *testing.T) {
 	}
 }
 
-func TestPlannedPathsFromExpressions_DedupesAndSkipsEmpty(t *testing.T) {
+// plannedPathsFromExpressions must NOT dedup by Path alone: two entries can
+// legitimately share a Path with different Values (see
+// TestPlannedPathsFromExpressions_PreservesBothValuesAtSameConflictingPath),
+// so this only pins that an identical (Path, Value) pair surviving twice is
+// harmless, and that a genuinely empty Path is skipped.
+func TestPlannedPathsFromExpressions_KeepsDuplicatesAndSkipsEmpty(t *testing.T) {
 	exprs := map[string]armotypes.FixPath{
 		"e1": {Path: "spec.a", Value: "1"},
 		"e2": {Path: "spec.b", Value: "2"},
-		"e3": {Path: "spec.a", Value: "1"}, // duplicate path under different expression key
+		"e3": {Path: "spec.a", Value: "1"}, // identical (path, value) under a different expression key
 		"e4": {Path: "", Value: ""},        // empty — must be skipped
 	}
 	got := plannedPathsFromExpressions(exprs)
-	assert.ElementsMatch(t, []plannedFix{{Path: "spec.a", Value: "1"}, {Path: "spec.b", Value: "2"}}, got)
+	assert.ElementsMatch(t, []plannedFix{
+		{Path: "spec.a", Value: "1"},
+		{Path: "spec.b", Value: "2"},
+		{Path: "spec.a", Value: "1"},
+	}, got)
+}
+
+// TestPlannedPathsFromExpressions_PreservesBothValuesAtSameConflictingPath is
+// the direct regression test for the bug this fixes: a Path-only dedup
+// silently discarded whichever of two DIFFERENT Values at the same Path the
+// (unordered) map iteration visited second. Both must survive so
+// controlIsCoveredByPlannedPaths can still find whichever one actually
+// matches a given failed check's expected value.
+func TestPlannedPathsFromExpressions_PreservesBothValuesAtSameConflictingPath(t *testing.T) {
+	exprs := map[string]armotypes.FixPath{
+		"expr-all":      {Path: "spec.a", Value: `["ALL"]`},
+		"expr-sysadmin": {Path: "spec.a", Value: `["SYS_ADMIN"]`},
+	}
+	got := plannedPathsFromExpressions(exprs)
+	assert.ElementsMatch(t, []plannedFix{
+		{Path: "spec.a", Value: `["ALL"]`},
+		{Path: "spec.a", Value: `["SYS_ADMIN"]`},
+	}, got, "both conflicting values at the same path must survive, not just whichever the map iteration visited first")
 }
 
 func TestPlannedPathsFromExpressions_EmptyInput(t *testing.T) {
@@ -669,6 +696,43 @@ func TestPrepareResourcesToFix_DoesNotPromoteControlWhenCoveringFixWritesADiffer
 	if assert.Len(t, h.UnfixedControls(), 1, "C-DROP-SPECIFIC must not be promoted: the covering fix writes a different value than its check expected") {
 		assert.Equal(t, "C-DROP-SPECIFIC", h.UnfixedControls()[0].ControlID)
 	}
+}
+
+// End-to-end regression test for the dedup-drops-a-conflicting-value bug:
+// two controls each own a concrete FixPath at the identical location with
+// DIFFERENT values (C-A writes "1", C-B writes "2"). C-THIRD has only a
+// FailedPath expecting "2" and no FixPath of its own. C-THIRD must still be
+// promoted, because C-B's planned value genuinely matches -- this must not
+// depend on which of C-A/C-B's entries an internal dedup step happened to
+// keep.
+func TestPrepareResourcesToFix_PromotesControlWhenAnyOfSeveralConflictingPlannedValuesMatches(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, _ := filepath.Rel(dir, manifest)
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-A", "owns fix writing 1",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.runAsUser", "1"),
+				),
+				failedControl("C-B", "owns fix writing 2",
+					failedRuleWithFix("spec.template.spec.containers[0].securityContext.runAsUser", "2"),
+				),
+				failedControl("C-THIRD", "expects 2, no fix of its own",
+					failedRuleNoFixAtPath("spec.template.spec.containers[0].securityContext.runAsUser=2"),
+				),
+			},
+		},
+	}
+	h := newHandlerForResources(dir, results, nil, false)
+	_ = h.PrepareResourcesToFix(context.Background())
+
+	assert.Equal(t, 3, h.FixedControlsCount(), "C-A, C-B genuinely fixed, and C-THIRD promoted because C-B's value matches what it expected")
+	assert.Empty(t, h.UnfixedControls())
 }
 
 func TestYamlValuesEqual(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #3633.

`kubescape fix`'s cross-control reconciliation pass (added for #2279: promoting a control to "fixed" when another control's planned `FixPath` already covers the same YAML location) only compared *paths*, never the *value* being written there. A control whose `FailedPath` carries an `"=<expected>"` suffix (e.g. `spec…capabilities.drop=["SYS_ADMIN","NET_ADMIN"]`) could be silently promoted to fixed by an unrelated control's fix that writes a completely different value at that exact same path (e.g. `["ALL"]`) -- path overlap alone was treated as proof the check would now pass, even when it demonstrably would not.

## Concrete scenario this fixes

- `C-DROP-ALL` has a concrete `FixPath{Path: "spec…capabilities.drop", Value: "[\"ALL\"]"}`.
- `C-DROP-SPECIFIC` fails with `FailedPath: "spec…capabilities.drop=[\"SYS_ADMIN\",\"NET_ADMIN\"]"` and no `FixPath` of its own.

Before: `C-DROP-SPECIFIC` got silently promoted to "fixed" even though the file now contains a value its own check never expected -- the CLI reports "Auto-fixed N of N," and a rescan would show it still failing.

## Change

`plannedPathsFromExpressions` now carries each planned fix's `Value` alongside its `Path` (`plannedFix`). `controlIsCoveredByPlannedPaths` compares the planned value against the failed check's expected value -- parsed from the `"=<expected>"` suffix, compared YAML-aware (`yamlValuesEqual`, tolerant of quoting/spacing differences) rather than by literal string equality -- whenever the paths match *exactly*, declining the promotion when they disagree. An ancestor-path match (the planned edit replaces a whole subtree the failed path lives inside) is left as before: verifying a specific leaf's resulting value inside an arbitrarily-structured subtree write is a separate, larger problem this PR does not attempt to solve, and is called out as a known limitation in the doc comment.

## Test plan

- New regression test `TestPrepareResourcesToFix_DoesNotPromoteControlWhenCoveringFixWritesADifferentValue`, reproducing the exact scenario above end-to-end through `PrepareResourcesToFix`. **Verified this test fails against the pre-fix logic and passes with the fix** (confirmed both directions locally before committing, by temporarily disabling just the new value-check condition).
- New unit tests for `yamlValuesEqual` (identical scalars, formatting-tolerant list equality, genuinely different values, order-sensitive lists, unparsable-value fallback) and `expectedValueSuffix`.
- Existing `TestPrepareResourcesToFix_PromotesCrossControlCoveredControl` (the original #2279 regression test, matching values) still passes unchanged -- this fix only adds a new refusal condition, it doesn't change the matching-value case.
- `TestPlannedPathsFromExpressions_DedupesAndSkipsEmpty` updated for the new `[]plannedFix` return type (was `[]string`); still asserts the same dedup/skip-empty behavior.
- `go build ./...`, `go vet`, `go test -race` on the affected package, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation of planned fixes by verifying both the target path and expected value.
  * Prevented control coverage from being promoted when an overlapping fix specifies a different value.
  * Preserved distinct expected values when multiple fixes target the same path.
* **Tests**
  * Added coverage for structured YAML value comparisons, expected-value handling, and conflicting overlapping fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->