### PR TITLE
feat(policy): scaffold custom Rego rules and refresh test fixtures from rule output

### DIFF
--- a/cmd/policy/init.go
+++ b/cmd/policy/init.go
@@ -1,0 +1,50 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/policytest"
+	"github.com/spf13/cobra"
+)
+
+func getPolicyInitCmd() *cobra.Command {
+	var opts policytest.ScaffoldOptions
+
+	cmd := &cobra.Command{
+		Use:   "init <path>",
+		Short: "Scaffold a custom Rego control with runnable test fixtures",
+		Long: fmt.Sprintf(`Creates a rule directory at <path> holding raw.rego, rule.metadata.json and two test cases (%s and %s), then records each case's evaluator output in its expected.json so 'policy test' passes straight away.
+
+The directory name becomes the rule name, and 'scan --custom-rules' picks it up from the parent directory.`,
+			"flagged", "clean"),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPolicyInit(cmd, args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Kind, "kind", "Deployment", fmt.Sprintf("Kubernetes kind the generated rule matches. Supported: %s", strings.Join(policytest.SupportedKinds(), ", ")))
+	cmd.Flags().StringVar(&opts.Description, "description", "", "Rule description recorded in rule.metadata.json")
+	cmd.Flags().StringVar(&opts.Remediation, "remediation", "", "Remediation text recorded in rule.metadata.json")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite an existing rule directory")
+
+	return cmd
+}
+
+func runPolicyInit(cmd *cobra.Command, path string, opts policytest.ScaffoldOptions) error {
+	files, err := policytest.Scaffold(context.Background(), path, opts)
+
+	out := cmd.OutOrStdout()
+	for _, file := range files {
+		fmt.Fprintf(out, "wrote %s\n", file)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "\nRun '%s policy test %s' to verify.\n", cmd.Root().Name(), path)
+
+	return nil
+}

--- a/cmd/policy/policy.go
+++ b/cmd/policy/policy.go
@@ -18,6 +18,15 @@ var policyCmdExamples = fmt.Sprintf(`
 
   # Run a single rule's test fixtures
   %[1]s policy test ./rules/my-custom-rule
+
+  # Scaffold a new rule, with fixtures that already pass
+  %[1]s policy init ./rules/no-privileged-containers
+
+  # Scaffold a rule matching a different kind
+  %[1]s policy init ./rules/no-privileged-pods --kind Pod
+
+  # Rewrite the fixtures' expected.json from the rule's current output
+  %[1]s policy test ./rules/my-custom-rule --update
 `, cautils.ExecName())
 
 func GetPolicyCmd() *cobra.Command {
@@ -28,6 +37,7 @@ func GetPolicyCmd() *cobra.Command {
 		Example: policyCmdExamples,
 	}
 
+	policyCmd.AddCommand(getPolicyInitCmd())
 	policyCmd.AddCommand(getPolicyTestCmd())
 
 	return policyCmd

--- a/cmd/policy/policy_test.go
+++ b/cmd/policy/policy_test.go
@@ -1,0 +1,98 @@
+package policy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := &cobra.Command{Use: "kubescape"}
+	root.AddCommand(GetPolicyCmd())
+
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	return out.String(), err
+}
+
+func TestPolicyInit_ScaffoldsRuleThatPassesTest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "no-privileged-containers")
+
+	out, err := runCmd(t, "policy", "init", dir)
+	require.NoError(t, err)
+	assert.Contains(t, out, "wrote")
+	assert.Contains(t, out, "raw.rego")
+	assert.Contains(t, out, "expected.json")
+
+	out, err = runCmd(t, "policy", "test", dir)
+	require.NoError(t, err)
+	assert.Contains(t, out, "2/2 cases passed")
+}
+
+func TestPolicyInit_HonoursKindFlag(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "no-privileged-pods")
+
+	_, err := runCmd(t, "policy", "init", dir, "--kind", "Pod")
+	require.NoError(t, err)
+
+	metadata, err := os.ReadFile(filepath.Join(dir, "rule.metadata.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(metadata), `"Pod"`)
+
+	_, err = runCmd(t, "policy", "test", dir)
+	require.NoError(t, err)
+}
+
+func TestPolicyInit_RejectsUnsupportedKind(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "check-service")
+
+	_, err := runCmd(t, "policy", "init", dir, "--kind", "Service")
+	require.ErrorContains(t, err, "unsupported kind")
+}
+
+func TestPolicyTestUpdate_RewritesExpectations(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "no-privileged-containers")
+	_, err := runCmd(t, "policy", "init", dir)
+	require.NoError(t, err)
+
+	expected := filepath.Join(dir, "test", "flagged", "expected.json")
+	require.NoError(t, os.WriteFile(expected, []byte("[]\n"), 0o600))
+
+	_, err = runCmd(t, "policy", "test", dir)
+	require.Error(t, err)
+
+	out, err := runCmd(t, "policy", "test", dir, "--update")
+	require.NoError(t, err)
+	assert.Contains(t, out, "UPDATED")
+	assert.Contains(t, out, "1 case(s) updated")
+
+	_, err = runCmd(t, "policy", "test", dir)
+	require.NoError(t, err)
+}
+
+func TestPolicyTestUpdate_IsIdempotent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "no-privileged-containers")
+	_, err := runCmd(t, "policy", "init", dir)
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "policy", "test", dir, "--update")
+	require.NoError(t, err)
+	assert.Contains(t, out, "UNCHANGED")
+	assert.Contains(t, out, "0 case(s) updated")
+}
+
+func TestPolicyTest_ReportsMissingRules(t *testing.T) {
+	_, err := runCmd(t, "policy", "test", t.TempDir())
+	require.ErrorContains(t, err, "no rule directories")
+}

--- a/cmd/policy/test.go
+++ b/cmd/policy/test.go
@@ -9,24 +9,75 @@ import (
 )
 
 func getPolicyTestCmd() *cobra.Command {
-	return &cobra.Command{
+	var update bool
+
+	cmd := &cobra.Command{
 		Use:   "test <path>",
 		Short: "Run a Rego control's test fixtures and report pass/fail",
 		Long:  `Discovers rule directories (raw.rego + rule.metadata.json, with test cases under test/<case>/{input,expected.json}) under <path>, evaluates every case, and reports which ones match their expected.json.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if update {
+				return runPolicyUpdate(cmd, args[0])
+			}
 			return runPolicyTest(cmd, args[0])
 		},
 	}
+
+	cmd.Flags().BoolVar(&update, "update", false, "Rewrite each case's expected.json from the rule's current output instead of comparing against it")
+
+	return cmd
+}
+
+func runPolicyUpdate(cmd *cobra.Command, path string) error {
+	rules, err := discoverRules(path)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	changed, failed := 0, 0
+	for _, rule := range rules {
+		if len(rule.Cases) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: no test cases\n", rule.Name)
+			continue
+		}
+		for _, result := range policytest.UpdateRule(ctx, rule) {
+			switch {
+			case result.Err != nil:
+				failed++
+				fmt.Fprintf(cmd.OutOrStdout(), "ERROR %s/%s: %v\n", result.RuleName, result.CaseName, result.Err)
+			case result.Changed:
+				changed++
+				fmt.Fprintf(cmd.OutOrStdout(), "UPDATED %s/%s\n", result.RuleName, result.CaseName)
+			default:
+				fmt.Fprintf(cmd.OutOrStdout(), "UNCHANGED %s/%s\n", result.RuleName, result.CaseName)
+			}
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%d case(s) updated\n", changed)
+	if failed > 0 {
+		return fmt.Errorf("%d test case(s) could not be evaluated", failed)
+	}
+	return nil
+}
+
+func discoverRules(path string) ([]policytest.RuleUnderTest, error) {
+	rules, err := policytest.DiscoverPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("discover rules: %w", err)
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("no rule directories (raw.rego + rule.metadata.json) found under %q", path)
+	}
+	return rules, nil
 }
 
 func runPolicyTest(cmd *cobra.Command, path string) error {
-	rules, err := policytest.DiscoverPath(path)
+	rules, err := discoverRules(path)
 	if err != nil {
-		return fmt.Errorf("discover rules: %w", err)
-	}
-	if len(rules) == 0 {
-		return fmt.Errorf("no rule directories (raw.rego + rule.metadata.json) found under %q", path)
+		return err
 	}
 
 	ctx := context.Background()

--- a/core/pkg/policytest/load.go
+++ b/core/pkg/policytest/load.go
@@ -42,13 +42,13 @@ func LoadCaseInput(dir string) ([]workloadinterface.IMetadata, error) {
 // LoadCaseExpected reads dir/expected.json as the RuleResponse list the rule
 // must produce for this case's input.
 func LoadCaseExpected(dir string) ([]reporthandling.RuleResponse, error) {
-	raw, err := os.ReadFile(filepath.Join(dir, "expected.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, expectedFileName))
 	if err != nil {
-		return nil, fmt.Errorf("read expected.json: %w", err)
+		return nil, fmt.Errorf("read %s: %w", expectedFileName, err)
 	}
 	var expected []reporthandling.RuleResponse
 	if err := json.Unmarshal(raw, &expected); err != nil {
-		return nil, fmt.Errorf("parse expected.json: %w", err)
+		return nil, fmt.Errorf("parse %s: %w", expectedFileName, err)
 	}
 	return expected, nil
 }

--- a/core/pkg/policytest/run.go
+++ b/core/pkg/policytest/run.go
@@ -3,10 +3,6 @@ package policytest
 import (
 	"context"
 	"fmt"
-
-	"github.com/kubescape/kubescape/v4/core/cautils"
-	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor"
-	"github.com/kubescape/opa-utils/resources"
 )
 
 // CaseResult is the outcome of running one test case.
@@ -33,23 +29,15 @@ func RunRule(ctx context.Context, rule RuleUnderTest) []CaseResult {
 func runCase(ctx context.Context, rule RuleUnderTest, c Case) CaseResult {
 	result := CaseResult{RuleName: rule.Name, CaseName: c.Name}
 
-	resourcesToScan, err := LoadCaseInput(c.Dir)
-	if err != nil {
-		result.Err = fmt.Errorf("load input: %w", err)
-		return result
-	}
 	expected, err := LoadCaseExpected(c.Dir)
 	if err != nil {
 		result.Err = fmt.Errorf("load expected: %w", err)
 		return result
 	}
 
-	sessionObj := cautils.NewOPASessionObjMock()
-	proc := opaprocessor.NewOPAProcessor(sessionObj, &resources.RegoDependenciesData{}, "", "", "", false, nil)
-
-	got, err := proc.EvaluateRule(ctx, &rule.Rule, resourcesToScan, rule.Name)
+	got, err := EvaluateCase(ctx, rule, c)
 	if err != nil {
-		result.Err = fmt.Errorf("evaluate rule: %w", err)
+		result.Err = err
 		return result
 	}
 

--- a/core/pkg/policytest/scaffold.go
+++ b/core/pkg/policytest/scaffold.go
@@ -1,0 +1,281 @@
+package policytest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/ruledir"
+)
+
+const (
+	flaggedCaseName = "flagged"
+	cleanCaseName   = "clean"
+	dirPerm         = 0o755
+	filePerm        = 0o644
+)
+
+var ruleNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// ScaffoldOptions configures the rule directory Scaffold writes.
+type ScaffoldOptions struct {
+	Kind        string
+	Description string
+	Remediation string
+	Force       bool
+}
+
+type workloadKind struct {
+	apiVersion     string
+	regoContainers string
+	failedPathBase string
+	manifest       func(name, containers string) string
+}
+
+var workloadKinds = map[string]workloadKind{
+	"Pod": {
+		apiVersion:     "v1",
+		regoContainers: "wl.spec.containers[i]",
+		failedPathBase: "spec.",
+		manifest: func(name, containers string) string {
+			return fmt.Sprintf("apiVersion: v1\nkind: Pod\nmetadata:\n  name: %s\n  namespace: default\nspec:\n  containers:\n%s", name, indentBlock(containers, 4))
+		},
+	},
+	"Deployment": {
+		apiVersion:     "apps/v1",
+		regoContainers: "wl.spec.template.spec.containers[i]",
+		failedPathBase: "spec.template.spec.",
+		manifest:       podTemplateManifest("apps/v1", "Deployment", ""),
+	},
+	"DaemonSet": {
+		apiVersion:     "apps/v1",
+		regoContainers: "wl.spec.template.spec.containers[i]",
+		failedPathBase: "spec.template.spec.",
+		manifest:       podTemplateManifest("apps/v1", "DaemonSet", ""),
+	},
+	"StatefulSet": {
+		apiVersion:     "apps/v1",
+		regoContainers: "wl.spec.template.spec.containers[i]",
+		failedPathBase: "spec.template.spec.",
+		manifest:       podTemplateManifest("apps/v1", "StatefulSet", "  serviceName: %s\n"),
+	},
+	"Job": {
+		apiVersion:     "batch/v1",
+		regoContainers: "wl.spec.template.spec.containers[i]",
+		failedPathBase: "spec.template.spec.",
+		manifest: func(name, containers string) string {
+			return fmt.Sprintf("apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: %s\n  namespace: default\nspec:\n  template:\n    spec:\n      restartPolicy: Never\n      containers:\n%s", name, indentBlock(containers, 8))
+		},
+	},
+	"CronJob": {
+		apiVersion:     "batch/v1",
+		regoContainers: "wl.spec.jobTemplate.spec.template.spec.containers[i]",
+		failedPathBase: "spec.jobTemplate.spec.template.spec.",
+		manifest: func(name, containers string) string {
+			return fmt.Sprintf("apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: %s\n  namespace: default\nspec:\n  schedule: \"0 * * * *\"\n  jobTemplate:\n    spec:\n      template:\n        spec:\n          restartPolicy: Never\n          containers:\n%s", name, indentBlock(containers, 12))
+		},
+	},
+}
+
+func podTemplateManifest(apiVersion, kind, extraSpec string) func(name, containers string) string {
+	return func(name, containers string) string {
+		extra := ""
+		if extraSpec != "" {
+			extra = fmt.Sprintf(extraSpec, name)
+		}
+		return fmt.Sprintf("apiVersion: %s\nkind: %s\nmetadata:\n  name: %s\n  namespace: default\nspec:\n%s  selector:\n    matchLabels:\n      app: %s\n  template:\n    metadata:\n      labels:\n        app: %s\n    spec:\n      containers:\n%s",
+			apiVersion, kind, name, extra, name, name, indentBlock(containers, 8))
+	}
+}
+
+// SupportedKinds returns the workload kinds Scaffold can target.
+func SupportedKinds() []string {
+	kinds := make([]string, 0, len(workloadKinds))
+	for kind := range workloadKinds {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+// Scaffold writes a rule directory at dir holding raw.rego, rule.metadata.json
+// and two test cases, then records each case's evaluator output in its
+// expected.json so the rule passes RunRule as generated. A case that cannot be
+// evaluated - one already in the directory with a malformed input, say - does
+// not stop the rest from being recorded: the returned paths are the files
+// written, sorted, alongside the joined errors for the cases that failed.
+func Scaffold(ctx context.Context, dir string, opts ScaffoldOptions) ([]string, error) {
+	name := filepath.Base(filepath.Clean(dir))
+	if !ruleNamePattern.MatchString(name) {
+		return nil, fmt.Errorf("rule name %q must be lowercase alphanumeric characters or '-', and start and end with an alphanumeric character", name)
+	}
+
+	kind := opts.Kind
+	if kind == "" {
+		kind = "Deployment"
+	}
+	template, ok := workloadKinds[kind]
+	if !ok {
+		return nil, fmt.Errorf("unsupported kind %q, supported: %s", kind, strings.Join(SupportedKinds(), ", "))
+	}
+
+	if !opts.Force && ruledir.Is(dir) {
+		return nil, fmt.Errorf("%q already holds a rule, use --force to overwrite", dir)
+	}
+
+	description := opts.Description
+	if description == "" {
+		description = fmt.Sprintf("fails when a %s runs a container with securityContext.privileged set to true", kind)
+	}
+	remediation := opts.Remediation
+	if remediation == "" {
+		remediation = "Remove securityContext.privileged from the container, or set it to false."
+	}
+
+	metadata, err := marshalMetadata(name, kind, description, remediation)
+	if err != nil {
+		return nil, err
+	}
+
+	files := map[string]string{
+		filepath.Join(dir, ruledir.RegoFileName):                              regoSource(kind, template),
+		filepath.Join(dir, ruledir.MetadataFileName):                          metadata,
+		filepath.Join(dir, "test", flaggedCaseName, "input", "resource.yaml"): template.manifest(name, containersBlock(true)),
+		filepath.Join(dir, "test", cleanCaseName, "input", "resource.yaml"):   template.manifest(name, containersBlock(false)),
+	}
+
+	written := make([]string, 0, len(files))
+	for path, content := range files {
+		if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+			return nil, fmt.Errorf("create %q: %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), filePerm); err != nil {
+			return nil, fmt.Errorf("write %q: %w", path, err)
+		}
+		written = append(written, path)
+	}
+
+	rules, err := DiscoverPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("discover scaffolded rule: %w", err)
+	}
+	if len(rules) != 1 {
+		return nil, fmt.Errorf("expected one rule directory at %q, found %d", dir, len(rules))
+	}
+
+	var errs []error
+	for _, c := range rules[0].Cases {
+		responses, err := EvaluateCase(ctx, rules[0], c)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("evaluate case %q: %w", c.Name, err))
+			continue
+		}
+		changed, err := WriteExpected(c, responses)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("case %q: %w", c.Name, err))
+			continue
+		}
+		if changed {
+			written = append(written, filepath.Join(c.Dir, expectedFileName))
+		}
+	}
+
+	sort.Strings(written)
+	return written, errors.Join(errs...)
+}
+
+type ruleMetadata struct {
+	Name             string              `json:"name"`
+	Attributes       map[string]any      `json:"attributes"`
+	RuleLanguage     string              `json:"ruleLanguage"`
+	Match            []ruleMetadataMatch `json:"match"`
+	RuleDependencies []any               `json:"ruleDependencies"`
+	Description      string              `json:"description"`
+	Remediation      string              `json:"remediation"`
+	RuleQuery        string              `json:"ruleQuery"`
+}
+
+type ruleMetadataMatch struct {
+	APIGroups   []string `json:"apiGroups"`
+	APIVersions []string `json:"apiVersions"`
+	Resources   []string `json:"resources"`
+}
+
+func marshalMetadata(name, kind, description, remediation string) (string, error) {
+	metadata := ruleMetadata{
+		Name:         name,
+		Attributes:   map[string]any{},
+		RuleLanguage: "Rego",
+		Match: []ruleMetadataMatch{{
+			APIGroups:   []string{"*"},
+			APIVersions: []string{"*"},
+			Resources:   []string{kind},
+		}},
+		RuleDependencies: []any{},
+		Description:      description,
+		Remediation:      remediation,
+		RuleQuery:        "armo_builtins",
+	}
+
+	encoded, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode %s: %w", ruledir.MetadataFileName, err)
+	}
+	return string(encoded) + "\n", nil
+}
+
+func regoSource(kind string, template workloadKind) string {
+	const source = `package armo_builtins
+
+import rego.v1
+
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "__KIND__"
+	container := __CONTAINERS__
+	container.securityContext.privileged == true
+
+	path := sprintf("__PATH_BASE__containers[%d].securityContext.privileged", [i])
+
+	msga := {
+		"alertMessage": sprintf("container %v in __KIND__ %v runs as privileged", [container.name, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+`
+
+	return strings.NewReplacer(
+		"__KIND__", kind,
+		"__CONTAINERS__", template.regoContainers,
+		"__PATH_BASE__", template.failedPathBase,
+	).Replace(source)
+}
+
+func containersBlock(privileged bool) string {
+	block := "- name: app\n  image: nginx:1.25\n"
+	if privileged {
+		block += "  securityContext:\n    privileged: true\n"
+	}
+	return block
+}
+
+func indentBlock(block string, spaces int) string {
+	pad := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimRight(block, "\n"), "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = pad + line
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/core/pkg/policytest/scaffold_test.go
+++ b/core/pkg/policytest/scaffold_test.go
@@ -1,0 +1,192 @@
+package policytest
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/ruledir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const extraCaseManifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extra
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: extra
+  template:
+    metadata:
+      labels:
+        app: extra
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25
+`
+
+func scaffoldRule(t *testing.T, name string, opts ScaffoldOptions) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	_, err := Scaffold(context.Background(), dir, opts)
+	require.NoError(t, err)
+	return dir
+}
+
+func TestScaffold_WritesRuleDirectory(t *testing.T) {
+	dir := scaffoldRule(t, "no-privileged-containers", ScaffoldOptions{})
+
+	assert.True(t, ruledir.Is(dir))
+	for _, rel := range []string{
+		ruledir.RegoFileName,
+		ruledir.MetadataFileName,
+		filepath.Join("test", "flagged", "input", "resource.yaml"),
+		filepath.Join("test", "clean", "input", "resource.yaml"),
+	} {
+		assert.FileExists(t, filepath.Join(dir, rel))
+	}
+
+	rule, ok, err := ruledir.Load(dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "no-privileged-containers", rule.Rule.Name)
+	assert.Equal(t, []string{"Deployment"}, rule.Rule.Match[0].Resources)
+	assert.Contains(t, rule.Rule.Rule, "package armo_builtins")
+}
+
+func TestScaffold_EverySupportedKindProducesPassingCases(t *testing.T) {
+	for _, kind := range SupportedKinds() {
+		t.Run(kind, func(t *testing.T) {
+			dir := scaffoldRule(t, "check-"+strings.ToLower(kind), ScaffoldOptions{Kind: kind})
+
+			rules, err := DiscoverPath(dir)
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+			require.Len(t, rules[0].Cases, 2)
+
+			ctx := context.Background()
+			for _, result := range UpdateRule(ctx, rules[0]) {
+				require.NoError(t, result.Err)
+			}
+
+			byCase := map[string][]byte{}
+			for _, c := range rules[0].Cases {
+				raw, err := os.ReadFile(filepath.Join(c.Dir, expectedFileName))
+				require.NoError(t, err)
+				byCase[c.Name] = raw
+			}
+
+			var flagged, clean []map[string]any
+			require.NoError(t, json.Unmarshal(byCase[flaggedCaseName], &flagged))
+			require.NoError(t, json.Unmarshal(byCase[cleanCaseName], &clean))
+			assert.Len(t, flagged, 1, "the flagged fixture must trigger the rule")
+			assert.Empty(t, clean, "the clean fixture must not trigger the rule")
+
+			for _, result := range RunRule(ctx, rules[0]) {
+				require.NoError(t, result.Err)
+				assert.True(t, result.Passed, result.Diff)
+			}
+		})
+	}
+}
+
+func TestScaffold_RejectsInvalidName(t *testing.T) {
+	_, err := Scaffold(context.Background(), filepath.Join(t.TempDir(), "Bad_Name"), ScaffoldOptions{})
+	require.ErrorContains(t, err, "must be lowercase alphanumeric")
+}
+
+func TestScaffold_RejectsUnsupportedKind(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "check-service")
+	_, err := Scaffold(context.Background(), dir, ScaffoldOptions{Kind: "Service"})
+	require.ErrorContains(t, err, "unsupported kind")
+	assert.NoDirExists(t, dir, "nothing should be written when the kind is rejected")
+}
+
+func TestScaffold_RefusesExistingRuleWithoutForce(t *testing.T) {
+	dir := scaffoldRule(t, "already-here", ScaffoldOptions{})
+
+	_, err := Scaffold(context.Background(), dir, ScaffoldOptions{})
+	require.ErrorContains(t, err, "--force")
+
+	_, err = Scaffold(context.Background(), dir, ScaffoldOptions{Force: true})
+	require.NoError(t, err)
+}
+
+func TestScaffold_UsesSuppliedDescriptionAndRemediation(t *testing.T) {
+	dir := scaffoldRule(t, "custom-text", ScaffoldOptions{
+		Description: "fails when the workload is bad",
+		Remediation: "make it good",
+	})
+
+	rule, ok, err := ruledir.Load(dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "fails when the workload is bad", rule.Rule.Description)
+	assert.Equal(t, "make it good", rule.Rule.Remediation)
+}
+
+func TestScaffold_ForceReportsOnlyTheFilesItRewrote(t *testing.T) {
+	dir := scaffoldRule(t, "force-target", ScaffoldOptions{})
+
+	extraCase := filepath.Join(dir, "test", "extra", "input")
+	require.NoError(t, os.MkdirAll(extraCase, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(extraCase, "resource.yaml"), []byte(extraCaseManifest), 0o600))
+
+	first, err := Scaffold(context.Background(), dir, ScaffoldOptions{Force: true})
+	require.NoError(t, err)
+	extraExpected := filepath.Join(dir, "test", "extra", expectedFileName)
+	assert.Contains(t, first, extraExpected, "a newly written expectation must be reported")
+
+	second, err := Scaffold(context.Background(), dir, ScaffoldOptions{Force: true})
+	require.NoError(t, err)
+	assert.NotContains(t, second, extraExpected, "an expectation left untouched must not be reported as written")
+}
+
+func TestScaffold_UnevaluableCaseDoesNotStopTheGeneratedOnes(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "my-rule")
+	brokenInput := filepath.Join(dir, "test", "broken", "input")
+	require.NoError(t, os.MkdirAll(brokenInput, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(brokenInput, "bad.yaml"), []byte("this: [is: not valid yaml\n"), 0o600))
+
+	files, err := Scaffold(context.Background(), dir, ScaffoldOptions{})
+	require.ErrorContains(t, err, `evaluate case "broken"`)
+
+	for _, name := range []string{flaggedCaseName, cleanCaseName} {
+		expected := filepath.Join(dir, "test", name, expectedFileName)
+		assert.FileExists(t, expected, "the generated cases must still be recorded")
+		assert.Contains(t, files, expected)
+	}
+
+	rules, err := DiscoverPath(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+
+	for _, result := range RunRule(context.Background(), rules[0]) {
+		if result.CaseName == "broken" {
+			continue
+		}
+		require.NoError(t, result.Err)
+		assert.True(t, result.Passed, result.Diff)
+	}
+}
+
+func TestScaffold_ReportsEveryUnevaluableCase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "my-rule")
+	for _, name := range []string{"broken-one", "broken-two"} {
+		input := filepath.Join(dir, "test", name, "input")
+		require.NoError(t, os.MkdirAll(input, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(input, "bad.yaml"), []byte("bad: [yaml\n"), 0o600))
+	}
+
+	_, err := Scaffold(context.Background(), dir, ScaffoldOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken-one")
+	assert.Contains(t, err.Error(), "broken-two")
+}

--- a/core/pkg/policytest/update.go
+++ b/core/pkg/policytest/update.go
@@ -1,0 +1,91 @@
+package policytest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/resources"
+)
+
+const expectedFileName = "expected.json"
+
+// UpdateResult is the outcome of regenerating one case's expected.json.
+type UpdateResult struct {
+	RuleName string
+	CaseName string
+	Changed  bool
+	Err      error
+}
+
+// EvaluateCase runs rule against the case input and returns the responses the
+// evaluator produced. It does not read expected.json, so it works for a case
+// that does not have one yet.
+func EvaluateCase(ctx context.Context, rule RuleUnderTest, c Case) ([]reporthandling.RuleResponse, error) {
+	resourcesToScan, err := LoadCaseInput(c.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("load input: %w", err)
+	}
+
+	sessionObj := cautils.NewOPASessionObjMock()
+	proc := opaprocessor.NewOPAProcessor(sessionObj, &resources.RegoDependenciesData{}, "", "", "", false, nil)
+
+	got, err := proc.EvaluateRule(ctx, &rule.Rule, resourcesToScan, rule.Name)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate rule: %w", err)
+	}
+	return got, nil
+}
+
+// WriteExpected writes responses to the case's expected.json and reports
+// whether it rewrote the file. A file the rule already satisfies is left
+// untouched: equality here is the same comparison RunRule applies, so a fixture
+// that differs only in field order, path order or an omitted empty list is not
+// rewritten for cosmetic reasons.
+func WriteExpected(c Case, responses []reporthandling.RuleResponse) (bool, error) {
+	if responses == nil {
+		responses = []reporthandling.RuleResponse{}
+	}
+
+	if existing, err := LoadCaseExpected(c.Dir); err == nil && Compare(responses, existing) == "" {
+		return false, nil
+	}
+
+	encoded, err := json.MarshalIndent(responses, "", "    ")
+	if err != nil {
+		return false, fmt.Errorf("encode responses: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	path := filepath.Join(c.Dir, expectedFileName)
+	if err := os.WriteFile(path, encoded, filePerm); err != nil {
+		return false, fmt.Errorf("write %s: %w", expectedFileName, err)
+	}
+	return true, nil
+}
+
+// UpdateRule regenerates expected.json for every case under rule.
+func UpdateRule(ctx context.Context, rule RuleUnderTest) []UpdateResult {
+	results := make([]UpdateResult, 0, len(rule.Cases))
+	for _, c := range rule.Cases {
+		result := UpdateResult{RuleName: rule.Name, CaseName: c.Name}
+
+		responses, err := EvaluateCase(ctx, rule, c)
+		if err != nil {
+			result.Err = err
+			results = append(results, result)
+			continue
+		}
+
+		changed, err := WriteExpected(c, responses)
+		result.Changed = changed
+		result.Err = err
+		results = append(results, result)
+	}
+	return results
+}

--- a/core/pkg/policytest/update_test.go
+++ b/core/pkg/policytest/update_test.go
@@ -1,0 +1,161 @@
+package policytest
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func scaffoldedRuleUnderTest(t *testing.T) RuleUnderTest {
+	t.Helper()
+	dir := scaffoldRule(t, "update-target", ScaffoldOptions{})
+	rules, err := DiscoverPath(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	return rules[0]
+}
+
+func caseByName(t *testing.T, rule RuleUnderTest, name string) Case {
+	t.Helper()
+	for _, c := range rule.Cases {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("case %q not found", name)
+	return Case{}
+}
+
+func TestEvaluateCase_DoesNotRequireExpectedFile(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, flaggedCaseName)
+	require.NoError(t, os.Remove(filepath.Join(c.Dir, expectedFileName)))
+
+	responses, err := EvaluateCase(context.Background(), rule, c)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+}
+
+func TestWriteExpected_ReportsChangeOnlyWhenContentDiffers(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, flaggedCaseName)
+
+	responses, err := EvaluateCase(context.Background(), rule, c)
+	require.NoError(t, err)
+
+	changed, err := WriteExpected(c, responses)
+	require.NoError(t, err)
+	assert.False(t, changed, "Scaffold already recorded the evaluator's output")
+
+	require.NoError(t, os.WriteFile(filepath.Join(c.Dir, expectedFileName), []byte("[]\n"), 0o600))
+	changed, err = WriteExpected(c, responses)
+	require.NoError(t, err)
+	assert.True(t, changed)
+}
+
+func TestWriteExpected_CreatesMissingFileWithEmptyList(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, cleanCaseName)
+	path := filepath.Join(c.Dir, expectedFileName)
+	require.NoError(t, os.Remove(path))
+
+	changed, err := WriteExpected(c, nil)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", string(raw))
+}
+
+func TestUpdateRule_RepairsBrokenExpectations(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, flaggedCaseName)
+	require.NoError(t, os.WriteFile(filepath.Join(c.Dir, expectedFileName), []byte("[]\n"), 0o600))
+
+	for _, result := range RunRule(context.Background(), rule) {
+		if result.CaseName == flaggedCaseName {
+			require.False(t, result.Passed, "precondition: the case must be failing")
+		}
+	}
+
+	changedCases := map[string]bool{}
+	for _, result := range UpdateRule(context.Background(), rule) {
+		require.NoError(t, result.Err)
+		changedCases[result.CaseName] = result.Changed
+	}
+	assert.True(t, changedCases[flaggedCaseName])
+	assert.False(t, changedCases[cleanCaseName])
+
+	for _, result := range RunRule(context.Background(), rule) {
+		require.NoError(t, result.Err)
+		assert.True(t, result.Passed, result.Diff)
+	}
+}
+
+func TestUpdateRule_ReportsEvaluationFailure(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	rule.Rule.Rule = "package armo_builtins\nthis is not valid rego {{{"
+
+	results := UpdateRule(context.Background(), rule)
+	require.NotEmpty(t, results)
+	for _, result := range results {
+		assert.Error(t, result.Err)
+		assert.False(t, result.Changed)
+	}
+}
+
+func TestWriteExpected_OutputRoundTripsThroughLoad(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, flaggedCaseName)
+
+	responses, err := EvaluateCase(context.Background(), rule, c)
+	require.NoError(t, err)
+	_, err = WriteExpected(c, responses)
+	require.NoError(t, err)
+
+	loaded, err := LoadCaseExpected(c.Dir)
+	require.NoError(t, err)
+	assert.Empty(t, Compare(responses, loaded))
+	assert.IsType(t, []reporthandling.RuleResponse{}, loaded)
+}
+
+func TestWriteExpected_LeavesCosmeticallyDifferentFixtureAlone(t *testing.T) {
+	rule := scaffoldedRuleUnderTest(t)
+	c := caseByName(t, rule, flaggedCaseName)
+
+	responses, err := EvaluateCase(context.Background(), rule, c)
+	require.NoError(t, err)
+
+	compact, err := json.Marshal(responses)
+	require.NoError(t, err)
+	path := filepath.Join(c.Dir, expectedFileName)
+	require.NoError(t, os.WriteFile(path, compact, 0o600))
+
+	changed, err := WriteExpected(c, responses)
+	require.NoError(t, err)
+	assert.False(t, changed, "a semantically equal fixture must not be rewritten")
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(compact), string(raw), "the file must be left byte-for-byte alone")
+}
+
+func TestUpdateRule_IsNoOpForInTreeRules(t *testing.T) {
+	rules, err := Discover(rulesRoot(t))
+	require.NoError(t, err)
+	require.NotEmpty(t, rules)
+
+	for _, rule := range rules {
+		for _, result := range UpdateRule(context.Background(), rule) {
+			require.NoError(t, result.Err)
+			assert.False(t, result.Changed, "%s/%s: committed fixture must not be rewritten", result.RuleName, result.CaseName)
+		}
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -190,6 +190,31 @@ kubescape policy test ./myrules
 kubescape scan ./manifests --custom-rules ./myrules
 ```
 
+`kubescape policy init` writes that layout for you, including a flagged and a
+clean test case whose `expected.json` already matches the generated rule, so the
+new rule passes `policy test` before you start editing it:
+
+```bash
+kubescape policy init ./myrules/no-privileged-containers
+kubescape policy init ./myrules/no-privileged-pods --kind Pod
+```
+
+`--kind` selects the workload the generated rule matches (`CronJob`,
+`DaemonSet`, `Deployment`, `Job`, `Pod`, `StatefulSet`; default `Deployment`),
+and `--description`, `--remediation` and `--force` set the metadata text and
+allow overwriting an existing rule directory.
+
+Once you change the rule, `--update` rewrites each case's `expected.json` from
+the rule's current output instead of comparing against it, which saves
+hand-writing the matched object into the fixture:
+
+```bash
+kubescape policy test ./myrules --update
+```
+
+Review the resulting diff before committing it: `--update` records whatever the
+rule currently produces, so it will happily bless a regression.
+
 Pass either the parent directory or a single rule directory. The metadata
 supplies the rule's name, description, remediation and `match` selectors, so the
 rule is only evaluated against the kinds it targets.


### PR DESCRIPTION
## Summary

- `policy` is described as "author and test custom Rego controls" but only shipped `test`, so authoring meant hand-writing `raw.rego`, `rule.metadata.json`, and an `expected.json` that embeds the whole matched object.
- Adds `policy init <path>`, which writes the rule directory plus a flagged and a clean case, then records the evaluator's own output so the rule passes `policy test` as generated.
- Adds `policy test --update` to rewrite each case's `expected.json` from the rule's current output, the usual golden-file workflow.
- `--kind` covers Pod, Deployment, DaemonSet, StatefulSet, Job and CronJob; `--description`, `--remediation` and `--force` fill in the metadata or overwrite an existing rule.
- `--update` only rewrites a fixture the rule no longer satisfies, using the same comparison `policy test` applies, so it is a no-op across the 105 fixtures already in `rules/`.
- Covered by `TestScaffold_EverySupportedKindProducesPassingCases`, `TestUpdateRule_IsNoOpForInTreeRules` and `TestScaffold_UnevaluableCaseDoesNotStopTheGeneratedOnes`.

**Which issue(s) this PR fixes:**
None, found while working in `cmd/policy`.

**Special notes for your reviewer:**
The generated rule flags privileged containers; it is meant as a starting point to edit, not a control worth shipping. Scaffolding lives in `policytest` because it reuses the evaluator to record expectations, which is also why `init` on a directory with an unrelated broken case still writes the cases it owns and reports the failures rather than aborting.

**Does this PR introduce a user-facing change?**
Yes new `kubescape policy init` command and a `--update` flag on `kubescape policy test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `policy init` to generate custom policy rule directories with metadata and test fixtures.
  * Added options for workload kind, description, remediation, and controlled overwriting.
  * Added `policy test --update` to regenerate expected test outputs and report changes or errors.

* **Documentation**
  * Updated CLI reference and help examples with the new commands, options, supported workload kinds, and overwrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->