### PR TITLE
feat(printer): add github-actions output format for inline PR annotations

### DIFF
--- a/cmd/scan/scan_test.go
+++ b/cmd/scan/scan_test.go
@@ -479,7 +479,7 @@ func TestGetScanCommand_RunE_FormatFlagInvalid(t *testing.T) {
 	require.NoError(t, cmd.PersistentFlags().Set("format", "xml"))
 
 	err := cmd.RunE(cmd, []string{"."})
-	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, yaml, csv, markdown, cyclonedx-json, spdx-json, policyreport, exceptions"
+	errMessage := "invalid format \"xml\", supported formats: pretty-printer, json, junit, prometheus, pdf, html, sarif, gitlab-sast, github-actions, yaml, csv, markdown, cyclonedx-json, spdx-json, policyreport, exceptions"
 	assert.EqualError(t, err, errMessage)
 }
 

--- a/core/pkg/resultshandling/printer/printresults.go
+++ b/core/pkg/resultshandling/printer/printresults.go
@@ -16,25 +16,26 @@ import (
 var INDENT = "   "
 
 const (
-	PrettyFormat       string = "pretty-printer"
-	JsonFormat         string = "json"
-	JunitResultFormat  string = "junit"
-	PrometheusFormat   string = "prometheus"
-	PdfFormat          string = "pdf"
-	HtmlFormat         string = "html"
-	SARIFFormat        string = "sarif"
-	GitLabSASTFormat   string = "gitlab-sast"
-	YamlFormat         string = "yaml"
-	CsvFormat          string = "csv"
-	MarkdownFormat     string = "markdown"
-	CycloneDXFormat    string = "cyclonedx-json"
-	SPDXFormat         string = "spdx-json"
-	PolicyReportFormat string = "policyreport"
-	ExceptionsFormat   string = "exceptions"
+	PrettyFormat        string = "pretty-printer"
+	JsonFormat          string = "json"
+	JunitResultFormat   string = "junit"
+	PrometheusFormat    string = "prometheus"
+	PdfFormat           string = "pdf"
+	HtmlFormat          string = "html"
+	SARIFFormat         string = "sarif"
+	GitLabSASTFormat    string = "gitlab-sast"
+	GitHubActionsFormat string = "github-actions"
+	YamlFormat          string = "yaml"
+	CsvFormat           string = "csv"
+	MarkdownFormat      string = "markdown"
+	CycloneDXFormat     string = "cyclonedx-json"
+	SPDXFormat          string = "spdx-json"
+	PolicyReportFormat  string = "policyreport"
+	ExceptionsFormat    string = "exceptions"
 )
 
 // AllFormats lists every output format kubescape can emit.
-var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat, PolicyReportFormat, ExceptionsFormat}
+var AllFormats = []string{PrettyFormat, JsonFormat, JunitResultFormat, PrometheusFormat, PdfFormat, HtmlFormat, SARIFFormat, GitLabSASTFormat, GitHubActionsFormat, YamlFormat, CsvFormat, MarkdownFormat, CycloneDXFormat, SPDXFormat, PolicyReportFormat, ExceptionsFormat}
 
 // ImageFormats lists formats whose printers support image-scan data. CSV is
 // deliberately excluded: CsvPrinter.ActionPrint requires opaSessionObj and
@@ -60,6 +61,7 @@ const (
 	SPDXOutputExt         = ".spdx.json"
 	PolicyReportOutputExt = ".yaml"
 	ExceptionsOutputExt   = ".exceptions.json"
+	GitHubActionsOutExt   = ".txt"
 )
 
 // HasOutputExt reports whether outputFile already ends with ext, compared
@@ -114,21 +116,22 @@ func ResolveDefaultOutputFile(format, defaultBaseName string) string {
 // than re-deriving it, so a format can never resolve to a path its printer
 // does not write. Every entry in AllFormats is covered.
 var FormatOutputExt = map[string]string{
-	PrettyFormat:       PrettyOutputExt,
-	JsonFormat:         JsonOutputExt,
-	JunitResultFormat:  JunitOutputExt,
-	PrometheusFormat:   PrometheusOutputExt,
-	PdfFormat:          PdfOutputExt,
-	HtmlFormat:         HtmlOutputExt,
-	SARIFFormat:        SARIFOutputExt,
-	GitLabSASTFormat:   JsonOutputExt,
-	YamlFormat:         YamlOutputExt,
-	CsvFormat:          CsvOutputExt,
-	MarkdownFormat:     MarkdownOutputExt,
-	CycloneDXFormat:    CycloneDXOutputExt,
-	SPDXFormat:         SPDXOutputExt,
-	PolicyReportFormat: PolicyReportOutputExt,
-	ExceptionsFormat:   ExceptionsOutputExt,
+	PrettyFormat:        PrettyOutputExt,
+	JsonFormat:          JsonOutputExt,
+	JunitResultFormat:   JunitOutputExt,
+	PrometheusFormat:    PrometheusOutputExt,
+	PdfFormat:           PdfOutputExt,
+	HtmlFormat:          HtmlOutputExt,
+	SARIFFormat:         SARIFOutputExt,
+	GitLabSASTFormat:    JsonOutputExt,
+	YamlFormat:          YamlOutputExt,
+	CsvFormat:           CsvOutputExt,
+	MarkdownFormat:      MarkdownOutputExt,
+	CycloneDXFormat:     CycloneDXOutputExt,
+	SPDXFormat:          SPDXOutputExt,
+	PolicyReportFormat:  PolicyReportOutputExt,
+	ExceptionsFormat:    ExceptionsOutputExt,
+	GitHubActionsFormat: GitHubActionsOutExt,
 }
 
 type IPrinter interface {

--- a/core/pkg/resultshandling/printer/v2/githubactionsprinter.go
+++ b/core/pkg/resultshandling/printer/v2/githubactionsprinter.go
@@ -1,0 +1,235 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+const (
+	githubActionsOutputFile = "github-actions"
+
+	// githubActionsMaxAnnotations mirrors the GitHub Actions runner's per-step
+	// cap: at most 10 error annotations are rendered per step and the rest are
+	// silently dropped, so emitting more would lose findings invisibly.
+	githubActionsMaxAnnotations = 10
+)
+
+var _ printer.IPrinter = &GitHubActionsPrinter{}
+
+// GitHubActionsPrinter emits failed High and Critical controls as GitHub
+// Actions workflow commands (::error file=...,line=...::message), which the
+// runner renders as inline annotations on the pull request. Unlike SARIF
+// code-scanning, annotations require no GitHub Advanced Security license and
+// work on private repositories. Findings without a repository-relative
+// manifest path cannot be anchored to a PR line and are skipped with a
+// warning, following the same rules as the GitLab SAST printer.
+type GitHubActionsPrinter struct {
+	writer *os.File
+}
+
+func NewGitHubActionsPrinter() *GitHubActionsPrinter {
+	return &GitHubActionsPrinter{}
+}
+
+// Score is a no-op: workflow commands carry no aggregate score.
+func (gp *GitHubActionsPrinter) Score(float32) {}
+
+// PrintNextSteps is a no-op: annotations are consumed by the Actions runner,
+// not read by a human at the terminal.
+func (gp *GitHubActionsPrinter) PrintNextSteps() {}
+
+// SetWriter defaults to stdout — the Actions runner parses workflow commands
+// from the step's log, so writing there is what makes annotations zero-config
+// — and honors an explicit --output path for users who want to cat the file in
+// a later step.
+func (gp *GitHubActionsPrinter) SetWriter(ctx context.Context, outputFile string) error {
+	outputFile, explicitOutput := printer.ResolveOutputFile(printer.GitHubActionsFormat, outputFile, githubActionsOutputFile)
+	if explicitOutput {
+		var err error
+		gp.writer, err = printer.GetWriterNoFallback(outputFile)
+		return err
+	}
+	gp.writer = printer.GetWriter(ctx, outputFile)
+	return nil
+}
+
+// ActionPrint writes failed High/Critical controls as workflow commands. Only
+// configuration scans are supported: image findings have no manifest location
+// to anchor an annotation to.
+func (gp *GitHubActionsPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	if opaSessionObj == nil {
+		return fmt.Errorf("github-actions output is only supported for configuration scanning: image findings have no manifest location to annotate")
+	}
+
+	annotations, belowThreshold := gp.collectAnnotations(ctx, opaSessionObj)
+
+	// Critical before High, then stable ControlID/ResourceID order, so the
+	// ten most severe findings are the ones that survive the runner's cap.
+	sort.SliceStable(annotations, func(i, j int) bool {
+		if annotations[i].severityRank != annotations[j].severityRank {
+			return annotations[i].severityRank > annotations[j].severityRank
+		}
+		if annotations[i].controlID != annotations[j].controlID {
+			return annotations[i].controlID < annotations[j].controlID
+		}
+		return annotations[i].resourceID < annotations[j].resourceID
+	})
+
+	emitted := 0
+	for _, annotation := range annotations {
+		if emitted == githubActionsMaxAnnotations {
+			break
+		}
+		fmt.Fprintf(gp.writer, "::error file=%s,line=%d,title=%s::%s\n",
+			escapeAnnotationProperty(annotation.file),
+			annotation.line,
+			escapeAnnotationProperty(annotation.title),
+			escapeAnnotationData(annotation.message))
+		emitted++
+	}
+
+	fmt.Fprintf(gp.writer, "Kubescape: %d of %d High/Critical finding(s) annotated; %d suppressed by GitHub's 10-annotation step limit; %d finding(s) below the High severity threshold. Use --format json for the complete report.\n",
+		emitted, len(annotations), len(annotations)-emitted, belowThreshold)
+
+	printer.LogOutputFile(gp.writer.Name())
+	return nil
+}
+
+// ghAnnotation is one candidate workflow command before the per-step cap.
+type ghAnnotation struct {
+	severityRank int
+	severity     string
+	controlID    string
+	resourceID   string
+	file         string
+	line         int
+	title        string
+	message      string
+}
+
+// collectAnnotations resolves every failed High/Critical control on every
+// failed resource into one annotation candidate, following the same
+// file-location rules as the GitLab SAST printer: findings without a
+// repository-relative manifest path cannot be anchored to a PR line and are
+// skipped with a warning. belowThreshold counts failed findings at severities
+// the format deliberately does not annotate.
+func (gp *GitHubActionsPrinter) collectAnnotations(ctx context.Context, opaSessionObj *cautils.OPASessionObj) (annotations []ghAnnotation, belowThreshold int) {
+	basePath := getBasePathFromMetadata(*opaSessionObj)
+
+	var withoutFilePath, outsideRepository int
+	failed := make([]scannedResource, 0, len(opaSessionObj.ResourcesResult))
+	for resourceID, result := range opaSessionObj.ResourcesResult {
+		if !result.GetStatus(nil).IsFailed() {
+			continue
+		}
+
+		resourceSource := opaSessionObj.ResourceSource[resourceID]
+		relPath := resourceSource.RelativePath
+
+		if relPath == "" {
+			withoutFilePath++
+			logger.L().Debug("resource has no file path, skipping", helpers.String("resourceID", resourceID))
+			continue
+		}
+		if !isRepositoryRelative(relPath) {
+			outsideRepository++
+			logger.L().Debug("resource path is not repository-relative, skipping", helpers.String("path", relPath), helpers.String("resourceID", resourceID))
+			continue
+		}
+
+		failed = append(failed, scannedResource{
+			resourceID: resourceID,
+			relPath:    relPath,
+			absPath:    filepath.Join(effectiveBasePath(resourceSource, basePath), relPath),
+		})
+	}
+
+	// The same skipped-resource warnings the GitLab SAST printer emits, so both
+	// location-anchoring formats explain exclusions identically.
+	if outsideRepository > 0 {
+		logger.L().Ctx(ctx).Warning("some failed resources were excluded from the GitHub Actions annotations because their paths are outside the repository root; scan a path inside the repository to include them",
+			helpers.Int("excludedResources", outsideRepository))
+	}
+	if withoutFilePath > 0 && basePath != "" {
+		logger.L().Ctx(ctx).Warning("some failed resources were excluded from the GitHub Actions annotations because they are not associated with a file",
+			helpers.Int("excludedResources", withoutFilePath))
+	}
+
+	var caches manifestCache
+	for _, resource := range groupByManifest(failed) {
+		locationResolver := caches.get(resource.absPath).locationResolver(resource.absPath, "GitHub Actions")
+
+		for _, toPin := range opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls {
+			ac := toPin
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+
+			ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
+			if ctl == nil {
+				logger.L().Debug("control not found in summary details, skipping", helpers.String("controlID", ac.GetID()))
+				continue
+			}
+
+			severityRank := apis.ControlSeverityToInt(ctl.GetScoreFactor())
+			if severityRank < apis.SeverityHigh {
+				belowThreshold++
+				continue
+			}
+
+			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
+			annotations = append(annotations, ghAnnotation{
+				severityRank: severityRank,
+				severity:     apis.ControlSeverityToString(ctl.GetScoreFactor()),
+				controlID:    ctl.GetID(),
+				resourceID:   resource.resourceID,
+				file:         resource.relPath,
+				line:         location.Line,
+				title:        fmt.Sprintf("%s %s", ctl.GetID(), ctl.GetName()),
+				message: fmt.Sprintf("%s severity finding on %s. Remediation: %s",
+					apis.ControlSeverityToString(ctl.GetScoreFactor()), resource.resourceID, cautils.GetControlLink(ctl.GetID())),
+			})
+		}
+	}
+
+	return annotations, belowThreshold
+}
+
+// escapeAnnotationData escapes the message portion of a workflow command,
+// where only %, CR and LF break the command syntax.
+func escapeAnnotationData(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+// escapeAnnotationProperty escapes a workflow-command property value, which in
+// addition to the data escapes must mask ',' and ':' — the property
+// delimiters.
+func escapeAnnotationProperty(s string) string {
+	s = escapeAnnotationData(s)
+	s = strings.ReplaceAll(s, ",", "%2C")
+	s = strings.ReplaceAll(s, ":", "%3A")
+	return s
+}
+
+// CloseWriter closes the annotations output writer, returning any error from
+// flushing or closing.
+func (gp *GitHubActionsPrinter) CloseWriter() error {
+	if gp.writer != nil && gp.writer != os.Stdout {
+		return gp.writer.Close()
+	}
+	return nil
+}

--- a/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,7 +150,8 @@ func TestGitHubActionsPrinter_GoldenAnnotation(t *testing.T) {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	require.NotEmpty(t, lines)
 	assert.Equal(t,
-		"::error file=deploy.yaml,line=13,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057",
+		fmt.Sprintf("::error file=deploy.yaml,line=%d,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057",
+			privilegedLine),
 		lines[0], "the first line must be the exact workflow command")
 	assert.Contains(t, output, "1 of 1 High/Critical finding(s) annotated")
 }

--- a/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
@@ -1,0 +1,308 @@
+package printer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ghSessionFixture builds a session with one failed control on a real
+// manifest, so the location resolver has a file to read. It mirrors the
+// gitlab-sast fixture.
+func ghSessionFixture(t *testing.T, controlID string, scoreFactor float32) *cautils.OPASessionObj {
+	t.Helper()
+
+	manifestDir := t.TempDir()
+	manifestPath := filepath.Join(manifestDir, "deploy.yaml")
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata: {name: demo, namespace: default}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: demo}}
+  template:
+    metadata: {labels: {app: demo}}
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.23
+        securityContext: {privileged: true}
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	obj := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath("deploy.yaml:0")
+
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "privileged-container",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{
+						FixPath: armotypes.FixPath{
+							Path:  "spec.template.spec.containers[0].securityContext.privileged",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	session := cautils.NewOPASessionObjMock()
+	session.Metadata = &reporthandlingv2.Metadata{
+		ScanMetadata: reporthandlingv2.ScanMetadata{
+			ScanningTarget: reporthandlingv2.File,
+		},
+		ContextMetadata: reporthandlingv2.ContextMetadata{
+			FileContextMetadata: &reporthandlingv2.FileContextMetadata{
+				FilePath: manifestPath,
+			},
+		},
+	}
+	session.ResourcesResult[resourceID] = resourcesresults.Result{
+		ResourceID:         resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
+	}
+	session.ResourceSource = map[string]reporthandling.Source{
+		resourceID: {
+			Path:         manifestDir,
+			RelativePath: "deploy.yaml",
+			FileType:     reporthandling.SourceTypeYaml,
+		},
+	}
+	session.AllResources[resourceID] = lw
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				controlID: reportsummary.ControlSummary{
+					ControlID:   controlID,
+					Name:        "Privileged container",
+					Description: "Do not run privileged containers",
+					Remediation: "Set privileged to false",
+					ScoreFactor: scoreFactor,
+				},
+			},
+		},
+	}
+	return session
+}
+
+// ghOutputFor runs the printer against a session and returns the raw output.
+func ghOutputFor(t *testing.T, session *cautils.OPASessionObj) string {
+	t.Helper()
+
+	tmp, err := os.CreateTemp("", "github-actions-*.txt")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	})
+
+	gp := NewGitHubActionsPrinter()
+	gp.writer = tmp
+	require.NoError(t, gp.ActionPrint(context.Background(), session, nil))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return string(raw)
+}
+
+// TestGitHubActionsPrinter_GoldenAnnotation verifies the exact workflow-command
+// shape and the resolved line number for a known failing control.
+func TestGitHubActionsPrinter_GoldenAnnotation(t *testing.T) {
+	const privilegedLine = 13
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(t.TempDir()))
+
+	output := ghOutputFor(t, ghSessionFixture(t, "C-0057", 8.0))
+
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	require.NotEmpty(t, lines)
+	assert.Equal(t,
+		"::error file=deploy.yaml,line=13,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057",
+		lines[0], "the first line must be the exact workflow command")
+	assert.Contains(t, output, "1 of 1 High/Critical finding(s) annotated")
+}
+
+// TestGitHubActionsPrinter_EscapesPropertyValues pins the workflow-command
+// escaping: control names containing ',' and ':' would otherwise corrupt the
+// annotation's property list.
+func TestGitHubActionsPrinter_EscapesPropertyValues(t *testing.T) {
+	session := ghSessionFixture(t, "C-0001", 9.0)
+	session.Report.SummaryDetails.Controls["C-0001"] = reportsummary.ControlSummary{
+		ControlID:   "C-0001",
+		Name:        "Privileged, with colon: and %percent",
+		ScoreFactor: 9,
+	}
+
+	output := ghOutputFor(t, session)
+
+	assert.Contains(t, output, "title=C-0001 Privileged%2C with colon%3A and %25percent",
+		"property values must escape ',', ':' and '%'")
+	assert.NotContains(t, output, "title=C-0001 Privileged, with colon:")
+}
+
+// TestGitHubActionsPrinter_FiltersBelowHighSeverity verifies only High and
+// Critical findings become annotations; lower severities are counted in the
+// summary instead.
+func TestGitHubActionsPrinter_FiltersBelowHighSeverity(t *testing.T) {
+	session := ghSessionFixture(t, "C-0001", 9.0)
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	result := session.ResourcesResult[resourceID]
+	for _, extra := range []struct {
+		id          string
+		scoreFactor float32
+	}{
+		{id: "C-0002", scoreFactor: 5},
+		{id: "C-0003", scoreFactor: 2},
+	} {
+		result.AssociatedControls = append(result.AssociatedControls, resourcesresults.ResourceAssociatedControl{
+			ControlID: extra.id,
+			Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		})
+		session.Report.SummaryDetails.Controls[extra.id] = reportsummary.ControlSummary{
+			ControlID:   extra.id,
+			Name:        "Lower severity control",
+			ScoreFactor: extra.scoreFactor,
+		}
+	}
+	session.ResourcesResult[resourceID] = result
+
+	output := ghOutputFor(t, session)
+
+	assert.Equal(t, 1, strings.Count(output, "::error "), "only the High/Critical finding may be annotated")
+	assert.Contains(t, output, "2 finding(s) below the High severity threshold")
+}
+
+// TestGitHubActionsPrinter_CapsAtTenAnnotations mirrors GitHub's per-step cap:
+// with twelve eligible findings, exactly the ten most severe (Critical before
+// High, then ControlID order) are emitted and the remainder are summarized.
+func TestGitHubActionsPrinter_CapsAtTenAnnotations(t *testing.T) {
+	session := ghSessionFixture(t, "C-0001", 9.0)
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	result := session.ResourcesResult[resourceID]
+	for _, controlID := range []string{"C-0012", "C-0003", "C-0007", "C-0002", "C-0009", "C-0004", "C-0011", "C-0005", "C-0010", "C-0006", "C-0008", "C-0013"} {
+		result.AssociatedControls = append(result.AssociatedControls, resourcesresults.ResourceAssociatedControl{
+			ControlID: controlID,
+			Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		})
+		session.Report.SummaryDetails.Controls[controlID] = reportsummary.ControlSummary{
+			ControlID:   controlID,
+			Name:        "Control " + controlID,
+			ScoreFactor: 9,
+		}
+	}
+	session.ResourcesResult[resourceID] = result
+
+	output := ghOutputFor(t, session)
+
+	assert.Equal(t, 10, strings.Count(output, "::error "), "GitHub renders at most 10 error annotations per step")
+	for _, controlID := range []string{"C-0001", "C-0002", "C-0003", "C-0004", "C-0005", "C-0006", "C-0007", "C-0008", "C-0009", "C-0010"} {
+		assert.Contains(t, output, "title="+controlID+" ", "the lowest ControlIDs must be prioritized under the cap")
+	}
+	assert.NotContains(t, output, "title=C-0011 ")
+	assert.NotContains(t, output, "title=C-0012 ")
+	assert.NotContains(t, output, "title=C-0013 ")
+	assert.Contains(t, output, "3 suppressed by GitHub's 10-annotation step limit")
+}
+
+// TestGitHubActionsPrinter_SkipsResourcesWithoutFilePath mirrors the GitLab
+// SAST exclusion rules: findings with no repository-relative manifest path
+// cannot be anchored to a PR line.
+func TestGitHubActionsPrinter_SkipsResourcesWithoutFilePath(t *testing.T) {
+	session := ghSessionFixture(t, "C-0057", 9.0)
+
+	resourceID := "apps/v1/Deployment/default/demo"
+	session.ResourceSource[resourceID] = reporthandling.Source{RelativePath: ""}
+
+	output := ghOutputFor(t, session)
+
+	assert.NotContains(t, output, "::error")
+	assert.Contains(t, output, "0 of 0 High/Critical finding(s) annotated")
+}
+
+// TestGitHubActionsPrinter_RejectsImageScanData pins the config-scan boundary:
+// image findings have no manifest location to anchor an annotation to.
+func TestGitHubActionsPrinter_RejectsImageScanData(t *testing.T) {
+	gp := NewGitHubActionsPrinter()
+
+	err := gp.ActionPrint(context.Background(), nil, []cautils.ImageScanData{{}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only supported for configuration scanning")
+}
+
+// TestGitHubActionsPrinter_EmitsOnlyHighAndCritical pins the severity filter
+// boundary: score factor 7 (High) is annotated, 6 (Medium) is not.
+func TestGitHubActionsPrinter_EmitsOnlyHighAndCritical(t *testing.T) {
+	tests := []struct {
+		name          string
+		scoreFactor   float32
+		wantAnnotated bool
+	}{
+		{name: "critical is annotated", scoreFactor: 9, wantAnnotated: true},
+		{name: "high is annotated", scoreFactor: 7, wantAnnotated: true},
+		{name: "medium is not annotated", scoreFactor: 6, wantAnnotated: false},
+		{name: "low is not annotated", scoreFactor: 2, wantAnnotated: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := ghOutputFor(t, ghSessionFixture(t, "C-0057", tt.scoreFactor))
+			if tt.wantAnnotated {
+				assert.Contains(t, output, "::error file=deploy.yaml,")
+			} else {
+				assert.NotContains(t, output, "::error")
+			}
+		})
+	}
+}
+
+// TestEscapeAnnotationData verifies the message-part escaping GitHub's
+// workflow-command syntax requires.
+func TestEscapeAnnotationData(t *testing.T) {
+	assert.Equal(t, "100%25 done", escapeAnnotationData("100% done"))
+	assert.Equal(t, "line1%0Aline2", escapeAnnotationData("line1\nline2"))
+	assert.Equal(t, "cr%0Dend", escapeAnnotationData("cr\rend"))
+	assert.Equal(t, "comma,colon:no", escapeAnnotationData("comma,colon:no"),
+		"the data portion tolerates ',' and ':' — only the property list escapes them")
+}
+
+// TestEscapeAnnotationProperty verifies the property-part escaping, which must
+// additionally mask the ',' and ':' delimiters.
+func TestEscapeAnnotationProperty(t *testing.T) {
+	assert.Equal(t, "100%25 done", escapeAnnotationProperty("100% done"))
+	assert.Equal(t, "a%2Cb%3Ac", escapeAnnotationProperty("a,b:c"))
+	assert.Equal(t, "nl%0Aend", escapeAnnotationProperty("nl\nend"))
+}

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -391,6 +391,8 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		return printerv2.NewSARIFPrinter()
 	case printer.GitLabSASTFormat:
 		return printerv2.NewGitLabSASTPrinter()
+	case printer.GitHubActionsFormat:
+		return printerv2.NewGitHubActionsPrinter()
 	case printer.CycloneDXFormat:
 		return printerv2.NewCycloneDXPrinter()
 	case printer.SPDXFormat:
@@ -417,8 +419,8 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 		}
 		return false, fmt.Errorf("format \"%s\" is not supported for image scanning", printFormat)
 	}
-	if printFormat == printer.SARIFFormat || printFormat == printer.GitLabSASTFormat {
-		// SARIF and GitLab SAST resolve file locations, so they only apply to local files
+	if printFormat == printer.SARIFFormat || printFormat == printer.GitLabSASTFormat || printFormat == printer.GitHubActionsFormat {
+		// SARIF, GitLab SAST and GitHub Actions resolve file locations, so they only apply to local files
 		switch scanContext {
 		case cautils.ContextDir, cautils.ContextFile, cautils.ContextGitLocal, cautils.ContextGitRemote:
 			return false, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -294,6 +294,19 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name:      "github-actions format for cluster scan should return error",
+			scanType:  cautils.ScanTypeCluster,
+			format:    printer.GitHubActionsFormat,
+			expectErr: errors.New("format \"github-actions\" is only supported when scanning local files"),
+		},
+		{
+			name:        "github-actions format for local dir scan should not return error",
+			scanType:    cautils.ScanTypeCluster,
+			scanContext: cautils.ContextDir,
+			format:      printer.GitHubActionsFormat,
+			expectErr:   nil,
+		},
+		{
 			name:      "html format for cluster scan should not return error",
 			scanType:  cautils.ScanTypeCluster,
 			format:    printer.HtmlFormat,
@@ -858,6 +871,7 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 		{"spdx", printerv2.NewSPDXPrinter()},
 		{"cyclonedx", printerv2.NewCycloneDXPrinter()},
 		{"gitlabsast", printerv2.NewGitLabSASTPrinter()},
+		{"githubactions", printerv2.NewGitHubActionsPrinter()},
 		{"csv", printerv2.NewCsvPrinter()},
 		{"exceptions", printerv2.NewExceptionsPrinter()},
 		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "", false, false)},

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,7 +46,7 @@ kubescape scan [target] [flags]
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--audit-exceptions` | Include exception usage details in supported scan outputs | `false` |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
-| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `csv`, `markdown`, `policyreport`, `exceptions` — see [generating an exceptions baseline](#generating-an-exceptions-baseline) | `pretty-printer` |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `github-actions`, `yaml`, `csv`, `markdown`, `policyreport`, `exceptions` — see [generating an exceptions baseline](#generating-an-exceptions-baseline). `github-actions` emits failed High/Critical controls as `::error` workflow commands for inline PR annotations; local file scans only, capped at GitHub's 10-annotations-per-step limit | `pretty-printer` |
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--host-scan` | Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use `--host-scan=false` to disable host data collection. See the [Kubescape operator](https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator) for a managed alternative. | auto-detect |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -484,6 +484,7 @@ kubescape scan image <image>:<tag> [flags]
 | Flag | Description |
 |------|-------------|
 | `--exceptions <path>` | Path to exceptions file |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `markdown`, `cyclonedx-json`, `spdx-json` |
 | `-p, --password <pass>` | Registry password |
 | `--platform <platform>` | OCI platform to scan, for example `linux/amd64`, `linux/arm64/v8`, or `windows/amd64` |
 | `-u, --username <user>` | Registry username |


### PR DESCRIPTION
Closes #3636.

## Overview

**Current state:** teams running Kubescape in GitHub Actions who want findings displayed directly on the PR have two options — wire up SARIF code-scanning (requires paid GitHub Advanced Security on private repositories) or post-process `--format json` output with custom scripting. Kubescape has native formats for GitLab (`gitlab-sast`), but no GitHub-native one.

**New behavior:** a `--format github-actions` printer that emits failed High and Critical controls as `::error file=…,line=…::message` workflow commands, which the Actions runner renders as inline annotations on the pull request — free, zero-config, and available on private repositories.

## Additional Information

Design shaped by the community discussion on #3636 :

- **10-annotation cap:** GitHub renders at most 10 error annotations per step. The printer emits at most 10, prioritized Critical → High → ControlID → ResourceID, and logs a summary line for suppressed and below-threshold findings so nothing silently disappears.
- **Configuration scans only:** image findings have no manifest location to anchor an annotation to; cluster scans are rejected by `ValidatePrinter`, mirroring the sarif/gitlab-sast context gate.
- **Escaping:** annotation data and property values are escaped per GitHub's workflow-command syntax (`%`, CR, LF, and `,`/`:` in properties), so control names containing those characters cannot corrupt the command.
- **File/line attribution:** reuses the same `locationresolver` machinery as the gitlab-sast printer, including the skip-and-warn behavior for findings without a repository-relative manifest path.
- **Output:** stdout by default (the runner parses workflow commands from the step's log — that is what makes it zero-config), honoring `--output` via the shared `ResolveOutputFile` pattern.
- **Registration:** registered across every output-format integration point — format constant, `AllFormats`, output-extension map, printer factory, `ValidatePrinter` local-file gate, printer error-closer table, CLI docs. `kubescape diff` intentionally does not support it (its own format validation rejects the format before the diff engine runs).
- Severity filtering boundary: score factor ≥ 7 (High/Critical) is annotated; Medium/Low are counted in the summary line and remain available via `--format json`.

## How to Test

```bash
go build ./...
go vet ./core/pkg/resultshandling/... ./cmd/scan/... ./cmd/diff/... ./cmd/shared/...
go test ./core/pkg/resultshandling/... -count=1
go test ./cmd/scan/ ./cmd/diff/ ./cmd/shared/ -count=1
```

Manual verification:

1. Scan a manifest directory with failing High/Critical controls and `--format github-actions`:
   `kubescape scan /path/to/manifests --format github-actions`
   → each failed High/Critical control prints a `::error file=…,line=…,title=…::` line
2. Run the same scan inside a GitHub Actions workflow → the lines render as inline PR annotations
3. Cluster scans and `--format github-actions` → clean validation error (file locations do not exist)
4. New regression tests: `TestGitHubActionsPrinter_*`, `TestEscapeAnnotation*`

## Examples/Screenshots

Example output for a manifest scan:

```
::error file=deploy.yaml,line=13,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057
Kubescape: 1 of 1 High/Critical finding(s) annotated; 0 suppressed by GitHub's 10-annotation step limit; 0 finding(s) below the High severity threshold. Use --format json for the complete report.
```

## Related issues/PRs

* Closes #3636
* Reuses the file/line attribution machinery from the gitlab-sast printer (#2782)
* Community discussion: Aug 20 Slack thread (dolly chahar — GHAS licensing gap; Naitik Rishu — 10-annotation cap)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `github-actions` as a scan output format.
  * Produces inline GitHub Actions annotations for High and Critical findings.
  * Supports custom output files and limits annotations to 10 per step.
* **Bug Fixes**
  * Clarified that GitHub Actions output is supported only for local file scans.
* **Documentation**
  * Updated CLI reference documentation with format behavior, limitations, and image-scan format options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->