### PR TITLE
feat(sarif): add stable scan fingerprints

### DIFF
--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -114,7 +114,7 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 // reviewPathLocations, when non-empty, adds one relatedLocation per resolved ReviewPath so each
 // field that actually caused the failure gets its own precise location in the manifest, distinct
 // from the single primary location (which points at the fix, not necessarily at every failed field).
-func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
+func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resourceID string, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
 	msg := ctl.GetDescription()
 	if resource != nil {
 		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
@@ -134,6 +134,9 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 				),
 			),
 		})
+	result.WithPartialFingerPrints(map[string]interface{}{
+		"kubescapeFindingFingerprint": sarifFindingFingerprint(ctl.GetID(), resourceID, filepath, location, ac),
+	})
 
 	// Sort for deterministic output - map iteration order is randomized and this feeds
 	// directly into the written SARIF file.
@@ -159,6 +162,238 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 	}
 
 	return result
+}
+
+func sarifFindingFingerprint(controlID, resourceID, relPath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl) string {
+	identity := sarifFindingIdentity{
+		ControlID:  controlID,
+		ResourceID: resourceID,
+		Path:       normalizeSARIFIdentityPart(relPath),
+		Line:       location.Line,
+		Column:     location.Column,
+	}
+	if ac != nil {
+		identity.Evidence = sarifEvidenceIdentity(ac)
+	}
+	encoded, _ := json.Marshal(identity)
+	sum := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", sum)
+}
+
+type sarifFindingIdentity struct {
+	ControlID  string                  `json:"controlID"`
+	ResourceID string                  `json:"resourceID"`
+	Path       string                  `json:"path"`
+	Line       int                     `json:"line"`
+	Column     int                     `json:"column"`
+	Evidence   []sarifEvidenceFragment `json:"evidence,omitempty"`
+}
+
+type sarifEvidenceFragment struct {
+	RuleName            string   `json:"ruleName"`
+	ReviewPaths         []string `json:"reviewPaths,omitempty"`
+	FailedPaths         []string `json:"failedPaths,omitempty"`
+	DeletePaths         []string `json:"deletePaths,omitempty"`
+	RelatedResourcesIDs []string `json:"relatedResourcesIDs,omitempty"`
+}
+
+func sarifEvidenceIdentity(ac *resourcesresults.ResourceAssociatedControl) []sarifEvidenceFragment {
+	if ac == nil {
+		return nil
+	}
+	fragments := make([]sarifEvidenceFragment, 0, len(ac.ResourceAssociatedRules))
+	for _, rule := range ac.ResourceAssociatedRules {
+		if !rule.GetStatus(nil).IsFailed() {
+			continue
+		}
+		fragment := sarifEvidenceFragment{
+			RuleName:            normalizeSARIFIdentityPart(rule.Name),
+			RelatedResourcesIDs: normalizedSortedStrings(rule.RelatedResourcesIDs),
+		}
+		for _, path := range rule.Paths {
+			fragment.ReviewPaths = appendNormalizedIdentityPart(fragment.ReviewPaths, path.ReviewPath)
+			fragment.FailedPaths = appendNormalizedIdentityPart(fragment.FailedPaths, path.FailedPath)
+			fragment.DeletePaths = appendNormalizedIdentityPart(fragment.DeletePaths, path.DeletePath)
+		}
+		fragment.sortAndCompact()
+		fragments = append(fragments, fragment)
+	}
+	sort.SliceStable(fragments, func(i, j int) bool {
+		left, _ := json.Marshal(fragments[i])
+		right, _ := json.Marshal(fragments[j])
+		return string(left) < string(right)
+	})
+	return fragments
+}
+
+func (f *sarifEvidenceFragment) sortAndCompact() {
+	f.ReviewPaths = compactSortedStrings(f.ReviewPaths)
+	f.FailedPaths = compactSortedStrings(f.FailedPaths)
+	f.DeletePaths = compactSortedStrings(f.DeletePaths)
+	f.RelatedResourcesIDs = compactSortedStrings(f.RelatedResourcesIDs)
+}
+
+func appendNormalizedIdentityPart(values []string, value string) []string {
+	value = normalizeSARIFIdentityPart(value)
+	if value == "" {
+		return values
+	}
+	return append(values, value)
+}
+
+func normalizedSortedStrings(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = appendNormalizedIdentityPart(normalized, value)
+	}
+	return compactSortedStrings(normalized)
+}
+
+func compactSortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Strings(values)
+	compacted := values[:0]
+	for _, value := range values {
+		if len(compacted) == 0 || compacted[len(compacted)-1] != value {
+			compacted = append(compacted, value)
+		}
+	}
+	return compacted
+}
+
+func normalizeSARIFIdentityPart(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\\", "/")
+	return filepath.ToSlash(value)
+}
+
+func addImageSARIFFingerprints(run *sarif.Run) {
+	if run == nil {
+		return
+	}
+	for _, result := range run.Results {
+		if result == nil || len(result.PartialFingerprints) > 0 {
+			continue
+		}
+		result.WithPartialFingerPrints(map[string]interface{}{
+			"kubescapeImageFindingFingerprint": imageSARIFFindingFingerprint(result),
+		})
+	}
+}
+
+func imageSARIFFindingFingerprint(result *sarif.Result) string {
+	if result == nil {
+		sum := sha256.Sum256([]byte("{}"))
+		return fmt.Sprintf("%x", sum)
+	}
+	identity := imageSARIFFindingIdentity{
+		RuleID:         stringPointerValue(result.RuleID),
+		Level:          stringPointerValue(result.Level),
+		Message:        sarifMessageText(result.Message),
+		AnalysisTarget: sarifArtifactURI(result.AnalysisTarget),
+		Locations:      sarifLocationIdentities(result.Locations),
+	}
+	encoded, _ := json.Marshal(identity)
+	sum := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", sum)
+}
+
+type imageSARIFFindingIdentity struct {
+	RuleID         string                  `json:"ruleID"`
+	Level          string                  `json:"level,omitempty"`
+	Message        string                  `json:"message,omitempty"`
+	AnalysisTarget string                  `json:"analysisTarget,omitempty"`
+	Locations      []sarifLocationIdentity `json:"locations,omitempty"`
+}
+
+type sarifLocationIdentity struct {
+	URI         string `json:"uri,omitempty"`
+	URIBaseID   string `json:"uriBaseID,omitempty"`
+	StartLine   int    `json:"startLine,omitempty"`
+	StartColumn int    `json:"startColumn,omitempty"`
+	EndLine     int    `json:"endLine,omitempty"`
+	EndColumn   int    `json:"endColumn,omitempty"`
+}
+
+func sarifLocationIdentities(locations []*sarif.Location) []sarifLocationIdentity {
+	if len(locations) == 0 {
+		return nil
+	}
+	identities := make([]sarifLocationIdentity, 0, len(locations))
+	for _, location := range locations {
+		identity, ok := sarifLocationIdentityFromLocation(location)
+		if !ok {
+			continue
+		}
+		identities = append(identities, identity)
+	}
+	sort.SliceStable(identities, func(i, j int) bool {
+		left, _ := json.Marshal(identities[i])
+		right, _ := json.Marshal(identities[j])
+		return string(left) < string(right)
+	})
+	return identities
+}
+
+func sarifLocationIdentityFromLocation(location *sarif.Location) (sarifLocationIdentity, bool) {
+	if location == nil || location.PhysicalLocation == nil {
+		return sarifLocationIdentity{}, false
+	}
+	physical := location.PhysicalLocation
+	identity := sarifLocationIdentity{
+		URI:       sarifArtifactURI(physical.ArtifactLocation),
+		URIBaseID: sarifArtifactBaseID(physical.ArtifactLocation),
+	}
+	if physical.Region != nil {
+		identity.StartLine = intPointerValue(physical.Region.StartLine)
+		identity.StartColumn = intPointerValue(physical.Region.StartColumn)
+		identity.EndLine = intPointerValue(physical.Region.EndLine)
+		identity.EndColumn = intPointerValue(physical.Region.EndColumn)
+	}
+	return identity, identity != (sarifLocationIdentity{})
+}
+
+func sarifArtifactURI(location *sarif.ArtifactLocation) string {
+	if location == nil {
+		return ""
+	}
+	return normalizeSARIFIdentityPart(stringPointerValue(location.URI))
+}
+
+func sarifArtifactBaseID(location *sarif.ArtifactLocation) string {
+	if location == nil {
+		return ""
+	}
+	return normalizeSARIFIdentityPart(stringPointerValue(location.URIBaseId))
+}
+
+func sarifMessageText(message sarif.Message) string {
+	if message.Text != nil {
+		return strings.TrimSpace(*message.Text)
+	}
+	if message.Markdown != nil {
+		return strings.TrimSpace(*message.Markdown)
+	}
+	if message.ID != nil {
+		return strings.TrimSpace(*message.ID)
+	}
+	return strings.TrimSpace(strings.Join(message.Arguments, "\x00"))
+}
+
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func intPointerValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 // resolveReviewPathLocations resolves each of ac's ReviewPaths to its location in the source
@@ -276,6 +511,7 @@ func (sp *SARIFPrinter) printImageScan(scanResults []cautils.ImageScanData) erro
 			if run.Tool.Driver != nil {
 				run.Tool.Driver.Name = "Kubescape"
 			}
+			addImageSARIFFingerprints(run)
 			combinedReport.AddRun(run)
 		}
 	}
@@ -374,7 +610,7 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 				reviewPathLocations := resolveReviewPathLocations(opaSessionObj, locationResolver, &ac, resource.resourceID)
 				sp.addRule(run, ctl)
 				rsrc := opaSessionObj.AllResources[resource.resourceID]
-				r := sp.addResult(run, ctl, resource.relPath, location, &ac, rsrc, reviewPathLocations)
+				r := sp.addResult(run, ctl, resource.relPath, location, &ac, resource.resourceID, rsrc, reviewPathLocations)
 				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
 			}
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -399,12 +399,364 @@ func TestAddResult_AnnotatesInitAndEphemeralContainerNames(t *testing.T) {
 	ac := makeControlWithPaths(privilegedInitAndEphemeralPaths(), nil)
 	ac.ControlID = "C-0057"
 
-	result := sp.addResult(run, control, "pod.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, privilegedInitAndEphemeralPod(), nil)
+	result := sp.addResult(run, control, "pod.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "apps/v1/Deployment/default/demo", privilegedInitAndEphemeralPod(), nil)
 	require.NotNil(t, result.Message)
 	require.NotNil(t, result.Message.Text)
 	for _, path := range privilegedInitAndEphemeralNamedPaths() {
 		assert.Contains(t, *result.Message.Text, path)
 	}
+	require.NotNil(t, result.PartialFingerprints)
+	assert.NotEmpty(t, result.PartialFingerprints["kubescapeFindingFingerprint"])
+}
+
+func TestSARIFFindingFingerprintStableAcrossEvidenceOrdering(t *testing.T) {
+	left := fingerprintControlWithRules(
+		fingerprintRule("rule-b", "spec.template.spec.containers[1].image", "spec.template.spec.containers[1].securityContext.privileged"),
+		fingerprintRule("rule-a", "spec.template.spec.containers[0].image", "spec.template.spec.containers[0].securityContext.privileged"),
+	)
+	right := fingerprintControlWithRules(
+		fingerprintRule("rule-a", "spec.template.spec.containers[0].image", "spec.template.spec.containers[0].securityContext.privileged"),
+		fingerprintRule("rule-b", "spec.template.spec.containers[1].image", "spec.template.spec.containers[1].securityContext.privileged"),
+	)
+
+	leftFingerprint := sarifFindingFingerprint("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml", locationresolver.Location{Line: 12, Column: 9}, &left)
+	rightFingerprint := sarifFindingFingerprint("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml", locationresolver.Location{Line: 12, Column: 9}, &right)
+
+	assert.Equal(t, leftFingerprint, rightFingerprint)
+}
+
+func TestSARIFFindingFingerprintChangesWithIdentity(t *testing.T) {
+	base := fingerprintControlWithRules(
+		fingerprintRule("rule-a", "spec.template.spec.containers[0].image", "spec.template.spec.containers[0].securityContext.privileged"),
+	)
+	baseFingerprint := sarifFindingFingerprint("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml", locationresolver.Location{Line: 12, Column: 9}, &base)
+
+	tests := []struct {
+		name        string
+		controlID   string
+		resourceID  string
+		path        string
+		location    locationresolver.Location
+		association resourcesresults.ResourceAssociatedControl
+	}{
+		{
+			name:        "control id changes",
+			controlID:   "C-9999",
+			resourceID:  "apps/v1/Deployment/default/demo",
+			path:        "deploy.yaml",
+			location:    locationresolver.Location{Line: 12, Column: 9},
+			association: base,
+		},
+		{
+			name:        "resource id changes",
+			controlID:   "C-0057",
+			resourceID:  "apps/v1/Deployment/default/other",
+			path:        "deploy.yaml",
+			location:    locationresolver.Location{Line: 12, Column: 9},
+			association: base,
+		},
+		{
+			name:        "artifact path changes",
+			controlID:   "C-0057",
+			resourceID:  "apps/v1/Deployment/default/demo",
+			path:        "nested/deploy.yaml",
+			location:    locationresolver.Location{Line: 12, Column: 9},
+			association: base,
+		},
+		{
+			name:        "primary location changes",
+			controlID:   "C-0057",
+			resourceID:  "apps/v1/Deployment/default/demo",
+			path:        "deploy.yaml",
+			location:    locationresolver.Location{Line: 13, Column: 9},
+			association: base,
+		},
+		{
+			name:       "evidence path changes",
+			controlID:  "C-0057",
+			resourceID: "apps/v1/Deployment/default/demo",
+			path:       "deploy.yaml",
+			location:   locationresolver.Location{Line: 12, Column: 9},
+			association: fingerprintControlWithRules(
+				fingerprintRule("rule-a", "spec.template.spec.containers[0].image", "spec.template.spec.containers[1].securityContext.privileged"),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := sarifFindingFingerprint(test.controlID, test.resourceID, test.path, test.location, &test.association)
+			assert.NotEqual(t, baseFingerprint, got)
+		})
+	}
+}
+
+func TestSARIFFindingFingerprintStableAcrossRemediationChanges(t *testing.T) {
+	left := fingerprintControlWithRules(
+		resourcesresults.ResourceAssociatedRule{
+			Name:   "rule-a",
+			Status: apis.StatusFailed,
+			Paths: []armotypes.PosturePaths{
+				{
+					ReviewPath: "spec.template.spec.containers[0].securityContext.privileged",
+					FailedPath: "spec.template.spec.containers[0].securityContext.privileged",
+					FixCommand: "kubectl patch deployment demo --type json",
+					FixPath: armotypes.FixPath{
+						Path:  "spec.template.spec.containers[0].securityContext.privileged",
+						Value: "false",
+					},
+				},
+			},
+		},
+	)
+	right := fingerprintControlWithRules(
+		resourcesresults.ResourceAssociatedRule{
+			Name:   "rule-a",
+			Status: apis.StatusFailed,
+			Paths: []armotypes.PosturePaths{
+				{
+					ReviewPath: "spec.template.spec.containers[0].securityContext.privileged",
+					FailedPath: "spec.template.spec.containers[0].securityContext.privileged",
+					FixCommand: "kubectl edit deployment demo",
+					FixPath: armotypes.FixPath{
+						Path:  "spec.template.spec.initContainers[0].securityContext.privileged",
+						Value: "null",
+					},
+				},
+			},
+		},
+	)
+
+	leftFingerprint := sarifFindingFingerprint("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml", locationresolver.Location{Line: 12, Column: 9}, &left)
+	rightFingerprint := sarifFindingFingerprint("C-0057", "apps/v1/Deployment/default/demo", "deploy.yaml", locationresolver.Location{Line: 12, Column: 9}, &right)
+
+	assert.Equal(t, leftFingerprint, rightFingerprint)
+}
+
+func TestSARIFEvidenceIdentityNormalizesAndDeduplicates(t *testing.T) {
+	ac := fingerprintControlWithRules(
+		resourcesresults.ResourceAssociatedRule{
+			Name:   " rule-a ",
+			Status: apis.StatusFailed,
+			RelatedResourcesIDs: []string{
+				"apps/v1/Deployment/default/demo",
+				" apps/v1/Deployment/default/demo ",
+			},
+			Paths: []armotypes.PosturePaths{
+				{
+					ReviewPath: " spec.template.spec.containers[0].image ",
+					FailedPath: "spec.template.spec.containers[0].image",
+					DeletePath: " spec.template.spec.containers[0].env[0] ",
+					FixCommand: "kubectl patch deployment demo",
+					FixPath: armotypes.FixPath{
+						Path:  "spec.template.spec.containers[0].image",
+						Value: "nginx:1.25",
+					},
+				},
+				{
+					ReviewPath: "spec.template.spec.containers[0].image",
+					FailedPath: "spec.template.spec.containers[0].image",
+					DeletePath: "spec.template.spec.containers[0].env[0]",
+					FixCommand: " kubectl patch deployment demo ",
+					FixPath: armotypes.FixPath{
+						Path:  " spec.template.spec.containers[0].image ",
+						Value: "nginx:1.25",
+					},
+				},
+			},
+		},
+	)
+
+	got := sarifEvidenceIdentity(&ac)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "rule-a", got[0].RuleName)
+	assert.Equal(t, []string{"spec.template.spec.containers[0].image"}, got[0].ReviewPaths)
+	assert.Equal(t, []string{"spec.template.spec.containers[0].image"}, got[0].FailedPaths)
+	assert.Equal(t, []string{"spec.template.spec.containers[0].env[0]"}, got[0].DeletePaths)
+	assert.Equal(t, []string{"apps/v1/Deployment/default/demo"}, got[0].RelatedResourcesIDs)
+}
+
+func TestSARIFEvidenceIdentityIgnoresPassingRules(t *testing.T) {
+	ac := fingerprintControlWithRules(
+		resourcesresults.ResourceAssociatedRule{
+			Name:   "passing",
+			Status: apis.StatusPassed,
+			Paths:  []armotypes.PosturePaths{{ReviewPath: "spec.template.spec.containers[0].image"}},
+		},
+		fingerprintRule("failed", "spec.template.spec.containers[0].image", "spec.template.spec.containers[0].securityContext.privileged"),
+	)
+
+	got := sarifEvidenceIdentity(&ac)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "failed", got[0].RuleName)
+}
+
+func TestNormalizeSARIFIdentityPartUsesSlashPaths(t *testing.T) {
+	assert.Equal(t, "dir/file.yaml", normalizeSARIFIdentityPart(" dir\\file.yaml "))
+}
+
+func TestAddImageSARIFFingerprintsAddsMissingFingerprint(t *testing.T) {
+	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+	result := imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+	)
+	run.Results = []*sarif.Result{result, nil}
+
+	addImageSARIFFingerprints(run)
+
+	require.NotNil(t, result.PartialFingerprints)
+	assert.NotEmpty(t, result.PartialFingerprints["kubescapeImageFindingFingerprint"])
+}
+
+func TestAddImageSARIFFingerprintsPreservesExistingFingerprint(t *testing.T) {
+	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+	result := imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+	)
+	result.PartialFingerprints = map[string]interface{}{"upstream": "fingerprint"}
+	run.Results = []*sarif.Result{result}
+
+	addImageSARIFFingerprints(run)
+
+	assert.Equal(t, map[string]interface{}{"upstream": "fingerprint"}, result.PartialFingerprints)
+}
+
+func TestImageSARIFFindingFingerprintStableAcrossLocationOrdering(t *testing.T) {
+	left := imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+		imageSARIFLocation("pkg/manifest.json", 20, 5),
+	)
+	right := imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+		imageSARIFLocation("pkg/manifest.json", 20, 5),
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+	)
+	left.AnalysisTarget = sarif.NewSimpleArtifactLocation("registry.example.com/team/app:1.0.0")
+	right.AnalysisTarget = sarif.NewSimpleArtifactLocation("registry.example.com/team/app:1.0.0")
+
+	assert.Equal(t, imageSARIFFindingFingerprint(left), imageSARIFFindingFingerprint(right))
+}
+
+func TestImageSARIFFindingFingerprintChangesWithIdentity(t *testing.T) {
+	base := imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+	)
+	base.AnalysisTarget = sarif.NewSimpleArtifactLocation("registry.example.com/team/app:1.0.0")
+	baseFingerprint := imageSARIFFindingFingerprint(base)
+
+	tests := []struct {
+		name   string
+		result *sarif.Result
+	}{
+		{
+			name: "rule id changes",
+			result: imageSARIFResult("CVE-2026-0002-libssl", "error", "libssl has a critical vulnerability",
+				imageSARIFLocation("pkg/catalog.json", 14, 3),
+			),
+		},
+		{
+			name: "level changes",
+			result: imageSARIFResult("CVE-2026-0001-libssl", "warning", "libssl has a critical vulnerability",
+				imageSARIFLocation("pkg/catalog.json", 14, 3),
+			),
+		},
+		{
+			name: "message changes",
+			result: imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl vulnerability is fixed upstream",
+				imageSARIFLocation("pkg/catalog.json", 14, 3),
+			),
+		},
+		{
+			name: "location uri changes",
+			result: imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+				imageSARIFLocation("pkg/other.json", 14, 3),
+			),
+		},
+		{
+			name: "location region changes",
+			result: imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+				imageSARIFLocation("pkg/catalog.json", 18, 3),
+			),
+		},
+		{
+			name: "analysis target changes",
+			result: imageSARIFResult("CVE-2026-0001-libssl", "error", "libssl has a critical vulnerability",
+				imageSARIFLocation("pkg/catalog.json", 14, 3),
+			),
+		},
+	}
+	tests[len(tests)-1].result.AnalysisTarget = sarif.NewSimpleArtifactLocation("registry.example.com/team/app:2.0.0")
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.result.AnalysisTarget == nil {
+				test.result.AnalysisTarget = sarif.NewSimpleArtifactLocation("registry.example.com/team/app:1.0.0")
+			}
+			assert.NotEqual(t, baseFingerprint, imageSARIFFindingFingerprint(test.result))
+		})
+	}
+}
+
+func TestSARIFLocationIdentitiesSkipEmptyLocations(t *testing.T) {
+	got := sarifLocationIdentities([]*sarif.Location{
+		nil,
+		sarif.NewLocation(),
+		imageSARIFLocation("pkg/catalog.json", 14, 3),
+	})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, sarifLocationIdentity{
+		URI:         "pkg/catalog.json",
+		StartLine:   14,
+		StartColumn: 3,
+	}, got[0])
+}
+
+func TestSARIFMessageTextFallbacks(t *testing.T) {
+	assert.Equal(t, "plain text", sarifMessageText(*sarif.NewTextMessage(" plain text ")))
+	assert.Equal(t, "markdown text", sarifMessageText(*sarif.NewMarkdownMessage(" markdown text ")))
+	assert.Equal(t, "message-id", sarifMessageText(*sarif.NewMessage().WithID(" message-id ")))
+	assert.Equal(t, "arg-a\x00arg-b", sarifMessageText(*sarif.NewMessage().WithArguments([]string{"arg-a", "arg-b"})))
+}
+
+func fingerprintControlWithRules(rules ...resourcesresults.ResourceAssociatedRule) resourcesresults.ResourceAssociatedControl {
+	return resourcesresults.ResourceAssociatedControl{
+		ControlID:               "C-0057",
+		Status:                  apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: rules,
+	}
+}
+
+func fingerprintRule(name, fixPath, reviewPath string) resourcesresults.ResourceAssociatedRule {
+	return resourcesresults.ResourceAssociatedRule{
+		Name:   name,
+		Status: apis.StatusFailed,
+		Paths: []armotypes.PosturePaths{
+			{
+				ReviewPath: reviewPath,
+				FixPath: armotypes.FixPath{
+					Path:  fixPath,
+					Value: "false",
+				},
+			},
+		},
+	}
+}
+
+func imageSARIFResult(ruleID, level, message string, locations ...*sarif.Location) *sarif.Result {
+	return sarif.NewRuleResult(ruleID).
+		WithLevel(level).
+		WithMessage(sarif.NewTextMessage(message)).
+		WithLocations(locations)
+}
+
+func imageSARIFLocation(uri string, line, column int) *sarif.Location {
+	return sarif.NewLocationWithPhysicalLocation(
+		sarif.NewPhysicalLocation().
+			WithArtifactLocation(sarif.NewSimpleArtifactLocation(uri)).
+			WithRegion(sarif.NewRegion().WithStartLine(line).WithStartColumn(column)),
+	)
 }
 
 func TestPrintConfigurationScan_MissingControl(t *testing.T) {


### PR DESCRIPTION
## Summary
- add deterministic partialFingerprints to configuration scan SARIF results
- add fallback partialFingerprints to image scan SARIF results when upstream output has none
- normalize and sort finding identity fields so alert tracking is stable across output ordering

Closes #3638

## Testing
- go test ./core/pkg/resultshandling/printer/v2
- go test ./core/pkg/resultshandling/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable fingerprints to configuration-scan SARIF findings for consistent identification across reports.
  * Added distinct fingerprints to image-scan SARIF findings when one is not already available.
  * Fingerprints remain deterministic despite changes in evidence or location ordering.

* **Bug Fixes**
  * Improved finding identity by normalizing paths, removing duplicates, and excluding passing rules.
  * Preserved existing image-scan fingerprints when adding fingerprint information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->