### PR TITLE
feat(scan): record contract runner input digests

### DIFF
--- a/core/cautils/getter/interfaces.go
+++ b/core/cautils/getter/interfaces.go
@@ -34,6 +34,13 @@ type (
 	IAttackTracksGetter interface {
 		GetAttackTracks() ([]v1alpha1.AttackTrack, error)
 	}
+
+	// ConsumedFileDigester is implemented by local getters that retain the
+	// digest of the exact file bytes they successfully consumed. It is optional
+	// so remote and CRD-backed getters keep their existing interfaces.
+	ConsumedFileDigester interface {
+		ConsumedFileDigest() (path, digest string, ok bool)
+	}
 )
 
 // isContextErr reports whether err was caused by context cancellation or a deadline.

--- a/core/cautils/getter/loadpolicy.go
+++ b/core/cautils/getter/loadpolicy.go
@@ -2,12 +2,14 @@ package getter
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/go-logger"
@@ -47,7 +49,10 @@ func getCacheDir() string {
 
 // LoadPolicy loads policies from a local repository.
 type LoadPolicy struct {
-	filePaths []string
+	filePaths       []string
+	consumedInputMu sync.Mutex
+	consumedPath    string
+	consumedDigest  string
 }
 
 // NewLoadPolicy builds a LoadPolicy.
@@ -270,6 +275,9 @@ func (lp *LoadPolicy) GetExceptions(_ context.Context, _ /* clusterName */ strin
 
 	exception := make([]armotypes.PostureExceptionPolicy, 0, 300)
 	err = json.Unmarshal(buf, &exception)
+	if err == nil {
+		lp.recordConsumedFile(filePath, buf)
+	}
 
 	return exception, err
 }
@@ -301,8 +309,31 @@ func (lp *LoadPolicy) GetControlsInputs(_ context.Context, _ /* clusterName */ s
 
 		return nil, formattedError
 	}
+	if len(controlInputs) > 0 {
+		lp.recordConsumedFile(filePath, buf)
+	}
 
 	return controlInputs, nil
+}
+
+// ConsumedFileDigest returns the digest of the exact local input bytes that
+// this getter successfully used. The path is kept internal until a caller
+// applies its own safe-reporting policy.
+func (lp *LoadPolicy) ConsumedFileDigest() (path, digest string, ok bool) {
+	lp.consumedInputMu.Lock()
+	defer lp.consumedInputMu.Unlock()
+	if lp.consumedDigest == "" {
+		return "", "", false
+	}
+	return lp.consumedPath, lp.consumedDigest, true
+}
+
+func (lp *LoadPolicy) recordConsumedFile(path string, contents []byte) {
+	digest := sha256.Sum256(contents)
+	lp.consumedInputMu.Lock()
+	defer lp.consumedInputMu.Unlock()
+	lp.consumedPath = path
+	lp.consumedDigest = fmt.Sprintf("sha256:%x", digest)
 }
 
 // GetAttackTracks yields the attack tracks from a config file.

--- a/core/cautils/getter/loadpolicy_test.go
+++ b/core/cautils/getter/loadpolicy_test.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -330,6 +331,14 @@ func TestLoadPolicy(t *testing.T) {
 			inputs, err := p.GetControlsInputs(context.TODO(), cluster)
 			require.NoError(t, err)
 			require.EqualValues(t, expected, inputs)
+
+			contents, err := os.ReadFile(fixture)
+			require.NoError(t, err)
+			digest := sha256.Sum256(contents)
+			path, gotDigest, ok := p.ConsumedFileDigest()
+			require.True(t, ok)
+			require.Equal(t, fixture, path)
+			require.Equal(t, fmt.Sprintf("sha256:%x", digest), gotDigest)
 		})
 
 		t.Run("edge case: corrupted json", func(t *testing.T) {

--- a/core/cautils/getter/mergedexceptionsgetter.go
+++ b/core/cautils/getter/mergedexceptionsgetter.go
@@ -60,6 +60,19 @@ func (g *MergedExceptionsGetter) GetExceptions(ctx context.Context, clusterName 
 	return deduplicateExceptions(exceptions, crdExceptions), nil
 }
 
+// ConsumedFileDigest forwards provenance from the primary local source. CRD
+// exceptions are not files and therefore deliberately have no file digest.
+func (g *MergedExceptionsGetter) ConsumedFileDigest() (path, digest string, ok bool) {
+	if g == nil {
+		return "", "", false
+	}
+	digester, ok := g.primary.(ConsumedFileDigester)
+	if !ok {
+		return "", "", false
+	}
+	return digester.ConsumedFileDigest()
+}
+
 // deduplicateExceptions enforces the design review's precedence rule: cloud/file
 // (primary) exceptions are added first, and a CRD exception is appended only for the
 // control+workload designators not already covered by a primary exception. Partial

--- a/core/cautils/scancontract_provenance.go
+++ b/core/cautils/scancontract_provenance.go
@@ -3,6 +3,7 @@ package cautils
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kubescape/backend/pkg/versioncheck"
@@ -99,25 +100,10 @@ func cloneEffectiveSettings(settings *reporthandlingv2.ScanContractEffectiveSett
 	return &clone
 }
 
-// RecordScanContractRunnerInputs records only the local runner files whose
-// exact bytes were successfully consumed by the policy getters. It never
-// rereads a path for hashing, avoiding a hash-then-load race.
-func RecordScanContractRunnerInputs(scanInfo *ScanInfo, getters *Getters) {
-	if scanInfo == nil || scanInfo.ScanContract == nil || getters == nil {
-		return
-	}
-
-	inputs := make([]reporthandlingv2.ScanContractRunnerInput, 0, 2)
-	if input, ok := consumedRunnerInput("controlsConfig", getters.ControlsInputsGetter); ok {
-		inputs = append(inputs, input)
-	}
-	if input, ok := consumedRunnerInput("exceptions", getters.ExceptionsGetter); ok {
-		inputs = append(inputs, input)
-	}
-	scanInfo.ScanContract.RunnerInputs = inputs
-}
-
-func consumedRunnerInput(role string, source any) (reporthandlingv2.ScanContractRunnerInput, bool) {
+// CaptureScanContractRunnerInput captures provenance for the exact local
+// runner bytes that a getter consumed. It never rereads a path for hashing,
+// avoiding a hash-then-load race.
+func CaptureScanContractRunnerInput(role string, source any) (reporthandlingv2.ScanContractRunnerInput, bool) {
 	digester, ok := source.(getter.ConsumedFileDigester)
 	if !ok {
 		return reporthandlingv2.ScanContractRunnerInput{}, false
@@ -131,6 +117,35 @@ func consumedRunnerInput(role string, source any) (reporthandlingv2.ScanContract
 		Source: safeContractRunnerInputSource(path),
 		Digest: digest,
 	}, true
+}
+
+// RecordScanContractRunnerInput adds or replaces the input for a role. Cache
+// users can replay a previously captured input with RecordCachedScanContractRunnerInput.
+func RecordScanContractRunnerInput(scanInfo *ScanInfo, role string, source any) (reporthandlingv2.ScanContractRunnerInput, bool) {
+	input, ok := CaptureScanContractRunnerInput(role, source)
+	if !ok {
+		return reporthandlingv2.ScanContractRunnerInput{}, false
+	}
+	RecordCachedScanContractRunnerInput(scanInfo, input)
+	return input, true
+}
+
+// RecordCachedScanContractRunnerInput replays provenance captured when a
+// cached policy input was first read. The stored value is already path-safe.
+func RecordCachedScanContractRunnerInput(scanInfo *ScanInfo, input reporthandlingv2.ScanContractRunnerInput) {
+	if scanInfo == nil || scanInfo.ScanContract == nil || input.Role == "" || input.Digest == "" {
+		return
+	}
+	for i := range scanInfo.ScanContract.RunnerInputs {
+		if scanInfo.ScanContract.RunnerInputs[i].Role == input.Role {
+			scanInfo.ScanContract.RunnerInputs[i] = input
+			return
+		}
+	}
+	scanInfo.ScanContract.RunnerInputs = append(scanInfo.ScanContract.RunnerInputs, input)
+	sort.Slice(scanInfo.ScanContract.RunnerInputs, func(i, j int) bool {
+		return scanInfo.ScanContract.RunnerInputs[i].Role < scanInfo.ScanContract.RunnerInputs[j].Role
+	})
 }
 
 func safeContractRunnerInputSource(path string) string {

--- a/core/cautils/scancontract_provenance.go
+++ b/core/cautils/scancontract_provenance.go
@@ -1,9 +1,14 @@
 package cautils
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/kubescape/backend/pkg/versioncheck"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	contractv1alpha1 "github.com/kubescape/kubescape/v4/core/pkg/scancontract/v1alpha1"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -52,25 +57,18 @@ func finalizeScanContractMetadata(scanInfo *ScanInfo, policyIdentifiers []Policy
 		metadata.Effective.Policy = &policy
 	}
 
-	// Controls-config and exceptions are consumed later by their getters. Do not
-	// hash them here: reading now and reopening later would create a hash-then-
-	// load race. Until that handoff preserves the exact consumed bytes, omit the
-	// effective-run digest rather than publish an incomplete reproducibility
-	// claim.
-	if scanInfo.ControlsInputs == "" && scanInfo.UseExceptions == "" {
-		digest, err := contractv1alpha1.DigestEffectiveRun(effectiveRunDigestInput{
-			DigestSchema:     contractv1alpha1.EffectiveRunDigestSchema,
-			KubescapeVersion: versioncheck.BuildNumber,
-			Effective:        metadata.Effective,
-			AllowedSections:  metadata.AllowedSections,
-			DeniedSections:   metadata.DeniedSections,
-			RunnerInputs:     metadata.RunnerInputs,
-		})
-		if err != nil {
-			logger.L().Warning("failed to derive repository scan contract effective-run digest", helpers.Error(err))
-		} else {
-			metadata.EffectiveRunDigest = digest
-		}
+	digest, err := contractv1alpha1.DigestEffectiveRun(effectiveRunDigestInput{
+		DigestSchema:     contractv1alpha1.EffectiveRunDigestSchema,
+		KubescapeVersion: versioncheck.BuildNumber,
+		Effective:        metadata.Effective,
+		AllowedSections:  metadata.AllowedSections,
+		DeniedSections:   metadata.DeniedSections,
+		RunnerInputs:     metadata.RunnerInputs,
+	})
+	if err != nil {
+		logger.L().Warning("failed to derive repository scan contract effective-run digest", helpers.Error(err))
+	} else {
+		metadata.EffectiveRunDigest = digest
 	}
 
 	return &metadata
@@ -99,4 +97,53 @@ func cloneEffectiveSettings(settings *reporthandlingv2.ScanContractEffectiveSett
 		clone.Output = &output
 	}
 	return &clone
+}
+
+// RecordScanContractRunnerInputs records only the local runner files whose
+// exact bytes were successfully consumed by the policy getters. It never
+// rereads a path for hashing, avoiding a hash-then-load race.
+func RecordScanContractRunnerInputs(scanInfo *ScanInfo, getters *Getters) {
+	if scanInfo == nil || scanInfo.ScanContract == nil || getters == nil {
+		return
+	}
+
+	inputs := make([]reporthandlingv2.ScanContractRunnerInput, 0, 2)
+	if input, ok := consumedRunnerInput("controlsConfig", getters.ControlsInputsGetter); ok {
+		inputs = append(inputs, input)
+	}
+	if input, ok := consumedRunnerInput("exceptions", getters.ExceptionsGetter); ok {
+		inputs = append(inputs, input)
+	}
+	scanInfo.ScanContract.RunnerInputs = inputs
+}
+
+func consumedRunnerInput(role string, source any) (reporthandlingv2.ScanContractRunnerInput, bool) {
+	digester, ok := source.(getter.ConsumedFileDigester)
+	if !ok {
+		return reporthandlingv2.ScanContractRunnerInput{}, false
+	}
+	path, digest, ok := digester.ConsumedFileDigest()
+	if !ok {
+		return reporthandlingv2.ScanContractRunnerInput{}, false
+	}
+	return reporthandlingv2.ScanContractRunnerInput{
+		Role:   role,
+		Source: safeContractRunnerInputSource(path),
+		Digest: digest,
+	}, true
+}
+
+func safeContractRunnerInputSource(path string) string {
+	clean := filepath.Clean(path)
+	if filepath.IsAbs(clean) {
+		if workingDirectory, err := os.Getwd(); err == nil {
+			if relative, err := filepath.Rel(workingDirectory, clean); err == nil {
+				clean = relative
+			}
+		}
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+		return "external"
+	}
+	return filepath.ToSlash(clean)
 }

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -144,10 +144,10 @@ func TestScanContractProvenanceRecordsConsumedRunnerInputs(t *testing.T) {
 		DigestSchema:   "kubescape-scan-contract:v1",
 		ContractDigest: "sha256:contract",
 	}}
-	RecordScanContractRunnerInputs(scanInfo, &Getters{
-		ControlsInputsGetter: controls,
-		ExceptionsGetter:     getter.NewMergedExceptionsGetter(exceptions, nil),
-	})
+	_, ok := RecordScanContractRunnerInput(scanInfo, "controlsConfig", controls)
+	require.True(t, ok)
+	_, ok = RecordScanContractRunnerInput(scanInfo, "exceptions", getter.NewMergedExceptionsGetter(exceptions, nil))
+	require.True(t, ok)
 
 	metadata := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
 	provenance := metadata.ScanMetadata.ScanContract

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -15,6 +15,7 @@ import (
 	giturl "github.com/kubescape/go-git-url"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+	"github.com/kubescape/kubescape/v4/internal/testutils"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
@@ -126,10 +127,40 @@ func TestScanContractProvenanceUsesFinalPolicySelection(t *testing.T) {
 	assert.Equal(t, []string{"C-0001"}, provenance.Effective.Policy.Controls)
 	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, provenance.EffectiveRunDigest)
 	assert.Equal(t, []string{"mitre"}, scanInfo.ScanContract.Effective.Policy.Frameworks, "report finalization must not mutate the reusable scan input")
+}
 
-	scanInfo.ControlsInputs = "runner-controls.json"
-	metadata = scanInfoToScanMetadata(context.Background(), scanInfo, nil)
-	assert.Empty(t, metadata.ScanMetadata.ScanContract.EffectiveRunDigest, "a later getter owns runner-file bytes, so no incomplete digest is emitted")
+func TestScanContractProvenanceRecordsConsumedRunnerInputs(t *testing.T) {
+	controls := getter.NewLoadPolicy([]string{filepath.Join(testutils.CurrentDir(), "getter", "testdata", "controls-inputs.json")})
+	_, err := controls.GetControlsInputs(context.Background(), "")
+	require.NoError(t, err)
+
+	exceptions := getter.NewLoadPolicy([]string{filepath.Join(testutils.CurrentDir(), "getter", "testdata", "exceptions.json")})
+	_, err = exceptions.GetExceptions(context.Background(), "")
+	require.NoError(t, err)
+
+	scanInfo := &ScanInfo{ScanContract: &reporthandlingv2.ScanContractMetadata{
+		APIVersion:     "config.kubescape.io/v1alpha1",
+		Contract:       "ci",
+		DigestSchema:   "kubescape-scan-contract:v1",
+		ContractDigest: "sha256:contract",
+	}}
+	RecordScanContractRunnerInputs(scanInfo, &Getters{
+		ControlsInputsGetter: controls,
+		ExceptionsGetter:     getter.NewMergedExceptionsGetter(exceptions, nil),
+	})
+
+	metadata := scanInfoToScanMetadata(context.Background(), scanInfo, nil)
+	provenance := metadata.ScanMetadata.ScanContract
+	require.NotNil(t, provenance)
+	require.Len(t, provenance.RunnerInputs, 2)
+	assert.Equal(t, "controlsConfig", provenance.RunnerInputs[0].Role)
+	assert.Equal(t, "exceptions", provenance.RunnerInputs[1].Role)
+	for _, input := range provenance.RunnerInputs {
+		assert.NotEmpty(t, input.Source)
+		assert.False(t, filepath.IsAbs(input.Source))
+		assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, input.Digest)
+	}
+	assert.Regexp(t, `^sha256:[0-9a-f]{64}$`, provenance.EffectiveRunDigest)
 }
 
 func TestResolveClusterContextNameRejectsInvalidSelection(t *testing.T) {

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"go.opentelemetry.io/otel"
 )
 
@@ -25,6 +26,16 @@ type cachedPoliciesEntry struct {
 	frameworks  []reporthandling.Framework
 }
 
+type cachedExceptionsEntry struct {
+	exceptions  []armotypes.PostureExceptionPolicy
+	runnerInput reporthandlingv2.ScanContractRunnerInput
+}
+
+type cachedControlInputsEntry struct {
+	controlInputs map[string][]string
+	runnerInput   reporthandlingv2.ScanContractRunnerInput
+}
+
 type policyArtifactPersistence interface {
 	ShouldPersistPolicyArtifacts() bool
 }
@@ -33,8 +44,8 @@ type policyArtifactPersistence interface {
 type PolicyHandler struct {
 	clusterName         string
 	cachedPolicies      *TimedCache[cachedPoliciesEntry]
-	cachedExceptions    *TimedCache[[]armotypes.PostureExceptionPolicy]
-	cachedControlInputs *TimedCache[map[string][]string]
+	cachedExceptions    *TimedCache[cachedExceptionsEntry]
+	cachedControlInputs *TimedCache[cachedControlInputsEntry]
 }
 
 // NewPolicyHandler returns the shared, cluster-isolated *PolicyHandler for
@@ -68,8 +79,8 @@ func NewRequestScopedPolicyHandler(clusterName string) *PolicyHandler {
 	return &PolicyHandler{
 		clusterName:         clusterName,
 		cachedPolicies:      NewTimedCache[cachedPoliciesEntry](cacheTtl),
-		cachedExceptions:    NewTimedCache[[]armotypes.PostureExceptionPolicy](cacheTtl),
-		cachedControlInputs: NewTimedCache[map[string][]string](cacheTtl),
+		cachedExceptions:    NewTimedCache[cachedExceptionsEntry](cacheTtl),
+		cachedControlInputs: NewTimedCache[cachedControlInputsEntry](cacheTtl),
 	}
 }
 
@@ -88,11 +99,10 @@ func (policyHandler *PolicyHandler) Close() {
 
 func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (*cautils.OPASessionObj, error) {
 	// get policies, exceptions and controls inputs
-	policies, exceptions, controlInputs, degradations, err := policyHandler.getPolicies(ctx, policyIdentifier, getters)
+	policies, exceptions, controlInputs, degradations, err := policyHandler.getPolicies(ctx, policyIdentifier, scanInfo, getters)
 	if err != nil {
 		return cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier), err
 	}
-	cautils.RecordScanContractRunnerInputs(scanInfo, getters)
 	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier)
 
 	// load user-authored custom rules, if any
@@ -130,7 +140,7 @@ func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyI
 	return opaSessionObj, nil
 }
 
-func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, getters *cautils.Getters) (policies []reporthandling.Framework, exceptions []armotypes.PostureExceptionPolicy, controlInputs map[string][]string, degradations []cautils.PolicyDegradation, err error) {
+func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (policies []reporthandling.Framework, exceptions []armotypes.PostureExceptionPolicy, controlInputs map[string][]string, degradations []cautils.PolicyDegradation, err error) {
 	ctx, span := otel.Tracer("").Start(ctx, "policyHandler.getPolicies")
 	defer span.End()
 
@@ -149,7 +159,7 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	logger.L().Start("Loading exceptions...")
 
 	// get exceptions
-	if exceptions, err = policyHandler.getExceptions(ctx, getters); err != nil {
+	if exceptions, err = policyHandler.getExceptions(ctx, scanInfo, getters); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load exceptions", helpers.Error(err))
 		degradations = append(degradations, cautils.PolicyDegradation{Component: "exceptions", Reason: err.Error()})
 		exceptions = []armotypes.PostureExceptionPolicy{}
@@ -160,7 +170,7 @@ func (policyHandler *PolicyHandler) getPolicies(ctx context.Context, policyIdent
 	logger.L().Start("Loading account configurations...")
 
 	// get account configuration
-	if controlInputs, err = policyHandler.getControlInputs(ctx, getters); err != nil {
+	if controlInputs, err = policyHandler.getControlInputs(ctx, scanInfo, getters); err != nil {
 		logger.L().Ctx(ctx).StopError("Failed to load account configurations", helpers.Error(err))
 		degradations = append(degradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: err.Error()})
 
@@ -287,24 +297,27 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 	return frameworks, nil
 }
 
-func (policyHandler *PolicyHandler) getExceptions(ctx context.Context, getters *cautils.Getters) ([]armotypes.PostureExceptionPolicy, error) {
+func (policyHandler *PolicyHandler) getExceptions(ctx context.Context, scanInfo *cautils.ScanInfo, getters *cautils.Getters) ([]armotypes.PostureExceptionPolicy, error) {
 	if cachedExceptions, exist := policyHandler.cachedExceptions.Get(); exist {
 		logger.L().Info("Using cached exceptions")
-		return cachedExceptions, nil
+		cautils.RecordCachedScanContractRunnerInput(scanInfo, cachedExceptions.runnerInput)
+		return cachedExceptions.exceptions, nil
 	}
 
 	exceptions, err := getters.ExceptionsGetter.GetExceptions(ctx, policyHandler.clusterName)
 	if err == nil {
-		policyHandler.cachedExceptions.Set(exceptions)
+		runnerInput, _ := cautils.RecordScanContractRunnerInput(scanInfo, "exceptions", getters.ExceptionsGetter)
+		policyHandler.cachedExceptions.Set(cachedExceptionsEntry{exceptions: exceptions, runnerInput: runnerInput})
 	}
 
 	return exceptions, err
 }
 
-func (policyHandler *PolicyHandler) getControlInputs(ctx context.Context, getters *cautils.Getters) (map[string][]string, error) {
+func (policyHandler *PolicyHandler) getControlInputs(ctx context.Context, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (map[string][]string, error) {
 	if cachedControlInputs, exist := policyHandler.cachedControlInputs.Get(); exist {
 		logger.L().Info("Using cached control inputs")
-		return cachedControlInputs, nil
+		cautils.RecordCachedScanContractRunnerInput(scanInfo, cachedControlInputs.runnerInput)
+		return cachedControlInputs.controlInputs, nil
 	}
 
 	controlInputs, err := getters.ControlsInputsGetter.GetControlsInputs(ctx, policyHandler.clusterName)
@@ -315,6 +328,7 @@ func (policyHandler *PolicyHandler) getControlInputs(ctx context.Context, getter
 		return nil, fmt.Errorf("no control configuration inputs available")
 	}
 
-	policyHandler.cachedControlInputs.Set(controlInputs)
+	runnerInput, _ := cautils.RecordScanContractRunnerInput(scanInfo, "controlsConfig", getters.ControlsInputsGetter)
+	policyHandler.cachedControlInputs.Set(cachedControlInputsEntry{controlInputs: controlInputs, runnerInput: runnerInput})
 	return controlInputs, nil
 }

--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -87,13 +87,13 @@ func (policyHandler *PolicyHandler) Close() {
 }
 
 func (policyHandler *PolicyHandler) CollectPolicies(ctx context.Context, policyIdentifier []cautils.PolicyIdentifier, scanInfo *cautils.ScanInfo, getters *cautils.Getters) (*cautils.OPASessionObj, error) {
-	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier)
-
 	// get policies, exceptions and controls inputs
 	policies, exceptions, controlInputs, degradations, err := policyHandler.getPolicies(ctx, policyIdentifier, getters)
 	if err != nil {
-		return opaSessionObj, err
+		return cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier), err
 	}
+	cautils.RecordScanContractRunnerInputs(scanInfo, getters)
+	opaSessionObj := cautils.NewOPASessionObj(ctx, nil, nil, scanInfo, policyIdentifier)
 
 	// load user-authored custom rules, if any
 	if scanInfo.CustomRules != "" {

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	"github.com/kubescape/kubescape/v4/core/mocks"
+	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -244,7 +246,7 @@ func TestGetExceptions(t *testing.T) {
 	getters := &cautils.Getters{
 		ExceptionsGetter: &ExceptionsGetterMock{},
 	}
-	exceptions, err := policyHandler.getExceptions(context.TODO(), getters)
+	exceptions, err := policyHandler.getExceptions(context.TODO(), nil, getters)
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedExceptions, exceptions)
@@ -257,10 +259,54 @@ func TestGetControlInputs(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs(context.TODO(), getters)
+	controlInputs, err := policyHandler.getControlInputs(context.TODO(), nil, getters)
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedControlInputs, controlInputs)
+}
+
+func TestCollectPolicies_ReplaysRunnerInputProvenanceFromCache(t *testing.T) {
+	t.Setenv(PoliciesCacheTtlEnvVar, "1m")
+	handler := NewRequestScopedPolicyHandler("test-cluster")
+	defer handler.Close()
+
+	newScanInfo := func() *cautils.ScanInfo {
+		return &cautils.ScanInfo{ScanContract: &reporthandlingv2.ScanContractMetadata{
+			APIVersion:     "config.kubescape.io/v1alpha1",
+			Contract:       "ci",
+			DigestSchema:   "kubescape-scan-contract:v1",
+			ContractDigest: "sha256:contract",
+		}}
+	}
+	newGetters := func() *cautils.Getters {
+		testdata := filepath.Join("..", "..", "cautils", "getter", "testdata")
+		return &cautils.Getters{
+			PolicyGetter:         &nonPersistentPolicyGetterMock{},
+			ExceptionsGetter:     getter.NewLoadPolicy([]string{filepath.Join(testdata, "exceptions.json")}),
+			ControlsInputsGetter: getter.NewLoadPolicy([]string{filepath.Join(testdata, "controls-inputs.json")}),
+		}
+	}
+	identifiers := []cautils.PolicyIdentifier{{Identifier: FrameworkName, Kind: apisv1.KindFramework}}
+
+	first, err := handler.CollectPolicies(context.Background(), identifiers, newScanInfo(), newGetters())
+	require.NoError(t, err)
+	firstContract := first.Metadata.ScanMetadata.ScanContract
+	require.NotNil(t, firstContract)
+	require.Len(t, firstContract.RunnerInputs, 2)
+
+	secondGetters := newGetters()
+	second, err := handler.CollectPolicies(context.Background(), identifiers, newScanInfo(), secondGetters)
+	require.NoError(t, err)
+	secondContract := second.Metadata.ScanMetadata.ScanContract
+	require.NotNil(t, secondContract)
+
+	assert.Equal(t, firstContract.RunnerInputs, secondContract.RunnerInputs,
+		"a cache hit must replay the file digests captured when the cached values were first consumed")
+	assert.Equal(t, firstContract.EffectiveRunDigest, secondContract.EffectiveRunDigest)
+	_, _, consumed := secondGetters.ExceptionsGetter.(getter.ConsumedFileDigester).ConsumedFileDigest()
+	assert.False(t, consumed, "the second scan should receive exceptions from PolicyHandler's cache")
+	_, _, consumed = secondGetters.ControlsInputsGetter.(getter.ConsumedFileDigester).ConsumedFileDigest()
+	assert.False(t, consumed, "the second scan should receive control inputs from PolicyHandler's cache")
 }
 
 func TestDownloadScanPolicies_LocalCacheBypass(t *testing.T) {
@@ -394,7 +440,7 @@ func TestGetControlInputs_EmptyReturnsErrorNotCached(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterEmptyMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs(context.TODO(), getters)
+	controlInputs, err := policyHandler.getControlInputs(context.TODO(), nil, getters)
 
 	assert.Error(t, err)
 	assert.Nil(t, controlInputs)
@@ -411,7 +457,7 @@ func TestGetControlInputs_NonNilResultIsCached(t *testing.T) {
 		ControlsInputsGetter: &ControlsInputsGetterMock{},
 	}
 
-	controlInputs, err := policyHandler.getControlInputs(context.TODO(), getters)
+	controlInputs, err := policyHandler.getControlInputs(context.TODO(), nil, getters)
 
 	assert.NoError(t, err)
 	assert.Equal(t, CachedControlInputs, controlInputs)


### PR DESCRIPTION
## Summary

Completes the runner-input provenance portion of the repository scan-contract rollout from [design proposal #12](https://github.com/kubescape/designs-and-proposals/pull/12).

When a scan contract is active, Kubescape now records SHA-256 digests for the exact local `--controls-config` and `--exceptions` file bytes that were successfully consumed. Those digests are included in the effective-run digest, so reports remain reproducible without exposing input contents or unsafe absolute paths.

## Details

- Capture the digest from the same in-memory bytes parsed by local getters, avoiding a hash-then-load race.
- Propagate explicit local exception provenance through the merged exception getter.
- Create report metadata only after policy inputs have been loaded.
- Omit runner inputs that failed to load or were not used.
- Preserve repository-relative source labels when safe; otherwise report `external`.

## Validation

- `go test ./core/cautils ./core/cautils/getter ./core/pkg/policyhandler`
- `go vet ./core/cautils ./core/cautils/getter ./core/pkg/policyhandler`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scan provenance now records the exact controls and exceptions files consumed, including paths and SHA-256 digests.
  - Effective run digests incorporate these inputs for improved reproducibility.
  - External input paths are clearly labeled when they cannot be normalized locally.
  - Cached policy results preserve and replay runner-input provenance.

- **Bug Fixes**
  - Fixed missing runner-input information when controls or exceptions files were used.
  - Improved policy-loading error handling while preserving a usable session object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->