### PR TITLE
feat(config): support --format / -f flag in config view (#3641)

### DIFF
--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -14,13 +14,17 @@ func getViewCmd(ks meta.IKubescape) *cobra.Command {
 		Short: "View cached configurations",
 		Long:  `View cached Kubescape configuration in a human-readable text format, or render it as JSON or YAML.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			outputFormat, _ := cmd.Flags().GetString("output")
+			outputFormat, _ := cmd.Flags().GetString("format")
+			if !cmd.Flags().Changed("format") && cmd.Flags().Changed("output") {
+				outputFormat, _ = cmd.Flags().GetString("output")
+			}
 			includeEmpty, _ := cmd.Flags().GetBool("include-empty")
 			return ks.ViewCachedConfig(&v1.ViewConfig{Writer: os.Stdout, OutputFormat: outputFormat, IncludeEmpty: includeEmpty})
 		},
 	}
 
-	viewCmd.Flags().StringP("output", "o", "text", "Output format: text, json, or yaml")
+	viewCmd.Flags().StringP("format", "f", "text", "Output format: text, json, or yaml")
+	viewCmd.Flags().StringP("output", "o", "text", "Output format: text, json, or yaml (alias for --format)")
 	viewCmd.Flags().BoolP("include-empty", "e", false, "Include empty values in the rendered output")
 	return viewCmd
 }

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -33,14 +33,23 @@ func TestGetViewCmd(t *testing.T) {
 	assert.Equal(t, "View cached configurations", configCmd.Short)
 	assert.Equal(t, "View cached Kubescape configuration in a human-readable text format, or render it as JSON or YAML.", configCmd.Long)
 
+	formatFlag := configCmd.Flag("format")
+	if assert.NotNil(t, formatFlag) {
+		assert.Equal(t, "f", formatFlag.Shorthand)
+		assert.Equal(t, "text", formatFlag.DefValue)
+		assert.Equal(t, "Output format: text, json, or yaml", formatFlag.Usage)
+	}
+
 	outputFlag := configCmd.Flag("output")
 	if assert.NotNil(t, outputFlag) {
+		assert.Equal(t, "o", outputFlag.Shorthand)
 		assert.Equal(t, "text", outputFlag.DefValue)
-		assert.Equal(t, "Output format: text, json, or yaml", outputFlag.Usage)
+		assert.Equal(t, "Output format: text, json, or yaml (alias for --format)", outputFlag.Usage)
 	}
 
 	includeEmptyFlag := configCmd.Flag("include-empty")
 	if assert.NotNil(t, includeEmptyFlag) {
+		assert.Equal(t, "e", includeEmptyFlag.Shorthand)
 		assert.Equal(t, "false", includeEmptyFlag.DefValue)
 		assert.Equal(t, "Include empty values in the rendered output", includeEmptyFlag.Usage)
 	}
@@ -54,10 +63,14 @@ func TestGetViewCmd_RunEPassesFlags(t *testing.T) {
 		wantEmpty  bool
 	}{
 		{name: "defaults", args: []string{}, wantFormat: "text", wantEmpty: false},
+		{name: "format json", args: []string{"--format", "json"}, wantFormat: "json", wantEmpty: false},
+		{name: "short format yaml", args: []string{"-f", "yaml"}, wantFormat: "yaml", wantEmpty: false},
 		{name: "output json", args: []string{"--output", "json"}, wantFormat: "json", wantEmpty: false},
 		{name: "short output yaml", args: []string{"-o", "yaml"}, wantFormat: "yaml", wantEmpty: false},
+		{name: "format takes precedence over output", args: []string{"--format", "yaml", "--output", "json"}, wantFormat: "yaml", wantEmpty: false},
 		{name: "include-empty", args: []string{"--include-empty"}, wantFormat: "text", wantEmpty: true},
-		{name: "json with include-empty short flags", args: []string{"-o", "json", "-e"}, wantFormat: "json", wantEmpty: true},
+		{name: "format json with include-empty short flags", args: []string{"-f", "json", "-e"}, wantFormat: "json", wantEmpty: true},
+		{name: "output json with include-empty short flags", args: []string{"-o", "json", "-e"}, wantFormat: "json", wantEmpty: true},
 	}
 
 	for _, tt := range tests {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -912,10 +912,10 @@ Manage Kubescape configuration.
 kubescape config view
 
 # View configuration as JSON
-kubescape config view -o json
+kubescape config view --format json
 
 # View configuration as YAML
-kubescape config view -o yaml
+kubescape config view -f yaml
 
 # Set account ID
 kubescape config set accountID <account-id>

--- a/docs/config-output.md
+++ b/docs/config-output.md
@@ -90,12 +90,13 @@ Example output:
 ## Command reference
 
 ```bash
-kubescape config view [--output text|json|yaml] [--include-empty]
+kubescape config view [--format text|json|yaml] [--include-empty]
 ```
 
 ### Flags
 
-- `-o, --output`: select the rendering format
+- `-f, --format`: select the rendering format (`text`, `json`, `yaml`)
+- `-o, --output`: alias for `--format`
 - `-e, --include-empty`: include empty values in the rendered payload
 
 ## Integration notes


### PR DESCRIPTION

## Overview
Across Kubescape CLI subcommands (`scan`, `list`, `version`, `diff`), output formats are consistently configured using `--format` (or `-f`).

However, `kubescape config view` only exposed `--output` / `-o` and failed with `unknown flag: --format` when users tried to pass `--format json` or `-f yaml`.

This PR:
- Adds `--format` / `-f` flag support to `kubescape config view` while maintaining `--output` / `-o` as a backwards-compatible alias.
- Updates documentation in `docs/cli-reference.md` and `docs/config-output.md`.
- Adds table tests in `cmd/config/view_test.go` verifying flag resolution, short options, and precedence.

## How to Test
1. Run unit tests:
   ```bash
   go test -v ./cmd/config/... -run TestGetViewCmd
   ```
2. Test CLI commands:
   ```bash
   kubescape config view --format json
   kubescape config view -f yaml
   kubescape config view -o json
   ```

## Related issues/PRs:
* Resolved #3641

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--format` (`-f`) option to select JSON or YAML output for `config view`.
  * Existing `--output` (`-o`) remains supported as an alias.

* **Documentation**
  * Updated CLI examples and flag references to use `--format` as the preferred option.
  * Clarified compatibility with the existing `--output` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->