### PR TITLE
feat(config): Filter configurations by key in kubescape config view

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -35,7 +35,7 @@ func TestGetConfigCmd(t *testing.T) {
 			assert.Equal(t, "Set configurations, supported: "+strings.Join(stringKeysToSlice(supportConfigSet), "/"), subcmd.Short)
 		case "view":
 			// Verify that the view subcommand is added correctly
-			assert.Equal(t, "view", subcmd.Use)
+			assert.Equal(t, "view [KEY]", subcmd.Use)
 			assert.Equal(t, "View cached configurations", subcmd.Short)
 		default:
 			t.Errorf("Unexpected subcommand name: %s", subcmd.Name())

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -10,13 +10,25 @@ import (
 
 func getViewCmd(ks meta.IKubescape) *cobra.Command {
 	viewCmd := &cobra.Command{
-		Use:   "view",
+		Use:   "view [KEY]",
 		Short: "View cached configurations",
 		Long:  `View cached Kubescape configuration in a human-readable text format, or render it as JSON or YAML.`,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat, _ := cmd.Flags().GetString("output")
 			includeEmpty, _ := cmd.Flags().GetBool("include-empty")
-			return ks.ViewCachedConfig(&v1.ViewConfig{Writer: os.Stdout, OutputFormat: outputFormat, IncludeEmpty: includeEmpty})
+
+			key := ""
+			if len(args) > 0 {
+				key = args[0]
+			}
+
+			return ks.ViewCachedConfig(&v1.ViewConfig{
+				Writer:       os.Stdout,
+				OutputFormat: outputFormat,
+				IncludeEmpty: includeEmpty,
+				Key:          key,
+			})
 		},
 	}
 

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -29,7 +29,7 @@ func TestGetViewCmd(t *testing.T) {
 	configCmd := getViewCmd(mockKubescape)
 
 	// Verify the command name and short description
-	assert.Equal(t, "view", configCmd.Use)
+	assert.Equal(t, "view [KEY]", configCmd.Use)
 	assert.Equal(t, "View cached configurations", configCmd.Short)
 	assert.Equal(t, "View cached Kubescape configuration in a human-readable text format, or render it as JSON or YAML.", configCmd.Long)
 

--- a/core/cautils/config_output.go
+++ b/core/cautils/config_output.go
@@ -8,9 +8,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type configOutputField struct {
-	name  string
-	value string
+type ConfigOutputField struct {
+	Name  string
+	Value string
 }
 
 // FormatConfigOutput renders configuration data in the requested output format.
@@ -39,9 +39,9 @@ func FormatConfigOutput(cfg *ConfigObj, format string, includeEmpty bool) ([]byt
 
 func formatConfigOutputJSON(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	payload := map[string]string{}
-	for _, field := range configOutputFields(cfg) {
-		if includeEmpty || field.value != "" {
-			payload[field.name] = field.value
+	for _, field := range ConfigOutputFields(cfg) {
+		if includeEmpty || field.Value != "" {
+			payload[field.Name] = field.Value
 		}
 	}
 	return json.MarshalIndent(payload, "", "  ")
@@ -49,9 +49,9 @@ func formatConfigOutputJSON(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 
 func formatConfigOutputYAML(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	payload := map[string]string{}
-	for _, field := range configOutputFields(cfg) {
-		if includeEmpty || field.value != "" {
-			payload[field.name] = field.value
+	for _, field := range ConfigOutputFields(cfg) {
+		if includeEmpty || field.Value != "" {
+			payload[field.Name] = field.Value
 		}
 	}
 	return yaml.Marshal(payload)
@@ -59,21 +59,40 @@ func formatConfigOutputYAML(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 
 func formatConfigOutputText(cfg *ConfigObj, includeEmpty bool) ([]byte, error) {
 	var lines []string
-	for _, field := range configOutputFields(cfg) {
-		if includeEmpty || field.value != "" {
-			lines = append(lines, fmt.Sprintf("%s: %s", field.name, field.value))
+	for _, field := range ConfigOutputFields(cfg) {
+		if includeEmpty || field.Value != "" {
+			lines = append(lines, fmt.Sprintf("%s: %s", field.Name, field.Value))
 		}
 	}
 	return []byte(strings.Join(lines, "\n") + "\n"), nil
 }
 
-func configOutputFields(cfg *ConfigObj) []configOutputField {
-	return []configOutputField{
-		{name: "accountID", value: cfg.AccountID},
-		{name: "clusterName", value: cfg.ClusterName},
-		{name: "cloudReportURL", value: cfg.CloudReportURL},
-		{name: "cloudAPIURL", value: cfg.CloudAPIURL},
-		{name: "accessKey", value: maskAccessKey(cfg.AccessKey)},
+func ConfigOutputFields(cfg *ConfigObj) []ConfigOutputField {
+	return []ConfigOutputField{
+		{Name: "accountID", Value: cfg.AccountID},
+		{Name: "clusterName", Value: cfg.ClusterName},
+		{Name: "cloudReportURL", Value: cfg.CloudReportURL},
+		{Name: "cloudAPIURL", Value: cfg.CloudAPIURL},
+		{Name: "accessKey", Value: maskAccessKey(cfg.AccessKey)},
+	}
+}
+
+// FormatConfigFieldOutput renders a single configuration field.
+func FormatConfigFieldOutput(field ConfigOutputField, format string) ([]byte, error) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if format == "" {
+		format = "text"
+	}
+
+	switch format {
+	case "json":
+		return json.MarshalIndent(map[string]string{field.Name: field.Value}, "", "  ")
+	case "yaml":
+		return yaml.Marshal(map[string]string{field.Name: field.Value})
+	case "text":
+		return []byte(field.Value + "\n"), nil
+	default:
+		return nil, fmt.Errorf("unsupported output format %q", format)
 	}
 }
 

--- a/core/cautils/config_output_test.go
+++ b/core/cautils/config_output_test.go
@@ -205,3 +205,52 @@ func TestFormatConfigOutputKeepsEmptyAccessKeyEmpty(t *testing.T) {
 	require.True(t, ok, "--include-empty must still render the accessKey field")
 	assert.Equal(t, "", accessKey)
 }
+
+func TestFormatConfigFieldOutput(t *testing.T) {
+	field := ConfigOutputField{Name: "accountID", Value: "test-account"}
+
+	tests := []struct {
+		name    string
+		format  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "Text format",
+			format: "text",
+			want:   "test-account\n",
+		},
+		{
+			name:   "Default format",
+			format: "",
+			want:   "test-account\n",
+		},
+		{
+			name:   "JSON format",
+			format: "json",
+			want:   "{\n  \"accountID\": \"test-account\"\n}",
+		},
+		{
+			name:   "YAML format",
+			format: "yaml",
+			want:   "accountID: test-account\n",
+		},
+		{
+			name:    "Unsupported format",
+			format:  "xml",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FormatConfigFieldOutput(field, tt.format)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, string(got))
+			}
+		})
+	}
+}

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
@@ -27,10 +28,58 @@ func (ks *Kubescape) SetCachedConfig(setConfig *metav1.SetConfig) error {
 	return tenant.UpdateCachedConfig()
 }
 
+func getNormalizedKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, "_", "")
+	if key == "account" {
+		return "accountid"
+	}
+	return key
+}
+
 // View cached configurations
 func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
 	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", getKubernetesApi()) // change k8sinterface
 	configObj := tenant.GetConfigObj()
+
+	if viewConfig.Key != "" {
+		normalizedKey := getNormalizedKey(viewConfig.Key)
+		var val string
+		var found bool
+
+		switch normalizedKey {
+		case "accountid":
+			val = configObj.AccountID
+			found = true
+		case "clustername":
+			val = configObj.ClusterName
+			found = true
+		case "cloudreporturl":
+			val = configObj.CloudReportURL
+			found = true
+		case "cloudapiurl":
+			val = configObj.CloudAPIURL
+			found = true
+		case "accesskey":
+			val = configObj.AccessKey
+			found = true
+		}
+
+		if !found {
+			return fmt.Errorf("key %q is not supported", viewConfig.Key)
+		}
+		if val == "" {
+			return fmt.Errorf("key %q is not set", viewConfig.Key)
+		}
+
+		if viewConfig.Writer != nil {
+			_, err := fmt.Fprint(viewConfig.Writer, val+"\n")
+			return err
+		}
+		return nil
+	}
+
 	outputFormat := viewConfig.OutputFormat
 	if outputFormat == "" {
 		outputFormat = "text"

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -45,36 +45,30 @@ func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
 
 	if viewConfig.Key != "" {
 		normalizedKey := getNormalizedKey(viewConfig.Key)
-		var val string
-		var found bool
+		var foundField *cautils.ConfigOutputField
 
-		switch normalizedKey {
-		case "accountid":
-			val = configObj.AccountID
-			found = true
-		case "clustername":
-			val = configObj.ClusterName
-			found = true
-		case "cloudreporturl":
-			val = configObj.CloudReportURL
-			found = true
-		case "cloudapiurl":
-			val = configObj.CloudAPIURL
-			found = true
-		case "accesskey":
-			val = configObj.AccessKey
-			found = true
+		for _, field := range cautils.ConfigOutputFields(configObj) {
+			if strings.ToLower(field.Name) == normalizedKey {
+				// Make a copy so we can take its address safely if needed, or just assign it
+				f := field
+				foundField = &f
+				break
+			}
 		}
 
-		if !found {
+		if foundField == nil {
 			return fmt.Errorf("key %q is not supported", viewConfig.Key)
 		}
-		if val == "" {
+		if foundField.Value == "" {
 			return fmt.Errorf("key %q is not set", viewConfig.Key)
 		}
 
 		if viewConfig.Writer != nil {
-			_, err := fmt.Fprint(viewConfig.Writer, val+"\n")
+			formatted, err := cautils.FormatConfigFieldOutput(*foundField, viewConfig.OutputFormat)
+			if err != nil {
+				return err
+			}
+			_, err = viewConfig.Writer.Write(formatted)
 			return err
 		}
 		return nil

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -40,7 +40,7 @@ func getNormalizedKey(key string) string {
 
 // View cached configurations
 func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
-	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", getKubernetesApi()) // change k8sinterface
+	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", kubernetesAPIFunc()) // change k8sinterface
 	configObj := tenant.GetConfigObj()
 
 	if viewConfig.Key != "" {

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestViewCachedConfig_KeyedLookup(t *testing.T) {
+	// Setup temporary config store
+	originalStore := getter.DefaultLocalStore
+	getter.DefaultLocalStore = t.TempDir()
+	t.Cleanup(func() { getter.DefaultLocalStore = originalStore })
+
+	ks := NewKubescape(context.Background())
+
+	// Set cached config values
+	setConfig := &metav1.SetConfig{
+		Account:   "test-account-id",
+		AccessKey: "test-secret-key-123", // length > 8, should mask everything except last 4
+	}
+	require.NoError(t, ks.SetCachedConfig(setConfig))
+
+	tests := []struct {
+		name       string
+		key        string
+		format     string
+		want       string
+		wantErr    string
+	}{
+		{
+			name:   "Found key",
+			key:    "accountID",
+			format: "text", // default
+			want:   "test-account-id\n",
+		},
+		{
+			name:   "Key normalization",
+			key:    "Account",
+			format: "",
+			want:   "test-account-id\n",
+		},
+		{
+			name:   "Masked access key",
+			key:    "accessKey",
+			format: "",
+			want:   "****-123\n", // Length > 8, masks last 4. 'test-secret-key-123' is 19 chars. last 4 is '-123'
+		},
+		{
+			name:    "Unsupported key",
+			key:     "unknownKey",
+			format:  "",
+			wantErr: `key "unknownKey" is not supported`,
+		},
+		{
+			name:    "Unset key",
+			key:     "clusterName",
+			format:  "",
+			wantErr: `key "clusterName" is not set`,
+		},
+		{
+			name:   "Format JSON",
+			key:    "accountID",
+			format: "json",
+			want:   "{\n  \"accountID\": \"test-account-id\"\n}",
+		},
+		{
+			name:   "Format YAML",
+			key:    "accountID",
+			format: "yaml",
+			want:   "accountID: test-account-id\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			viewConfig := &metav1.ViewConfig{
+				Key:          tt.key,
+				OutputFormat: tt.format,
+				Writer:       &buf,
+			}
+
+			err := ks.ViewCachedConfig(viewConfig)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, buf.String())
+			}
+		})
+	}
+}

--- a/core/core/cachedconfig_test.go
+++ b/core/core/cachedconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,11 @@ func TestViewCachedConfig_KeyedLookup(t *testing.T) {
 	getter.DefaultLocalStore = t.TempDir()
 	t.Cleanup(func() { getter.DefaultLocalStore = originalStore })
 
+	// stub k8s API to prevent flaky tests in cluster-connected environments
+	origK8s := kubernetesAPIFunc
+	kubernetesAPIFunc = func() *k8sinterface.KubernetesApi { return nil }
+	t.Cleanup(func() { kubernetesAPIFunc = origK8s })
+
 	ks := NewKubescape(context.Background())
 
 	// Set cached config values
@@ -27,11 +33,11 @@ func TestViewCachedConfig_KeyedLookup(t *testing.T) {
 	require.NoError(t, ks.SetCachedConfig(setConfig))
 
 	tests := []struct {
-		name       string
-		key        string
-		format     string
-		want       string
-		wantErr    string
+		name    string
+		key     string
+		format  string
+		want    string
+		wantErr string
 	}{
 		{
 			name:   "Found key",

--- a/core/meta/datastructures/v1/config.go
+++ b/core/meta/datastructures/v1/config.go
@@ -12,6 +12,7 @@ type ViewConfig struct {
 	Writer       io.Writer
 	OutputFormat string
 	IncludeEmpty bool
+	Key          string
 }
 type DeleteConfig struct {
 }


### PR DESCRIPTION
## Overview
This PR updates the `config view` command to optionally take a single positional argument representing the key to view (e.g. `kubescape config view accountID`).
- Preserves the current behavior of showing all configurations if run without arguments.
- If run with one argument, extracts only the requested key and prints its value.
- If the key doesn't exist, returns an error stating the key isn't supported or isn't set.

## Related issues/PRs:
* Resolved #3643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing a single cached configuration value with `view [KEY]`.
  * Keys accept capitalization differences, dashes, underscores, and common aliases.
  * Single-value results support text, JSON, and YAML output formats.
  * Sensitive access-key values remain masked.
  * Unsupported or unset keys return a clear error.
  * Viewing configuration without a key continues to display the full configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->