### PR TITLE
feat(notification): add Microsoft Teams Adaptive Card support for --notify webhooks

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -228,7 +228,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.LabelSelector, "label-selector", "", "Filter collected Kubernetes resources by label selector. Accepts any selector that kubectl -l supports, e.g: --label-selector app=nginx,env!=dev")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to configured backend.")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Output, "output", "o", "", "Output file. Print output to file and not stdout")
-	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.NotifyURLs, "notify", nil, "POST the scan summary to this webhook URL; Slack incoming webhooks use Block Kit; repeat for multiple destinations")
+	scanCmd.PersistentFlags().StringArrayVar(&scanInfo.NotifyURLs, "notify", nil, "POST the scan summary to this webhook URL; Slack incoming webhooks use Block Kit and Microsoft Teams webhooks an Adaptive Card; repeat for multiple destinations")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ShowEvidence, "show-evidence", "E", false, "Show evidence paths with current field values for each failed control (pretty-printer only)")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.ShowSecrets, "show-secrets", false, "Show secret field values in evidence output. By default secret values are redacted. Only effective with --show-evidence")

--- a/core/pkg/resultshandling/notification/payload.go
+++ b/core/pkg/resultshandling/notification/payload.go
@@ -12,10 +12,15 @@ import (
 )
 
 const (
-	maxSlackFailingControls     = 10
+	maxFailingControls          = 10
 	maxSlackSectionTextLength   = 3000
 	maxSlackControlIDTextLength = 80
 	slackTopControlsHeading     = "*Top failing controls*"
+
+	maxTeamsControlIDLength   = 80
+	maxTeamsControlNameLength = 160
+	teamsCardVersion          = "1.4"
+	teamsTopControlsHeading   = "Top failing controls"
 )
 
 var slackTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
@@ -54,16 +59,20 @@ func IsSlackEndpoint(endpoint string) bool {
 }
 
 // MarshalPayload formats summary for endpoint. Slack incoming webhooks receive
-// a compact Block Kit message; every other endpoint receives the existing
-// generic SummaryDetails JSON object.
+// a compact Block Kit message, Microsoft Teams webhooks an Adaptive Card, and
+// every other endpoint the existing generic SummaryDetails JSON object.
 func MarshalPayload(endpoint string, summary *reportsummary.SummaryDetails) ([]byte, error) {
 	if summary == nil {
 		return nil, fmt.Errorf("marshal notification payload: summary is nil")
 	}
-	if IsSlackEndpoint(endpoint) {
+	switch {
+	case IsSlackEndpoint(endpoint):
 		return json.Marshal(newSlackPayload(summary))
+	case IsTeamsEndpoint(endpoint):
+		return json.Marshal(newTeamsPayload(summary))
+	default:
+		return json.Marshal(summary)
 	}
-	return json.Marshal(summary)
 }
 
 func newSlackPayload(summary *reportsummary.SummaryDetails) slackPayload {
@@ -144,8 +153,8 @@ func summarizeControls(controls reportsummary.ControlSummaries) controlSummary {
 		}
 		return left.Name < right.Name
 	})
-	if len(result.topFailing) > maxSlackFailingControls {
-		result.topFailing = result.topFailing[:maxSlackFailingControls]
+	if len(result.topFailing) > maxFailingControls {
+		result.topFailing = result.topFailing[:maxFailingControls]
 	}
 	return result
 }
@@ -179,14 +188,18 @@ func maxSlackControlLineLength() int {
 	// Reserve one newline for each possible entry. Bounding every line to the
 	// remaining equal share guarantees the complete section stays within Slack's
 	// 3,000-character section text limit even when all ten entries are present.
-	return (maxSlackSectionTextLength - utf8.RuneCountInString(slackTopControlsHeading) - maxSlackFailingControls) / maxSlackFailingControls
+	return (maxSlackSectionTextLength - utf8.RuneCountInString(slackTopControlsHeading) - maxFailingControls) / maxFailingControls
 }
 
 func escapeAndTruncateSlackText(value string, maxLength int) string {
+	return escapeAndTruncate(slackTextEscaper, value, maxLength)
+}
+
+func escapeAndTruncate(escaper *strings.Replacer, value string, maxLength int) string {
 	if maxLength <= 0 {
 		return ""
 	}
-	escaped := escapeSlackText(value)
+	escaped := escaper.Replace(value)
 	if utf8.RuneCountInString(escaped) <= maxLength {
 		return escaped
 	}
@@ -197,7 +210,7 @@ func escapeAndTruncateSlackText(value string, maxLength int) string {
 	var result strings.Builder
 	used := 0
 	for _, r := range value {
-		piece := escapeSlackText(string(r))
+		piece := escaper.Replace(string(r))
 		pieceLength := utf8.RuneCountInString(piece)
 		if used+pieceLength > maxLength-1 {
 			break

--- a/core/pkg/resultshandling/notification/payload_test.go
+++ b/core/pkg/resultshandling/notification/payload_test.go
@@ -102,8 +102,8 @@ func TestMarshalPayloadBuildsDeterministicSlackBlockKit(t *testing.T) {
 }
 
 func TestMarshalPayloadLimitsSlackMessageToTopTenFailingControls(t *testing.T) {
-	controls := make(reportsummary.ControlSummaries, maxSlackFailingControls+1)
-	for i := 0; i <= maxSlackFailingControls; i++ {
+	controls := make(reportsummary.ControlSummaries, maxFailingControls+1)
+	for i := 0; i <= maxFailingControls; i++ {
 		id := fmt.Sprintf("C-%02d", i)
 		controls[id] = failedControl(id, "Failed control", 7, 1)
 	}
@@ -114,14 +114,14 @@ func TestMarshalPayloadLimitsSlackMessageToTopTenFailingControls(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &got))
 	require.Len(t, got.Blocks, 3)
 	require.NotNil(t, got.Blocks[2].Text)
-	assert.Equal(t, maxSlackFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
+	assert.Equal(t, maxFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
 	assert.Contains(t, got.Blocks[2].Text.Text, "C-09")
 	assert.NotContains(t, got.Blocks[2].Text.Text, "C-10")
 }
 
 func TestMarshalPayloadBoundsLongSlackControlNames(t *testing.T) {
-	controls := make(reportsummary.ControlSummaries, maxSlackFailingControls)
-	for i := 0; i < maxSlackFailingControls; i++ {
+	controls := make(reportsummary.ControlSummaries, maxFailingControls)
+	for i := 0; i < maxFailingControls; i++ {
 		id := fmt.Sprintf("C-%02d-%s", i, strings.Repeat("<", 500))
 		controls[id] = failedControl(id, strings.Repeat("@channel <&>", 500), 7, 1)
 	}
@@ -134,7 +134,7 @@ func TestMarshalPayloadBoundsLongSlackControlNames(t *testing.T) {
 	require.NotNil(t, got.Blocks[2].Text)
 	assert.True(t, got.Blocks[2].Text.Verbatim)
 	assert.LessOrEqual(t, utf8.RuneCountInString(got.Blocks[2].Text.Text), maxSlackSectionTextLength)
-	assert.Equal(t, maxSlackFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
+	assert.Equal(t, maxFailingControls, strings.Count(got.Blocks[2].Text.Text, "\n• "))
 	assert.Contains(t, got.Blocks[2].Text.Text, "@channel")
 	assert.NotContains(t, got.Blocks[2].Text.Text, "&am…")
 	assert.NotContains(t, got.Blocks[2].Text.Text, "&l…")

--- a/core/pkg/resultshandling/notification/teams.go
+++ b/core/pkg/resultshandling/notification/teams.go
@@ -1,0 +1,139 @@
+package notification
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+var teamsTextEscaper = strings.NewReplacer(
+	"\\", "\\\\",
+	"*", "\\*",
+	"_", "\\_",
+	"[", "\\[",
+	"]", "\\]",
+)
+
+type teamsPayload struct {
+	Type        string            `json:"type"`
+	Attachments []teamsAttachment `json:"attachments"`
+}
+
+type teamsAttachment struct {
+	ContentType string            `json:"contentType"`
+	ContentURL  *string           `json:"contentUrl"`
+	Content     teamsAdaptiveCard `json:"content"`
+}
+
+type teamsAdaptiveCard struct {
+	Schema  string           `json:"$schema"`
+	Type    string           `json:"type"`
+	Version string           `json:"version"`
+	Body    []teamsCardBlock `json:"body"`
+}
+
+type teamsCardBlock struct {
+	Type   string      `json:"type"`
+	Text   string      `json:"text,omitempty"`
+	Size   string      `json:"size,omitempty"`
+	Weight string      `json:"weight,omitempty"`
+	Wrap   bool        `json:"wrap,omitempty"`
+	Facts  []teamsFact `json:"facts,omitempty"`
+}
+
+type teamsFact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+// IsTeamsEndpoint reports whether endpoint is a Microsoft Teams incoming
+// webhook URL. Only the documented Teams connector hosts are matched, so a
+// Power Automate workflow URL on a shared Azure domain falls through to the
+// generic JSON payload rather than being guessed at.
+func IsTeamsEndpoint(endpoint string) bool {
+	u, err := validateEndpoint(endpoint)
+	if err != nil || !strings.EqualFold(u.Scheme, "https") {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	switch host {
+	case "outlook.office.com", "outlook.office365.com":
+		return true
+	}
+	return strings.HasSuffix(host, ".webhook.office.com")
+}
+
+func newTeamsPayload(summary *reportsummary.SummaryDetails) teamsPayload {
+	controls := summarizeControls(summary.Controls)
+
+	body := []teamsCardBlock{
+		{
+			Type:   "TextBlock",
+			Text:   "Kubescape scan results",
+			Size:   "Large",
+			Weight: "Bolder",
+			Wrap:   true,
+		},
+		{
+			Type: "FactSet",
+			Facts: []teamsFact{
+				{Title: "Compliance score", Value: fmt.Sprintf("%.1f%%", summary.ComplianceScore)},
+				{Title: "Controls failed", Value: fmt.Sprintf("%d of %d", controls.failed, controls.total)},
+				{Title: "Passed", Value: fmt.Sprintf("%d", controls.passed)},
+				{Title: "Skipped", Value: fmt.Sprintf("%d", controls.skipped)},
+			},
+		},
+	}
+
+	if len(controls.topFailing) > 0 {
+		facts := make([]teamsFact, 0, len(controls.topFailing))
+		for _, control := range controls.topFailing {
+			facts = append(facts, teamsControlFact(control))
+		}
+		body = append(body,
+			teamsCardBlock{
+				Type:   "TextBlock",
+				Text:   teamsTopControlsHeading,
+				Weight: "Bolder",
+				Wrap:   true,
+			},
+			teamsCardBlock{Type: "FactSet", Facts: facts},
+		)
+	}
+
+	return teamsPayload{
+		Type: "message",
+		Attachments: []teamsAttachment{{
+			ContentType: "application/vnd.microsoft.card.adaptive",
+			Content: teamsAdaptiveCard{
+				Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+				Type:    "AdaptiveCard",
+				Version: teamsCardVersion,
+				Body:    body,
+			},
+		}},
+	}
+}
+
+func teamsControlFact(control reportsummary.ControlSummary) teamsFact {
+	id := control.ControlID
+	if id == "" {
+		id = "unknown"
+	}
+	name := control.Name
+	if name == "" {
+		name = "Unnamed control"
+	}
+
+	severity := teamsTextEscaper.Replace(apis.ControlSeverityToString(control.ScoreFactor))
+	return teamsFact{
+		Title: escapeAndTruncateTeamsText(id, maxTeamsControlIDLength),
+		Value: fmt.Sprintf("%s — %s", severity, escapeAndTruncateTeamsText(name, maxTeamsControlNameLength)),
+	}
+}
+
+func escapeAndTruncateTeamsText(value string, maxLength int) string {
+	return escapeAndTruncate(teamsTextEscaper, value, maxLength)
+}

--- a/core/pkg/resultshandling/notification/teams_test.go
+++ b/core/pkg/resultshandling/notification/teams_test.go
@@ -1,0 +1,208 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decodeTeamsCard(t *testing.T, payload []byte) teamsAdaptiveCard {
+	t.Helper()
+
+	var decoded teamsPayload
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	assert.Equal(t, "message", decoded.Type)
+	require.Len(t, decoded.Attachments, 1)
+	assert.Equal(t, "application/vnd.microsoft.card.adaptive", decoded.Attachments[0].ContentType)
+	return decoded.Attachments[0].Content
+}
+
+func teamsFactsByBlock(card teamsAdaptiveCard) [][]teamsFact {
+	var sets [][]teamsFact
+	for _, block := range card.Body {
+		if block.Type == "FactSet" {
+			sets = append(sets, block.Facts)
+		}
+	}
+	return sets
+}
+
+func TestIsTeamsEndpoint(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://contoso.webhook.office.com/webhookb2/guid@guid/IncomingWebhook/id/key",
+		"https://CONTOSO.WEBHOOK.OFFICE.COM/webhookb2/guid@guid/IncomingWebhook/id/key",
+		"https://outlook.office.com/webhook/guid@guid/IncomingWebhook/id/key",
+		"https://outlook.office365.com/webhook/guid@guid/IncomingWebhook/id/key",
+	} {
+		assert.True(t, IsTeamsEndpoint(endpoint), endpoint)
+	}
+
+	for _, endpoint := range []string{
+		"http://contoso.webhook.office.com/webhookb2/id",
+		"https://user:secret@contoso.webhook.office.com/webhookb2/id",
+		"https://contoso.webhook.office.com/webhookb2/id#fragment",
+		"https://webhook.office.com.example.com/webhookb2/id",
+		"https://example.com/contoso.webhook.office.com",
+		"https://prod-12.westus.logic.azure.com/workflows/id/triggers/manual/paths/invoke",
+		"https://hooks.slack.com/services/T000/B000/secret",
+		"not a URL",
+	} {
+		assert.False(t, IsTeamsEndpoint(endpoint), endpoint)
+	}
+}
+
+func TestMarshalPayloadBuildsDeterministicTeamsAdaptiveCard(t *testing.T) {
+	summary := &reportsummary.SummaryDetails{
+		ComplianceScore: 73.25,
+		Controls: reportsummary.ControlSummaries{
+			"C-CRITICAL": failedControl("C-CRITICAL", "Critical control", 9.5, 1),
+			"C-HIGH-C":   failedControl("C-HIGH-C", "High with most failures", 8, 4),
+			"C-HIGH-A":   failedControl("C-HIGH-A", "High alpha", 8, 2),
+			"C-LOW":      failedControl("C-LOW", "Low control", 2, 20),
+			"C-PASSED":   {ControlID: "C-PASSED", Name: "Passed", Status: apis.StatusPassed},
+			"C-SKIPPED":  {ControlID: "C-SKIPPED", Name: "Skipped", Status: apis.StatusSkipped},
+		},
+	}
+
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", summary)
+	require.NoError(t, err)
+
+	card := decodeTeamsCard(t, payload)
+	assert.Equal(t, "AdaptiveCard", card.Type)
+	assert.Equal(t, teamsCardVersion, card.Version)
+	require.NotEmpty(t, card.Body)
+	assert.Equal(t, "Kubescape scan results", card.Body[0].Text)
+
+	sets := teamsFactsByBlock(card)
+	require.Len(t, sets, 2)
+	assert.Equal(t, []teamsFact{
+		{Title: "Compliance score", Value: "73.2%"},
+		{Title: "Controls failed", Value: "4 of 6"},
+		{Title: "Passed", Value: "1"},
+		{Title: "Skipped", Value: "1"},
+	}, sets[0])
+
+	ids := make([]string, 0, len(sets[1]))
+	for _, fact := range sets[1] {
+		ids = append(ids, fact.Title)
+	}
+	assert.Equal(t, []string{"C-CRITICAL", "C-HIGH-C", "C-HIGH-A", "C-LOW"}, ids)
+	assert.Equal(t, "Critical — Critical control", sets[1][0].Value)
+}
+
+func TestMarshalPayloadLimitsTeamsCardToTopTenFailingControls(t *testing.T) {
+	controls := reportsummary.ControlSummaries{}
+	for i := 0; i < maxFailingControls+5; i++ {
+		id := fmt.Sprintf("C-%03d", i)
+		controls[id] = failedControl(id, fmt.Sprintf("Control %d", i), 8, i)
+	}
+
+	payload, err := MarshalPayload("https://outlook.office.com/webhook/id", &reportsummary.SummaryDetails{Controls: controls})
+	require.NoError(t, err)
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+	assert.Len(t, sets[1], maxFailingControls)
+}
+
+func TestMarshalPayloadBoundsLongTeamsControlText(t *testing.T) {
+	longID := strings.Repeat("I", maxTeamsControlIDLength*2)
+	longName := strings.Repeat("N", maxTeamsControlNameLength*2)
+
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{longID: failedControl(longID, longName, 8, 1)},
+	})
+	require.NoError(t, err)
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+	require.Len(t, sets[1], 1)
+
+	fact := sets[1][0]
+	assert.LessOrEqual(t, utf8.RuneCountInString(fact.Title), maxTeamsControlIDLength)
+	assert.True(t, strings.HasSuffix(fact.Title, "…"))
+	assert.True(t, strings.HasSuffix(fact.Value, "…"))
+}
+
+func TestMarshalPayloadTeamsEscapesMarkdownInControlText(t *testing.T) {
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": failedControl("C-0001", "Uses *bold* and _underscore_ and [link]", 8, 1),
+		},
+	})
+	require.NoError(t, err)
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+	assert.Contains(t, sets[1][0].Value, `\*bold\*`)
+	assert.Contains(t, sets[1][0].Value, `\_underscore\_`)
+	assert.Contains(t, sets[1][0].Value, `\[link\]`)
+}
+
+func TestMarshalPayloadTeamsOmitsFailingSectionWhenAllControlsPass(t *testing.T) {
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		ComplianceScore: 100,
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": {ControlID: "C-0001", Name: "Passed", Status: apis.StatusPassed},
+		},
+	})
+	require.NoError(t, err)
+
+	card := decodeTeamsCard(t, payload)
+	assert.Len(t, teamsFactsByBlock(card), 1)
+	for _, block := range card.Body {
+		assert.NotEqual(t, teamsTopControlsHeading, block.Text)
+	}
+}
+
+func TestMarshalPayloadTeamsFallsBackForUnknownControlText(t *testing.T) {
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{"": failedControl("", "", 8, 1)},
+	})
+	require.NoError(t, err)
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+	assert.Equal(t, "unknown", sets[1][0].Title)
+	assert.Contains(t, sets[1][0].Value, "Unnamed control")
+}
+
+func TestTeamsEscaperLeavesUninterpretedMarkdownAlone(t *testing.T) {
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": failedControl("C-0001", "Issue #12 ~approx~ `code`", 8, 1),
+		},
+	})
+	require.NoError(t, err)
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+	assert.Contains(t, sets[1][0].Value, "Issue #12 ~approx~ `code`")
+	assert.NotContains(t, sets[1][0].Value, `\`)
+}
+
+func TestMarshalPayloadTeamsTruncatesMultiByteNamesOnRuneBoundaries(t *testing.T) {
+	name := strings.Repeat("日本語テスト🔒", 60)
+
+	payload, err := MarshalPayload("https://contoso.webhook.office.com/webhookb2/id", &reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{"C-0001": failedControl("C-0001", name, 9, 1)},
+	})
+	require.NoError(t, err)
+	require.True(t, json.Valid(payload))
+
+	sets := teamsFactsByBlock(decodeTeamsCard(t, payload))
+	require.Len(t, sets, 2)
+
+	value := sets[1][0].Value
+	assert.True(t, utf8.ValidString(value))
+	assert.True(t, strings.HasSuffix(value, "…"))
+	assert.NotContains(t, value, "�")
+	assert.LessOrEqual(t, utf8.RuneCountInString(value), utf8.RuneCountInString("Critical — ")+maxTeamsControlNameLength)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,7 +52,7 @@ kubescape scan [target] [flags]
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
 | `--label-selector <selector>` | Filter collected resources by Kubernetes label selector. Accepts any expression `kubectl -l` supports, e.g. `app=nginx,env!=dev` or `env in (prod,staging)`. Syntax is validated before scanning begins; filtering is applied during live cluster collection and ignored when scanning local files. | - |
 | `--keep-local` | Don't report results to backend | `false` |
-| `--notify <url>` | POST the posture scan summary to a webhook URL. Slack incoming webhooks receive Block Kit; other destinations receive generic JSON. Repeat for multiple endpoints. Delivery is best-effort and does not affect scan exit status. Not supported by `scan image`. | - |
+| `--notify <url>` | POST the posture scan summary to a webhook URL. Slack incoming webhooks receive Block Kit, Microsoft Teams webhooks an Adaptive Card, and other destinations generic JSON. Repeat for multiple endpoints. Delivery is best-effort and does not affect scan exit status. Not supported by `scan image`. | - |
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
 | `--otel-endpoint <endpoint>` | Export scan traces and metrics to an OTLP collector — see [OpenTelemetry export](#opentelemetry-export). Accepts `host:port` (plaintext) or a `http(s)://` URL. | `OTEL_EXPORTER_OTLP_ENDPOINT` |
@@ -70,11 +70,14 @@ kubescape scan [target] [flags]
 
 ### Webhook notifications
 
-Use `--notify` to send a compact summary after a posture scan. Official Slack and GovSlack incoming webhook URLs receive a Block Kit message; every other URL receives the existing JSON `summaryDetails` object:
+Use `--notify` to send a compact summary after a posture scan. Official Slack and GovSlack incoming webhook URLs receive a Block Kit message, Microsoft Teams incoming webhooks (`*.webhook.office.com`, `outlook.office.com`, `outlook.office365.com`) receive an Adaptive Card, and every other URL receives the existing JSON `summaryDetails` object:
 
 ```bash
 export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/T00000000/B00000000/SECRET'
 kubescape scan manifests/ --notify "$SLACK_WEBHOOK_URL"
+
+export TEAMS_WEBHOOK_URL='https://contoso.webhook.office.com/webhookb2/00000000-0000-0000-0000-000000000000@.../IncomingWebhook/.../...'
+kubescape scan manifests/ --notify "$TEAMS_WEBHOOK_URL"
 kubescape scan manifests/ --notify https://hooks.example.com/kubescape
 kubescape scan manifests/ --notify https://ops.example.com/kubescape --notify https://audit.example.com/kubescape
 ```
@@ -97,6 +100,36 @@ Slack messages contain the compliance score, passed/failed/skipped control count
 }
 ```
 
+Teams messages carry the same content as an Adaptive Card wrapped in the incoming-webhook envelope, with the counts in a `FactSet` and the failing controls keyed by control ID. For example:
+
+```json
+{
+  "type": "message",
+  "attachments": [{
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "contentUrl": null,
+    "content": {
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "type": "AdaptiveCard",
+      "version": "1.4",
+      "body": [
+        {"type": "TextBlock", "text": "Kubescape scan results", "size": "Large", "weight": "Bolder", "wrap": true},
+        {"type": "FactSet", "facts": [
+          {"title": "Compliance score", "value": "73.2%"},
+          {"title": "Controls failed", "value": "2 of 8"},
+          {"title": "Passed", "value": "5"},
+          {"title": "Skipped", "value": "1"}
+        ]},
+        {"type": "TextBlock", "text": "Top failing controls", "weight": "Bolder", "wrap": true},
+        {"type": "FactSet", "facts": [
+          {"title": "C-0001", "value": "Critical — Privileged container"}
+        ]}
+      ]
+    }
+  }]
+}
+```
+
 Generic destinations continue to receive only the scan summary. An abridged example is:
 
 ```json
@@ -109,7 +142,7 @@ Generic destinations continue to receive only the scan summary. An abridged exam
 }
 ```
 
-The summary and Slack control names may contain identifiers from the scan. Use `--hide` where appropriate and send only to trusted webhook endpoints. A Slack webhook URL is itself a secret; keep it out of source control and prefer passing it through an environment variable. Microsoft Teams Adaptive Card formatting is not currently included.
+The summary and control names may contain identifiers from the scan. Use `--hide` where appropriate and send only to trusted webhook endpoints. Slack and Teams webhook URLs are secrets; keep them out of source control and prefer passing them through environment variables.
 
 ### Generating an exceptions baseline
 


### PR DESCRIPTION
## Summary

- `--notify` already handled Slack (Block Kit) and generic JSON; Teams users had no native path and had to script the POST themselves
- Added `IsTeamsEndpoint` in `notification/teams.go` detects `outlook.office.com`, `outlook.office365.com`, and `*.webhook.office.com` hosts; all other URLs stay on the generic JSON fallback
- Wired Teams into the `MarshalPayload` switch in `notification/payload.go` alongside the existing Slack branch
- Adaptive Card body: heading + FactSet with compliance score, failed/passed/skipped counts, and a top-10 failing controls section (severity + name, escaped and rune-boundary-truncated)
- Refactored `escapeSlackText` → shared `escapeAndTruncate(escaper, value, maxLength)` helper; renamed `maxSlackFailingControls` → `maxFailingControls` so both senders share the cap
- 208 test lines covering endpoint detection, card structure, top-10 cap, long-text bounds, markdown escaping, all-pass omission, unknown control fallback, and multi-byte truncation
- `--notify` flag help and `docs/cli-reference.md` updated to document Teams support

**Which issue(s) this PR fixes:**
None, no existing issue covers this.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan --notify https://<org>.webhook.office.com/...` now POSTs a formatted Adaptive Card instead of raw JSON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Microsoft Teams webhook notifications using Adaptive Cards.
  - Scan notifications include compliance metrics and the top ten failing controls.
  - Long or formatted control details are safely truncated and escaped.
  - Generic JSON and Slack notification formats remain supported.

- **Documentation**
  - Updated the `--notify` reference with supported Teams webhook formats, usage examples, sample Adaptive Card output, and security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->