### PR TITLE
fix(mapreconcile): match the subresource form of a resource rule

### DIFF
--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -39,6 +39,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		mcp.WithString("api_group", mcp.Description("API group of the resource (omit or empty for the core group, e.g. Pod/ConfigMap)")),
 		mcp.WithString("api_version", mcp.Required(), mcp.Description("API version of the resource, e.g. v1")),
 		mcp.WithString("resource", mcp.Required(), mcp.Description("Plural resource name, e.g. pods, deployments")),
+		mcp.WithString("subresource", mcp.Description("Subresource the request targets, e.g. status or scale (omit for the resource itself). A policy scoped to the resource does not cover its subresources, and the reverse, so this changes which policies match")),
 		mcp.WithString("operation", mcp.Description("Admission operation to check: CREATE, UPDATE, or CONNECT (default CREATE)")),
 		mcp.WithBoolean("cluster_scoped", mcp.Description("Set true for a cluster-scoped resource (namespace is ignored, and any namespaceSelector is treated as non-restricting, matching the Kubernetes API's own documented behavior)")),
 	)
@@ -64,6 +65,14 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		apiGroup, _ := args["api_group"].(string)
 		namespace, _ := args["namespace"].(string)
 		clusterScoped, _ := args["cluster_scoped"].(bool)
+
+		// A subresource is one path segment: "status", not "pods/status". A
+		// caller repeating the parent would otherwise match no rule at all and
+		// read as "nothing mutates this".
+		subresource, _ := args["subresource"].(string)
+		if strings.Contains(subresource, "/") {
+			return mcp.NewToolResultError(fmt.Sprintf("subresource must name one subresource without the parent resource (got %q, want e.g. %q)", subresource, "status")), nil
+		}
 
 		// A Namespace object is itself cluster-scoped ("Namespace API
 		// objects are cluster-scoped", per Rule.Scope's own doc comment)
@@ -120,6 +129,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 			Group:             apiGroup,
 			Version:           apiVersion,
 			Resource:          resource,
+			Subresource:       subresource,
 			Name:              name,
 			Namespace:         namespace,
 			Labels:            obj.GetLabels(),

--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -69,7 +69,10 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		// A subresource is one path segment: "status", not "pods/status". A
 		// caller repeating the parent would otherwise match no rule at all and
 		// read as "nothing mutates this".
-		subresource, _ := args["subresource"].(string)
+		subresource, subresourceErr := optionalStringArg(args, "subresource")
+		if subresourceErr != nil {
+			return mcp.NewToolResultError(subresourceErr.Error()), nil
+		}
 		if strings.Contains(subresource, "/") {
 			return mcp.NewToolResultError(fmt.Sprintf("subresource must name one subresource without the parent resource (got %q, want e.g. %q)", subresource, "status")), nil
 		}
@@ -170,6 +173,23 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})
+}
+
+// optionalStringArg reads one optional string tool argument. The server runs
+// without input schema validation, so a wrong type arrives here untouched and
+// asserting it away would coerce it to "". For an argument that narrows a
+// query that silently widens the answer instead of refusing it, so a present
+// non-string is an error. An explicit null counts as absent.
+func optionalStringArg(args map[string]any, key string) (string, error) {
+	raw, present := args[key]
+	if !present || raw == nil {
+		return "", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string (got %T)", key, raw)
+	}
+	return value, nil
 }
 
 func buildMatchSummaries(matches []mapreconcile.MatchedPolicy) []map[string]any {

--- a/cmd/mcpserver/mutating_policy_impact_test.go
+++ b/cmd/mcpserver/mutating_policy_impact_test.go
@@ -409,6 +409,9 @@ func matchConstraintsForResources(group, version string, resources ...string) ma
 	}
 }
 
+// matchedPolicyNames pulls the matched policy names out of a tool result, so a
+// test can assert on which policies matched without restating the whole
+// response shape.
 func matchedPolicyNames(t *testing.T, result *mcp.CallToolResult) []string {
 	t.Helper()
 
@@ -507,4 +510,59 @@ func TestAnalyzeMutatingAdmissionPolicyImpact_SubresourceWithParentIsRejected(t 
 	args["subresource"] = "pods/status"
 	rejected := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
 	require.True(t, rejected.IsError)
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_NonStringSubresourceIsRejected goes
+// through the registered tools/call path, which is where a wrongly typed
+// argument actually arrives: the server runs without input schema validation,
+// so a number here used to assert away to "" and answer for the bare pod.
+func TestAnalyzeMutatingAdmissionPolicyImpact_NonStringSubresourceIsRejected(t *testing.T) {
+	policy := unstructuredMutatingPolicy("mutate-pods", allPodsMatchConstraints(),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("mutate-pods-binding", "mutate-pods")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	for _, subresource := range []any{float64(7), true, map[string]any{"name": "status"}, []any{"status"}} {
+		result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+			"namespace":   "prod",
+			"name":        "server",
+			"api_version": "v1",
+			"resource":    "pods",
+			"subresource": subresource,
+		}))
+		require.True(t, result.IsError, "a %T subresource must be refused, not read as the resource itself", subresource)
+	}
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_OmittedAndNullSubresourceMeanTheResource
+// keeps the type check from turning the ordinary no-subresource query into an
+// error. An explicit JSON null is how a client may render an unset optional
+// argument, so it has to mean the same as leaving it out.
+func TestAnalyzeMutatingAdmissionPolicyImpact_OmittedAndNullSubresourceMeanTheResource(t *testing.T) {
+	policy := unstructuredMutatingPolicy("mutate-pods", allPodsMatchConstraints(),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("mutate-pods-binding", "mutate-pods")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	args := map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}
+
+	omitted := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, omitted.IsError)
+	require.Equal(t, []string{"mutate-pods"}, matchedPolicyNames(t, omitted))
+
+	args["subresource"] = nil
+	null := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, null.IsError)
+	require.Equal(t, []string{"mutate-pods"}, matchedPolicyNames(t, null))
 }

--- a/cmd/mcpserver/mutating_policy_impact_test.go
+++ b/cmd/mcpserver/mutating_policy_impact_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -386,4 +387,124 @@ func TestAnalyzeMutatingAdmissionPolicyImpact_ClusterScopedResourceIgnoresNamesp
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	matches := parsed["matches"].([]any)
 	require.Len(t, matches, 1, "namespaceSelector must not skip a cluster-scoped resource even with no namespace given")
+}
+
+// matchConstraintsForResources is allPodsMatchConstraints for an arbitrary
+// group/version/resources triple, so a test can scope a policy with the
+// subresource form a resources entry may carry.
+func matchConstraintsForResources(group, version string, resources ...string) map[string]any {
+	named := make([]any, 0, len(resources))
+	for _, resource := range resources {
+		named = append(named, resource)
+	}
+	return map[string]any{
+		"resourceRules": []any{
+			map[string]any{
+				"apiGroups":   []any{group},
+				"apiVersions": []any{version},
+				"resources":   named,
+				"operations":  []any{"*"},
+			},
+		},
+	}
+}
+
+func matchedPolicyNames(t *testing.T, result *mcp.CallToolResult) []string {
+	t.Helper()
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.True(t, parsed["supported"].(bool))
+
+	matches, _ := parsed["matches"].([]any)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, m.(map[string]any)["policy_name"].(string))
+	}
+	return names
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_PolicyScopedToEveryResourceIsReported
+// covers a policy scoped with "*/*", the documented way to name every resource
+// and subresource. Reporting no match for it would hide a policy that mutates
+// the whole cluster.
+func TestAnalyzeMutatingAdmissionPolicyImpact_PolicyScopedToEveryResourceIsReported(t *testing.T) {
+	policy := unstructuredMutatingPolicy("mutate-everything", matchConstraintsForResources("*", "*", "*/*"),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("mutate-everything-binding", "mutate-everything")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}))
+	require.False(t, result.IsError)
+	require.Equal(t, []string{"mutate-everything"}, matchedPolicyNames(t, result))
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_SubresourceIsMatchedSeparately walks
+// both directions of the parent/subresource split through the tool: a policy
+// scoped to pods leaves pods/status alone, and one scoped to pods/status leaves
+// the pod alone.
+func TestAnalyzeMutatingAdmissionPolicyImpact_SubresourceIsMatchedSeparately(t *testing.T) {
+	mutation := map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}}
+
+	podPolicy := unstructuredMutatingPolicy("mutate-pods", allPodsMatchConstraints(), mutation)
+	podBinding := unstructuredMutatingPolicyBinding("mutate-pods-binding", "mutate-pods")
+	statusPolicy := unstructuredMutatingPolicy("mutate-pod-status", matchConstraintsForResources("", "v1", "pods/status"), mutation)
+	statusBinding := unstructuredMutatingPolicyBinding("mutate-pod-status-binding", "mutate-pod-status")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, podPolicy, podBinding, statusPolicy, statusBinding, pod)
+
+	args := map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}
+
+	bare := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, bare.IsError)
+	require.Equal(t, []string{"mutate-pods"}, matchedPolicyNames(t, bare))
+
+	args["subresource"] = "status"
+	status := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, status.IsError)
+	require.Equal(t, []string{"mutate-pod-status"}, matchedPolicyNames(t, status))
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_SubresourceWithParentIsRejected keeps
+// a caller from writing the parent twice, which would silently match nothing.
+// The cluster is stocked so the same call without the bad subresource succeeds,
+// leaving the argument check as the only thing the error can come from.
+func TestAnalyzeMutatingAdmissionPolicyImpact_SubresourceWithParentIsRejected(t *testing.T) {
+	policy := unstructuredMutatingPolicy("mutate-pod-status", matchConstraintsForResources("", "v1", "pods/status"),
+		map[string]any{"patchType": "JSONPatch", "jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`}},
+	)
+	binding := unstructuredMutatingPolicyBinding("mutate-pod-status-binding", "mutate-pod-status")
+	pod := unstructuredTestPod("prod", "server", map[string]any{"app": "server"})
+
+	ksServer := newMutatingPolicyTestServer(t, policy, binding, pod)
+
+	args := map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+		"subresource": "status",
+	}
+
+	accepted := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, accepted.IsError)
+	require.Equal(t, []string{"mutate-pod-status"}, matchedPolicyNames(t, accepted))
+
+	args["subresource"] = "pods/status"
+	rejected := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.True(t, rejected.IsError)
 }

--- a/core/pkg/mapreconcile/index_test.go
+++ b/core/pkg/mapreconcile/index_test.go
@@ -216,3 +216,68 @@ func TestMatches_ApplyConfigurationMutationExpressionIsCarried(t *testing.T) {
 	assert.Equal(t, admissionregistrationv1alpha1.PatchTypeApplyConfiguration, matches[0].Mutations[0].PatchType)
 	assert.Contains(t, matches[0].Mutations[0].Expression, "serviceAccountName")
 }
+
+// TestMatches_PolicyConstrainedToEveryResourceIsReported covers the headline
+// case for the subresource form: "*/*" is the documented way to scope a policy
+// to every resource, so a policy written that way mutates the queried object.
+func TestMatches_PolicyConstrainedToEveryResourceIsReported(t *testing.T) {
+	everything := &admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{"*"}, []string{"*"}, []string{"*/*"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	}
+	p := policy("mutate-everything", everything, jsonPatchMutation(`[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`))
+	b := binding("mutate-everything-binding", "mutate-everything", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.Equal(t, "mutate-everything", matches[0].PolicyName)
+	assert.True(t, matches[0].Determinable)
+}
+
+// TestMatches_ExcludeRuleWithSubresourceWildcardExcludes is the same root cause
+// in the direction that reports a mutation which will not happen: "pods/*" on
+// the exclude side reaches the bare pod too.
+func TestMatches_ExcludeRuleWithSubresourceWildcardExcludes(t *testing.T) {
+	constraints := allPods()
+	constraints.ExcludeResourceRules = []admissionregistrationv1alpha1.NamedRuleWithOperations{
+		rule([]string{""}, []string{"v1"}, []string{"pods/*"}, admissionregistrationv1alpha1.OperationAll),
+	}
+	p := policy("mutate-pods", constraints)
+	b := binding("mutate-pods-binding", "mutate-pods", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	assert.Empty(t, idx.Matches(obj(nil)), "an exclude rule covering every pod subresource covers the pod itself")
+}
+
+// TestMatches_BindingExcludeRuleWithSubresourceWildcardExcludes is the same
+// exclusion arriving on the binding's matchResources, which compiles
+// separately from the policy's matchConstraints.
+func TestMatches_BindingExcludeRuleWithSubresourceWildcardExcludes(t *testing.T) {
+	p := policy("mutate-pods", allPods())
+	b := binding("mutate-pods-binding", "mutate-pods", &admissionregistrationv1alpha1.MatchResources{
+		ExcludeResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{""}, []string{"v1"}, []string{"pods/*"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	})
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	assert.Empty(t, idx.Matches(obj(nil)))
+}
+
+// TestMatches_SubresourceRequestNotCoveredByBareResourceRule is the other half
+// of the split: a policy scoped to "pods" does not mutate a pods/status
+// request, so a subresource query must not inherit the parent's match.
+func TestMatches_SubresourceRequestNotCoveredByBareResourceRule(t *testing.T) {
+	p := policy("mutate-pods", allPods())
+	b := binding("mutate-pods-binding", "mutate-pods", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	assert.Empty(t, idx.Matches(obj(func(o *ObjectInfo) { o.Subresource = "status" })))
+	assert.Len(t, idx.Matches(obj(nil)), 1)
+}

--- a/core/pkg/mapreconcile/match.go
+++ b/core/pkg/mapreconcile/match.go
@@ -121,11 +121,17 @@ func operationMatches(ops []admissionregistrationv1alpha1.OperationType, op admi
 // verbatim.
 func stringRuleMatches(values []string, candidate string) bool {
 	for _, v := range values {
-		if v == "*" || v == candidate {
+		if wildcardOrEqual(v, candidate) {
 			return true
 		}
 	}
 	return false
+}
+
+// wildcardOrEqual reports whether one rule value covers candidate. Only the
+// rule side may carry "*": an object's own API coordinates are always concrete.
+func wildcardOrEqual(value, candidate string) bool {
+	return value == "*" || value == candidate
 }
 
 // resourceRulesVerdict OR-combines every rule in rules against obj. An empty

--- a/core/pkg/mapreconcile/match.go
+++ b/core/pkg/mapreconcile/match.go
@@ -1,6 +1,8 @@
 package mapreconcile
 
 import (
+	"strings"
+
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -18,6 +20,11 @@ type ObjectInfo struct {
 	Namespace string // empty for a cluster-scoped object
 	Labels    map[string]string
 	Operation admissionregistrationv1alpha1.OperationType
+
+	// Subresource is the subresource the request targets, e.g. "scale" for a
+	// deployments/scale update. Empty means the resource itself, which is what
+	// a rule's bare "pods" entry covers and its "pods/exec" entry does not.
+	Subresource string
 
 	// ClusterScoped marks obj as a cluster-scoped resource. A Namespace
 	// object is itself cluster-scoped ("Namespace API objects are
@@ -61,7 +68,7 @@ func ruleMatches(rule admissionregistrationv1alpha1.NamedRuleWithOperations, obj
 	if !stringRuleMatches(rule.APIVersions, obj.Version) {
 		return false
 	}
-	if !stringRuleMatches(rule.Resources, obj.Resource) {
+	if !resourceRuleMatches(rule.Resources, obj) {
 		return false
 	}
 	if !resourceNamesMatch(rule.ResourceNames, obj.Name) {
@@ -116,9 +123,9 @@ func operationMatches(ops []admissionregistrationv1alpha1.OperationType, op admi
 }
 
 // stringRuleMatches reports whether candidate is covered by values, where
-// values comes from a Rule's APIGroups/APIVersions/Resources: "*" (alone, or
+// values comes from a Rule's APIGroups or APIVersions: "*" (alone, or
 // alongside other entries) matches anything, otherwise candidate must appear
-// verbatim.
+// verbatim. Resources go through resourceRuleMatches instead.
 func stringRuleMatches(values []string, candidate string) bool {
 	for _, v := range values {
 		if wildcardOrEqual(v, candidate) {
@@ -132,6 +139,33 @@ func stringRuleMatches(values []string, candidate string) bool {
 // rule side may carry "*": an object's own API coordinates are always concrete.
 func wildcardOrEqual(value, candidate string) bool {
 	return value == "*" || value == candidate
+}
+
+// resourceRuleMatches is stringRuleMatches for a Rule's Resources, which carry
+// a subresource half the other rule fields do not: "pods" is the resource
+// itself, "pods/*" every subresource of pods, "*/scale" every scale
+// subresource, and "*/*" both. Each half is matched on its own, the way the
+// apiserver's own rule matcher splits them, so a bare "*" never reaches a
+// subresource request while "pods/*" does reach the bare pod.
+func resourceRuleMatches(values []string, obj ObjectInfo) bool {
+	for _, v := range values {
+		resource, subresource := splitSubresource(v)
+		if wildcardOrEqual(resource, obj.Resource) && wildcardOrEqual(subresource, obj.Subresource) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitSubresource splits one Resources entry into its resource and
+// subresource halves. An entry with no "/" names a bare resource, so its
+// subresource half is empty.
+func splitSubresource(value string) (string, string) {
+	resource, subresource, found := strings.Cut(value, "/")
+	if !found {
+		return value, ""
+	}
+	return resource, subresource
 }
 
 // resourceRulesVerdict OR-combines every rule in rules against obj. An empty
@@ -268,13 +302,15 @@ func (c *compiledMatchResources) matches(obj ObjectInfo) (matched bool, determin
 // HorizontalPodAutoscalers) that this package is not given. A rule that does
 // not even name this resource (e.g. "configmaps" when obj is a "pods") is
 // never ambiguous: two unrelated resource kinds are never equivalent under
-// any matchPolicy.
+// any matchPolicy. Neither are a resource and its subresource, so the rule has
+// to cover obj's subresource half too before the group/version question is
+// worth asking.
 func resourceRulesAmbiguousUnderEquivalence(rules []admissionregistrationv1alpha1.NamedRuleWithOperations, obj ObjectInfo) bool {
 	for _, rule := range rules {
 		if !operationMatches(rule.Operations, obj.Operation) {
 			continue
 		}
-		if !stringRuleMatches(rule.Resources, obj.Resource) {
+		if !resourceRuleMatches(rule.Resources, obj) {
 			continue
 		}
 		if !stringRuleMatches(rule.APIGroups, obj.Group) || !stringRuleMatches(rule.APIVersions, obj.Version) {

--- a/core/pkg/mapreconcile/match_test.go
+++ b/core/pkg/mapreconcile/match_test.go
@@ -286,3 +286,82 @@ func TestCompileMatchResources_ExactMatchPolicyMissIsAConfidentNonMatch(t *testi
 	assert.False(t, matched)
 	assert.True(t, determinable, "Exact matchPolicy has no equivalence expansion to be uncertain about")
 }
+
+// TestRuleMatches_SubresourceForm pins the Resources examples Rule.Resources'
+// own doc comment gives, plus the two the apiserver's matcher settles beyond
+// the doc: a bare "*" never reaches a subresource request, and a "resource/*"
+// entry does reach the bare parent.
+func TestRuleMatches_SubresourceForm(t *testing.T) {
+	tests := []struct {
+		name        string
+		resources   []string
+		resource    string
+		subresource string
+		want        bool
+	}{
+		{name: "bare resource named verbatim", resources: []string{"pods"}, resource: "pods", want: true},
+		{name: "resource wildcard covers a bare resource", resources: []string{"*"}, resource: "pods", want: true},
+		{name: "resource wildcard does not reach a subresource", resources: []string{"*"}, resource: "pods", subresource: "status", want: false},
+		{name: "full wildcard covers a bare resource", resources: []string{"*/*"}, resource: "pods", want: true},
+		{name: "full wildcard covers a subresource", resources: []string{"*/*"}, resource: "deployments", subresource: "scale", want: true},
+		{name: "subresource wildcard covers its bare parent", resources: []string{"pods/*"}, resource: "pods", want: true},
+		{name: "subresource wildcard covers a subresource", resources: []string{"pods/*"}, resource: "pods", subresource: "exec", want: true},
+		{name: "subresource wildcard does not cross resources", resources: []string{"configmaps/*"}, resource: "pods", want: false},
+		{name: "named subresource does not cover its bare parent", resources: []string{"pods/status"}, resource: "pods", want: false},
+		{name: "named subresource matches verbatim", resources: []string{"pods/status"}, resource: "pods", subresource: "status", want: true},
+		{name: "named subresource does not cover another subresource", resources: []string{"pods/status"}, resource: "pods", subresource: "exec", want: false},
+		{name: "one subresource across every resource", resources: []string{"*/scale"}, resource: "deployments", subresource: "scale", want: true},
+		{name: "one subresource across every resource ignores others", resources: []string{"*/scale"}, resource: "deployments", subresource: "status", want: false},
+		{name: "one matching entry among several", resources: []string{"configmaps", "pods/*"}, resource: "pods", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := rule([]string{"*"}, []string{"*"}, tt.resources, admissionregistrationv1alpha1.OperationAll)
+			got := ruleMatches(r, obj(func(o *ObjectInfo) {
+				o.Resource = tt.resource
+				o.Subresource = tt.subresource
+			}))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCompileMatchResources_EquivalentMatchPolicyWildcardResourceAtAnotherVersion
+// checks that a full-wildcard rule reaches the equivalence question at all: it
+// covers the queried resource, so a version the rule does not name is the
+// indeterminate case Equivalent matchPolicy resolves with discovery data this
+// package is not given.
+func TestCompileMatchResources_EquivalentMatchPolicyWildcardResourceAtAnotherVersion(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{"autoscaling"}, []string{"v1"}, []string{"*/*"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	})
+	require.NoError(t, err)
+
+	_, determinable := c.matches(obj(func(o *ObjectInfo) {
+		o.Group = "autoscaling"
+		o.Version = "v2"
+		o.Resource = "horizontalpodautoscalers"
+	}))
+	assert.False(t, determinable, "a rule covering this resource at another version is the indeterminate case, not a confident non-match")
+}
+
+// TestCompileMatchResources_EquivalentMatchPolicySubresourceIsNeverEquivalent
+// is the boundary the subresource split must not cross. Group/version
+// equivalence maps a resource onto the same resource at another version; it
+// never turns a subresource rule into coverage of the parent, so this stays a
+// confident non-match instead of becoming indeterminate.
+func TestCompileMatchResources_EquivalentMatchPolicySubresourceIsNeverEquivalent(t *testing.T) {
+	c, err := compileMatchResources(&admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{""}, []string{"v1"}, []string{"pods/exec"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	})
+	require.NoError(t, err)
+
+	matched, determinable := c.matches(obj(func(o *ObjectInfo) { o.Version = "v2" }))
+	assert.False(t, matched)
+	assert.True(t, determinable)
+}


### PR DESCRIPTION
`core/pkg/mapreconcile` landed recently with a reimplementation of the apiserver's MatchResources semantics, and it compares a resource rule's `resources` entry as one opaque string. The apiserver splits that entry on the slash and matches each half on its own, which is what makes `pods` the resource itself, `pods/*` every subresource of pods, `*/scale` every scale subresource and `*/*` everything. Comparing the whole string means none of the wildcard forms ever match anything.

The direction that matters most is a policy whose matchConstraints say `resources: ["*/*"]`, which is the documented way to scope a policy to the whole cluster. Today `analyze_mutating_admission_policy_impact` reports no match for it, so a live MutatingAdmissionPolicy that rewrites every object admitted to the cluster reads as "nothing mutates this resource". The same root cause runs the other way on `excludeResourceRules`, where an exclusion written `pods/*` fails to exclude the pod and the tool reports a mutation that will not happen. Both are the failure this tool exists to prevent, so I would rather it be wrong in neither direction.

The fix follows the apiserver's own rule matcher: split the entry, then match the resource half and the subresource half separately, with `*` on the rule side covering either. That also settles the two cases the field's doc comment leaves implicit and the apiserver decides in code, and both are pinned by tests. A bare `*` never reaches a subresource request, and `pods/*` does reach the bare pod. Worth noting this repo already handles the same form correctly in `cmd/vap` (`resourcesOverlap`), and `core/pkg/opaprocessor/cel/scope.go` accounts for it too, so mapreconcile was the odd one out rather than this being a new idea.

Since the object side of the match now carries a subresource coordinate, the MCP tool gets an optional `subresource` argument. Without it nothing can populate the field and only half of the fix is reachable from the tool. Asking what mutates `deployments/scale` on an update is a real question here, and a policy scoped to `deployments` genuinely is not the answer to it. A value that repeats the parent, `pods/status` instead of `status`, is refused rather than quietly matching nothing.

The detail most likely to regress is the boundary in `resourceRulesAmbiguousUnderEquivalence`. Group and version equivalence maps a resource onto the same resource at another version, and it never turns a subresource rule into coverage of the parent, so a `pods/exec` rule against a bare pod at a version the rule does not name has to stay a confident non-match instead of becoming indeterminate. `TestCompileMatchResources_EquivalentMatchPolicySubresourceIsNeverEquivalent` passes both before and after this change on purpose, to hold that line.

The first commit is plumbing only. It routes the existing whole-value comparison through one helper and changes no behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy impact analysis now supports requests targeting subresources.
  * Resource matching recognizes specific subresources and wildcard patterns, including resource-wide and subresource-wide rules.
  * Policy matching distinguishes parent resources from their subresources for more accurate results.

* **Bug Fixes**
  * Invalid subresource values, including path-qualified or non-string values, are now rejected.
  * Wildcard resource and exclusion rules now match consistently across resources and subresources.
  * Omitted and explicitly null subresources are handled consistently as requests for the parent resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->