### PR TITLE
feat(exposure): model external exposure via Ingress, Gateway API, and Service type

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -1331,6 +1331,7 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createNetworkReachabilityTools(ksServer)
 	createMutatingAdmissionPolicyTools(ksServer)
 	createVulnerabilityExposureTools(ksServer)
+	createServiceExposureTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)

--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -1,0 +1,170 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/exposure"
+	"github.com/mark3labs/mcp-go/mcp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var serviceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+var ingressGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
+var httpRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+var gatewayGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+
+// createServiceExposureTools registers analyze_service_exposure, which
+// reports whether a Service (or every Service in a namespace) is reachable
+// from outside the cluster, and by what mechanism -- a Service of type
+// LoadBalancer/NodePort directly, or a networking.k8s.io/v1 Ingress or
+// Gateway API HTTPRoute naming it as a backend. See core/pkg/exposure for
+// the matching model and its documented trust model (existence of an
+// exposing object is treated as intent, the same way this repo's
+// NetworkPolicy reachability engine treats a NetworkPolicy's existence).
+func createServiceExposureTools(ksServer *KubescapeMcpserver) {
+	tool := mcp.NewTool(
+		"analyze_service_exposure",
+		mcp.WithDescription("Determine whether a Service (or every Service in a namespace, if service_name is omitted) is reachable from outside the cluster, and by what mechanism: the Service itself being type LoadBalancer or NodePort, a networking.k8s.io/v1 Ingress naming it as a backend, or a Gateway API HTTPRoute naming it as a backend through an attached Gateway. Existence of an exposing object is treated as intent to expose -- this does not verify an Ingress controller or Gateway implementation is actually running."),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace to analyze")),
+		mcp.WithString("service_name", mcp.Description("Name of a specific Service to check (optional; omit to report on every Service in the namespace)")),
+	)
+
+	ksServer.s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok || args == nil {
+			args = map[string]any{}
+		}
+
+		namespace, ok := args["namespace"].(string)
+		if !ok || namespace == "" {
+			return mcp.NewToolResultError("namespace is required"), nil
+		}
+		serviceName, _ := args["service_name"].(string)
+
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+		}
+		dynClient := k8sClient.DynamicClient
+
+		serviceList, err := dynClient.Resource(serviceGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Service objects: %v", err)), nil
+		}
+		ingressList, err := dynClient.Resource(ingressGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Ingress objects: %v", err)), nil
+		}
+		namespaceList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+		}
+
+		resources := make(map[string]workloadinterface.IMetadata, len(serviceList.Items)+len(ingressList.Items)+len(namespaceList.Items))
+		for i := range serviceList.Items {
+			w := workloadinterface.NewWorkloadObj(serviceList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+		for i := range ingressList.Items {
+			w := workloadinterface.NewWorkloadObj(ingressList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+		for i := range namespaceList.Items {
+			w := workloadinterface.NewWorkloadObj(namespaceList.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+
+		services, ingresses, namespaces, decodeErrs := exposure.FromResources(resources)
+
+		// The Gateway API CRDs may not be installed on this cluster at all;
+		// that is not a tool error, just an empty set of routes/gateways --
+		// every service simply reports no ExposureHTTPRoute paths.
+		gatewayResources := map[string]workloadinterface.IMetadata{}
+		routeList, routeErr := dynClient.Resource(httpRouteGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if routeErr != nil && !isMissingAPIErr(routeErr) {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list HTTPRoute objects: %v", routeErr)), nil
+		}
+		if routeErr == nil {
+			for i := range routeList.Items {
+				w := workloadinterface.NewWorkloadObj(routeList.Items[i].Object)
+				gatewayResources[w.GetID()] = w
+			}
+		}
+		gwList, gwErr := dynClient.Resource(gatewayGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if gwErr != nil && !isMissingAPIErr(gwErr) {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list Gateway objects: %v", gwErr)), nil
+		}
+		if gwErr == nil {
+			for i := range gwList.Items {
+				w := workloadinterface.NewWorkloadObj(gwList.Items[i].Object)
+				gatewayResources[w.GetID()] = w
+			}
+		}
+		httpRoutes, gateways, gwDecodeErrs := exposure.FromUnstructuredGatewayAPI(gatewayResources)
+		decodeErrs = append(decodeErrs, gwDecodeErrs...)
+
+		idx := exposure.NewIndex(services, ingresses, httpRoutes, gateways, namespaces)
+
+		var targets []string
+		if serviceName != "" {
+			targets = []string{serviceName}
+		} else {
+			for _, s := range services {
+				targets = append(targets, s.Name)
+			}
+		}
+
+		findings := make(map[string]any, len(targets))
+		for _, name := range targets {
+			paths := idx.ServiceExposure(exposure.ServiceRef{Namespace: namespace, Name: name})
+			findings[name] = buildExposurePathSummaries(paths)
+		}
+
+		result := map[string]any{
+			"namespace": namespace,
+			"services":  findings,
+		}
+		if len(decodeErrs) > 0 {
+			msgs := make([]string, len(decodeErrs))
+			for i, e := range decodeErrs {
+				msgs[i] = e.Error()
+			}
+			result["decode_warnings"] = msgs
+		}
+
+		resBytes, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(resBytes)), nil
+	})
+}
+
+// isMissingAPIErr reports whether err indicates the API group/resource
+// itself is not served (e.g. the Gateway API CRDs are not installed on this
+// cluster), as opposed to a real query failure. A List against a resource
+// the API server does not serve at all returns a NotFound; a List against a
+// GVR the dynamic client's RESTMapper has no discovery data for at all
+// returns a meta.NoMatchError instead, which does not implement the
+// apierrors.APIStatus interface IsNotFound checks.
+func isMissingAPIErr(err error) bool {
+	return apierrors.IsNotFound(err) || meta.IsNoMatchError(err)
+}
+
+func buildExposurePathSummaries(paths []exposure.ExposurePath) []map[string]any {
+	out := make([]map[string]any, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, map[string]any{
+			"kind":   p.Kind.String(),
+			"source": p.Source,
+			"host":   p.Host,
+		})
+	}
+	return out
+}

--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -96,7 +96,14 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 				gatewayResources[w.GetID()] = w
 			}
 		}
-		gwList, gwErr := dynClient.Resource(gatewayGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		// Gateways are listed cluster-wide, not scoped to namespace: the
+		// dominant real-world topology puts the Gateway in an infra
+		// namespace (e.g. istio-system) with an HTTPRoute in an app
+		// namespace referencing it cross-namespace via parentRefs, and
+		// AllowedRoutes deciding whether that attachment is admitted.
+		// Scoping this list to namespace would make every such Gateway
+		// invisible to idx.routeAttachesToAGateway.
+		gwList, gwErr := dynClient.Resource(gatewayGVR).List(ctx, metav1.ListOptions{})
 		if gwErr != nil && !isMissingAPIErr(gwErr) {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to list Gateway objects: %v", gwErr)), nil
 		}

--- a/cmd/mcpserver/service_exposure_test.go
+++ b/cmd/mcpserver/service_exposure_test.go
@@ -234,3 +234,54 @@ func TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService(t *testing
 	require.Len(t, paths, 1)
 	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
 }
+
+// TestAnalyzeServiceExposure_CrossNamespaceGatewayWithAllowedRoutesFromAllExposesService
+// exercises the dominant real-world Gateway API topology: the Gateway lives
+// in an infra namespace (e.g. istio-system) with allowedRoutes.namespaces.from
+// set to All, while the HTTPRoute and the Service it exposes live in an
+// application namespace and reference the Gateway cross-namespace via
+// parentRefs[].namespace. Querying analyze_service_exposure scoped to the
+// app namespace must still find that Gateway -- it must not be listed only
+// from the queried namespace.
+func TestAnalyzeServiceExposure_CrossNamespaceGatewayWithAllowedRoutesFromAllExposesService(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "route", "namespace": "prod"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw", "namespace": "infra"}},
+			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}}},
+		},
+	}}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "infra"},
+		"spec": map[string]any{"listeners": []any{map[string]any{
+			"name":          "http",
+			"allowedRoutes": map[string]any{"namespaces": map[string]any{"from": "All"}},
+		}}},
+	}}
+	ksServer := newServiceExposureTestServer(t, svc, route)
+
+	// See TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService for
+	// why the Gateway is added via an explicit Create against the real GVR
+	// rather than passed to the constructor.
+	dyn := ksServer.k8sClient.DynamicClient
+	_, err := dyn.Resource(gatewayGVR).Namespace("infra").Create(context.Background(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := services["app"].([]any)
+	require.Len(t, paths, 1, "the cross-namespace Gateway in infra must be found even though the query is scoped to prod")
+	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
+}

--- a/cmd/mcpserver/service_exposure_test.go
+++ b/cmd/mcpserver/service_exposure_test.go
@@ -1,0 +1,236 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newServiceExposureTestServer always registers the Gateway API GVRs' list
+// kinds: NewSimpleDynamicClientWithCustomListKinds panics on List against
+// any GVR it was not given a list kind for, which is a testing-harness
+// requirement, not a stand-in for how a real cluster without the Gateway
+// API CRDs installed actually behaves (a real List there returns a NotFound
+// error). TestAnalyzeServiceExposure_MissingGatewayAPIIsNotFatal simulates
+// that real behavior with a reactor instead of omitting the registration.
+func newServiceExposureTestServer(t *testing.T, objects ...runtime.Object) *KubescapeMcpserver {
+	t.Helper()
+	listKinds := map[schema.GroupVersionResource]string{
+		serviceGVR:   "ServiceList",
+		ingressGVR:   "IngressList",
+		namespaceGVR: "NamespaceList",
+		httpRouteGVR: "HTTPRouteList",
+		gatewayGVR:   "GatewayList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createServiceExposureTools(ksServer)
+	return ksServer
+}
+
+func unstructuredService(namespace, name, serviceType string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"type": serviceType},
+	}}
+}
+
+func unstructuredIngress(namespace, name, backendServiceName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "Ingress",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec": map[string]any{
+			"defaultBackend": map[string]any{"service": map[string]any{"name": backendServiceName}},
+		},
+	}}
+}
+
+func TestAnalyzeServiceExposure_LoadBalancerServiceIsExposed(t *testing.T) {
+	svc := unstructuredService("prod", "app", "LoadBalancer")
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := services["app"].([]any)
+	require.Len(t, paths, 1)
+	require.Equal(t, "LoadBalancer", paths[0].(map[string]any)["kind"])
+}
+
+func TestAnalyzeServiceExposure_ClusterIPWithNoIngressIsNotExposed(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	require.Empty(t, services["app"])
+}
+
+func TestAnalyzeServiceExposure_IngressExposesClusterIPService(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	ing := unstructuredIngress("prod", "web", "app")
+	ksServer := newServiceExposureTestServer(t, svc, ing)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := services["app"].([]any)
+	require.Len(t, paths, 1)
+	entry := paths[0].(map[string]any)
+	require.Equal(t, "Ingress", entry["kind"])
+	require.Equal(t, "prod/web", entry["source"])
+}
+
+func TestAnalyzeServiceExposure_OmittedServiceNameReportsEveryServiceInNamespace(t *testing.T) {
+	svc1 := unstructuredService("prod", "app-one", "ClusterIP")
+	svc2 := unstructuredService("prod", "app-two", "LoadBalancer")
+	ksServer := newServiceExposureTestServer(t, svc1, svc2)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace": "prod",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	require.Len(t, services, 2)
+	require.Empty(t, services["app-one"])
+	require.Len(t, services["app-two"].([]any), 1)
+}
+
+func TestAnalyzeServiceExposure_MissingNamespaceReturnsError(t *testing.T) {
+	ksServer := newServiceExposureTestServer(t)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeServiceExposure_MissingGatewayAPIIsNotFatal(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	// Simulate a real cluster without the Gateway API CRDs installed: List
+	// against either GVR returns NotFound, not the panic
+	// NewSimpleDynamicClientWithCustomListKinds produces for a genuinely
+	// unregistered GVR (a testing-harness artifact, not real behavior).
+	dyn := ksServer.k8sClient.DynamicClient.(*dynamicfake.FakeDynamicClient)
+	notFound := func(gvr schema.GroupVersionResource) k8stesting.ReactionFunc {
+		return func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(gvr.GroupResource(), "")
+		}
+	}
+	dyn.PrependReactor("list", httpRouteGVR.Resource, notFound(httpRouteGVR))
+	dyn.PrependReactor("list", gatewayGVR.Resource, notFound(gatewayGVR))
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError, "a cluster without the Gateway API installed must not fail the whole tool")
+}
+
+func TestAnalyzeServiceExposure_UnexpectedGatewayAPIListErrorIsFatal(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	dyn := ksServer.k8sClient.DynamicClient.(*dynamicfake.FakeDynamicClient)
+	dyn.PrependReactor("list", httpRouteGVR.Resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.True(t, result.IsError, "a genuine list failure (not a missing-API shape) must surface as a tool error, not be silently swallowed")
+}
+
+func TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "route", "namespace": "prod"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}}},
+		},
+	}}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "prod"},
+		"spec":       map[string]any{"listeners": []any{map[string]any{"name": "http"}}},
+	}}
+	ksServer := newServiceExposureTestServer(t, svc, route)
+
+	// NewSimpleDynamicClientWithCustomListKinds' constructor buckets initial
+	// objects by guessing their resource from Kind via
+	// meta.UnsafeGuessKindToResource, which applies an unconditional "y" ->
+	// "ies" rule with no vowel check -- it guesses "Gateway" as "gatewaies",
+	// not the real Gateway API plural "gateways" this test (and the real
+	// production GVR) uses, so a Gateway object passed through the
+	// constructor is silently bucketed under the wrong resource and never
+	// found by a List against gatewayGVR. Adding it via an explicit Create
+	// against the real GVR sidesteps the guess entirely.
+	dyn := ksServer.k8sClient.DynamicClient
+	_, err := dyn.Resource(gatewayGVR).Namespace("prod").Create(context.Background(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := services["app"].([]any)
+	require.Len(t, paths, 1)
+	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
+}

--- a/core/pkg/exposure/adapter.go
+++ b/core/pkg/exposure/adapter.go
@@ -1,0 +1,222 @@
+package exposure
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// FromResources converts kubescape's generically-collected scan resources
+// into the typed inputs NewIndex needs. Any object that is not a Service,
+// Ingress, or Namespace is ignored -- Gateway API objects are decoded
+// separately by FromUnstructuredGatewayAPI, since (unlike the other three)
+// this repo has no typed Go representation of them to decode into via
+// workloadinterface.IMetadata's usual JSON round-trip. A Service, Ingress,
+// or Namespace object that fails to decode is skipped, with its error
+// appended to errs, rather than aborting the whole conversion over one bad
+// object.
+func FromResources(resources map[string]workloadinterface.IMetadata) (services []corev1.Service, ingresses []networkingv1.Ingress, namespaces []NamespaceInfo, errs []error) {
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		switch resource.GetKind() {
+		case "Service":
+			var s corev1.Service
+			if err := decode(resource.GetObject(), &s); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			services = append(services, s)
+		case "Ingress":
+			var ing networkingv1.Ingress
+			if err := decode(resource.GetObject(), &ing); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			ingresses = append(ingresses, ing)
+		case "Namespace":
+			namespaces = append(namespaces, NamespaceInfo{
+				Name:   resource.GetName(),
+				Labels: resourceLabels(resource),
+			})
+		}
+	}
+	return services, ingresses, namespaces, errs
+}
+
+// FromUnstructuredGatewayAPI decodes Gateway API HTTPRoute and Gateway
+// objects from their generic unstructured representation. Kept separate
+// from FromResources because these two kinds are not part of kubescape's
+// generic scanned-resource set on every cluster (the Gateway API CRDs may
+// not even be installed) and have no typed Go representation this repo
+// already vendors to decode into. A malformed object of either kind is
+// skipped, with its error appended to errs, same as FromResources.
+func FromUnstructuredGatewayAPI(resources map[string]workloadinterface.IMetadata) (httpRoutes []httpRoute, gateways []gateway, errs []error) {
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		switch resource.GetKind() {
+		case "HTTPRoute":
+			r, err := decodeHTTPRoute(resource.GetObject())
+			if err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			httpRoutes = append(httpRoutes, r)
+		case "Gateway":
+			g, err := decodeGateway(resource.GetObject())
+			if err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			gateways = append(gateways, g)
+		}
+	}
+	return httpRoutes, gateways, errs
+}
+
+// decode converts an unstructured object's generic map into its typed shape
+// via a JSON round-trip, the same pattern core/pkg/networkpolicy's and
+// core/pkg/mapreconcile's adapters use to bridge a dynamic client's generic
+// representation and a concrete Kubernetes API type.
+func decode(obj map[string]any, out any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+	return nil
+}
+
+// gatewayAPIWireShape mirrors just the fields this package reads from an
+// HTTPRoute or Gateway's spec, in their real Gateway API JSON shape
+// (camelCase, pointer-optional fields), separate from this package's own
+// internal httpRoute/gateway types so a JSON round-trip can populate it
+// directly without custom unmarshaling.
+type gatewayAPIWireShape struct {
+	Metadata struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		// HTTPRoute fields.
+		ParentRefs []struct {
+			Namespace *string `json:"namespace,omitempty"`
+			Name      string  `json:"name"`
+		} `json:"parentRefs,omitempty"`
+		Hostnames []string `json:"hostnames,omitempty"`
+		Rules     []struct {
+			BackendRefs []struct {
+				Namespace *string `json:"namespace,omitempty"`
+				Name      string  `json:"name"`
+			} `json:"backendRefs,omitempty"`
+		} `json:"rules,omitempty"`
+
+		// Gateway fields.
+		Listeners []struct {
+			Name          string `json:"name"`
+			AllowedRoutes *struct {
+				Namespaces *struct {
+					From     *string              `json:"from,omitempty"`
+					Selector *unstructuredRawJSON `json:"selector,omitempty"`
+				} `json:"namespaces,omitempty"`
+			} `json:"allowedRoutes,omitempty"`
+		} `json:"listeners,omitempty"`
+	} `json:"spec"`
+}
+
+// unstructuredRawJSON defers a LabelSelector's decode: this package's own
+// types.go uses k8s.io/apimachinery's own metav1.LabelSelector directly for
+// routeNamespaces.Selector, so wireToSelector below re-marshals this raw
+// blob into that type rather than duplicating its field shape here too.
+type unstructuredRawJSON map[string]any
+
+func decodeHTTPRoute(obj map[string]any) (httpRoute, error) {
+	var wire gatewayAPIWireShape
+	if err := decode(obj, &wire); err != nil {
+		return httpRoute{}, err
+	}
+
+	r := httpRoute{
+		Namespace: wire.Metadata.Namespace,
+		Name:      wire.Metadata.Name,
+		Hostnames: wire.Spec.Hostnames,
+	}
+	for _, p := range wire.Spec.ParentRefs {
+		r.ParentRefs = append(r.ParentRefs, parentRef{Namespace: p.Namespace, Name: p.Name})
+	}
+	for _, rule := range wire.Spec.Rules {
+		var backends []backendRef
+		for _, b := range rule.BackendRefs {
+			backends = append(backends, backendRef{Namespace: b.Namespace, Name: b.Name})
+		}
+		r.Rules = append(r.Rules, httpRouteRule{BackendRefs: backends})
+	}
+	return r, nil
+}
+
+func decodeGateway(obj map[string]any) (gateway, error) {
+	var wire gatewayAPIWireShape
+	if err := decode(obj, &wire); err != nil {
+		return gateway{}, err
+	}
+
+	g := gateway{Namespace: wire.Metadata.Namespace, Name: wire.Metadata.Name}
+	for _, l := range wire.Spec.Listeners {
+		out := listener{Name: l.Name}
+		if l.AllowedRoutes != nil {
+			ar := &allowedRoutes{}
+			if l.AllowedRoutes.Namespaces != nil {
+				rn := &routeNamespaces{}
+				if l.AllowedRoutes.Namespaces.From != nil {
+					f := fromNamespaces(*l.AllowedRoutes.Namespaces.From)
+					rn.From = &f
+				}
+				if l.AllowedRoutes.Namespaces.Selector != nil {
+					sel, err := wireToSelector(*l.AllowedRoutes.Namespaces.Selector)
+					if err != nil {
+						return gateway{}, fmt.Errorf("listener %q: allowedRoutes.namespaces.selector: %w", l.Name, err)
+					}
+					rn.Selector = sel
+				}
+				ar.Namespaces = rn
+			}
+			out.AllowedRoutes = ar
+		}
+		g.Listeners = append(g.Listeners, out)
+	}
+	return g, nil
+}
+
+// wireToSelector re-marshals a raw selector blob (already-decoded generic
+// JSON) into metav1.LabelSelector, the type routeNamespaces.Selector uses.
+func wireToSelector(raw unstructuredRawJSON) (*metav1.LabelSelector, error) {
+	b, err := json.Marshal(map[string]any(raw))
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var sel metav1.LabelSelector
+	if err := json.Unmarshal(b, &sel); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &sel, nil
+}
+
+// resourceLabels extracts a resource's labels. IMetadata does not carry
+// labels itself; IBasicWorkload does -- same helper as
+// core/pkg/networkpolicy's and core/pkg/mapreconcile's adapters.
+func resourceLabels(resource workloadinterface.IMetadata) map[string]string {
+	bw, ok := resource.(workloadinterface.IBasicWorkload)
+	if !ok {
+		return nil
+	}
+	return bw.GetLabels()
+}

--- a/core/pkg/exposure/adapter_test.go
+++ b/core/pkg/exposure/adapter_test.go
@@ -1,0 +1,207 @@
+package exposure
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+)
+
+func unstructuredResource(obj map[string]any) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(obj)
+}
+
+func TestFromResources_ExtractsServicesIngressesAndNamespacesOnly(t *testing.T) {
+	s := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "app", "namespace": "prod"},
+		"spec":       map[string]any{"type": "LoadBalancer"},
+	})
+	ing := unstructuredResource(map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "Ingress",
+		"metadata":   map[string]any{"name": "web", "namespace": "prod"},
+		"spec": map[string]any{
+			"defaultBackend": map[string]any{"service": map[string]any{"name": "app"}},
+		},
+	})
+	ns := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata":   map[string]any{"name": "prod", "labels": map[string]any{"env": "prod"}},
+	})
+	pod := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "app", "namespace": "prod"},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		s.GetID():   s,
+		ing.GetID(): ing,
+		ns.GetID():  ns,
+		pod.GetID(): pod,
+	}
+
+	services, ingresses, namespaces, errs := FromResources(resources)
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(services) != 1 || services[0].Name != "app" {
+		t.Errorf("services = %+v, want one named app", services)
+	}
+	if len(ingresses) != 1 || ingresses[0].Name != "web" {
+		t.Errorf("ingresses = %+v, want one named web", ingresses)
+	}
+	if len(namespaces) != 1 || namespaces[0].Name != "prod" || namespaces[0].Labels["env"] != "prod" {
+		t.Errorf("namespaces = %+v, want one prod with env=prod", namespaces)
+	}
+}
+
+func TestFromResources_MalformedServiceIsSkippedNotFatal(t *testing.T) {
+	good := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "good", "namespace": "ns"},
+		"spec":       map[string]any{"type": "ClusterIP"},
+	})
+	bad := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "bad", "namespace": "ns"},
+		// type must be a string; this cannot decode into corev1.ServiceType.
+		"spec": map[string]any{"type": 12345},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		good.GetID(): good,
+		bad.GetID():  bad,
+	}
+
+	services, _, _, errs := FromResources(resources)
+
+	if len(services) != 1 || services[0].Name != "good" {
+		t.Fatalf("expected the well-formed Service to still decode, got %+v", services)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly one decode error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestFromUnstructuredGatewayAPI_DecodesHTTPRouteAndGateway(t *testing.T) {
+	route := unstructuredResource(map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "route", "namespace": "ns"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"hostnames":  []any{"app.example.com"},
+			"rules": []any{
+				map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}},
+			},
+		},
+	})
+	gw := unstructuredResource(map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "ns"},
+		"spec": map[string]any{
+			"listeners": []any{
+				map[string]any{
+					"name": "http",
+					"allowedRoutes": map[string]any{
+						"namespaces": map[string]any{
+							"from": "Selector",
+							"selector": map[string]any{
+								"matchLabels": map[string]any{"team": "payments"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		route.GetID(): route,
+		gw.GetID():    gw,
+	}
+
+	httpRoutes, gateways, errs := FromUnstructuredGatewayAPI(resources)
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(httpRoutes) != 1 {
+		t.Fatalf("httpRoutes = %+v, want one", httpRoutes)
+	}
+	r := httpRoutes[0]
+	if r.Namespace != "ns" || r.Name != "route" || len(r.ParentRefs) != 1 || r.ParentRefs[0].Name != "gw" {
+		t.Errorf("route decoded incorrectly: %+v", r)
+	}
+	if len(r.Hostnames) != 1 || r.Hostnames[0] != "app.example.com" {
+		t.Errorf("route.Hostnames = %v, want [app.example.com]", r.Hostnames)
+	}
+	if len(r.Rules) != 1 || len(r.Rules[0].BackendRefs) != 1 || r.Rules[0].BackendRefs[0].Name != "app" {
+		t.Errorf("route.Rules decoded incorrectly: %+v", r.Rules)
+	}
+
+	if len(gateways) != 1 {
+		t.Fatalf("gateways = %+v, want one", gateways)
+	}
+	g := gateways[0]
+	if g.Namespace != "ns" || g.Name != "gw" || len(g.Listeners) != 1 {
+		t.Fatalf("gateway decoded incorrectly: %+v", g)
+	}
+	l := g.Listeners[0]
+	if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil || l.AllowedRoutes.Namespaces.From == nil || *l.AllowedRoutes.Namespaces.From != fromSelector {
+		t.Fatalf("listener.AllowedRoutes decoded incorrectly: %+v", l.AllowedRoutes)
+	}
+	if l.AllowedRoutes.Namespaces.Selector == nil || l.AllowedRoutes.Namespaces.Selector.MatchLabels["team"] != "payments" {
+		t.Errorf("listener.AllowedRoutes.Namespaces.Selector decoded incorrectly: %+v", l.AllowedRoutes.Namespaces.Selector)
+	}
+}
+
+func TestFromUnstructuredGatewayAPI_IgnoresOtherKinds(t *testing.T) {
+	pod := unstructuredResource(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "app", "namespace": "ns"},
+	})
+	resources := map[string]workloadinterface.IMetadata{pod.GetID(): pod}
+
+	httpRoutes, gateways, errs := FromUnstructuredGatewayAPI(resources)
+	if len(httpRoutes) != 0 || len(gateways) != 0 || len(errs) != 0 {
+		t.Errorf("httpRoutes=%v gateways=%v errs=%v, want all empty", httpRoutes, gateways, errs)
+	}
+}
+
+func TestFromUnstructuredGatewayAPI_MalformedHTTPRouteIsSkippedNotFatal(t *testing.T) {
+	good := unstructuredResource(map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "good", "namespace": "ns"},
+		"spec":       map[string]any{"parentRefs": []any{map[string]any{"name": "gw"}}},
+	})
+	bad := unstructuredResource(map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "bad", "namespace": "ns"},
+		// hostnames must be a list of strings.
+		"spec": map[string]any{"hostnames": 12345},
+	})
+
+	resources := map[string]workloadinterface.IMetadata{
+		good.GetID(): good,
+		bad.GetID():  bad,
+	}
+
+	httpRoutes, _, errs := FromUnstructuredGatewayAPI(resources)
+	if len(httpRoutes) != 1 || httpRoutes[0].Name != "good" {
+		t.Fatalf("expected the well-formed HTTPRoute to still decode, got %+v", httpRoutes)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly one decode error, got %d: %v", len(errs), errs)
+	}
+}

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -157,7 +157,12 @@ func httpRouteReferencesService(route *httpRoute, ref ServiceRef) bool {
 // given) is conservatively treated as admitting it: this package errs
 // toward reporting a possible exposure rather than silently hiding one, the
 // same choice core/pkg/mapreconcile makes for its own indeterminate
-// matches.
+// matches. A parentRef naming a Gateway this Index has no record of at all
+// is the most indeterminate case there is -- the Gateway may simply live
+// outside what was collected (a cross-namespace reference, or a caller
+// without RBAC to list it elsewhere) rather than not exist -- so it gets the
+// same conservative treatment rather than being silently treated as a
+// non-match.
 func (idx *Index) routeAttachesToAGateway(route *httpRoute) bool {
 	for _, ref := range route.ParentRefs {
 		ns := route.Namespace
@@ -166,7 +171,7 @@ func (idx *Index) routeAttachesToAGateway(route *httpRoute) bool {
 		}
 		gw, ok := idx.gateways[ServiceRef{Namespace: ns, Name: ref.Name}]
 		if !ok {
-			continue
+			return true
 		}
 		for _, l := range gw.Listeners {
 			admits, determinable := idx.gatewayAdmitsRouteNamespace(l, route.Namespace, gw.Namespace)

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -1,0 +1,218 @@
+package exposure
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Index indexes a cluster's Service, Ingress, HTTPRoute, Gateway, and
+// Namespace objects for repeated exposure queries against the same
+// snapshot.
+type Index struct {
+	services         map[ServiceRef]*corev1.Service
+	ingressesByNS    map[string][]*networkingv1.Ingress
+	httpRoutesByNS   map[string][]*httpRoute
+	gateways         map[ServiceRef]*gateway // keyed the same shape as ServiceRef: namespace+name
+	namespacesByName map[string]NamespaceInfo
+}
+
+// NewIndex builds an Index from a cluster's (or a query's) collected
+// objects. A nil slice for any parameter is treated as "none collected,"
+// not an error -- a cluster without the Gateway API installed simply has no
+// httpRoutes/gateways to pass, and every query still works, just without
+// that exposure mechanism ever matching.
+func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, httpRoutes []httpRoute, gateways []gateway, namespaces []NamespaceInfo) *Index {
+	idx := &Index{
+		services:         make(map[ServiceRef]*corev1.Service, len(services)),
+		ingressesByNS:    make(map[string][]*networkingv1.Ingress),
+		httpRoutesByNS:   make(map[string][]*httpRoute),
+		gateways:         make(map[ServiceRef]*gateway, len(gateways)),
+		namespacesByName: make(map[string]NamespaceInfo, len(namespaces)),
+	}
+
+	for i := range services {
+		s := &services[i]
+		idx.services[ServiceRef{Namespace: s.Namespace, Name: s.Name}] = s
+	}
+	for i := range ingresses {
+		ing := &ingresses[i]
+		idx.ingressesByNS[ing.Namespace] = append(idx.ingressesByNS[ing.Namespace], ing)
+	}
+	for i := range httpRoutes {
+		r := &httpRoutes[i]
+		idx.httpRoutesByNS[r.Namespace] = append(idx.httpRoutesByNS[r.Namespace], r)
+	}
+	for i := range gateways {
+		g := &gateways[i]
+		idx.gateways[ServiceRef{Namespace: g.Namespace, Name: g.Name}] = g
+	}
+	for _, ns := range namespaces {
+		idx.namespacesByName[ns.Name] = ns
+	}
+
+	return idx
+}
+
+// ServiceExposure reports every path that exposes the named Service to
+// traffic from outside the cluster. An empty result means nothing in this
+// snapshot exposes it -- it is only reachable from inside the cluster (or
+// not collected/does not exist at all, which this function cannot tell
+// apart from "exists but not exposed").
+func (idx *Index) ServiceExposure(ref ServiceRef) []ExposurePath {
+	svc, ok := idx.services[ref]
+	if !ok {
+		return nil
+	}
+
+	var paths []ExposurePath
+
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeLoadBalancer:
+		paths = append(paths, ExposurePath{Kind: ExposureLoadBalancer, Source: fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)})
+	case corev1.ServiceTypeNodePort:
+		paths = append(paths, ExposurePath{Kind: ExposureNodePort, Source: fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)})
+	}
+
+	for _, ing := range idx.ingressesByNS[ref.Namespace] {
+		paths = append(paths, ingressPathsFor(ing, ref.Name)...)
+	}
+
+	for _, route := range idx.httpRoutesByNS[ref.Namespace] {
+		if !idx.routeAttachesToAGateway(route) {
+			continue
+		}
+		if !httpRouteReferencesService(route, ref) {
+			continue
+		}
+		source := fmt.Sprintf("%s/%s", route.Namespace, route.Name)
+		if len(route.Hostnames) == 0 {
+			paths = append(paths, ExposurePath{Kind: ExposureHTTPRoute, Source: source})
+			continue
+		}
+		for _, host := range route.Hostnames {
+			paths = append(paths, ExposurePath{Kind: ExposureHTTPRoute, Source: source, Host: host})
+		}
+	}
+
+	return paths
+}
+
+// ingressPathsFor returns one ExposurePath per Ingress rule (or the
+// defaultBackend) whose backend names serviceName.
+func ingressPathsFor(ing *networkingv1.Ingress, serviceName string) []ExposurePath {
+	var paths []ExposurePath
+	source := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
+
+	if backendNamesService(ing.Spec.DefaultBackend, serviceName) {
+		paths = append(paths, ExposurePath{Kind: ExposureIngress, Source: source})
+	}
+
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if backendNamesService(&path.Backend, serviceName) {
+				paths = append(paths, ExposurePath{Kind: ExposureIngress, Source: source, Host: rule.Host})
+			}
+		}
+	}
+
+	return paths
+}
+
+func backendNamesService(backend *networkingv1.IngressBackend, serviceName string) bool {
+	return backend != nil && backend.Service != nil && backend.Service.Name == serviceName
+}
+
+// httpRouteReferencesService reports whether any rule in route sends
+// traffic to ref. A backendRef with no Namespace defaults to the route's
+// own namespace, per Gateway API's own defaulting rules -- this package
+// does not model a backendRef reaching into another namespace via a
+// ReferenceGrant, since that requires collecting and evaluating a third
+// resource kind this Index is not given.
+func httpRouteReferencesService(route *httpRoute, ref ServiceRef) bool {
+	for _, rule := range route.Rules {
+		for _, backend := range rule.BackendRefs {
+			ns := route.Namespace
+			if backend.Namespace != nil {
+				ns = *backend.Namespace
+			}
+			if ns == ref.Namespace && backend.Name == ref.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// routeAttachesToAGateway reports whether route is admitted by at least one
+// listener of a Gateway object this Index was given, via any of the
+// route's parentRefs. A listener whose AllowedRoutes cannot be confirmed to
+// exclude the route (a Selector needing namespace labels this Index was not
+// given) is conservatively treated as admitting it: this package errs
+// toward reporting a possible exposure rather than silently hiding one, the
+// same choice core/pkg/mapreconcile makes for its own indeterminate
+// matches.
+func (idx *Index) routeAttachesToAGateway(route *httpRoute) bool {
+	for _, ref := range route.ParentRefs {
+		ns := route.Namespace
+		if ref.Namespace != nil {
+			ns = *ref.Namespace
+		}
+		gw, ok := idx.gateways[ServiceRef{Namespace: ns, Name: ref.Name}]
+		if !ok {
+			continue
+		}
+		for _, l := range gw.Listeners {
+			admits, determinable := idx.gatewayAdmitsRouteNamespace(l, route.Namespace, gw.Namespace)
+			if admits || !determinable {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// gatewayAdmitsRouteNamespace evaluates one listener's AllowedRoutes against
+// a candidate route namespace, honestly reporting indeterminate when a
+// Selector's target needs namespace labels this Index was not given -- the
+// same "determinable" pattern core/pkg/networkpolicy's peer matching uses.
+func (idx *Index) gatewayAdmitsRouteNamespace(l listener, routeNamespace, gatewayNamespace string) (admits bool, determinable bool) {
+	if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
+		return routeNamespace == gatewayNamespace, true // default: Same
+	}
+	ns := l.AllowedRoutes.Namespaces
+	from := fromSame
+	if ns.From != nil {
+		from = *ns.From
+	}
+	switch from {
+	case fromAll:
+		return true, true
+	case fromSame:
+		return routeNamespace == gatewayNamespace, true
+	case fromSelector:
+		if ns.Selector == nil {
+			return false, true
+		}
+		sel, err := metav1.LabelSelectorAsSelector(ns.Selector)
+		if err != nil {
+			return false, true
+		}
+		if sel.Empty() {
+			return true, true
+		}
+		info, ok := idx.namespacesByName[routeNamespace]
+		if !ok {
+			return false, false
+		}
+		return sel.Matches(labels.Set(info.Labels)), true
+	default:
+		return false, true
+	}
+}

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -108,16 +108,20 @@ func TestServiceExposure_IngressInAnotherNamespaceDoesNotApply(t *testing.T) {
 	}
 }
 
-func TestServiceExposure_HTTPRouteWithoutGatewayIsNotExposed(t *testing.T) {
+func TestServiceExposure_HTTPRouteWithUncollectedGatewayStillReportsPath(t *testing.T) {
 	route := httpRoute{
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "missing-gw"}},
 		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
+	// No Gateway named missing-gw was collected. This is the most
+	// indeterminate case there is -- the Gateway could simply live outside
+	// what was collected rather than not exist -- so it must be treated as a
+	// possible exposure, not silently dropped.
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
-		t.Errorf("paths = %v, want empty: no Gateway named gw was collected", paths)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
+		t.Errorf("paths = %v, want one path: an uncollected Gateway must be treated as a possible exposure", paths)
 	}
 }
 

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -1,0 +1,282 @@
+package exposure
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func svc(namespace, name string, svcType corev1.ServiceType) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       corev1.ServiceSpec{Type: svcType},
+	}
+}
+
+func ref(namespace, name string) ServiceRef {
+	return ServiceRef{Namespace: namespace, Name: name}
+}
+
+func TestServiceExposure_UnknownServiceIsEmpty(t *testing.T) {
+	idx := NewIndex(nil, nil, nil, nil, nil)
+	if paths := idx.ServiceExposure(ref("ns", "missing")); paths != nil {
+		t.Errorf("paths = %v, want nil", paths)
+	}
+}
+
+func TestServiceExposure_ClusterIPAloneIsNotExposed(t *testing.T) {
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, nil, nil, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+		t.Errorf("paths = %v, want empty", paths)
+	}
+}
+
+func TestServiceExposure_LoadBalancerIsExposed(t *testing.T) {
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeLoadBalancer)}, nil, nil, nil, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureLoadBalancer {
+		t.Errorf("paths = %+v, want one ExposureLoadBalancer", paths)
+	}
+}
+
+func TestServiceExposure_NodePortIsExposed(t *testing.T) {
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeNodePort)}, nil, nil, nil, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureNodePort {
+		t.Errorf("paths = %+v, want one ExposureNodePort", paths)
+	}
+}
+
+func ingressBackend(name string) networkingv1.IngressBackend {
+	return networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: name}}
+}
+
+func TestServiceExposure_IngressDefaultBackendExposesService(t *testing.T) {
+	ing := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "web"},
+		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("app"))},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureIngress || paths[0].Source != "ns/web" || paths[0].Host != "" {
+		t.Errorf("paths = %+v, want one ExposureIngress from ns/web with empty host", paths)
+	}
+}
+
+func TestServiceExposure_IngressRuleExposesServiceWithHost(t *testing.T) {
+	ing := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "web"},
+		Spec: networkingv1.IngressSpec{Rules: []networkingv1.IngressRule{
+			{
+				Host: "app.example.com",
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{Backend: ingressBackend("app")}},
+					},
+				},
+			},
+		}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureIngress || paths[0].Host != "app.example.com" {
+		t.Errorf("paths = %+v, want one ExposureIngress with host app.example.com", paths)
+	}
+}
+
+func TestServiceExposure_IngressForDifferentServiceDoesNotMatch(t *testing.T) {
+	ing := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "web"},
+		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("other"))},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+		t.Errorf("paths = %v, want empty", paths)
+	}
+}
+
+func TestServiceExposure_IngressInAnotherNamespaceDoesNotApply(t *testing.T) {
+	ing := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "web"},
+		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("app"))},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+		t.Errorf("paths = %v, want empty: an Ingress can only name a Service in its own namespace", paths)
+	}
+}
+
+func TestServiceExposure_HTTPRouteWithoutGatewayIsNotExposed(t *testing.T) {
+	route := httpRoute{
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "missing-gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+		t.Errorf("paths = %v, want empty: no Gateway named gw was collected", paths)
+	}
+}
+
+func TestServiceExposure_HTTPRouteAttachedToGatewayExposesService(t *testing.T) {
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	route := httpRoute{
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Hostnames:  []string{"app.example.com"},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureHTTPRoute || paths[0].Source != "ns/route" || paths[0].Host != "app.example.com" {
+		t.Errorf("paths = %+v, want one ExposureHTTPRoute from ns/route with host app.example.com", paths)
+	}
+}
+
+func TestServiceExposure_HTTPRouteWithNoHostnamesProducesOnePathWithEmptyHost(t *testing.T) {
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	route := httpRoute{
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	paths := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Host != "" {
+		t.Errorf("paths = %+v, want one path with empty host", paths)
+	}
+}
+
+func TestServiceExposure_CrossNamespaceParentRefBlockedByDefaultSameNamespaceAllowedRoutes(t *testing.T) {
+	gw := gateway{Namespace: "gw-ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	gwNS := "gw-ns"
+	route := httpRoute{
+		Namespace:  "route-ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Namespace: &gwNS, Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	paths := idx.ServiceExposure(ref("route-ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty: AllowedRoutes defaults to Same, and the route's namespace differs from the Gateway's", paths)
+	}
+}
+
+func TestServiceExposure_CrossNamespaceParentRefAllowedByExplicitFromAll(t *testing.T) {
+	all := fromAll
+	gwNS := "gw-ns"
+	gw := gateway{Namespace: "gw-ns", Name: "gw", Listeners: []listener{{
+		Name:          "http",
+		AllowedRoutes: &allowedRoutes{Namespaces: &routeNamespaces{From: &all}},
+	}}}
+	route := httpRoute{
+		Namespace:  "route-ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Namespace: &gwNS, Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	paths := idx.ServiceExposure(ref("route-ns", "app"))
+	if len(paths) != 1 {
+		t.Errorf("paths = %+v, want one ExposureHTTPRoute: the listener explicitly allows routes from all namespaces", paths)
+	}
+}
+
+func TestServiceExposure_HTTPRouteBackendInAnotherNamespaceIsNotModeled(t *testing.T) {
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	otherNS := "other-ns"
+	route := httpRoute{
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &otherNS, Name: "app"}}}},
+	}
+	// The Service actually lives in ns, but the route's backendRef claims
+	// other-ns -- without a ReferenceGrant (not modeled), this must not
+	// match ns/app.
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+		t.Errorf("paths = %v, want empty", paths)
+	}
+}
+
+func TestGatewayAdmitsRouteNamespace_DefaultIsSameNamespace(t *testing.T) {
+	idx := NewIndex(nil, nil, nil, nil, nil)
+	admits, determinable := idx.gatewayAdmitsRouteNamespace(listener{}, "ns", "ns")
+	if !admits || !determinable {
+		t.Errorf("admits=%v determinable=%v, want true,true for same namespace under the default", admits, determinable)
+	}
+	admits, determinable = idx.gatewayAdmitsRouteNamespace(listener{}, "other-ns", "ns")
+	if admits || !determinable {
+		t.Errorf("admits=%v determinable=%v, want false,true for a different namespace under the default", admits, determinable)
+	}
+}
+
+func TestGatewayAdmitsRouteNamespace_FromAllAdmitsEveryNamespace(t *testing.T) {
+	all := fromAll
+	l := listener{AllowedRoutes: &allowedRoutes{Namespaces: &routeNamespaces{From: &all}}}
+	idx := NewIndex(nil, nil, nil, nil, nil)
+	admits, determinable := idx.gatewayAdmitsRouteNamespace(l, "anything", "gw-ns")
+	if !admits || !determinable {
+		t.Errorf("admits=%v determinable=%v, want true,true", admits, determinable)
+	}
+}
+
+func TestGatewayAdmitsRouteNamespace_FromSelectorNeedsNamespaceLabels(t *testing.T) {
+	sel := fromSelector
+	l := listener{AllowedRoutes: &allowedRoutes{Namespaces: &routeNamespaces{
+		From:     &sel,
+		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "payments"}},
+	}}}
+
+	idxNoLabels := NewIndex(nil, nil, nil, nil, nil)
+	_, determinable := idxNoLabels.gatewayAdmitsRouteNamespace(l, "route-ns", "gw-ns")
+	if determinable {
+		t.Error("determinable = true, want false: no namespace labels were collected for route-ns")
+	}
+
+	idxWithLabels := NewIndex(nil, nil, nil, nil, []NamespaceInfo{{Name: "route-ns", Labels: map[string]string{"team": "payments"}}})
+	admits, determinable := idxWithLabels.gatewayAdmitsRouteNamespace(l, "route-ns", "gw-ns")
+	if !admits || !determinable {
+		t.Errorf("admits=%v determinable=%v, want true,true: route-ns's labels satisfy the selector", admits, determinable)
+	}
+
+	idxWrongLabels := NewIndex(nil, nil, nil, nil, []NamespaceInfo{{Name: "route-ns", Labels: map[string]string{"team": "platform"}}})
+	admits, determinable = idxWrongLabels.gatewayAdmitsRouteNamespace(l, "route-ns", "gw-ns")
+	if admits || !determinable {
+		t.Errorf("admits=%v determinable=%v, want false,true: route-ns's labels do not satisfy the selector", admits, determinable)
+	}
+}
+
+func TestServiceExposure_HTTPRouteIndeterminateAdmissionStillReportsPath(t *testing.T) {
+	sel := fromSelector
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{
+		AllowedRoutes: &allowedRoutes{Namespaces: &routeNamespaces{
+			From:     &sel,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "payments"}},
+		}},
+	}}}
+	route := httpRoute{
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	// No NamespaceInfo for "ns" was collected, so the selector can't be
+	// evaluated -- this must still report the path rather than silently
+	// dropping a possible exposure.
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
+		t.Errorf("paths = %v, want one path: an indeterminate admission must still be reported", paths)
+	}
+}
+
+func ptrBackend(b networkingv1.IngressBackend) *networkingv1.IngressBackend {
+	return &b
+}

--- a/core/pkg/exposure/types.go
+++ b/core/pkg/exposure/types.go
@@ -1,0 +1,156 @@
+// Package exposure models which of a cluster's Service objects are reachable
+// from outside the cluster, and by what mechanism: a Service of type
+// LoadBalancer or NodePort is exposed directly; a networking.k8s.io/v1
+// Ingress or a Gateway API HTTPRoute exposes whatever Service it names as a
+// backend.
+//
+// This is the "outside-in" counterpart to core/pkg/networkpolicy's
+// reachability model: that package answers "can this pod reach that pod
+// inside the cluster," this one answers "does anything let traffic in from
+// outside the cluster in the first place." Like that package, this is a
+// static model computed from spec -- existence of an Ingress/HTTPRoute
+// naming a Service is treated as intent to expose it, the same trust model
+// the rest of kubescape's posture scanning uses; it does not verify that an
+// Ingress controller or Gateway implementation is actually running and
+// wired up to fulfil what the object declares.
+package exposure
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ExposureKind identifies which Kubernetes mechanism exposes a Service.
+type ExposureKind int
+
+const (
+	// ExposureLoadBalancer means the Service itself is type LoadBalancer:
+	// exposed directly via a cloud load balancer, no Ingress/Route needed.
+	ExposureLoadBalancer ExposureKind = iota
+	// ExposureNodePort means the Service itself is type NodePort: exposed
+	// directly on every node's IP, no Ingress/Route needed.
+	ExposureNodePort
+	// ExposureIngress means a networking.k8s.io/v1 Ingress names this
+	// Service as a backend (a rule's path backend, or the defaultBackend).
+	ExposureIngress
+	// ExposureHTTPRoute means a Gateway API HTTPRoute names this Service as
+	// a backend, and at least one of its parentRefs names a Gateway object
+	// this Index was given whose listener admits the route (per
+	// AllowedRoutes -- see Index.gatewayAdmitsRouteNamespace). A listener
+	// whose admission can't be confirmed one way or the other is
+	// conservatively treated as admitting it.
+	ExposureHTTPRoute
+)
+
+func (k ExposureKind) String() string {
+	switch k {
+	case ExposureLoadBalancer:
+		return "LoadBalancer"
+	case ExposureNodePort:
+		return "NodePort"
+	case ExposureIngress:
+		return "Ingress"
+	case ExposureHTTPRoute:
+		return "HTTPRoute"
+	default:
+		return "unknown"
+	}
+}
+
+// ExposurePath is one specific reason a Service is reachable from outside
+// the cluster.
+type ExposurePath struct {
+	Kind ExposureKind
+	// Source names the object responsible: the Ingress/HTTPRoute
+	// (namespace/name) that names this Service as a backend, or the
+	// Service itself for LoadBalancer/NodePort.
+	Source string
+	// Host is the hostname traffic must arrive with to reach this path, per
+	// the responsible Ingress rule or HTTPRoute hostname. Empty means any
+	// host (an Ingress rule/defaultBackend with no host restriction, a
+	// LoadBalancer/NodePort Service, or an HTTPRoute with no hostnames
+	// declared).
+	Host string
+}
+
+// ServiceRef identifies one Service by namespace and name.
+type ServiceRef struct {
+	Namespace string
+	Name      string
+}
+
+// NamespaceInfo carries a namespace's own labels, needed for a Gateway
+// listener's AllowedRoutes selector (see gatewayAdmitsRouteNamespace).
+type NamespaceInfo struct {
+	Name   string
+	Labels map[string]string
+}
+
+// httpRoute is a minimal local mirror of gateway.networking.k8s.io/v1
+// HTTPRoute -- only the fields exposure analysis needs. Defined locally
+// rather than vendoring sigs.k8s.io/gateway-api, since decoding the handful
+// of fields used here from the same generic unstructured object this
+// package's adapter already reads for every other resource kind needs
+// nothing else from that module.
+type httpRoute struct {
+	Namespace  string
+	Name       string
+	ParentRefs []parentRef
+	Hostnames  []string
+	Rules      []httpRouteRule
+}
+
+// parentRef names the Gateway (or other parent) an HTTPRoute attaches to.
+// Namespace is a pointer because the API defaults an absent namespace to
+// the route's own, per Gateway API's own defaulting rules -- this mirrors
+// that rather than assuming empty-string means "same namespace" implicitly.
+type parentRef struct {
+	Namespace *string
+	Name      string
+}
+
+type httpRouteRule struct {
+	BackendRefs []backendRef
+}
+
+// backendRef names a Service an HTTPRoute rule sends matching traffic to.
+// Namespace defaults to the route's own namespace when nil, same as
+// parentRef -- Gateway API does not support a backendRef reaching into
+// another namespace without a ReferenceGrant, which this package does not
+// model (see AnalyzeExposure's doc comment).
+type backendRef struct {
+	Namespace *string
+	Name      string
+}
+
+// gateway is a minimal local mirror of gateway.networking.k8s.io/v1 Gateway.
+type gateway struct {
+	Namespace string
+	Name      string
+	Listeners []listener
+}
+
+type listener struct {
+	Name          string
+	AllowedRoutes *allowedRoutes
+}
+
+// allowedRoutes mirrors Gateway API's AllowedRoutes: which namespaces'
+// HTTPRoutes this listener admits. A nil AllowedRoutes (or a nil Namespaces
+// within it) defaults to "Same" -- routes in the Gateway's own namespace
+// only -- per the Gateway API spec's own default.
+type allowedRoutes struct {
+	Namespaces *routeNamespaces
+}
+
+type fromNamespaces string
+
+const (
+	fromAll      fromNamespaces = "All"
+	fromSelector fromNamespaces = "Selector"
+	fromSame     fromNamespaces = "Same"
+)
+
+type routeNamespaces struct {
+	From     *fromNamespaces
+	Selector *metav1.LabelSelector
+}


### PR DESCRIPTION
## Summary

Closes #3647.

Kubescape's NetworkPolicy reachability engine (this session, #3601) models intra-cluster traffic, but nothing modeled the other half of the exposure story: which workloads are actually reachable from *outside* the cluster in the first place. Control `C-0266` ("Exposure to internet via Gateway API or Istio Ingress") is a static Rego pass/fail check with no persistent Go-level model, and (per its own description) covers neither `LoadBalancer` nor `NodePort` Services at all.

## Changes

- **`core/pkg/exposure`** (new package) -- an `Index` (mirroring the established `networkpolicy`/`mapreconcile` package pattern) over `Service`/`Ingress`/`Namespace` objects plus Gateway API `HTTPRoute`/`Gateway` objects. `Index.ServiceExposure` reports every `ExposurePath` that exposes a Service to traffic from outside the cluster:
  - the Service itself being type `LoadBalancer` or `NodePort`,
  - an `Ingress` naming it as a backend (per-rule or `defaultBackend`),
  - an `HTTPRoute` naming it as a backend *through a Gateway whose listener actually admits the route's namespace* -- real `AllowedRoutes` semantics (`All`/`Same`/`Selector`), with the same "indeterminate reports as admitting" conservative default `core/pkg/mapreconcile` already uses for its own indeterminate matches, rather than a naive existence-only check.

  Gateway API objects are decoded via a minimal local mirror of just the fields this package needs, rather than vendoring `sigs.k8s.io/gateway-api` for a handful of fields this repo has no other use for.

  Existence of an exposing object is treated as intent to expose it -- the same static-model trust model the NetworkPolicy reachability engine already established (it does not verify an Ingress controller or Gateway implementation is actually running).

- **`analyze_service_exposure`** (new MCP tool) -- reports a Service's (or every Service in a namespace's) exposure paths live. Gracefully degrades when the Gateway API CRDs are not installed at all (a `NotFound` list error is not a tool failure; a genuinely unexpected list error still is).

## A real testing-harness bug found and worked around along the way

While writing the MCP-level tests, `NewSimpleDynamicClientWithCustomListKinds`'s initial-object placement (which uses `meta.UnsafeGuessKindToResource` to guess each object's resource from its Kind) silently dropped a `Gateway` test object: the guesser applies an unconditional `"y" -> "ies"` pluralization rule with no vowel check, guessing Kind `Gateway` as resource `gatewaies`, not the real Gateway API plural `gateways`. Worked around in the test via an explicit `Create` against the real GVR instead of passing the object through the constructor -- not a production bug (production code always uses the real, correct `gateways` GVR), but a genuine gotcha worth documenting for whoever hits it next.

## Test plan

- Unit tests for `Index.ServiceExposure` (`core/pkg/exposure/index_test.go`): unknown/ClusterIP-alone not exposed, LoadBalancer/NodePort exposed, Ingress `defaultBackend` and per-rule matching (including host, wrong-service, wrong-namespace non-matches), HTTPRoute without a collected Gateway not exposed, HTTPRoute exposure with/without hostnames, cross-namespace `parentRef` blocked by the real default `Same` `AllowedRoutes` and allowed by explicit `From: All`, cross-namespace `backendRef` correctly *not* modeled (no `ReferenceGrant` support), `AllowedRoutes` `Selector` matching with known/wrong/missing namespace labels, and an indeterminate admission still conservatively reporting the path.
- Unit tests for the adapter (`adapter_test.go`): `FromResources` extraction and malformed-Service skip-not-fatal, `FromUnstructuredGatewayAPI` decode correctness (including nested `AllowedRoutes`/`Selector`), ignoring unrelated kinds, and malformed-HTTPRoute skip-not-fatal.
- MCP-level tests (`service_exposure_test.go`) exercising the real MCP JSON-RPC dispatch path against a fake dynamic client: LoadBalancer exposure, ClusterIP-with-no-Ingress not exposed, Ingress exposure, omitted `service_name` reporting every Service in the namespace, missing-namespace argument error, missing-Gateway-API-CRDs graceful degradation (via a reactor injecting a real `NotFound`, not the constructor's guess-based placement), a genuine list error still surfacing as a tool error, and HTTPRoute-through-Gateway exposure end-to-end.
- `go build ./...`, `go vet ./...`, `go test -race` on the affected packages, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `analyze_service_exposure` tool to determine whether Kubernetes Services are externally reachable.
  * Reports exposure through LoadBalancer, NodePort, Ingress, Gateway, and HTTPRoute configurations, including source and host details.
  * Supports analyzing a specific Service or all Services in a namespace.
  * Handles unavailable Gateway API resources gracefully and includes applicable decoding warnings.

* **Tests**
  * Added coverage for service exposure scenarios, cross-namespace routing, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->