### PR TITLE
Add URL context to repository scanner error messages

### DIFF
--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -107,7 +107,10 @@ func getRepository(fullURL string) (IRepository, error) {
 		repo.setIsFile(true)
 	default:
 		parsed, _ := giturls.Parse(fullURL)
-		return nil, fmt.Errorf("unknown repository host: %s, url: '%s'", hostUrl, parsed.Redacted())
+		if parsed != nil {
+			parsed.User = nil
+		}
+		return nil, fmt.Errorf("unknown repository host: %s, url: '%s'", hostUrl, parsed)
 	}
 
 	// Returns the host-url, and the part of the user and repository from the url
@@ -122,7 +125,8 @@ func (g *GitHubRepository) parse(fullURL string) error {
 
 	splittedRepo := strings.FieldsFunc(parsedURL.Path, func(c rune) bool { return c == '/' })
 	if len(splittedRepo) < 2 {
-		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s', url: '%s'", parsedURL.Path, parsedURL.Redacted())
+		parsedURL.User = nil
+		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s', url: '%s'", parsedURL.Path, parsedURL)
 	}
 	g.owner = splittedRepo[index]
 	index += 1

--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -106,7 +106,8 @@ func getRepository(fullURL string) (IRepository, error) {
 		repo = NewGitHubRepository()
 		repo.setIsFile(true)
 	default:
-		return nil, fmt.Errorf("unknown repository host: %s, url: '%s'", hostUrl, fullURL)
+		parsed, _ := giturls.Parse(fullURL)
+		return nil, fmt.Errorf("unknown repository host: %s, url: '%s'", hostUrl, parsed.Redacted())
 	}
 
 	// Returns the host-url, and the part of the user and repository from the url
@@ -121,7 +122,7 @@ func (g *GitHubRepository) parse(fullURL string) error {
 
 	splittedRepo := strings.FieldsFunc(parsedURL.Path, func(c rune) bool { return c == '/' })
 	if len(splittedRepo) < 2 {
-		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s', url: '%s'", parsedURL.Path, fullURL)
+		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s', url: '%s'", parsedURL.Path, parsedURL.Redacted())
 	}
 	g.owner = splittedRepo[index]
 	index += 1

--- a/core/pkg/resourcehandler/repositoryscanner.go
+++ b/core/pkg/resourcehandler/repositoryscanner.go
@@ -106,7 +106,7 @@ func getRepository(fullURL string) (IRepository, error) {
 		repo = NewGitHubRepository()
 		repo.setIsFile(true)
 	default:
-		return nil, fmt.Errorf("unknown repository host: %s", hostUrl)
+		return nil, fmt.Errorf("unknown repository host: %s, url: '%s'", hostUrl, fullURL)
 	}
 
 	// Returns the host-url, and the part of the user and repository from the url
@@ -121,7 +121,7 @@ func (g *GitHubRepository) parse(fullURL string) error {
 
 	splittedRepo := strings.FieldsFunc(parsedURL.Path, func(c rune) bool { return c == '/' })
 	if len(splittedRepo) < 2 {
-		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s'", parsedURL.Path)
+		return fmt.Errorf("expecting <user>/<repo> in url path, received: '%s', url: '%s'", parsedURL.Path, fullURL)
 	}
 	g.owner = splittedRepo[index]
 	index += 1


### PR DESCRIPTION
## Description:
close #3649
This PR improves the observability of repositoryscanner.go by including the original URL in repository scanner error messages.

## Changes:

Wrapped unknown repository host error with the original URL.
Wrapped expecting <user>/<repo> error with the original URL.
This is an observability improvement only — it changes error message strings, not control flow or output behavior, so users can quickly identify malformed --use-from or remote-git inputs.

## Testing:

go test ./core/pkg/resourcehandler passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository URL error messages by displaying a redacted URL.
  * Updated errors for unknown repository hosts and malformed paths to provide clearer, safer diagnostic information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->