### PR TITLE
fix(mapreconcile): a policy gated by matchConditions is not a confirmed match

### DIFF
--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -33,7 +33,7 @@ var mutatingAdmissionPolicyOperations = map[string]admissionregistrationv1alpha1
 func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 	tool := mcp.NewTool(
 		"analyze_mutating_admission_policy_impact",
-		mcp.WithDescription("Determine which of the cluster's live MutatingAdmissionPolicy objects would mutate a specific resource on a given operation (default CREATE), and what each one's raw CEL mutation expression is. This surfaces implicit mutation that happens at admission time and never appears in the manifest a user applied -- it reports that a policy's mutation would run and what its expression is, it does not evaluate the expression to compute the resulting object."),
+		mcp.WithDescription("Determine which of the cluster's live MutatingAdmissionPolicy objects would mutate a specific resource on a given operation (default CREATE), and what each one's raw CEL mutation expression is. This surfaces implicit mutation that happens at admission time and never appears in the manifest a user applied -- it reports that a policy's mutation would run and what its expression is, it does not evaluate the expression to compute the resulting object. A match with determinable false is one that might apply rather than one that does: match_conditions lists the CEL gates the apiserver still evaluates on the request."),
 		mcp.WithString("namespace", mcp.Description("Namespace of the resource (omit for a cluster-scoped resource)")),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the resource")),
 		mcp.WithString("api_group", mcp.Description("API group of the resource (omit or empty for the core group, e.g. Pod/ConfigMap)")),
@@ -202,13 +202,21 @@ func buildMatchSummaries(matches []mapreconcile.MatchedPolicy) []map[string]any 
 				"expression": mut.Expression,
 			})
 		}
+		conditions := make([]map[string]any, 0, len(m.MatchConditions))
+		for _, cond := range m.MatchConditions {
+			conditions = append(conditions, map[string]any{
+				"name":       cond.Name,
+				"expression": cond.Expression,
+			})
+		}
 		out = append(out, map[string]any{
-			"policy_name":    m.PolicyName,
-			"binding_name":   m.BindingName,
-			"mutations":      mutations,
-			"failure_policy": string(m.FailurePolicy),
-			"has_params":     m.HasParams,
-			"determinable":   m.Determinable,
+			"policy_name":      m.PolicyName,
+			"binding_name":     m.BindingName,
+			"mutations":        mutations,
+			"failure_policy":   string(m.FailurePolicy),
+			"has_params":       m.HasParams,
+			"match_conditions": conditions,
+			"determinable":     m.Determinable,
 		})
 	}
 	return out

--- a/cmd/mcpserver/mutating_policy_impact_test.go
+++ b/cmd/mcpserver/mutating_policy_impact_test.go
@@ -566,3 +566,81 @@ func TestAnalyzeMutatingAdmissionPolicyImpact_OmittedAndNullSubresourceMeanTheRe
 	require.False(t, null.IsError)
 	require.Equal(t, []string{"mutate-pods"}, matchedPolicyNames(t, null))
 }
+
+// withMatchConditions puts a spec.matchConditions gate on a policy fixture.
+func withMatchConditions(policy *unstructured.Unstructured, conditions ...map[string]any) *unstructured.Unstructured {
+	raw := make([]any, len(conditions))
+	for i, condition := range conditions {
+		raw[i] = condition
+	}
+	policy.Object["spec"].(map[string]any)["matchConditions"] = raw
+	return policy
+}
+
+func addLabelMutation() map[string]any {
+	return map[string]any{
+		"patchType": "JSONPatch",
+		"jsonPatch": map[string]any{"expression": `[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`},
+	}
+}
+
+func matchesFromToolResult(t *testing.T, ksServer *KubescapeMcpserver, args map[string]any) []any {
+	t.Helper()
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_mutating_admission_policy_impact", args))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.True(t, parsed["supported"].(bool))
+	return parsed["matches"].([]any)
+}
+
+func podImpactArgs() map[string]any {
+	return map[string]any{
+		"namespace":   "prod",
+		"name":        "server",
+		"api_version": "v1",
+		"resource":    "pods",
+	}
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_MatchConditionsLeaveTheMatchIndeterminate
+// covers the gate over the tools/call path: the apiserver still evaluates the
+// policy's own matchConditions before mutating, so the tool must report the
+// match as one that might apply and name what gates it.
+func TestAnalyzeMutatingAdmissionPolicyImpact_MatchConditionsLeaveTheMatchIndeterminate(t *testing.T) {
+	policy := withMatchConditions(
+		unstructuredMutatingPolicy("add-label", allPodsMatchConstraints(), addLabelMutation()),
+		map[string]any{"name": "only-opted-in", "expression": `object.metadata.?labels["mutate"].orValue("no") == "yes"`},
+	)
+	binding := unstructuredMutatingPolicyBinding("add-label-binding", "add-label")
+	pod := unstructuredTestPod("prod", "server", nil)
+
+	matches := matchesFromToolResult(t, newMutatingPolicyTestServer(t, policy, binding, pod), podImpactArgs())
+	require.Len(t, matches, 1)
+
+	match := matches[0].(map[string]any)
+	require.False(t, match["determinable"].(bool))
+
+	conditions, reported := match["match_conditions"].([]any)
+	require.True(t, reported, "the gate must be reported alongside the match")
+	require.Len(t, conditions, 1)
+	require.Equal(t, "only-opted-in", conditions[0].(map[string]any)["name"])
+	require.Contains(t, conditions[0].(map[string]any)["expression"], `labels["mutate"]`)
+}
+
+// TestAnalyzeMutatingAdmissionPolicyImpact_UngatedPolicyStaysDeterminable is the
+// contrast: a policy declaring no matchConditions still reports a confirmed
+// match, with an empty gate list rather than a missing field.
+func TestAnalyzeMutatingAdmissionPolicyImpact_UngatedPolicyStaysDeterminable(t *testing.T) {
+	policy := unstructuredMutatingPolicy("add-label", allPodsMatchConstraints(), addLabelMutation())
+	binding := unstructuredMutatingPolicyBinding("add-label-binding", "add-label")
+	pod := unstructuredTestPod("prod", "server", nil)
+
+	matches := matchesFromToolResult(t, newMutatingPolicyTestServer(t, policy, binding, pod), podImpactArgs())
+	require.Len(t, matches, 1)
+
+	match := matches[0].(map[string]any)
+	require.True(t, match["determinable"].(bool))
+	require.Empty(t, match["match_conditions"])
+}

--- a/core/pkg/mapreconcile/index.go
+++ b/core/pkg/mapreconcile/index.go
@@ -116,6 +116,10 @@ func NewIndex(policies []admissionregistrationv1alpha1.MutatingAdmissionPolicy, 
 // mutates anything -- MutatingAdmissionPolicy, like ValidatingAdmissionPolicy,
 // takes effect only once bound -- so it is silently excluded rather than
 // reported as an unbound near-miss.
+//
+// A pair is reported with Determinable false where something the apiserver
+// resolves at admission cannot be resolved here, spec.matchConditions
+// included; see MatchedPolicy.Determinable.
 func (idx *Index) Matches(obj ObjectInfo) []MatchedPolicy {
 	var out []MatchedPolicy
 	for _, cp := range idx.policies {
@@ -141,6 +145,15 @@ func (idx *Index) Matches(obj ObjectInfo) []MatchedPolicy {
 			if determinable && !matched {
 				continue
 			}
+
+			// spec.matchConditions is a CEL gate the apiserver applies to a
+			// request matchConstraints have already admitted, and this package
+			// evaluates no CEL. A gated policy may still be skipped at
+			// admission, so its match is reported as "might apply" rather than
+			// confirmed. The gate is read only here, after the confident
+			// non-match above: matchConditions only narrow, so they can never
+			// turn a non-match into a match.
+			determinable = determinable && len(cp.matchConditions) == 0
 
 			out = append(out, MatchedPolicy{
 				PolicyName:      cp.policy.Name,

--- a/core/pkg/mapreconcile/index.go
+++ b/core/pkg/mapreconcile/index.go
@@ -13,6 +13,14 @@ type MutationSummary struct {
 	Expression string
 }
 
+// MatchConditionSummary is one entry from a policy's spec.matchConditions,
+// reported verbatim for the same reason a Mutation is: it is a CEL expression
+// this package does not evaluate.
+type MatchConditionSummary struct {
+	Name       string
+	Expression string
+}
+
 // MatchedPolicy is one MutatingAdmissionPolicy (bound by one binding) whose
 // matchConstraints and matchResources together cover a queried object.
 type MatchedPolicy struct {
@@ -31,6 +39,11 @@ type MatchedPolicy struct {
 	// denied at admission depending on FailurePolicy -- the match reported
 	// here is necessary but not sufficient in that case.
 	HasParams bool
+	// MatchConditions is the policy's own spec.matchConditions, the CEL gate
+	// the apiserver applies to a request matchConstraints already admitted.
+	// Reported so a caller can see what still has to hold for the mutation to
+	// run.
+	MatchConditions []MatchConditionSummary
 	// Determinable is false when this policy's match could not be confirmed
 	// from the data available (see compiledMatchResources.matches): the
 	// caller should treat MatchedPolicy as "might apply," not "does apply."
@@ -42,6 +55,7 @@ type MatchedPolicy struct {
 type compiledPolicy struct {
 	policy          admissionregistrationv1alpha1.MutatingAdmissionPolicy
 	matchConstraint *compiledMatchResources
+	matchConditions []MatchConditionSummary
 	bindings        []compiledBinding
 }
 
@@ -78,7 +92,7 @@ func NewIndex(policies []admissionregistrationv1alpha1.MutatingAdmissionPolicy, 
 			continue
 		}
 
-		cp := &compiledPolicy{policy: p, matchConstraint: mc}
+		cp := &compiledPolicy{policy: p, matchConstraint: mc, matchConditions: matchConditionSummaries(p.Spec.MatchConditions)}
 		for _, b := range bindingsByPolicy[p.Name] {
 			var cmr *compiledMatchResources
 			if b.Spec.MatchResources != nil {
@@ -129,12 +143,13 @@ func (idx *Index) Matches(obj ObjectInfo) []MatchedPolicy {
 			}
 
 			out = append(out, MatchedPolicy{
-				PolicyName:    cp.policy.Name,
-				BindingName:   cb.binding.Name,
-				Mutations:     mutationSummaries(cp.policy.Spec.Mutations),
-				FailurePolicy: failurePolicyOrDefault(cp.policy.Spec.FailurePolicy),
-				HasParams:     cp.policy.Spec.ParamKind != nil,
-				Determinable:  determinable,
+				PolicyName:      cp.policy.Name,
+				BindingName:     cb.binding.Name,
+				Mutations:       mutationSummaries(cp.policy.Spec.Mutations),
+				FailurePolicy:   failurePolicyOrDefault(cp.policy.Spec.FailurePolicy),
+				MatchConditions: cp.matchConditions,
+				HasParams:       cp.policy.Spec.ParamKind != nil,
+				Determinable:    determinable,
 			})
 		}
 	}
@@ -156,6 +171,19 @@ func mutationSummaries(mutations []admissionregistrationv1alpha1.Mutation) []Mut
 			}
 		}
 		out = append(out, s)
+	}
+	return out
+}
+
+// matchConditionSummaries copies a policy's matchConditions into the reported
+// shape. A policy declaring none returns nil, so "gated" stays a length check.
+func matchConditionSummaries(conditions []admissionregistrationv1alpha1.MatchCondition) []MatchConditionSummary {
+	if len(conditions) == 0 {
+		return nil
+	}
+	out := make([]MatchConditionSummary, 0, len(conditions))
+	for _, c := range conditions {
+		out = append(out, MatchConditionSummary{Name: c.Name, Expression: c.Expression})
 	}
 	return out
 }

--- a/core/pkg/mapreconcile/index_test.go
+++ b/core/pkg/mapreconcile/index_test.go
@@ -281,3 +281,86 @@ func TestMatches_SubresourceRequestNotCoveredByBareResourceRule(t *testing.T) {
 	assert.Empty(t, idx.Matches(obj(func(o *ObjectInfo) { o.Subresource = "status" })))
 	assert.Len(t, idx.Matches(obj(nil)), 1)
 }
+
+func gatedPolicy(name string, matchConstraints *admissionregistrationv1alpha1.MatchResources, conditions ...admissionregistrationv1alpha1.MatchCondition) admissionregistrationv1alpha1.MutatingAdmissionPolicy {
+	p := policy(name, matchConstraints, jsonPatchMutation(`[JSONPatch{op: "add", path: "/metadata/labels/x", value: "y"}]`))
+	p.Spec.MatchConditions = conditions
+	return p
+}
+
+func optedInCondition() admissionregistrationv1alpha1.MatchCondition {
+	return admissionregistrationv1alpha1.MatchCondition{
+		Name:       "only-opted-in",
+		Expression: `object.metadata.?labels["mutate"].orValue("no") == "yes"`,
+	}
+}
+
+// TestMatches_PolicyGatedByMatchConditionsIsNotConfirmed is the headline case:
+// matchConditions filter a request matchConstraints have already admitted, so
+// a gated policy may be skipped at admission and its match cannot be reported
+// as confirmed.
+func TestMatches_PolicyGatedByMatchConditionsIsNotConfirmed(t *testing.T) {
+	p := gatedPolicy("add-label", allPods(), optedInCondition())
+	b := binding("add-label-binding", "add-label", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1, "a gated policy is still a possible match")
+	assert.False(t, matches[0].Determinable, "a matchCondition this package cannot evaluate must leave the match indeterminate")
+}
+
+// TestMatches_MatchConditionsAreCarriedOnTheMatch pins that the gate is
+// reported alongside the match, so a caller can say what still has to hold.
+func TestMatches_MatchConditionsAreCarriedOnTheMatch(t *testing.T) {
+	p := gatedPolicy("add-label", allPods(), optedInCondition())
+	b := binding("add-label-binding", "add-label", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0].MatchConditions, 1)
+	assert.Equal(t, "only-opted-in", matches[0].MatchConditions[0].Name)
+	assert.Contains(t, matches[0].MatchConditions[0].Expression, `labels["mutate"]`)
+}
+
+// TestMatches_PolicyWithoutMatchConditionsStaysConfirmed keeps the gate from
+// widening past the policies that declare one.
+func TestMatches_PolicyWithoutMatchConditionsStaysConfirmed(t *testing.T) {
+	p := gatedPolicy("add-label", allPods())
+	b := binding("add-label-binding", "add-label", nil)
+	idx, errs := NewIndex([]admissionregistrationv1alpha1.MutatingAdmissionPolicy{p}, []admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{b})
+	require.Empty(t, errs)
+
+	matches := idx.Matches(obj(nil))
+	require.Len(t, matches, 1)
+	assert.True(t, matches[0].Determinable)
+	assert.Empty(t, matches[0].MatchConditions)
+}
+
+// TestMatches_MatchConditionsNeverTurnANonMatchIntoAMatch is the regression
+// pin, and passes both before and after the fix on purpose: matchConditions
+// only narrow, so the gate has to be read after a confident non-match, never
+// instead of one.
+func TestMatches_MatchConditionsNeverTurnANonMatchIntoAMatch(t *testing.T) {
+	configmapsOnly := &admissionregistrationv1alpha1.MatchResources{
+		ResourceRules: []admissionregistrationv1alpha1.NamedRuleWithOperations{
+			rule([]string{""}, []string{"v1"}, []string{"configmaps"}, admissionregistrationv1alpha1.OperationAll),
+		},
+	}
+	outOfScope := gatedPolicy("configmap-only", configmapsOnly, optedInCondition())
+	excluded := gatedPolicy("add-label", allPods(), optedInCondition())
+	narrowing := binding("only-opted-in", "add-label", &admissionregistrationv1alpha1.MatchResources{
+		ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mutate": "yes"}},
+	})
+
+	idx, errs := NewIndex(
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicy{outOfScope, excluded},
+		[]admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{binding("b", "configmap-only", nil), narrowing},
+	)
+	require.Empty(t, errs)
+
+	assert.Empty(t, idx.Matches(obj(func(o *ObjectInfo) { o.Labels = map[string]string{"mutate": "no"} })),
+		"a gated policy the matchConstraints or the binding exclude is still no match at all")
+}

--- a/core/pkg/mapreconcile/reconcile.go
+++ b/core/pkg/mapreconcile/reconcile.go
@@ -11,6 +11,10 @@
 // apiserver-grade CEL/ApplyConfiguration machinery admission control itself
 // uses; reporting the match and the expression verbatim is honest about that
 // boundary rather than guessing at an evaluated result.
+//
+// A policy's spec.matchConditions are CEL too, and are reported the same way:
+// a gated policy is a match that *might* apply rather than one that does (see
+// MatchedPolicy.Determinable), with the conditions carried alongside it.
 package mapreconcile
 
 import (


### PR DESCRIPTION
`core/pkg/mapreconcile` reimplements the apiserver's MatchResources semantics so the MCP tool `analyze_mutating_admission_policy_impact` can answer "which MutatingAdmissionPolicy would mutate this object". It reads matchConstraints, the binding's matchResources, both selectors and the exclude rules, but it never looks at the policy's own `spec.matchConditions`.

matchConditions are the CEL gate the apiserver applies after matchConstraints have already admitted a request: if any condition evaluates to false the policy is skipped and none of its mutations run. The package evaluates no CEL, so it cannot know which way a gate goes, yet it was reporting a gated policy with `Determinable` true, which the package's own contract defines as "does apply" rather than "might apply". Someone asking what mutates their Pod got a flat answer naming a policy that may well never touch it, and the CEL deciding that was nowhere in the output.

The fix is the stance the package already takes for everything else it cannot resolve offline. A policy declaring matchConditions is reported with `Determinable` false, so it lands as a possible match rather than a confirmed one, and the conditions travel with the match as `MatchConditionSummary` values so a caller can read the expression verbatim, the same way a Mutation's expression is already reported rather than evaluated. The MCP tool surfaces them as `match_conditions`.

Worth noting that the sibling package `core/pkg/opaprocessor/cel` does honor matchConditions for ValidatingAdmissionPolicy, and has a real CEL engine to evaluate them with (`matchconditions.go`). mapreconcile has no such engine, so reporting the indeterminacy is the honest equivalent rather than a poor imitation.

The detail most likely to regress is where the gate is read. matchConditions can only narrow, never widen, so they have to be applied after the confident non-match check and never in place of it. Clearing determinability first would report a policy whose matchConstraints, or whose binding, actually exclude the object. `TestMatches_MatchConditionsNeverTurnANonMatchIntoAMatch` pins that, and passes both before and after the change on purpose.

Commit 1 is plumbing: the summary type, and carrying the conditions onto the match with no behavior change. Commit 2 is the determinability fix itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Policy impact analysis now reports match conditions, including their names and CEL expressions.
  - Policies with match conditions are identified as potential matches when the conditions cannot be evaluated.
  - Confident non-matches remain excluded when other policy constraints rule them out.

- **Documentation**
  - Updated tool and package guidance to clarify how match conditions affect policy impact results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->