### PR TITLE
fix(resourcesprioritization): don't drop attack tracks when a resource matches more than one

### DIFF
--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -97,7 +97,7 @@ type OPASessionObj struct {
 	ResourcesResult       map[string]resourcesresults.Result            // resources scan results, map[<resource ID>]<resource result>
 	ResourceSource        map[string]reporthandling.Source              // resources sources, map[<resource ID>]<resource result>
 	ResourcesPrioritized  map[string]prioritization.PrioritizedResource // resources prioritization information, map[<resource ID>]<prioritized resource>
-	ResourceAttackTracks  map[string]v1alpha1.IAttackTrack              // resources attack tracks, map[<resource ID>]<attack track>
+	ResourceAttackTracks  map[string][]v1alpha1.IAttackTrack            // resources attack tracks, map[<resource ID>][]<attack track> -- a resource can be implicated by more than one attack track at once, each contributing to its score
 	AttackTracks          map[string]v1alpha1.IAttackTrack
 	Report                *reporthandlingv2.PostureReport // scan results v2 - Remove
 	RegoInputData         RegoInputData                   // input passed to rego for scanning. map[<control name>][<input arguments>]

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -144,13 +144,13 @@ func transformSession(session *cautils.OPASessionObj, _ *Mapping, transformer Tr
 	}
 	session.ResourcesPrioritized = newResourcesPrioritized
 
-	newResourceAttackTracks := make(map[string]v1alpha1.IAttackTrack, len(session.ResourceAttackTracks))
-	for oldID, attackTrack := range session.ResourceAttackTracks {
+	newResourceAttackTracks := make(map[string][]v1alpha1.IAttackTrack, len(session.ResourceAttackTracks))
+	for oldID, attackTracks := range session.ResourceAttackTracks {
 		newID, err := resolveMappedID(transformer, idMapping, oldID, "ref")
 		if err != nil {
 			return err
 		}
-		newResourceAttackTracks[newID] = attackTrack
+		newResourceAttackTracks[newID] = attackTracks
 	}
 	session.ResourceAttackTracks = newResourceAttackTracks
 

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -138,7 +138,7 @@ func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 	}
 
 	err := transformSession(session, NewMapping(), NewMappingTransformer())
@@ -188,7 +188,7 @@ func TestTransformSession_CollidingNamesKeepDistinctResources(t *testing.T) {
 		},
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 	}
 
 	require.NoError(t, transformSession(session, NewMapping(), NewMappingTransformer()))
@@ -271,8 +271,8 @@ func TestTransformSession_IDConsistencyAcrossMaps(t *testing.T) {
 		ResourcesPrioritized: map[string]prioritization.PrioritizedResource{
 			oldID: {ResourceID: oldID},
 		},
-		ResourceAttackTracks: map[string]v1alpha1.IAttackTrack{
-			oldID: &v1alpha1.AttackTrack{},
+		ResourceAttackTracks: map[string][]v1alpha1.IAttackTrack{
+			oldID: {&v1alpha1.AttackTrack{}},
 		},
 		Report: &reporthandlingv2.PostureReport{
 			SummaryDetails: reportsummary.SummaryDetails{
@@ -455,7 +455,7 @@ func TestTransformSession_LabelHandling(t *testing.T) {
 				ResourcesResult:      make(map[string]resourcesresults.Result),
 				ResourceSource:       make(map[string]reporthandling.Source),
 				ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-				ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+				ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 				LabelsToCopy:         test.labelsToCopy,
 			}
 
@@ -639,7 +639,7 @@ func TestTransformSession_Annotations(t *testing.T) {
 				ResourcesResult:      make(map[string]resourcesresults.Result),
 				ResourceSource:       make(map[string]reporthandling.Source),
 				ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-				ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+				ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 			}
 
 			assert.NotPanics(t, func() {
@@ -676,7 +676,7 @@ func TestTransformSession_RepoContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{
@@ -1039,7 +1039,7 @@ func TestTransformSession_ResourceSourceEncryption(
 
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 	}
 
 	err = transformSession(
@@ -1378,7 +1378,7 @@ func TestTransformSession_DirectoryContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{DirectoryContextMetadata: directoryContext()},
@@ -1424,7 +1424,7 @@ func TestTransformSession_FileContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{FileContextMetadata: fileContext()},
@@ -1460,7 +1460,7 @@ func TestTransformSession_HostNameSharedAcrossContexts(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{
@@ -1483,7 +1483,7 @@ func TestTransformSession_NoDirectoryContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 		Metadata:             &reporthandlingv2.Metadata{},
 		Report:               &reporthandlingv2.PostureReport{},
 	}
@@ -1523,7 +1523,7 @@ func TestTransformSession_ClusterContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{ClusterContextMetadata: clusterContext()},
@@ -1585,7 +1585,7 @@ func TestTransformSession_ClusterNamespaceCountsStayJoinable(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{
@@ -1617,7 +1617,7 @@ func TestTransformSession_NoClusterContextMetadata(t *testing.T) {
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{},
 		Report:   &reporthandlingv2.PostureReport{},
@@ -1648,7 +1648,7 @@ func TestTransformSession_ClusterNamespaceCountsJoinAfterDecryption(t *testing.T
 		ResourcesResult:      make(map[string]resourcesresults.Result),
 		ResourceSource:       make(map[string]reporthandling.Source),
 		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
-		ResourceAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 
 		Metadata: &reporthandlingv2.Metadata{
 			ContextMetadata: reporthandlingv2.ContextMetadata{

--- a/core/pkg/resourcesprioritization/prioritizationhandler.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ResourcesPrioritizationHandler struct {
-	resourceToAttackTracks map[string]v1alpha1.IAttackTrack
+	resourceToAttackTracks map[string][]v1alpha1.IAttackTrack
 	attackTracks           []v1alpha1.IAttackTrack
 	supportedKinds         []string
 	podTemplateFallback    bool
@@ -42,7 +42,7 @@ func DefaultSupportedKinds() []string {
 func NewResourcesPrioritizationHandler(ctx context.Context, attackTracksGetter getter.IAttackTracksGetter, buildResourcesMap bool) (*ResourcesPrioritizationHandler, error) {
 	handler := &ResourcesPrioritizationHandler{
 		attackTracks:           make([]v1alpha1.IAttackTrack, 0),
-		resourceToAttackTracks: make(map[string]v1alpha1.IAttackTrack),
+		resourceToAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
 		podTemplateFallback:    true,
 		buildResourcesMap:      buildResourcesMap,
 	}
@@ -147,8 +147,20 @@ func (handler *ResourcesPrioritizationHandler) PrioritizeResources(sessionObj *c
 
 					// only build the map if the user requested it
 					if handler.buildResourcesMap {
-						// Store the attack track for returning to the caller
-						handler.resourceToAttackTracks[resourceId] = handler.copyAttackTrack(attackTrack, &controlsLookup)
+						// Store the attack track for returning to the caller. A
+						// resource can be implicated by more than one attack
+						// track at once (e.g. both an external-exposure track
+						// and a credential-access track can each have their own
+						// failed controls on the same resource) -- each one
+						// contributes its own vectors to the resource's score
+						// below, so each one is appended here too, rather than
+						// overwriting whichever attack track this loop visits
+						// last and silently dropping the others from the
+						// printed attack-tree output.
+						handler.resourceToAttackTracks[resourceId] = append(
+							handler.resourceToAttackTracks[resourceId],
+							handler.copyAttackTrack(attackTrack, &controlsLookup),
+						)
 					}
 
 					// Calculate all the paths for the attack track

--- a/core/pkg/resourcesprioritization/prioritizationhandler_test.go
+++ b/core/pkg/resourcesprioritization/prioritizationhandler_test.go
@@ -52,6 +52,15 @@ func (mock *AttackTracksGetterMock) GetAttackTracks() ([]v1alpha1.AttackTrack, e
 }
 
 func ControlMock(id string, baseScore float32, tags, categories []string) reporthandling.Control {
+	return ControlMockForAttackTrack(id, baseScore, tags, "TestAttackTrack", categories)
+}
+
+// ControlMockForAttackTrack is ControlMock with the attack track name
+// parameterized, so a test can build a control that maps into a DIFFERENT
+// attack track than the hardcoded "TestAttackTrack" every other mock control
+// uses -- needed to exercise a resource matching more than one attack track
+// at once (see TestResourcesPrioritizationHandler_PrioritizeResources_MultipleAttackTracks).
+func ControlMockForAttackTrack(id string, baseScore float32, tags []string, attackTrack string, categories []string) reporthandling.Control {
 	return reporthandling.Control{
 		ControlID: id,
 		BaseScore: baseScore,
@@ -60,7 +69,7 @@ func ControlMock(id string, baseScore float32, tags, categories []string) report
 				"controlTypeTags": tags,
 				"attackTracks": []reporthandling.AttackTrackCategories{
 					{
-						AttackTrack: "TestAttackTrack",
+						AttackTrack: attackTrack,
 						Categories:  categories,
 					},
 				},
@@ -216,6 +225,60 @@ func TestResourcesPrioritizationHandler_PrioritizeResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResourcesPrioritizationHandler_PrioritizeResources_MultipleAttackTracks
+// is the direct regression test for the bug this fixes: a resource whose
+// failed controls span TWO different attack tracks ("TestAttackTrack" and
+// "TestAttackTrack_2") must have both attack tracks recorded in
+// ResourceAttackTracks, not just whichever one handler.attackTracks happened
+// to visit last. The resource's score already correctly aggregated
+// contributions from every matching attack track before this fix -- only the
+// map used to build the printed --print-attack-tree output silently dropped
+// all but one.
+func TestResourcesPrioritizationHandler_PrioritizeResources_MultipleAttackTracks(t *testing.T) {
+	allPoliciesControls := map[string]reporthandling.Control{
+		// Maps into "TestAttackTrack" category "D", same as the other tests.
+		"C-001": ControlMock("C-001", 3, []string{"security"}, []string{"D"}),
+		// Maps into "TestAttackTrack_2", whose only step is named "Z".
+		"C-100": ControlMockForAttackTrack("C-100", 5, []string{"security"}, "TestAttackTrack_2", []string{"Z"}),
+	}
+	results := map[string]resourcesresults.Result{
+		"resource1": {
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedControlMock("C-001", apis.StatusFailed),
+				ResourceAssociatedControlMock("C-100", apis.StatusFailed),
+			},
+		},
+	}
+	controls := map[string]reportsummary.ControlSummary{
+		"C-001": {ControlID: "C-001", ScoreFactor: 3},
+		"C-100": {ControlID: "C-100", ScoreFactor: 5},
+	}
+	resources := map[string]workloadinterface.IMetadata{
+		"resource1": DeploymentWorkloadMock(1),
+	}
+
+	// buildResourcesMap: true is required to populate ResourceAttackTracks at
+	// all -- every other test in this file passes false and never touches
+	// this map.
+	handler, err := NewResourcesPrioritizationHandler(context.Background(), &AttackTracksGetterMock{}, true)
+	assert.NoError(t, err)
+
+	sessionObj := OPASessionObjMock(allPoliciesControls, results, controls, resources)
+	err = handler.PrioritizeResources(sessionObj)
+	assert.NoError(t, err)
+
+	tracks, ok := sessionObj.ResourceAttackTracks["resource1"]
+	if !assert.True(t, ok, "resource1 must have an entry in ResourceAttackTracks") {
+		return
+	}
+	if !assert.Len(t, tracks, 2, "resource1 matched two distinct attack tracks and both must be recorded, not just the last one visited") {
+		return
+	}
+
+	names := []string{tracks[0].GetName(), tracks[1].GetName()}
+	assert.ElementsMatch(t, []string{"TestAttackTrack", "TestAttackTrack_2"}, names)
 }
 
 func RolloutWorkloadMock(replicas int) workloadinterface.IMetadata {

--- a/core/pkg/resultshandling/printer/v2/attacktracks.go
+++ b/core/pkg/resultshandling/printer/v2/attacktracks.go
@@ -71,6 +71,7 @@ func (prettyPrinter *PrettyPrinter) buildTreeFromAttackTrackStep(tree gotree.Tre
 }
 
 func (prettyPrinter *PrettyPrinter) printResourceAttackGraph(attackTrack v1alpha1.IAttackTrack) {
+	fmt.Fprintf(prettyPrinter.writer, "Attack Track: %s\n", attackTrack.GetName())
 	tree := prettyPrinter.buildTreeFromAttackTrackStep(nil, attackTrack.GetData())
 	fmt.Fprintln(prettyPrinter.writer, tree.Print())
 }
@@ -118,8 +119,8 @@ func (prettyPrinter *PrettyPrinter) printAttackTracks(opaSessionObj *cautils.OPA
 		fmt.Fprintf(prettyPrinter.writer, "Severity: %s\n", apis.SeverityNumberToString(resource.Severity))
 		fmt.Fprintf(prettyPrinter.writer, "Total vectors: %v\n\n", len(resource.PriorityVector))
 
-		if v, found := resourceToAttackTrack[resource.ResourceID]; found {
-			prettyPrinter.printResourceAttackGraph(v)
+		for _, attackTrack := range resourceToAttackTrack[resource.ResourceID] {
+			prettyPrinter.printResourceAttackGraph(attackTrack)
 		}
 
 		sort.Slice(resource.PriorityVector, func(x, y int) bool {

--- a/core/pkg/resultshandling/reporter/v2/mockreporter_test.go
+++ b/core/pkg/resultshandling/reporter/v2/mockreporter_test.go
@@ -207,9 +207,9 @@ func mockOPASessionObj(t testing.TB) *cautils.OPASessionObj {
 		o.AllResources[k] = val
 	}
 
-	o.ResourceAttackTracks = make(map[string]v1alpha1.IAttackTrack, len(v.ResourceAttackTracks))
+	o.ResourceAttackTracks = make(map[string][]v1alpha1.IAttackTrack, len(v.ResourceAttackTracks))
 	for k, val := range v.ResourceAttackTracks {
-		o.ResourceAttackTracks[k] = val
+		o.ResourceAttackTracks[k] = []v1alpha1.IAttackTrack{val}
 	}
 
 	o.AttackTracks = make(map[string]v1alpha1.IAttackTrack, len(v.AttackTracks))


### PR DESCRIPTION
## Summary

Closes #3657.

`kubescape scan --print-attack-tree` silently dropped the attack-tree graph for every matching attack track except the last one visited, whenever a resource was implicated by more than one at once. The resource's score/severity was never affected -- that computation correctly aggregates vectors from every matching attack track -- but the printed graph output, which reads a separate map, only ever kept one.

## Root cause

`core/pkg/resourcesprioritization/prioritizationhandler.go`: `resourceToAttackTracks` was `map[string]v1alpha1.IAttackTrack` -- one value per resource, not a list. The loop over `handler.attackTracks` (every attack track with associated failed controls for a resource) did:

```go
handler.resourceToAttackTracks[resourceId] = handler.copyAttackTrack(attackTrack, &controlsLookup)
```

unconditionally overwriting the previous entry on every match. A resource failing controls that map into two different attack tracks (e.g. an external-exposure track and a separate credential-access track) only ever kept whichever one the loop visited last.

## Change

- `ResourceAttackTracks` (`core/cautils/datastructures.go`) and the handler's internal `resourceToAttackTracks` are now `map[string][]v1alpha1.IAttackTrack`, appending instead of overwriting.
- `core/pkg/resultshandling/printer/v2/attacktracks.go` now iterates and prints every attack track recorded for a resource, each labeled with its own name (`Attack Track: <name>`) since there can now legitimately be more than one graph per resource.
- `core/pkg/anonymizer/session.go`'s ID-remapping pass updated for the new slice-valued type.

## Test plan

- New regression test `TestResourcesPrioritizationHandler_PrioritizeResources_MultipleAttackTracks`: a resource failing controls mapped into two distinct attack tracks must have both recorded in `ResourceAttackTracks`. **Verified this test fails against the pre-fix overwrite logic (confirmed both directions locally before committing) and passes with the fix.**
- Existing prioritization, anonymizer, and printer tests updated for the new type and pass unchanged otherwise.
- `go build ./...`, `go vet ./...`, `go test -race` on all affected packages, the full `go test ./...`, `gofmt -l`, and `golangci-lint run --new-from-rev=upstream/master ./...` are all clean (0 new issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resources can now be associated with multiple attack tracks simultaneously.
  - Prioritization preserves all attack tracks contributing to a resource’s score.
  - Results display each associated attack track separately.

- **Bug Fixes**
  - Prevented later attack tracks from overwriting previously recorded associations for the same resource.

- **Tests**
  - Added coverage for resources linked to multiple attack tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->