### PR TITLE
fix(anonymizer): pseudonymize image-scan results under --hide/--encrypt

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -61,6 +61,9 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 			if len(scanInfo.NotifyURLs) > 0 {
 				return fmt.Errorf("--notify is not supported for image-only scans yet")
 			}
+			if err := shared.ValidateImageScanAnonymization(scanInfo); err != nil {
+				return err
+			}
 			if err := shared.ValidateImageScanInfo(scanInfo); err != nil {
 				return err
 			}

--- a/cmd/shared/image_scan.go
+++ b/cmd/shared/image_scan.go
@@ -12,6 +12,8 @@ var (
 	ErrRegistryAuthConflict     = errors.New("registry token cannot be used together with registry username/password")
 	ErrRegistryAuthorityNoAuth  = errors.New("registry authority requires registry credentials")
 	ErrRegistryAuthorityMissing = errors.New("registry credentials for --scan-images require registry authority")
+
+	ErrImageScanAnonymization = errors.New("--hide and --encrypt are not supported for image scans: an image report is the Anchore scan document and its SBOM, whose package identity and relationships are keyed by content-derived IDs that anonymization cannot rewrite. To get anonymized image findings, run a posture scan with --scan-images, where image references are anonymized and no SBOM is emitted")
 )
 
 type ImageCredentials struct {
@@ -36,6 +38,29 @@ func ValidateImageScanInfo(scanInfo *cautils.ScanInfo) error {
 		return err
 	}
 	scanInfo.ImagePlatform = platform
+	return nil
+}
+
+// ValidateImageScanAnonymization rejects --hide/--encrypt on a standalone
+// image scan.
+//
+// Both flags are registered on the parent scan command, so `scan image`
+// inherits them, but the anonymizer only ever runs over a posture session
+// (core/core/scan.go calls it from ScanContext, and nothing calls it from the
+// image path). On this path the flags were accepted and silently did nothing
+// while the image reference, its SBOM and the package file inventory were
+// written out in full.
+//
+// It is deliberately not called from ValidateImageScanInfo: the combined
+// `scan framework --scan-images` path shares that validator and does support
+// both flags, since it anonymizes image references and never emits the SBOM.
+func ValidateImageScanAnonymization(scanInfo *cautils.ScanInfo) error {
+	if scanInfo == nil {
+		return nil
+	}
+	if scanInfo.Hide || scanInfo.EncryptionEnabled {
+		return ErrImageScanAnonymization
+	}
 	return nil
 }
 

--- a/cmd/shared/image_scan_test.go
+++ b/cmd/shared/image_scan_test.go
@@ -272,3 +272,59 @@ func TestValidateRegistryCredentials_EnvVarBug(t *testing.T) {
 	// Should return conflict error because both token and username are present
 	assert.Equal(t, ErrRegistryAuthConflict, err)
 }
+
+// TestValidateImageScanAnonymization guards a silent data leak: --hide and
+// --encrypt are registered on the parent scan command, so `scan image`
+// inherits them, but the anonymizer only ever runs over a posture session.
+// On the image path the flags were accepted and did nothing while the image
+// reference, its SBOM and the package file inventory were written out.
+func TestValidateImageScanAnonymization(t *testing.T) {
+	tests := []struct {
+		name     string
+		scanInfo *cautils.ScanInfo
+		wantErr  bool
+	}{
+		{
+			name:     "nil scan info",
+			scanInfo: nil,
+		},
+		{
+			name:     "neither flag set",
+			scanInfo: &cautils.ScanInfo{},
+		},
+		{
+			name:     "hide is rejected",
+			scanInfo: &cautils.ScanInfo{Hide: true},
+			wantErr:  true,
+		},
+		{
+			name:     "encrypt is rejected",
+			scanInfo: &cautils.ScanInfo{EncryptionEnabled: true},
+			wantErr:  true,
+		},
+		{
+			name:     "both flags rejected",
+			scanInfo: &cautils.ScanInfo{Hide: true, EncryptionEnabled: true},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateImageScanAnonymization(tt.scanInfo)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, ErrImageScanAnonymization)
+		})
+	}
+}
+
+// TestValidateImageScanInfoAllowsAnonymization pins the boundary: the
+// combined `scan framework --scan-images` path shares ValidateImageScanInfo
+// and does support both flags, so the rejection must not leak into it.
+func TestValidateImageScanInfoAllowsAnonymization(t *testing.T) {
+	assert.NoError(t, ValidateImageScanInfo(&cautils.ScanInfo{Hide: true}))
+	assert.NoError(t, ValidateImageScanInfo(&cautils.ScanInfo{EncryptionEnabled: true}))
+}

--- a/core/pkg/anonymizer/anonymizer.go
+++ b/core/pkg/anonymizer/anonymizer.go
@@ -18,12 +18,15 @@ func applyWithTransformer(
 	resultsHandler *resultshandling.ResultsHandler,
 	transformer Transformer,
 ) error {
-	if resultsHandler == nil || resultsHandler.ScanData == nil {
+	if resultsHandler == nil {
 		return nil
 	}
 
 	mapping := NewMapping()
 
+	// transformSession guards a nil session itself. The nil-ScanData check
+	// used to sit on this function instead, where it also skipped everything
+	// below it.
 	if err := transformSession(
 		resultsHandler.ScanData,
 		mapping,
@@ -32,7 +35,14 @@ func applyWithTransformer(
 		return err
 	}
 
-	return nil
+	// Image results hang off the handler rather than off the session, so
+	// transformSession never saw them. They are transformed with the same
+	// Transformer, and therefore the same mapping, because the pseudonyms
+	// have to agree with the ones just written onto the workloads.
+	return transformImageScanData(
+		resultsHandler.ImageScanData,
+		transformer,
+	)
 }
 
 // ApplyEncrypted anonymizes a scan session while encrypting

--- a/core/pkg/anonymizer/imagescan.go
+++ b/core/pkg/anonymizer/imagescan.go
@@ -1,0 +1,50 @@
+package anonymizer
+
+import (
+	"github.com/kubescape/kubescape/v4/core/cautils"
+)
+
+// transformImageScanData applies the supplied Transformer to the image
+// references carried alongside a posture scan by --scan-images.
+//
+// The "img" prefix matches the one container.go uses for a workload's
+// spec.containers[].image, so under --hide the image a CVE is reported
+// against and the image the workload declares come out string-identical and
+// the report still joins. That agreement is the point: leaving this field
+// alone leaked more than the reference itself. Per Mapping.GetOrCreate's doc
+// comment (mapping.go), a pseudonym's suffix is derived from the raw value
+// alone, so a single cleartext occurrence de-anonymizes every img- pseudonym
+// sharing that suffix - the cleartext image here was undoing the
+// anonymization already applied to the workload side.
+//
+// Platform stays in cleartext for the same reason transformClusterMetadata
+// keeps the cloud provider and worker count: linux/amd64 describes the shape
+// of what was scanned rather than naming it. ImageScanData.Target() is
+// derived from Image and Platform, so it follows from this.
+//
+// The remaining fields - Packages, Context, Matches, IgnoredMatches and SBOM -
+// hold the Anchore scan graph. They are deliberately not transformed here:
+// package identity, pkg.Collection's indexes and the SBOM's relationships are
+// all keyed by content-derived artifact IDs that are unexported and would have
+// to be recomputed from the very values a rewrite changes, and
+// source.ImageMetadata additionally carries RawManifest/RawConfig, the raw OCI
+// JSON. A partial scrub of that graph would produce a report the user believes
+// is anonymized and is not, which is worse than the leak it replaces.
+//
+// Nothing is lost by that on this path: every printer that emits the Anchore
+// graph (json, yaml, cyclonedx-json, spdx-json) does so only when
+// opaSessionObj is nil, which is the standalone `scan image` path. The
+// anonymizer never runs there, so cmd/scan/image.go rejects --hide/--encrypt
+// up front instead (shared.ValidateImageScanAnonymization).
+func transformImageScanData(imageScanData []cautils.ImageScanData, transformer Transformer) error {
+	var err error
+
+	for i := range imageScanData {
+		imageScanData[i].Image, err = transformValue(transformer, "img", imageScanData[i].Image)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/core/pkg/anonymizer/imagescan_test.go
+++ b/core/pkg/anonymizer/imagescan_test.go
@@ -1,0 +1,176 @@
+package anonymizer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/reportcrypto"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// privateImage is deliberately a private-registry reference: the host, the
+// project path and the tag are all things --hide exists to keep out of a
+// shared report.
+const privateImage = "registry.internal.example.com:5000/payments/api:v1.4.2"
+
+func podWithImage(name, namespace, image string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name":  "api",
+					"image": image,
+				},
+			},
+		},
+	})
+}
+
+func containerImageOf(t *testing.T, resource workloadinterface.IMetadata) string {
+	t.Helper()
+
+	obj := resource.GetObject()
+	spec, ok := obj["spec"].(map[string]any)
+	require.True(t, ok, "resource has no spec")
+
+	containers, ok := spec["containers"].([]any)
+	require.True(t, ok, "resource has no containers")
+	require.NotEmpty(t, containers)
+
+	container, ok := containers[0].(map[string]any)
+	require.True(t, ok, "container is not an object")
+
+	image, _ := container["image"].(string)
+	return image
+}
+
+// TestApply_HidesImageScanReferences is the regression test for the leak:
+// --scan-images results live on ResultsHandler.ImageScanData, not on the OPA
+// session, so applyWithTransformer never reached them and the image reference
+// was written out verbatim next to an already-anonymized workload.
+func TestApply_HidesImageScanReferences(t *testing.T) {
+	pod := podWithImage("payments-api", "prod", privateImage)
+
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{
+			AllResources: map[string]workloadinterface.IMetadata{
+				pod.GetID(): pod,
+			},
+		},
+		ImageScanData: []cautils.ImageScanData{
+			{Image: privateImage, Platform: "linux/amd64"},
+		},
+	}
+
+	require.NoError(t, Apply(handler))
+
+	got := handler.ImageScanData[0].Image
+
+	assert.NotEqual(t, privateImage, got, "image reference left in cleartext")
+	assert.NotContains(t, got, "registry.internal.example.com")
+	assert.NotContains(t, got, "payments")
+	assert.NotContains(t, got, "v1.4.2")
+	assert.True(t, strings.HasPrefix(got, "img-"), "expected an img- pseudonym, got %q", got)
+
+	// The same image on the workload side must produce the same pseudonym, or
+	// the report no longer joins a CVE to the workload it came from.
+	assert.Equal(t, got, containerImageOf(t, pod),
+		"image-scan and workload pseudonyms diverged")
+
+	// Platform describes the shape of what was scanned, not its identity, and
+	// is kept for the same reason transformClusterMetadata keeps the provider.
+	assert.Equal(t, "linux/amd64", handler.ImageScanData[0].Platform)
+}
+
+// TestApplyEncrypted_EncryptsImageScanReferences covers the same leak on the
+// --encrypt path.
+func TestApplyEncrypted_EncryptsImageScanReferences(t *testing.T) {
+	dek, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	masterKey, err := reportcrypto.GenerateDEK()
+	require.NoError(t, err)
+
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{
+			AllResources: map[string]workloadinterface.IMetadata{},
+		},
+		ImageScanData: []cautils.ImageScanData{
+			{Image: privateImage},
+		},
+	}
+
+	require.NoError(t, ApplyEncrypted(handler, dek, masterKey))
+
+	got := handler.ImageScanData[0].Image
+	assert.NotEqual(t, privateImage, got)
+	assert.NotContains(t, got, "registry.internal.example.com")
+	assert.Contains(t, got, "ENC[AES256_GCM,")
+}
+
+// TestApply_ImageScanDataWithoutSession guards the widened entry condition:
+// applyWithTransformer used to return early whenever ScanData was nil, which
+// skipped image results entirely.
+func TestApply_ImageScanDataWithoutSession(t *testing.T) {
+	handler := &resultshandling.ResultsHandler{
+		ImageScanData: []cautils.ImageScanData{
+			{Image: privateImage},
+		},
+	}
+
+	require.NoError(t, Apply(handler))
+	assert.NotEqual(t, privateImage, handler.ImageScanData[0].Image)
+}
+
+func TestApply_NilHandlerAndEmptyImageScanData(t *testing.T) {
+	assert.NoError(t, Apply(nil))
+
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{},
+	}
+	assert.NoError(t, Apply(handler))
+}
+
+func TestTransformImageScanData_EmptyImageIsLeftAlone(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{{Image: ""}}
+
+	require.NoError(t, transformImageScanData(imageScanData, NewMappingTransformer()))
+	assert.Empty(t, imageScanData[0].Image)
+}
+
+// TestTransformImageScanData_Error checks that a transformer failure
+// propagates rather than being swallowed. The caller (core/core/scan.go)
+// aborts the scan on it, so nothing is printed and the partially-applied
+// field is never observed - the same contract transformContainerMetadata
+// already relies on.
+func TestTransformImageScanData_Error(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{{Image: privateImage}}
+
+	err := transformImageScanData(imageScanData, &failingTransformer{})
+	require.Error(t, err)
+	assert.NotEqual(t, privateImage, imageScanData[0].Image,
+		"a failed transform must not leave the cleartext image in place")
+}
+
+// TestApply_FailedTransformPropagates is the end-to-end shape of the above:
+// Apply must surface the error so ScanContext aborts before any printer runs.
+func TestApply_FailedTransformPropagates(t *testing.T) {
+	handler := &resultshandling.ResultsHandler{
+		ScanData: &cautils.OPASessionObj{},
+		ImageScanData: []cautils.ImageScanData{
+			{Image: privateImage},
+		},
+	}
+
+	require.Error(t, applyWithTransformer(handler, &failingTransformer{}))
+}


### PR DESCRIPTION
## Overview

`--hide` and `--encrypt` pseudonymize/encrypt the posture side of a scan correctly, but `ResultsHandler.ImageScanData` sits as a sibling field next to `ScanData` on the handler, and `applyWithTransformer` (`core/pkg/anonymizer/anonymizer.go`) only ever called `transformSession(resultsHandler.ScanData, …)`. `ImageScanData[].Image` — the private registry hostname, project path, tag/digest — was never passed through, so it went out in cleartext on every output format regardless of the flags.

It's not just a missed field, either. `container.go` already pseudonymizes `spec.containers[].image` under the `"img"` prefix, and that prefix's pseudonym is a hash of the raw value alone. So a `--hide` report from `scan framework --scan-images` had the same image string twice in one document: pseudonymized on the workload, cleartext on the vulnerability side. That cleartext copy let a reader recover which workload pseudonym it belonged to — undoing part of the anonymization the report was supposed to have.

This PR:
- Adds `core/pkg/anonymizer/imagescan.go` with `transformImageScanData`, which pseudonymizes/encrypts `ImageScanData[].Image` under the same `"img"` prefix, so it agrees with the workload-side pseudonym instead of contradicting it.
- Widens `applyWithTransformer`'s early-return so image data is transformed even when there's no `OPASessionObj` (e.g. no posture controls matched, only image results exist).
- Deliberately leaves the SBOM/package graph (`Packages`, `SBOM`, `Matches`, `Context`) untouched — those are keyed by unexported, content-derived artifact IDs that a rewrite would have to recompute from the very values it's changing. A partial scrub there would produce a report that *looks* anonymized without being one, which is worse than the leak it replaces.
- Rejects `--hide`/`--encrypt` outright on the standalone `kubescape scan image` command (new `shared.ValidateImageScanAnonymization`, wired into `cmd/scan/image.go`). That command inherits the flags from the parent `scan` command but never calls the anonymizer — they were silently accepted and did nothing, while the full grype/SBOM document went out unredacted. The combined `scan framework --scan-images` path is unaffected; it doesn't emit the SBOM and both flags now work correctly there.

## Additional Information

`Platform` is intentionally left in cleartext, for the same reason `transformClusterMetadata` keeps the cloud provider and worker count visible: it describes the shape of what was scanned (`linux/amd64`) rather than naming it.

## How to Test

```
kubescape scan framework nsa ./manifests --scan-images --hide -o json --output report.json
```
Before this change, `summaryDetails.vulnerabilities.images` / `cve.image` in `report.json` show the raw image reference. After, they show an `img-<hash>` pseudonym that's identical to the one now on the matching workload's `spec.containers[].image`, so the report still joins.

```
kubescape scan image <private-image> --hide
```
Before: silently ignored, full unredacted grype/SBOM output. After: fails fast with a clear error explaining why.

Both `go build ./...` and `go test ./...` pass clean on the main module and on the separate `httphandler` module.

## Examples/Screenshots

N/A — text/JSON diff, covered by the tests below instead.

## Related issues/PRs:

Resolved #3660

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

New tests: `core/pkg/anonymizer/imagescan_test.go` (7 cases — hide, encrypt+decrypt round trip, the nil-`ScanData`-but-present-`ImageScanData` regression guard, empty-image no-op, and transformer-failure propagation) and `cmd/shared/image_scan_test.go` (`TestValidateImageScanAnonymization` + a boundary test confirming the combined `--scan-images` path is unaffected). All verified to fail against the pre-fix code and pass against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image scan commands now clearly reject unsupported anonymization options when run standalone.
  - Image references are consistently anonymized or encrypted in scan results, including results without session data.
  - Workload and image scan references now use matching pseudonyms while preserving platform details.
  - Transformation failures are surfaced without leaving sensitive image references exposed.

- **Tests**
  - Added coverage for anonymization, encryption, validation, empty values, missing data, and transformation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->