### PR TITLE
feat(config): add cached config validation

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -10,8 +10,11 @@ import (
 
 var (
 	configExample = fmt.Sprintf(`
-  # View cached configurations 
+  # View cached configurations
   %[1]s config view
+
+  # Validate cached configurations
+  %[1]s config validate
 
   # Delete cached configurations
   %[1]s config delete
@@ -39,6 +42,7 @@ func GetConfigCmd(ks meta.IKubescape) *cobra.Command {
 
 	configCmd.AddCommand(getDeleteCmd(ks))
 	configCmd.AddCommand(getSetCmd(ks))
+	configCmd.AddCommand(getValidateCmd(ks))
 	configCmd.AddCommand(getViewCmd(ks))
 
 	return configCmd

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -21,7 +21,7 @@ func TestGetConfigCmd(t *testing.T) {
 	assert.Equal(t, configExample, configCmd.Example)
 
 	// Verify that the subcommands are added correctly
-	assert.Equal(t, 3, len(configCmd.Commands()))
+	assert.Equal(t, 4, len(configCmd.Commands()))
 
 	for _, subcmd := range configCmd.Commands() {
 		switch subcmd.Name() {
@@ -33,6 +33,9 @@ func TestGetConfigCmd(t *testing.T) {
 			// Verify that the set subcommand is added correctly
 			assert.Equal(t, "set", subcmd.Use)
 			assert.Equal(t, "Set configurations, supported: "+strings.Join(stringKeysToSlice(supportConfigSet), "/"), subcmd.Short)
+		case "validate":
+			assert.Equal(t, "validate", subcmd.Use)
+			assert.Equal(t, "Validate cached configurations", subcmd.Short)
 		case "view":
 			// Verify that the view subcommand is added correctly
 			assert.Equal(t, "view", subcmd.Use)

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+
+	"github.com/kubescape/kubescape/v4/core/meta"
+	v1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/spf13/cobra"
+)
+
+func getValidateCmd(ks meta.IKubescape) *cobra.Command {
+	validateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate cached configurations",
+		Long:  `Validate cached Kubescape configuration and render diagnostics as text, JSON, or YAML.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat, _ := cmd.Flags().GetString("format")
+			if !cmd.Flags().Changed("format") && cmd.Flags().Changed("output") {
+				outputFormat, _ = cmd.Flags().GetString("output")
+			}
+			profile, _ := cmd.Flags().GetString("profile")
+			includeOK, _ := cmd.Flags().GetBool("include-ok")
+			return ks.ValidateCachedConfig(&v1.ValidateConfig{Writer: os.Stdout, Format: outputFormat, Profile: profile, IncludeOK: includeOK})
+		},
+	}
+
+	validateCmd.Flags().StringP("format", "f", "text", "Output format: text, json, or yaml")
+	validateCmd.Flags().StringP("output", "o", "text", "Output format: text, json, or yaml (alias for --format)")
+	validateCmd.Flags().String("profile", "cloud", "Validation profile: cloud or offline")
+	validateCmd.Flags().Bool("include-ok", false, "Include passing validation checks in the rendered output")
+	return validateCmd
+}

--- a/cmd/config/validate_test.go
+++ b/cmd/config/validate_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingValidate struct {
+	mocks.MockIKubescape
+	got *metav1.ValidateConfig
+}
+
+func (c *capturingValidate) ValidateCachedConfig(vc *metav1.ValidateConfig) error {
+	c.got = vc
+	return nil
+}
+
+type validateCachedConfigErr struct {
+	mocks.MockIKubescape
+	got *metav1.ValidateConfig
+}
+
+func (v *validateCachedConfigErr) ValidateCachedConfig(vc *metav1.ValidateConfig) error {
+	v.got = vc
+	return fmt.Errorf("validation failed")
+}
+
+func TestGetValidateCmd(t *testing.T) {
+	cmd := getValidateCmd(&mocks.MockIKubescape{})
+
+	assert.Equal(t, "validate", cmd.Use)
+	assert.Equal(t, "Validate cached configurations", cmd.Short)
+	assert.Equal(t, "Validate cached Kubescape configuration and render diagnostics as text, JSON, or YAML.", cmd.Long)
+
+	formatFlag := cmd.Flag("format")
+	if assert.NotNil(t, formatFlag) {
+		assert.Equal(t, "f", formatFlag.Shorthand)
+		assert.Equal(t, "text", formatFlag.DefValue)
+		assert.Equal(t, "Output format: text, json, or yaml", formatFlag.Usage)
+	}
+
+	outputFlag := cmd.Flag("output")
+	if assert.NotNil(t, outputFlag) {
+		assert.Equal(t, "o", outputFlag.Shorthand)
+		assert.Equal(t, "text", outputFlag.DefValue)
+		assert.Equal(t, "Output format: text, json, or yaml (alias for --format)", outputFlag.Usage)
+	}
+
+	includeOKFlag := cmd.Flag("include-ok")
+	if assert.NotNil(t, includeOKFlag) {
+		assert.Equal(t, "", includeOKFlag.Shorthand)
+		assert.Equal(t, "false", includeOKFlag.DefValue)
+		assert.Equal(t, "Include passing validation checks in the rendered output", includeOKFlag.Usage)
+	}
+
+	profileFlag := cmd.Flag("profile")
+	if assert.NotNil(t, profileFlag) {
+		assert.Equal(t, "", profileFlag.Shorthand)
+		assert.Equal(t, "cloud", profileFlag.DefValue)
+		assert.Equal(t, "Validation profile: cloud or offline", profileFlag.Usage)
+	}
+}
+
+func TestGetValidateCmd_RunEPassesFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantFormat  string
+		wantProfile string
+		wantOK      bool
+	}{
+		{name: "defaults", args: []string{}, wantFormat: "text", wantProfile: "cloud", wantOK: false},
+		{name: "format json", args: []string{"--format", "json"}, wantFormat: "json", wantProfile: "cloud", wantOK: false},
+		{name: "short format yaml", args: []string{"-f", "yaml"}, wantFormat: "yaml", wantProfile: "cloud", wantOK: false},
+		{name: "output json", args: []string{"--output", "json"}, wantFormat: "json", wantProfile: "cloud", wantOK: false},
+		{name: "short output yaml", args: []string{"-o", "yaml"}, wantFormat: "yaml", wantProfile: "cloud", wantOK: false},
+		{name: "format takes precedence over output", args: []string{"--format", "yaml", "--output", "json"}, wantFormat: "yaml", wantProfile: "cloud", wantOK: false},
+		{name: "include ok", args: []string{"--include-ok"}, wantFormat: "text", wantProfile: "cloud", wantOK: true},
+		{name: "json include ok", args: []string{"--format", "json", "--include-ok"}, wantFormat: "json", wantProfile: "cloud", wantOK: true},
+		{name: "offline profile", args: []string{"--profile", "offline"}, wantFormat: "text", wantProfile: "offline", wantOK: false},
+		{name: "offline yaml include ok", args: []string{"--profile", "offline", "--format", "yaml", "--include-ok"}, wantFormat: "yaml", wantProfile: "offline", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &capturingValidate{}
+			cmd := getValidateCmd(ks)
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			require.NoError(t, err)
+			if !assert.NotNil(t, ks.got) {
+				return
+			}
+			assert.Equal(t, tt.wantFormat, ks.got.Format)
+			assert.Equal(t, tt.wantProfile, ks.got.Profile)
+			assert.Equal(t, tt.wantOK, ks.got.IncludeOK)
+			assert.Equal(t, os.Stdout, ks.got.Writer)
+		})
+	}
+}
+
+func TestGetValidateCmd_RunEReturnsValidationError(t *testing.T) {
+	ks := &validateCachedConfigErr{}
+	cmd := getValidateCmd(ks)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--format", "json"})
+
+	err := cmd.Execute()
+
+	require.EqualError(t, err, "validation failed")
+	require.NotNil(t, ks.got)
+	assert.Equal(t, "json", ks.got.Format)
+}

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -40,6 +40,9 @@ func (s *stubKubescape) Download(*metav1.DownloadInfo) (*metav1.DownloadResult, 
 }
 func (s *stubKubescape) SetCachedConfig(*metav1.SetConfig) error   { return nil }
 func (s *stubKubescape) ViewCachedConfig(*metav1.ViewConfig) error { return nil }
+func (s *stubKubescape) ValidateCachedConfig(*metav1.ValidateConfig) error {
+	return nil
+}
 func (s *stubKubescape) DeleteCachedConfig(*metav1.DeleteConfig) error {
 	return nil
 }

--- a/core/cautils/config_validation.go
+++ b/core/cautils/config_validation.go
@@ -1,0 +1,237 @@
+package cautils
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ConfigValidationStatus string
+type ConfigValidationProfile string
+
+const (
+	ConfigValidationStatusOK      ConfigValidationStatus = "ok"
+	ConfigValidationStatusMissing ConfigValidationStatus = "missing"
+	ConfigValidationStatusInvalid ConfigValidationStatus = "invalid"
+
+	ConfigValidationProfileCloud   ConfigValidationProfile = "cloud"
+	ConfigValidationProfileOffline ConfigValidationProfile = "offline"
+)
+
+type ConfigValidationCheck struct {
+	Field   string                 `json:"field" yaml:"field"`
+	Status  ConfigValidationStatus `json:"status" yaml:"status"`
+	Message string                 `json:"message" yaml:"message"`
+}
+
+type ConfigValidationResult struct {
+	Valid   bool                    `json:"valid" yaml:"valid"`
+	Profile ConfigValidationProfile `json:"profile" yaml:"profile"`
+	Checks  []ConfigValidationCheck `json:"checks" yaml:"checks"`
+}
+
+var requiredConfigFields = []string{
+	"accountID",
+	"accessKey",
+	"cloudAPIURL",
+	"cloudReportURL",
+}
+
+func ValidateConfig(cfg *ConfigObj, profile ConfigValidationProfile) ConfigValidationResult {
+	if cfg == nil {
+		cfg = &ConfigObj{}
+	}
+	profile = normalizeConfigValidationProfile(profile)
+	checks := validateConfigForProfile(cfg, profile)
+	return ConfigValidationResult{
+		Valid:   configValidationChecksPass(checks),
+		Profile: profile,
+		Checks:  checks,
+	}
+}
+
+func normalizeConfigValidationProfile(profile ConfigValidationProfile) ConfigValidationProfile {
+	switch ConfigValidationProfile(strings.ToLower(strings.TrimSpace(string(profile)))) {
+	case "", ConfigValidationProfileCloud:
+		return ConfigValidationProfileCloud
+	case ConfigValidationProfileOffline:
+		return ConfigValidationProfileOffline
+	default:
+		return profile
+	}
+}
+
+func ValidateConfigProfile(profile ConfigValidationProfile) error {
+	normalized := normalizeConfigValidationProfile(profile)
+	switch normalized {
+	case ConfigValidationProfileCloud, ConfigValidationProfileOffline:
+		return nil
+	default:
+		return fmt.Errorf("unsupported validation profile %q", profile)
+	}
+}
+
+func validateConfigForProfile(cfg *ConfigObj, profile ConfigValidationProfile) []ConfigValidationCheck {
+	switch profile {
+	case ConfigValidationProfileOffline:
+		return []ConfigValidationCheck{
+			validateOptionalConfigField("accountID", cfg.AccountID, "account ID is configured", "accountID is not required for offline validation"),
+			validateOptionalConfigField("accessKey", cfg.AccessKey, "access key is configured", "accessKey is not required for offline validation"),
+			validateOptionalURLConfigField("cloudAPIURL", cfg.CloudAPIURL, "cloud API URL is configured", "cloudAPIURL is not configured; offline scans can use local policy sources"),
+			validateOptionalURLConfigField("cloudReportURL", cfg.CloudReportURL, "cloud report URL is configured", "cloudReportURL is not configured; offline scans can skip cloud submission"),
+		}
+	default:
+		return []ConfigValidationCheck{
+			validateRequiredConfigField("accountID", cfg.AccountID, "account ID is configured"),
+			validateRequiredConfigField("accessKey", cfg.AccessKey, "access key is configured"),
+			validateRequiredURLConfigField("cloudAPIURL", cfg.CloudAPIURL, "cloud API URL is configured"),
+			validateRequiredURLConfigField("cloudReportURL", cfg.CloudReportURL, "cloud report URL is configured"),
+		}
+	}
+}
+
+func FormatConfigValidationResult(result ConfigValidationResult, format string, includeOK bool) ([]byte, error) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if format == "" {
+		format = "text"
+	}
+	result.Checks = filterConfigValidationChecks(result.Checks, includeOK)
+	switch format {
+	case "json":
+		return json.MarshalIndent(result, "", "  ")
+	case "yaml":
+		return yaml.Marshal(result)
+	case "text":
+		return formatConfigValidationText(result), nil
+	default:
+		return nil, fmt.Errorf("unsupported output format %q", format)
+	}
+}
+
+func configValidationChecksPass(checks []ConfigValidationCheck) bool {
+	for _, check := range checks {
+		if check.Status != ConfigValidationStatusOK {
+			return false
+		}
+	}
+	return true
+}
+
+func validateRequiredConfigField(field, value, okMessage string) ConfigValidationCheck {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusMissing,
+			Message: fmt.Sprintf("%s is required", field),
+		}
+	}
+	return ConfigValidationCheck{
+		Field:   field,
+		Status:  ConfigValidationStatusOK,
+		Message: okMessage,
+	}
+}
+
+func validateOptionalConfigField(field, value, okMessage, emptyMessage string) ConfigValidationCheck {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusOK,
+			Message: emptyMessage,
+		}
+	}
+	return ConfigValidationCheck{
+		Field:   field,
+		Status:  ConfigValidationStatusOK,
+		Message: okMessage,
+	}
+}
+
+func validateRequiredURLConfigField(field, value, okMessage string) ConfigValidationCheck {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusMissing,
+			Message: fmt.Sprintf("%s is required", field),
+		}
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusInvalid,
+			Message: fmt.Sprintf("%s must be a valid URL: %v", field, err),
+		}
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusInvalid,
+			Message: fmt.Sprintf("%s URL scheme must be http or https", field),
+		}
+	}
+	if parsed.Host == "" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusInvalid,
+			Message: fmt.Sprintf("%s URL host must not be empty", field),
+		}
+	}
+	return ConfigValidationCheck{
+		Field:   field,
+		Status:  ConfigValidationStatusOK,
+		Message: okMessage,
+	}
+}
+
+func validateOptionalURLConfigField(field, value, okMessage, emptyMessage string) ConfigValidationCheck {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ConfigValidationCheck{
+			Field:   field,
+			Status:  ConfigValidationStatusOK,
+			Message: emptyMessage,
+		}
+	}
+	return validateRequiredURLConfigField(field, value, okMessage)
+}
+
+func filterConfigValidationChecks(checks []ConfigValidationCheck, includeOK bool) []ConfigValidationCheck {
+	filtered := make([]ConfigValidationCheck, 0, len(checks))
+	for _, check := range checks {
+		if includeOK || check.Status != ConfigValidationStatusOK {
+			filtered = append(filtered, check)
+		}
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return configValidationFieldOrder(filtered[i].Field) < configValidationFieldOrder(filtered[j].Field)
+	})
+	return filtered
+}
+
+func configValidationFieldOrder(field string) int {
+	for i, required := range requiredConfigFields {
+		if field == required {
+			return i
+		}
+	}
+	return len(requiredConfigFields)
+}
+
+func formatConfigValidationText(result ConfigValidationResult) []byte {
+	lines := []string{
+		fmt.Sprintf("valid: %t", result.Valid),
+		fmt.Sprintf("profile: %s", result.Profile),
+	}
+	for _, check := range result.Checks {
+		lines = append(lines, fmt.Sprintf("%s: %s - %s", check.Field, check.Status, check.Message))
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
+}

--- a/core/cautils/config_validation_test.go
+++ b/core/cautils/config_validation_test.go
@@ -1,0 +1,351 @@
+package cautils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateConfig_AllRequiredFieldsPresent(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud)
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, ConfigValidationProfileCloud, result.Profile)
+	require.Len(t, result.Checks, 4)
+	for _, check := range result.Checks {
+		assert.Equal(t, ConfigValidationStatusOK, check.Status)
+		assert.NotEmpty(t, check.Message)
+	}
+}
+
+func TestValidateConfig_OfflineProfileAllowsEmptyCloudFields(t *testing.T) {
+	result := ValidateConfig(&ConfigObj{}, ConfigValidationProfileOffline)
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, ConfigValidationProfileOffline, result.Profile)
+	require.Len(t, result.Checks, 4)
+	for _, check := range result.Checks {
+		assert.Equal(t, ConfigValidationStatusOK, check.Status)
+		assert.Contains(t, check.Message, "not")
+	}
+}
+
+func TestValidateConfig_OfflineProfileValidatesURLsWhenPresent(t *testing.T) {
+	cfg := &ConfigObj{
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "ftp://report.example.com",
+	}
+
+	result := ValidateConfig(cfg, ConfigValidationProfileOffline)
+
+	assert.False(t, result.Valid)
+	assertConfigCheck(t, result.Checks, "accountID", ConfigValidationStatusOK)
+	assertConfigCheck(t, result.Checks, "accessKey", ConfigValidationStatusOK)
+	assertConfigCheck(t, result.Checks, "cloudAPIURL", ConfigValidationStatusOK)
+	assertConfigCheck(t, result.Checks, "cloudReportURL", ConfigValidationStatusInvalid)
+}
+
+func TestFormatConfigValidationResultOfflineProfileShowsOnlyFailuresByDefault(t *testing.T) {
+	result := ValidateConfig(&ConfigObj{
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "ssh://report.example.com",
+	}, ConfigValidationProfileOffline)
+
+	output, err := FormatConfigValidationResult(result, "json", false)
+	require.NoError(t, err)
+
+	var payload ConfigValidationResult
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.False(t, payload.Valid)
+	assert.Equal(t, ConfigValidationProfileOffline, payload.Profile)
+	require.Len(t, payload.Checks, 1)
+	assert.Equal(t, "cloudReportURL", payload.Checks[0].Field)
+	assert.Equal(t, ConfigValidationStatusInvalid, payload.Checks[0].Status)
+}
+
+func TestValidateConfig_DefaultsToCloudProfile(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), "")
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, ConfigValidationProfileCloud, result.Profile)
+}
+
+func TestValidateConfigProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile ConfigValidationProfile
+		wantErr string
+	}{
+		{name: "empty defaults to cloud", profile: ""},
+		{name: "cloud", profile: ConfigValidationProfileCloud},
+		{name: "cloud with spaces", profile: " CLOUD "},
+		{name: "offline", profile: ConfigValidationProfileOffline},
+		{name: "offline with spaces", profile: " offline "},
+		{name: "unsupported", profile: "strict", wantErr: `unsupported validation profile "strict"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfigProfile(tt.profile)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestValidateConfig_NilConfigReportsMissingRequiredFields(t *testing.T) {
+	result := ValidateConfig(nil, ConfigValidationProfileCloud)
+
+	assert.False(t, result.Valid)
+	require.Len(t, result.Checks, 4)
+	assertConfigCheck(t, result.Checks, "accountID", ConfigValidationStatusMissing)
+	assertConfigCheck(t, result.Checks, "accessKey", ConfigValidationStatusMissing)
+	assertConfigCheck(t, result.Checks, "cloudAPIURL", ConfigValidationStatusMissing)
+	assertConfigCheck(t, result.Checks, "cloudReportURL", ConfigValidationStatusMissing)
+}
+
+func TestValidateConfig_TrimsRequiredFields(t *testing.T) {
+	cfg := validConfigForValidation()
+	cfg.AccountID = "   "
+	cfg.AccessKey = "\t"
+
+	result := ValidateConfig(cfg, ConfigValidationProfileCloud)
+
+	assert.False(t, result.Valid)
+	assertConfigCheck(t, result.Checks, "accountID", ConfigValidationStatusMissing)
+	assertConfigCheck(t, result.Checks, "accessKey", ConfigValidationStatusMissing)
+}
+
+func TestValidateConfig_InvalidCloudAPIURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantText  string
+		wantField string
+	}{
+		{name: "not a url", value: "not a url", wantText: "must be a valid URL", wantField: "cloudAPIURL"},
+		{name: "missing host", value: "https://", wantText: "URL host must not be empty", wantField: "cloudAPIURL"},
+		{name: "unsupported scheme", value: "ftp://api.example.com", wantText: "URL scheme must be http or https", wantField: "cloudAPIURL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfigForValidation()
+			cfg.CloudAPIURL = tt.value
+
+			result := ValidateConfig(cfg, ConfigValidationProfileCloud)
+
+			assert.False(t, result.Valid)
+			check := requireConfigCheck(t, result.Checks, tt.wantField)
+			assert.Equal(t, ConfigValidationStatusInvalid, check.Status)
+			assert.Contains(t, check.Message, tt.wantText)
+		})
+	}
+}
+
+func TestValidateConfig_InvalidCloudReportURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantText string
+	}{
+		{name: "not a url", value: "not a url", wantText: "must be a valid URL"},
+		{name: "missing host", value: "http://", wantText: "URL host must not be empty"},
+		{name: "unsupported scheme", value: "ssh://report.example.com", wantText: "URL scheme must be http or https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfigForValidation()
+			cfg.CloudReportURL = tt.value
+
+			result := ValidateConfig(cfg, ConfigValidationProfileCloud)
+
+			assert.False(t, result.Valid)
+			check := requireConfigCheck(t, result.Checks, "cloudReportURL")
+			assert.Equal(t, ConfigValidationStatusInvalid, check.Status)
+			assert.Contains(t, check.Message, tt.wantText)
+		})
+	}
+}
+
+func TestFormatConfigValidationResultTextFailuresOnlyByDefault(t *testing.T) {
+	result := ValidateConfig(&ConfigObj{
+		AccountID:      "account-123",
+		AccessKey:      "",
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "ftp://report.example.com",
+	}, ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "text", false)
+	require.NoError(t, err)
+
+	text := string(output)
+	assert.Contains(t, text, "valid: false")
+	assert.Contains(t, text, "profile: cloud")
+	assert.Contains(t, text, "accessKey: missing")
+	assert.Contains(t, text, "cloudReportURL: invalid")
+	assert.NotContains(t, text, "accountID: ok")
+	assert.NotContains(t, text, "cloudAPIURL: ok")
+}
+
+func TestFormatConfigValidationResultTextIncludesPassingChecks(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "text", true)
+	require.NoError(t, err)
+
+	text := string(output)
+	assert.Contains(t, text, "valid: true")
+	assert.Contains(t, text, "profile: cloud")
+	assert.Contains(t, text, "accountID: ok")
+	assert.Contains(t, text, "accessKey: ok")
+	assert.Contains(t, text, "cloudAPIURL: ok")
+	assert.Contains(t, text, "cloudReportURL: ok")
+}
+
+func TestFormatConfigValidationResultJSON(t *testing.T) {
+	result := ValidateConfig(&ConfigObj{
+		AccountID:      "account-123",
+		AccessKey:      "access-key",
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "",
+	}, ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "json", false)
+	require.NoError(t, err)
+
+	var payload ConfigValidationResult
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.False(t, payload.Valid)
+	assert.Equal(t, ConfigValidationProfileCloud, payload.Profile)
+	require.Len(t, payload.Checks, 1)
+	assert.Equal(t, "cloudReportURL", payload.Checks[0].Field)
+	assert.Equal(t, ConfigValidationStatusMissing, payload.Checks[0].Status)
+}
+
+func TestFormatConfigValidationResultJSONIncludesPassingChecks(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "json", true)
+	require.NoError(t, err)
+
+	var payload ConfigValidationResult
+	require.NoError(t, json.Unmarshal(output, &payload))
+	assert.True(t, payload.Valid)
+	require.Len(t, payload.Checks, 4)
+	assert.Equal(t, []string{"accountID", "accessKey", "cloudAPIURL", "cloudReportURL"}, validationCheckFields(payload.Checks))
+}
+
+func TestFormatConfigValidationResultYAML(t *testing.T) {
+	result := ValidateConfig(&ConfigObj{
+		AccountID:      "",
+		AccessKey:      "access-key",
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "https://report.example.com",
+	}, ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "yaml", false)
+	require.NoError(t, err)
+
+	var payload ConfigValidationResult
+	require.NoError(t, yaml.Unmarshal(output, &payload))
+	assert.False(t, payload.Valid)
+	assert.Equal(t, ConfigValidationProfileCloud, payload.Profile)
+	require.Len(t, payload.Checks, 1)
+	assert.Equal(t, "accountID", payload.Checks[0].Field)
+	assert.Equal(t, ConfigValidationStatusMissing, payload.Checks[0].Status)
+}
+
+func TestFormatConfigValidationResultNormalizesFormat(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, " YAML ", true)
+	require.NoError(t, err)
+
+	var payload ConfigValidationResult
+	require.NoError(t, yaml.Unmarshal(output, &payload))
+	assert.True(t, payload.Valid)
+}
+
+func TestFormatConfigValidationResultDefaultsToText(t *testing.T) {
+	result := ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud)
+
+	output, err := FormatConfigValidationResult(result, "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "valid: true\nprofile: cloud\n", string(output))
+}
+
+func TestFormatConfigValidationResultUnsupportedFormat(t *testing.T) {
+	_, err := FormatConfigValidationResult(ValidateConfig(validConfigForValidation(), ConfigValidationProfileCloud), "table", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported output format "table"`)
+}
+
+func TestFilterConfigValidationChecksOrdersRequiredFields(t *testing.T) {
+	checks := []ConfigValidationCheck{
+		{Field: "cloudReportURL", Status: ConfigValidationStatusInvalid},
+		{Field: "accessKey", Status: ConfigValidationStatusMissing},
+		{Field: "accountID", Status: ConfigValidationStatusOK},
+		{Field: "cloudAPIURL", Status: ConfigValidationStatusOK},
+	}
+
+	filtered := filterConfigValidationChecks(checks, true)
+
+	assert.Equal(t, []string{"accountID", "accessKey", "cloudAPIURL", "cloudReportURL"}, validationCheckFields(filtered))
+}
+
+func TestFilterConfigValidationChecksDropsOKChecks(t *testing.T) {
+	checks := []ConfigValidationCheck{
+		{Field: "accountID", Status: ConfigValidationStatusOK},
+		{Field: "accessKey", Status: ConfigValidationStatusMissing},
+		{Field: "cloudAPIURL", Status: ConfigValidationStatusOK},
+	}
+
+	filtered := filterConfigValidationChecks(checks, false)
+
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "accessKey", filtered[0].Field)
+}
+
+func validConfigForValidation() *ConfigObj {
+	return &ConfigObj{
+		AccountID:      "account-123",
+		AccessKey:      "access-key",
+		CloudAPIURL:    "https://api.example.com",
+		CloudReportURL: "https://report.example.com",
+	}
+}
+
+func assertConfigCheck(t *testing.T, checks []ConfigValidationCheck, field string, status ConfigValidationStatus) {
+	t.Helper()
+	check := requireConfigCheck(t, checks, field)
+	assert.Equal(t, status, check.Status)
+}
+
+func requireConfigCheck(t *testing.T, checks []ConfigValidationCheck, field string) ConfigValidationCheck {
+	t.Helper()
+	for _, check := range checks {
+		if check.Field == field {
+			return check
+		}
+	}
+	require.FailNowf(t, "missing validation check", "field %q not found in %#v", field, checks)
+	return ConfigValidationCheck{}
+}
+
+func validationCheckFields(checks []ConfigValidationCheck) []string {
+	fields := make([]string, 0, len(checks))
+	for _, check := range checks {
+		fields = append(fields, check.Field)
+	}
+	return fields
+}

--- a/core/core/cachedconfig.go
+++ b/core/core/cachedconfig.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 )
+
+var ErrInvalidCachedConfig = errors.New("cached configuration is invalid")
 
 func (ks *Kubescape) SetCachedConfig(setConfig *metav1.SetConfig) error {
 	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", nil)
@@ -46,6 +49,37 @@ func (ks *Kubescape) ViewCachedConfig(viewConfig *metav1.ViewConfig) error {
 		return err
 	}
 
+	return nil
+}
+
+func (ks *Kubescape) ValidateCachedConfig(validateConfig *metav1.ValidateConfig) error {
+	if validateConfig == nil {
+		validateConfig = &metav1.ValidateConfig{}
+	}
+	tenant := cautils.GetTenantConfig(ks.Context(), "", "", "", "", getKubernetesApi()) // change k8sinterface
+	if err := cautils.ValidateConfigProfile(cautils.ConfigValidationProfile(validateConfig.Profile)); err != nil {
+		return err
+	}
+	result := cautils.ValidateConfig(tenant.GetConfigObj(), cautils.ConfigValidationProfile(validateConfig.Profile))
+	outputFormat := validateConfig.Format
+	if outputFormat == "" {
+		outputFormat = "text"
+	}
+
+	formatted, err := cautils.FormatConfigValidationResult(result, outputFormat, validateConfig.IncludeOK)
+	if err != nil {
+		return err
+	}
+
+	if validateConfig.Writer != nil {
+		if _, err := fmt.Fprint(validateConfig.Writer, string(formatted)); err != nil {
+			return err
+		}
+	}
+
+	if !result.Valid {
+		return ErrInvalidCachedConfig
+	}
 	return nil
 }
 

--- a/core/meta/datastructures/v1/config.go
+++ b/core/meta/datastructures/v1/config.go
@@ -13,5 +13,11 @@ type ViewConfig struct {
 	OutputFormat string
 	IncludeEmpty bool
 }
+type ValidateConfig struct {
+	Writer    io.Writer
+	Format    string
+	Profile   string
+	IncludeOK bool
+}
 type DeleteConfig struct {
 }

--- a/core/meta/ksinterface.go
+++ b/core/meta/ksinterface.go
@@ -27,6 +27,7 @@ type IKubescape interface {
 	// config
 	SetCachedConfig(setConfig *metav1.SetConfig) error
 	ViewCachedConfig(viewConfig *metav1.ViewConfig) error
+	ValidateCachedConfig(validateConfig *metav1.ValidateConfig) error
 	DeleteCachedConfig(deleteConfig *metav1.DeleteConfig) error
 
 	// fix

--- a/core/mocks/cmd_mocks.go
+++ b/core/mocks/cmd_mocks.go
@@ -40,6 +40,10 @@ func (m *MockIKubescape) ViewCachedConfig(_ *metav1.ViewConfig) error {
 	return nil
 }
 
+func (m *MockIKubescape) ValidateCachedConfig(_ *metav1.ValidateConfig) error {
+	return nil
+}
+
 func (m *MockIKubescape) DeleteCachedConfig(_ *metav1.DeleteConfig) error {
 	return nil
 }


### PR DESCRIPTION
This pull request introduces a new `validate` subcommand to the `config` CLI, allowing users to validate their cached Kubescape configurations and receive diagnostics in multiple formats. The implementation includes both the command logic and comprehensive tests, as well as a reusable configuration validation module.

**Key changes:**

### New CLI Features

* Added a `validate` subcommand to the `config` CLI, which checks the validity of cached configurations and supports output in text, JSON, or YAML formats. It also allows selection of validation profiles and inclusion of passing checks. (`cmd/config/config.go` [[1]](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68R16-R18) [[2]](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68R45); `cmd/config/validate.go` [[3]](diffhunk://#diff-805522e85a1b897c74ea4538bf6e4f3572378babef96fe97240d5acfe5c10e46R1-R32)

### Testing

* Introduced thorough unit tests for the new `validate` command, covering flag parsing, argument precedence, and error handling. (`cmd/config/config_test.go` [[1]](diffhunk://#diff-ab3ec949b572fd706003c5e19308bf2090a3a237f8e963bb74b37431941400efL24-R24) [[2]](diffhunk://#diff-ab3ec949b572fd706003c5e19308bf2090a3a237f8e963bb74b37431941400efR36-R38); `cmd/config/validate_test.go` [[3]](diffhunk://#diff-cc994d5622e76e327accc9eb52784f57ae7ca9df87f45374a5f6560e509394afR1-R123)
* Updated test stubs to support the new validation interface. (`cmd/update/update_test.go` [cmd/update/update_test.goR43-R45](diffhunk://#diff-37b1ba28f74aa6ac53780c6f9831afbcf01e16d8ee58d8b4faeee7f3cc58fed7R43-R45))

### Core Validation Logic

* Added a new `cautils/config_validation.go` module that encapsulates configuration validation logic, including:
  - Field-level checks for required and optional fields.
  - URL validation.
  - Support for "cloud" and "offline" validation profiles.
  - Formatting results as text, JSON, or YAML, and filtering checks based on status. (`core/cautils/config_validation.go` [core/cautils/config_validation.goR1-R237](diffhunk://#diff-88341803ddaa263780d5578f25988a32ca77ab841492791a52ed3ac17c162c48R1-R237))

### Closes #3662 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration validation command for checking cached settings.
  * Supports cloud and offline validation profiles.
  * Reports results in text, JSON, or YAML formats.
  * Added options to include passing checks and choose the output format.
* **Bug Fixes**
  * Clearly reports missing or invalid configuration values, including malformed URLs.
  * Returns an error when cached configuration validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->