### PR TITLE
fix(core): ensure OpenTelemetry spans are ended across all exit and error paths

### DIFF
--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -245,26 +245,14 @@ func (ks *Kubescape) Scan(scanInfo *cautils.ScanInfo, policyIdentifiers []cautil
 // mid-operation ks.Context() read could observe a different deadline than
 // the one that started the operation, or an already-restored/canceled one.
 func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier) (scanResult *resultshandling.ResultsHandler, scanErr error) {
-	ctxInit, spanInit := otel.Tracer("").Start(ctx, "initialization")
-	logger.L().Start("Kubescape scanner initializing...")
+	var (
+		interfaces             componentInterfaces
+		getters                cautils.Getters
+		controlInputsFromCache bool
+		exceptionsFromCache    bool
+		resultsHandling        *resultshandling.ResultsHandler
+	)
 
-	// ===================== Initialization =====================
-	policyIdentifiers = resolveDefaultScanAllPolicies(scanInfo, policyIdentifiers) // resolve the ScanAll expansion while Init can still cache its paths
-	if err := scanInfo.Init(ctxInit, policyIdentifiers); err != nil {              // initialize scan info
-		spanInit.End()
-		return nil, err
-	}
-	defer scanInfo.Cleanup()
-	if err := resolveClusterContext(scanInfo); err != nil {
-		spanInit.End()
-		return nil, err
-	}
-
-	interfaces, err := getInterfaces(ctxInit, scanInfo, policyIdentifiers)
-	if err != nil {
-		spanInit.End()
-		return nil, err
-	}
 	// Output printers open their writers during interface setup. Scan owns
 	// those writers until a successful return hands them to ResultsHandler.
 	printersOwnedByScan := true
@@ -275,91 +263,118 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 			}
 		}
 	}()
-	interfaces.report.SetTenantConfig(interfaces.tenantConfig)
 
 	// remove host scanner components
 	defer func() {
-		if err := interfaces.hostSensorHandler.TearDown(); err != nil {
-			logger.L().Ctx(ctx).StopError("Failed to tear down host scanner", helpers.Error(err))
+		if interfaces.hostSensorHandler != nil {
+			if err := interfaces.hostSensorHandler.TearDown(); err != nil {
+				logger.L().Ctx(ctx).StopError("Failed to tear down host scanner", helpers.Error(err))
+			}
 		}
 	}()
 
-	// Only create DownloadReleasedPolicy if not in air-gapped mode
-	airGapped := isAirGappedMode(scanInfo)
-	var downloadReleasedPolicy *getter.DownloadReleasedPolicy
-	if airGapped {
-		// In air-gapped mode (--use-from is set — the user explicitly wants to load everything
-		// from local files with no network access), don't initialize the downloader to prevent
-		// network access
-		downloadReleasedPolicy = nil
-	} else {
-		downloadReleasedPolicy = getter.NewDownloadReleasedPolicyWithVersion(scanInfo.ControlsVersion) // download config inputs from github release
-	}
+	// ===================== Initialization =====================
+	err := func() error {
+		ctxInit, spanInit := otel.Tracer("").Start(ctx, "initialization")
+		defer spanInit.End()
+		logger.L().Start("Kubescape scanner initializing...")
 
-	// set policy getter only after setting the customerGUID
-	var getters cautils.Getters
-	getters.PolicyGetter, err = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
-	if err != nil {
-		spanInit.End()
-		return nil, err
-	}
-	var controlInputsFromCache bool
-	getters.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetterForTarget(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped, interfaces.k8s)
-	if err != nil {
-		spanInit.End()
-		return nil, err
-	}
-	var exceptionsFromCache bool
-	getters.ExceptionsGetter, exceptionsFromCache, err = getExceptionsGetterForTarget(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped, interfaces.k8s)
-	if err != nil {
-		spanInit.End()
-		return nil, err
-	}
-	getters.AttackTracksGetter, err = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
-	if err != nil {
-		spanInit.End()
-		return nil, err
-	}
-
-	if scanInfo.ScanAll {
-		// Add all frameworks
-		policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, listFrameworksNames(getters.PolicyGetter), apisv1.KindFramework)
-
-		// Add all controls
-		if controls, err := getters.PolicyGetter.ListControls(); err == nil {
-			controlIDs := make([]string, 0, len(controls))
-			for _, control := range controls {
-				controlIDs = append(controlIDs, parseControlEntry(control).ID)
-			}
-			policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, controlIDs, apisv1.KindControl)
-		} else {
-			logger.L().Ctx(ctxInit).Warning("failed to list controls for ScanAll", helpers.Error(err))
+		policyIdentifiers = resolveDefaultScanAllPolicies(scanInfo, policyIdentifiers) // resolve the ScanAll expansion while Init can still cache its paths
+		if err := scanInfo.Init(ctxInit, policyIdentifiers); err != nil {              // initialize scan info
+			return err
 		}
+		if err := resolveClusterContext(scanInfo); err != nil {
+			return err
+		}
+
+		var err error
+		interfaces, err = getInterfaces(ctxInit, scanInfo, policyIdentifiers)
+		if err != nil {
+			return err
+		}
+		interfaces.report.SetTenantConfig(interfaces.tenantConfig)
+
+		// Only create DownloadReleasedPolicy if not in air-gapped mode
+		airGapped := isAirGappedMode(scanInfo)
+		var downloadReleasedPolicy *getter.DownloadReleasedPolicy
+		if airGapped {
+			// In air-gapped mode (--use-from is set — the user explicitly wants to load everything
+			// from local files with no network access), don't initialize the downloader to prevent
+			// network access
+			downloadReleasedPolicy = nil
+		} else {
+			downloadReleasedPolicy = getter.NewDownloadReleasedPolicyWithVersion(scanInfo.ControlsVersion) // download config inputs from github release
+		}
+
+		// set policy getter only after setting the customerGUID
+		getters.PolicyGetter, err = getPolicyGetter(ctxInit, scanInfo.UseFrom, interfaces.tenantConfig.GetAccountID(), scanInfo.FrameworkScan, downloadReleasedPolicy, airGapped)
+		if err != nil {
+			return err
+		}
+		getters.ControlsInputsGetter, controlInputsFromCache, err = getConfigInputsGetterForTarget(ctxInit, scanInfo.ControlsInputs, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, scanInfo.GetScanningContext() == cautils.ContextCluster, airGapped, interfaces.k8s)
+		if err != nil {
+			return err
+		}
+		getters.ExceptionsGetter, exceptionsFromCache, err = getExceptionsGetterForTarget(ctxInit, scanInfo.UseExceptions, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped, interfaces.k8s)
+		if err != nil {
+			return err
+		}
+		getters.AttackTracksGetter, err = getAttackTracksGetter(ctxInit, scanInfo.AttackTracks, interfaces.tenantConfig.GetAccountID(), downloadReleasedPolicy, airGapped)
+		if err != nil {
+			return err
+		}
+
+		if scanInfo.ScanAll {
+			// Add all frameworks
+			policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, listFrameworksNames(getters.PolicyGetter), apisv1.KindFramework)
+
+			// Add all controls
+			if controls, err := getters.PolicyGetter.ListControls(); err == nil {
+				controlIDs := make([]string, 0, len(controls))
+				for _, control := range controls {
+					controlIDs = append(controlIDs, parseControlEntry(control).ID)
+				}
+				policyIdentifiers = cautils.AppendPolicyIdentifiers(policyIdentifiers, controlIDs, apisv1.KindControl)
+			} else {
+				logger.L().Ctx(ctxInit).Warning("failed to list controls for ScanAll", helpers.Error(err))
+			}
+		}
+
+		logger.L().StopSuccess("Initialized scanner")
+		resultsHandling = resultshandling.NewResultsHandler(interfaces.report, interfaces.outputPrinters, interfaces.uiPrinter)
+		return nil
+	}()
+	defer scanInfo.Cleanup()
+	if err != nil {
+		return nil, err
 	}
-
-	logger.L().StopSuccess("Initialized scanner")
-
-	resultsHandling := resultshandling.NewResultsHandler(interfaces.report, interfaces.outputPrinters, interfaces.uiPrinter)
 
 	// ===================== policies =====================
-	ctxPolicies, spanPolicies := otel.Tracer("").Start(ctxInit, "policies")
-	scanData, err := collectPolicies(ctxPolicies, interfaces.tenantConfig.GetContextName(), policyIdentifiers, scanInfo, &getters)
+	var scanData *cautils.OPASessionObj
+	err = func() error {
+		ctxPolicies, spanPolicies := otel.Tracer("").Start(ctx, "policies")
+		defer spanPolicies.End()
+
+		var err error
+		scanData, err = collectPolicies(ctxPolicies, interfaces.tenantConfig.GetContextName(), policyIdentifiers, scanInfo, &getters)
+		if err != nil {
+			return err
+		}
+		if controlInputsFromCache {
+			scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: "failed to fetch from GitHub, loaded from local cache"})
+		}
+		if exceptionsFromCache {
+			scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "exceptions", Reason: "failed to fetch from GitHub, loaded from local cache"})
+		}
+		return nil
+	}()
 	if err != nil {
-		spanInit.End()
 		return resultsHandling, err
 	}
-	if controlInputsFromCache {
-		scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "controlInputs", Reason: "failed to fetch from GitHub, loaded from local cache"})
-	}
-	if exceptionsFromCache {
-		scanData.PolicyDegradations = append(scanData.PolicyDegradations, cautils.PolicyDegradation{Component: "exceptions", Reason: "failed to fetch from GitHub, loaded from local cache"})
-	}
-	spanPolicies.End()
 
 	if scanInfo.DryRun {
-		spanInit.End()
 		resultsHandling.SetData(scanData)
-		result, err := interfaces.resourceHandler.Preflight(ctxInit, scanData, scanInfo)
+		result, err := interfaces.resourceHandler.Preflight(ctx, scanData, scanInfo)
 		if err != nil {
 			return resultsHandling, err
 		}
@@ -372,8 +387,6 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 	}
 
 	// ===================== resources =====================
-	ctxResources, spanResources := otel.Tracer("").Start(ctxInit, "resources")
-
 	// Determine if streaming should be enabled
 	enableStreaming := scanInfo.EnableStreaming
 	// Snapshot the pre-scan cluster size before the streaming decision. The
@@ -383,13 +396,13 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 	// up front also covers explicit --enable-streaming on large clusters.
 	var estimatedClusterSize int
 	if scanInfo.GetScanningContext() == cautils.ContextCluster {
-		estimatedClusterSize = estimateClusterSize(interfaces.resourceHandler, ctxResources, scanInfo)
+		estimatedClusterSize = estimateClusterSize(interfaces.resourceHandler, ctx, scanInfo)
 	}
 	if !enableStreaming && scanInfo.GetScanningContext() == cautils.ContextCluster {
 		// Auto-enable streaming for large clusters
 		enableStreaming = cautils.IsLargeCluster(estimatedClusterSize)
 		if enableStreaming {
-			logger.L().Ctx(ctxResources).Info("Large cluster detected, enabling resource streaming")
+			logger.L().Ctx(ctx).Info("Large cluster detected, enabling resource streaming")
 		}
 	}
 
@@ -399,12 +412,22 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 
 	if enableStreaming {
 		// Use streaming approach for large clusters
-		err = collectAndProcessResourcesWithStreaming(ctxResources, interfaces.resourceHandler, scanData, scanInfo, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, scanInfo.ControlTimeout, estimatedClusterSize)
+		err = func() error {
+			ctxResources, spanResources := otel.Tracer("").Start(ctx, "resources")
+			defer spanResources.End()
+			return collectAndProcessResourcesWithStreaming(ctxResources, interfaces.resourceHandler, scanData, scanInfo, interfaces.tenantConfig.GetContextName(), scanInfo.ExcludedNamespaces, scanInfo.IncludeNamespaces, scanInfo.EnableRegoPrint, scanInfo.ControlTimeout, estimatedClusterSize)
+		}()
+		if err != nil {
+			return resultsHandling, err
+		}
 	} else {
 		// Use traditional approach for small clusters
-		err = resourcehandler.CollectResources(ctxResources, interfaces.resourceHandler, scanData, scanInfo)
+		err = func() error {
+			ctxResources, spanResources := otel.Tracer("").Start(ctx, "resources")
+			defer spanResources.End()
+			return resourcehandler.CollectResources(ctxResources, interfaces.resourceHandler, scanData, scanInfo)
+		}()
 		if err != nil {
-			spanInit.End()
 			return resultsHandling, err
 		}
 
@@ -432,25 +455,28 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 		}
 	}
 
-	if err != nil {
-		spanInit.End()
-		return resultsHandling, err
-	}
-	spanResources.End()
-	spanInit.End()
-
 	// ======================== prioritization ===================
 	if scanInfo.PrintAttackTree || isPrioritizationScanType(scanInfo.ScanType) {
-		_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
-		if priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, getters.AttackTracksGetter, scanInfo.PrintAttackTree); err != nil {
-			logger.L().Ctx(ctx).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
-		} else if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
-			return resultsHandling, fmt.Errorf("%w", err)
+		err := func() error {
+			_, spanPrioritization := otel.Tracer("").Start(ctxOpa, "prioritization")
+			defer spanPrioritization.End()
+
+			priotizationHandler, err := resourcesprioritization.NewResourcesPrioritizationHandler(ctxOpa, getters.AttackTracksGetter, scanInfo.PrintAttackTree)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("failed to get attack tracks, this may affect the scanning results", helpers.Error(err))
+				return nil
+			}
+			if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
+				return fmt.Errorf("%w", err)
+			}
+			if isPrioritizationScanType(scanInfo.ScanType) {
+				scanData.SetTopWorkloads()
+			}
+			return nil
+		}()
+		if err != nil {
+			return resultsHandling, err
 		}
-		if isPrioritizationScanType(scanInfo.ScanType) {
-			scanData.SetTopWorkloads()
-		}
-		spanPrioritization.End()
 	}
 
 	if scanInfo.ScanImages {

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -469,13 +469,13 @@ func (ks *Kubescape) ScanContext(ctx context.Context, scanInfo *cautils.ScanInfo
 			if err := priotizationHandler.PrioritizeResources(scanData); err != nil {
 				return fmt.Errorf("%w", err)
 			}
-			if isPrioritizationScanType(scanInfo.ScanType) {
-				scanData.SetTopWorkloads()
-			}
 			return nil
 		}()
 		if err != nil {
 			return resultsHandling, err
+		}
+		if isPrioritizationScanType(scanInfo.ScanType) {
+			scanData.SetTopWorkloads()
 		}
 	}
 

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -23,6 +23,9 @@ import (
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -892,4 +895,194 @@ func TestGetAllWorkloadImagesReturnsGetterErrorsAndPreservesOtherClasses(t *test
 			assert.Contains(t, containerErrors[0].Error(), "namespace: image-scan-test")
 		})
 	}
+}
+
+func setupSpanRecorder(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prevTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prevTP)
+	})
+	return exporter
+}
+
+func TestScanContext_SpanLifecycle_OPAError(t *testing.T) {
+	exporter := setupSpanRecorder(t)
+	scanInfo, policyIdentifiers, _ := buildBrokenRuleScanInfo(t)
+	ks := NewKubescape(context.Background())
+
+	results, err := ks.ScanContext(context.Background(), scanInfo, policyIdentifiers)
+	require.Error(t, err)
+	require.NotNil(t, results)
+
+	spans := exporter.GetSpans()
+	spanNames := make(map[string]tracetest.SpanStub)
+	for _, span := range spans {
+		spanNames[span.Name] = span
+		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
+	}
+
+	assert.Contains(t, spanNames, "initialization")
+	assert.Contains(t, spanNames, "policies")
+	assert.Contains(t, spanNames, "resources")
+	assert.Contains(t, spanNames, "opa testing")
+
+	initSpan := spanNames["initialization"]
+	policiesSpan := spanNames["policies"]
+	assert.True(t, !initSpan.EndTime.After(policiesSpan.StartTime) || initSpan.EndTime.Equal(policiesSpan.StartTime) || policiesSpan.StartTime.After(initSpan.StartTime),
+		"initialization must finish early in the scan")
+}
+
+// TestScanContext_SpanLifecycle_StreamingError is the direct regression test
+// for M-05: "scan.go leaks the spanInit when streaming errors". It forces the
+// streaming branch (EnableStreaming=true) and causes
+// collectAndProcessResourcesWithStreaming to return an error via a broken Rego
+// rule. Before the fix, both spanInit and spanResources were leaked on this
+// path.
+func TestScanContext_SpanLifecycle_StreamingError(t *testing.T) {
+	exporter := setupSpanRecorder(t)
+	scanInfo, policyIdentifiers, _ := buildBrokenRuleScanInfo(t)
+	scanInfo.EnableStreaming = true
+	ks := NewKubescape(context.Background())
+
+	results, err := ks.ScanContext(context.Background(), scanInfo, policyIdentifiers)
+	require.Error(t, err, "streaming with a broken rule must return an error")
+	require.NotNil(t, results)
+
+	spans := exporter.GetSpans()
+
+	spanNames := make(map[string]tracetest.SpanStub)
+	resourcesSpanCount := 0
+	for _, span := range spans {
+		spanNames[span.Name] = span
+		assert.False(t, span.EndTime.IsZero(), "span %q was not ended (leaked)", span.Name)
+		if span.Name == "resources" {
+			resourcesSpanCount++
+		}
+	}
+
+	assert.Contains(t, spanNames, "resources", "streaming branch must create a resources span")
+	assert.Equal(t, 1, resourcesSpanCount, "resources span must appear exactly once")
+	assert.Contains(t, spanNames, "initialization")
+	assert.False(t, spanNames["initialization"].EndTime.IsZero(), "initialization span must be ended even on streaming error")
+	assert.Contains(t, spanNames, "policies")
+	assert.False(t, spanNames["policies"].EndTime.IsZero(), "policies span must be ended even on streaming error")
+}
+
+func TestScanContext_SpanLifecycle_PolicyError(t *testing.T) {
+	exporter := setupSpanRecorder(t)
+	missingPolicy := "missing-" + filepath.Base(t.TempDir())
+	scanInfo := &cautils.ScanInfo{
+		InputPatterns: []string{"../cautils/testdata/mixed_extensions/pod.yaml"},
+		UseFrom:       []string{filepath.Join(t.TempDir(), missingPolicy+".json")},
+		Local:         true,
+		FrameworkScan: true,
+		ScanType:      cautils.ScanTypeFramework,
+	}
+	scanInfo.Submit.SetBool(false)
+
+	_, err := NewKubescape(context.Background()).ScanContext(context.Background(), scanInfo, cautils.BuildPolicyIdentifiers([]string{missingPolicy}, apisv1.KindFramework))
+	require.Error(t, err)
+
+	spans := exporter.GetSpans()
+	spanNames := make(map[string]tracetest.SpanStub)
+	for _, span := range spans {
+		spanNames[span.Name] = span
+		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
+	}
+
+	assert.Contains(t, spanNames, "initialization")
+	assert.Contains(t, spanNames, "policies")
+}
+
+func buildValidRuleScanInfo(t *testing.T) (*cautils.ScanInfo, []cautils.PolicyIdentifier) {
+	t.Helper()
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "pod.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+  namespace: default
+`), 0o600))
+
+	rule := reporthandling.PolicyRule{
+		Rule: `package armo_builtins
+
+deny[msga] {
+	false
+	msga := {}
+}
+`,
+		RuleLanguage: reporthandling.RegoLanguage,
+		Match: []reporthandling.RuleMatchObjects{{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"Pod"},
+		}},
+	}
+	rule.Name = "valid-rule"
+	control := reporthandling.Control{ControlID: "C-VALID", BaseScore: 5, Rules: []reporthandling.PolicyRule{rule}}
+	control.Name = "valid-control"
+	framework := reporthandling.Framework{Controls: []reporthandling.Control{control}}
+	framework.Name = "valid-framework"
+	frameworkBytes, err := json.Marshal(framework)
+	require.NoError(t, err)
+	frameworkPath := filepath.Join(dir, "framework.json")
+	require.NoError(t, os.WriteFile(frameworkPath, frameworkBytes, 0o600))
+	controlsInputsPath := filepath.Join(dir, "controls-inputs.json")
+	require.NoError(t, os.WriteFile(controlsInputsPath, []byte(`{"probe":["value"]}`), 0o600))
+	exceptionsPath := filepath.Join(dir, "exceptions.json")
+	require.NoError(t, os.WriteFile(exceptionsPath, []byte(`[]`), 0o600))
+	attackTracksPath := filepath.Join(dir, "attack-tracks.json")
+	require.NoError(t, os.WriteFile(attackTracksPath, []byte(`[]`), 0o600))
+
+	scanInfo := &cautils.ScanInfo{
+		UseFrom:          []string{frameworkPath},
+		ControlsInputs:   controlsInputsPath,
+		UseExceptions:    exceptionsPath,
+		AttackTracks:     attackTracksPath,
+		InputPatterns:    []string{manifestPath},
+		Local:            true,
+		FrameworkScan:    true,
+		ScanType:         cautils.ScanTypeFramework,
+		OmitRawResources: true,
+	}
+	scanInfo.Submit.SetBool(false)
+
+	policyIdentifiers := []cautils.PolicyIdentifier{{
+		Identifier: framework.Name,
+		Kind:       apisv1.KindFramework,
+	}}
+	return scanInfo, policyIdentifiers
+}
+
+func TestScanContext_SpanLifecycle_Success(t *testing.T) {
+	exporter := setupSpanRecorder(t)
+	scanInfo, policyIdentifiers := buildValidRuleScanInfo(t)
+	ks := NewKubescape(context.Background())
+
+	results, err := ks.ScanContext(context.Background(), scanInfo, policyIdentifiers)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+
+	spans := exporter.GetSpans()
+	spanNames := make(map[string]tracetest.SpanStub)
+	for _, span := range spans {
+		spanNames[span.Name] = span
+		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
+	}
+
+	assert.Contains(t, spanNames, "initialization")
+	assert.Contains(t, spanNames, "policies")
+	assert.Contains(t, spanNames, "resources")
+	assert.Contains(t, spanNames, "opa testing")
+
+	initSpan := spanNames["initialization"]
+	resourcesSpan := spanNames["resources"]
+	assert.True(t, !initSpan.EndTime.After(resourcesSpan.StartTime), "initialization must finish before resource collection starts")
 }

--- a/core/core/scan_test.go
+++ b/core/core/scan_test.go
@@ -897,21 +897,56 @@ func TestGetAllWorkloadImagesReturnsGetterErrorsAndPreservesOtherClasses(t *test
 	}
 }
 
-func setupSpanRecorder(t *testing.T) *tracetest.InMemoryExporter {
+func setupSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
 	t.Helper()
-	exporter := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	prevTP := otel.GetTracerProvider()
 	otel.SetTracerProvider(tp)
 	t.Cleanup(func() {
 		_ = tp.Shutdown(context.Background())
 		otel.SetTracerProvider(prevTP)
 	})
-	return exporter
+	return sr
+}
+
+func assertSpansEnded(t *testing.T, sr *tracetest.SpanRecorder, expectedPhases ...string) {
+	t.Helper()
+	started := sr.Started()
+	ended := sr.Ended()
+
+	startedCounts := make(map[string]int)
+	for _, s := range started {
+		startedCounts[s.Name()]++
+	}
+
+	endedCounts := make(map[string]int)
+	for _, s := range ended {
+		endedCounts[s.Name()]++
+		assert.False(t, s.EndTime().IsZero(), "span %q was not ended", s.Name())
+	}
+
+	// Every started span (including child spans) must be ended (no leaks)
+	assert.Equal(t, startedCounts, endedCounts, "all started spans must be ended (no leaks, no duplicates)")
+
+	// Every expected ScanContext phase must be started and ended exactly once
+	for _, phase := range expectedPhases {
+		assert.Equalf(t, 1, startedCounts[phase], "phase %q should be started exactly once", phase)
+		assert.Equalf(t, 1, endedCounts[phase], "phase %q should be ended exactly once", phase)
+	}
+}
+
+func findEndedSpan(sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	for _, s := range sr.Ended() {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
 }
 
 func TestScanContext_SpanLifecycle_OPAError(t *testing.T) {
-	exporter := setupSpanRecorder(t)
+	sr := setupSpanRecorder(t)
 	scanInfo, policyIdentifiers, _ := buildBrokenRuleScanInfo(t)
 	ks := NewKubescape(context.Background())
 
@@ -919,22 +954,14 @@ func TestScanContext_SpanLifecycle_OPAError(t *testing.T) {
 	require.Error(t, err)
 	require.NotNil(t, results)
 
-	spans := exporter.GetSpans()
-	spanNames := make(map[string]tracetest.SpanStub)
-	for _, span := range spans {
-		spanNames[span.Name] = span
-		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
-	}
+	assertSpansEnded(t, sr, "initialization", "policies", "resources", "opa testing")
 
-	assert.Contains(t, spanNames, "initialization")
-	assert.Contains(t, spanNames, "policies")
-	assert.Contains(t, spanNames, "resources")
-	assert.Contains(t, spanNames, "opa testing")
-
-	initSpan := spanNames["initialization"]
-	policiesSpan := spanNames["policies"]
-	assert.True(t, !initSpan.EndTime.After(policiesSpan.StartTime) || initSpan.EndTime.Equal(policiesSpan.StartTime) || policiesSpan.StartTime.After(initSpan.StartTime),
-		"initialization must finish early in the scan")
+	initSpan := findEndedSpan(sr, "initialization")
+	policiesSpan := findEndedSpan(sr, "policies")
+	require.NotNil(t, initSpan)
+	require.NotNil(t, policiesSpan)
+	assert.False(t, initSpan.EndTime().After(policiesSpan.StartTime()),
+		"initialization must finish before policies start")
 }
 
 // TestScanContext_SpanLifecycle_StreamingError is the direct regression test
@@ -944,7 +971,7 @@ func TestScanContext_SpanLifecycle_OPAError(t *testing.T) {
 // rule. Before the fix, both spanInit and spanResources were leaked on this
 // path.
 func TestScanContext_SpanLifecycle_StreamingError(t *testing.T) {
-	exporter := setupSpanRecorder(t)
+	sr := setupSpanRecorder(t)
 	scanInfo, policyIdentifiers, _ := buildBrokenRuleScanInfo(t)
 	scanInfo.EnableStreaming = true
 	ks := NewKubescape(context.Background())
@@ -953,28 +980,11 @@ func TestScanContext_SpanLifecycle_StreamingError(t *testing.T) {
 	require.Error(t, err, "streaming with a broken rule must return an error")
 	require.NotNil(t, results)
 
-	spans := exporter.GetSpans()
-
-	spanNames := make(map[string]tracetest.SpanStub)
-	resourcesSpanCount := 0
-	for _, span := range spans {
-		spanNames[span.Name] = span
-		assert.False(t, span.EndTime.IsZero(), "span %q was not ended (leaked)", span.Name)
-		if span.Name == "resources" {
-			resourcesSpanCount++
-		}
-	}
-
-	assert.Contains(t, spanNames, "resources", "streaming branch must create a resources span")
-	assert.Equal(t, 1, resourcesSpanCount, "resources span must appear exactly once")
-	assert.Contains(t, spanNames, "initialization")
-	assert.False(t, spanNames["initialization"].EndTime.IsZero(), "initialization span must be ended even on streaming error")
-	assert.Contains(t, spanNames, "policies")
-	assert.False(t, spanNames["policies"].EndTime.IsZero(), "policies span must be ended even on streaming error")
+	assertSpansEnded(t, sr, "initialization", "policies", "resources")
 }
 
 func TestScanContext_SpanLifecycle_PolicyError(t *testing.T) {
-	exporter := setupSpanRecorder(t)
+	sr := setupSpanRecorder(t)
 	missingPolicy := "missing-" + filepath.Base(t.TempDir())
 	scanInfo := &cautils.ScanInfo{
 		InputPatterns: []string{"../cautils/testdata/mixed_extensions/pod.yaml"},
@@ -988,15 +998,7 @@ func TestScanContext_SpanLifecycle_PolicyError(t *testing.T) {
 	_, err := NewKubescape(context.Background()).ScanContext(context.Background(), scanInfo, cautils.BuildPolicyIdentifiers([]string{missingPolicy}, apisv1.KindFramework))
 	require.Error(t, err)
 
-	spans := exporter.GetSpans()
-	spanNames := make(map[string]tracetest.SpanStub)
-	for _, span := range spans {
-		spanNames[span.Name] = span
-		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
-	}
-
-	assert.Contains(t, spanNames, "initialization")
-	assert.Contains(t, spanNames, "policies")
+	assertSpansEnded(t, sr, "initialization", "policies")
 }
 
 func buildValidRuleScanInfo(t *testing.T) (*cautils.ScanInfo, []cautils.PolicyIdentifier) {
@@ -1062,7 +1064,7 @@ deny[msga] {
 }
 
 func TestScanContext_SpanLifecycle_Success(t *testing.T) {
-	exporter := setupSpanRecorder(t)
+	sr := setupSpanRecorder(t)
 	scanInfo, policyIdentifiers := buildValidRuleScanInfo(t)
 	ks := NewKubescape(context.Background())
 
@@ -1070,19 +1072,34 @@ func TestScanContext_SpanLifecycle_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, results)
 
-	spans := exporter.GetSpans()
-	spanNames := make(map[string]tracetest.SpanStub)
-	for _, span := range spans {
-		spanNames[span.Name] = span
-		assert.False(t, span.EndTime.IsZero(), "span %q was not ended", span.Name)
-	}
+	assertSpansEnded(t, sr, "initialization", "policies", "resources", "opa testing")
 
-	assert.Contains(t, spanNames, "initialization")
-	assert.Contains(t, spanNames, "policies")
-	assert.Contains(t, spanNames, "resources")
-	assert.Contains(t, spanNames, "opa testing")
+	initSpan := findEndedSpan(sr, "initialization")
+	resourcesSpan := findEndedSpan(sr, "resources")
+	require.NotNil(t, initSpan)
+	require.NotNil(t, resourcesSpan)
+	assert.True(t, !initSpan.EndTime().After(resourcesSpan.StartTime()), "initialization must finish before resource collection starts")
+	assert.Nil(t, findEndedSpan(sr, "prioritization"), "prioritization span should not run when disabled")
+}
 
-	initSpan := spanNames["initialization"]
-	resourcesSpan := spanNames["resources"]
-	assert.True(t, !initSpan.EndTime.After(resourcesSpan.StartTime), "initialization must finish before resource collection starts")
+func TestScanContext_SpanLifecycle_SuccessWithPrioritization(t *testing.T) {
+	sr := setupSpanRecorder(t)
+	scanInfo, policyIdentifiers := buildValidRuleScanInfo(t)
+	scanInfo.PrintAttackTree = true // exercises the prioritization span branch
+	ks := NewKubescape(context.Background())
+
+	results, err := ks.ScanContext(context.Background(), scanInfo, policyIdentifiers)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+
+	assertSpansEnded(t, sr, "initialization", "policies", "resources", "opa testing", "prioritization")
+
+	initSpan := findEndedSpan(sr, "initialization")
+	resourcesSpan := findEndedSpan(sr, "resources")
+	prioSpan := findEndedSpan(sr, "prioritization")
+	require.NotNil(t, initSpan)
+	require.NotNil(t, resourcesSpan)
+	require.NotNil(t, prioSpan)
+	assert.True(t, !initSpan.EndTime().After(resourcesSpan.StartTime()), "initialization must finish before resource collection starts")
+	assert.True(t, !resourcesSpan.EndTime().After(prioSpan.StartTime()), "resources must finish before prioritization starts")
 }


### PR DESCRIPTION
Fixes #3664
## Overview

Fixes OpenTelemetry span lifecycle leaks in `ScanContext` (`core/core/scan.go`).

### Current Behavior

Spans (`spanInit`, `spanResources`, `spanPolicies`, and `spanPrioritization`) rely on manual `.End()` calls scattered across numerous return paths. Several error paths can return before those calls are reached:

* The streaming error path in `collectAndProcessResourcesWithStreaming` can return without reaching the existing `spanResources.End()` and `spanInit.End()` calls.
* `resourcehandler.CollectResources` failures can return before `spanResources.End()`.
* `ProcessRulesListener` failures can return before the later `spanInit.End()` and `spanResources.End()` calls.
* `collectPolicies` failures can return before `spanPolicies.End()`.
* `PrioritizeResources` failures can return before `spanPrioritization.End()`.
* `spanInit` remains open beyond scanner initialization, covering subsequent policy and resource processing.

### Future Behavior

Replaces scattered manual `.End()` calls with scoped closures and immediate `defer span.End()` for each logical phase:

* `"initialization"`: covers scanner setup, flag validation, interface creation, and getter initialization.
* `"policies"`: covers policy retrieval and policy degradation handling.
* `"resources"`: covers resource collection in non-streaming mode or streaming batch processing. In non-streaming mode, the span ends before OPA rule evaluation begins.
* `"prioritization"`: covers attack track prioritization.

This guarantees that each span is ended exactly once on both success and error paths, while keeping span lifetimes aligned with their respective phases.

## Additional Information

* Existing deferred cleanup for `scanInfo.Cleanup()`, printer ownership on failure, and host sensor teardown remains intact.
* Added lifecycle regression tests covering successful scans, policy failures, OPA processing failures, and streaming failures.
* Tests verify that spans are completed and that the relevant phase boundaries are preserved.

## How to Test

Run:

```bash
go test -v -run "TestScanContext_SpanLifecycle" ./core/core/...
go test ./core/core/...
go test -race ./core/core/...
```

All tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan reliability when errors occur during initialization, policy loading, resource collection, or rule evaluation.
  * Ensured scan progress and completion tracking remain accurate across streaming and non-streaming scans.
  * Prevented cleanup issues when scanner components are unavailable.
  * Preserved prioritization results only when prioritization completes successfully.

* **Improvements**
  * Added more consistent tracing across scan phases, including reliable completion tracking for successful and failed scans.
  * Improved error reporting by preserving failures throughout the scan process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->