### PR TITLE
fix(download): accept plural and alias target arguments (#3666)

### DIFF
--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -55,6 +55,7 @@ func normalizeDownloadTarget(target string) string {
 	}
 }
 
+// GetDownloadCmd returns the Cobra command for downloading Kubescape policies, frameworks, controls, and artifacts.
 func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 	var downloadInfo = v1.DownloadInfo{}
 

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -24,10 +24,7 @@ var (
   # Download the NSA framework. Run '%[1]s list frameworks' for all frameworks names
   %[1]s download framework nsa
 
-  # Download the "C-0001" control. Run '%[1]s list controls --id' for all controls ids
-  %[1]s download control "C-0001"
-
-  # Download the "C-0001" control. Run '%[1]s list controls --id' for all controls ids
+  # Download the "C-0001" control. Run '%[1]s list controls' for all controls ids
   %[1]s download control C-0001
 
   # Download the configured exceptions
@@ -37,6 +34,26 @@ var (
   %[1]s download controls-inputs 
 `, cautils.ExecName())
 )
+
+// normalizeDownloadTarget maps plurals and common aliases to canonical download targets.
+func normalizeDownloadTarget(target string) string {
+	switch strings.ToLower(target) {
+	case "controls", "control":
+		return core.TargetControl
+	case "frameworks", "framework":
+		return core.TargetFramework
+	case "controls-inputs", "controls-input", "control-inputs", "control-input", "controls-config", "control-config":
+		return core.TargetControlsInputs
+	case "exceptions", "exception":
+		return core.TargetExceptions
+	case "artifacts", "artifact":
+		return core.TargetArtifacts
+	case "attack-tracks", "attack-track", "attacktracks", "attacktrack":
+		return core.TargetAttackTracks
+	default:
+		return target
+	}
+}
 
 func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 	var downloadInfo = v1.DownloadInfo{}
@@ -51,7 +68,8 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 			if len(args) < 1 {
 				return fmt.Errorf("policy type required, supported: %v", supported)
 			}
-			if !slices.Contains(core.DownloadSupportCommands(), args[0]) {
+			target := normalizeDownloadTarget(args[0])
+			if !slices.Contains(core.DownloadSupportCommands(), target) {
 				return fmt.Errorf("invalid parameter '%s'. Supported parameters: %s", args[0], supported)
 			}
 			return nil
@@ -66,10 +84,10 @@ func GetDownloadCmd(ks meta.IKubescape) *cobra.Command {
 				downloadInfo.Path, downloadInfo.FileName = filepath.Split(downloadInfo.Path)
 			}
 
-			downloadInfo.Target = args[0]
+			downloadInfo.Target = normalizeDownloadTarget(args[0])
 			if len(args) >= 2 {
-				if args[1] == "" && (args[0] == "framework" || args[0] == "control") {
-					return fmt.Errorf("name cannot be empty for %s download", args[0])
+				if args[1] == "" && (downloadInfo.Target == "framework" || downloadInfo.Target == "control") {
+					return fmt.Errorf("name cannot be empty for %s download", downloadInfo.Target)
 				}
 				downloadInfo.Identifier = args[1]
 			}

--- a/cmd/download/download_test.go
+++ b/cmd/download/download_test.go
@@ -26,6 +26,7 @@ func (r *recordingDownloadKS) Download(info *v1.DownloadInfo) (*v1.DownloadResul
 	return &v1.DownloadResult{}, nil
 }
 
+// TestGetViewCmd verifies the download command metadata and default properties.
 func TestGetViewCmd(t *testing.T) {
 	// Create a mock Kubescape interface
 	mockKubescape := &mocks.MockIKubescape{}
@@ -40,6 +41,7 @@ func TestGetViewCmd(t *testing.T) {
 	assert.Equal(t, downloadExample, configCmd.Example)
 }
 
+// TestGetViewCmd_Args tests command argument validation with valid, invalid, plural, and alias target names.
 func TestGetViewCmd_Args(t *testing.T) {
 	// Create a mock Kubescape interface
 	mockKubescape := &mocks.MockIKubescape{}
@@ -98,6 +100,7 @@ func TestGetViewCmd_Args(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// TestNormalizeDownloadTarget tests normalization of target aliases and plurals to canonical targets.
 func TestNormalizeDownloadTarget(t *testing.T) {
 	tests := []struct {
 		input string

--- a/cmd/download/download_test.go
+++ b/cmd/download/download_test.go
@@ -73,11 +73,88 @@ func TestGetViewCmd_Args(t *testing.T) {
 	err = downloadCmd.Args(&cobra.Command{}, []string{"control", "C-0001"})
 	assert.Nil(t, err)
 
+	err = downloadCmd.Args(&cobra.Command{}, []string{"controls", "C-0001"})
+	assert.Nil(t, err)
+
+	err = downloadCmd.Args(&cobra.Command{}, []string{"frameworks", "nsa"})
+	assert.Nil(t, err)
+
+	err = downloadCmd.Args(&cobra.Command{}, []string{"controls-config"})
+	assert.Nil(t, err)
+
+	err = downloadCmd.Args(&cobra.Command{}, []string{"exception"})
+	assert.Nil(t, err)
+
+	err = downloadCmd.Args(&cobra.Command{}, []string{"artifact"})
+	assert.Nil(t, err)
+
+	err = downloadCmd.Args(&cobra.Command{}, []string{"attack-track"})
+	assert.Nil(t, err)
+
 	err = downloadCmd.Args(&cobra.Command{}, []string{"control", "C-0001", "C-0002"})
 	assert.Nil(t, err)
 
 	err = downloadCmd.RunE(&cobra.Command{}, []string{"control", "C-0001", "C-0002"})
 	assert.Nil(t, err)
+}
+
+func TestNormalizeDownloadTarget(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"control", core.TargetControl},
+		{"controls", core.TargetControl},
+		{"framework", core.TargetFramework},
+		{"frameworks", core.TargetFramework},
+		{"controls-inputs", core.TargetControlsInputs},
+		{"controls-input", core.TargetControlsInputs},
+		{"control-inputs", core.TargetControlsInputs},
+		{"control-input", core.TargetControlsInputs},
+		{"controls-config", core.TargetControlsInputs},
+		{"control-config", core.TargetControlsInputs},
+		{"exceptions", core.TargetExceptions},
+		{"exception", core.TargetExceptions},
+		{"artifacts", core.TargetArtifacts},
+		{"artifact", core.TargetArtifacts},
+		{"attack-tracks", core.TargetAttackTracks},
+		{"attack-track", core.TargetAttackTracks},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeDownloadTarget(tt.input))
+		})
+	}
+}
+
+// TestDownloadCmd_TargetNormalization verifies that plural and alias targets
+// are normalized to their canonical values before calling Kubescape.Download.
+func TestDownloadCmd_TargetNormalization(t *testing.T) {
+	tests := []struct {
+		args       []string
+		wantTarget string
+		wantID     string
+	}{
+		{args: []string{"controls", "C-0001"}, wantTarget: core.TargetControl, wantID: "C-0001"},
+		{args: []string{"frameworks", "nsa"}, wantTarget: core.TargetFramework, wantID: "nsa"},
+		{args: []string{"controls-config"}, wantTarget: core.TargetControlsInputs, wantID: ""},
+		{args: []string{"exception"}, wantTarget: core.TargetExceptions, wantID: ""},
+		{args: []string{"artifact"}, wantTarget: core.TargetArtifacts, wantID: ""},
+		{args: []string{"attack-track"}, wantTarget: core.TargetAttackTracks, wantID: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			ks := &recordingDownloadKS{}
+			cmd := GetDownloadCmd(ks)
+			require.NoError(t, cmd.RunE(cmd, tt.args))
+			require.NotNil(t, ks.captured)
+			assert.Equal(t, tt.wantTarget, ks.captured.Target)
+			assert.Equal(t, tt.wantID, ks.captured.Identifier)
+		})
+	}
 }
 
 // TestDownloadCmd_JSONOutputPathPreSplit pins the CLI half of the


### PR DESCRIPTION

## Overview
`kubescape list` outputs and documentation use plural targets (`controls`, `frameworks`, `controls-config`), but `kubescape download` previously required exact singular names (`control`, `framework`, `controls-inputs`).

When a user ran `kubescape download controls C-0001` or `kubescape download frameworks nsa` following the output of `kubescape list`, the command failed with:
`invalid parameter 'controls'. Supported parameters: artifacts,attack-tracks,control,controls-inputs,exceptions,framework`.

This PR:
- Adds `normalizeDownloadTarget` to normalize plural and common alias targets (`controls` → `control`, `frameworks` → `framework`, `controls-config` / `control-inputs` → `controls-inputs`, `artifact` → `artifacts`, `exception` → `exceptions`, `attack-track` → `attack-tracks`).
- Cleans up duplicate example entries referencing the deprecated `--id` flag in `downloadExample`.
- Adds unit tests in `cmd/download/download_test.go` covering target normalization, plural argument validation, and `DownloadInfo` parameter passing.

## How to Test
Run unit tests:
```bash
go test -v ./cmd/download/...
```

## Related issues/PRs:
* Resolved #3666

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for plural target names and aliases when downloading controls, frameworks, exceptions, artifacts, and attack tracks.
  * Target names are normalized automatically for consistent download behavior.
* **Bug Fixes**
  * Updated command validation to correctly handle normalized target names and empty framework or control values.
  * Updated usage guidance to reflect the current `list controls` command syntax.
  * Improved handling of alternate target names during downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->