### PR TITLE
perf: stream JSON outputs instead of massive byte array allocations in memory

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -98,13 +98,7 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 	reportWithSeverity.ExceptionAudit = opaSessionObj.ExceptionAudit
 
-	r, err := json.Marshal(reportWithSeverity)
-	if err != nil {
-		return err
-	}
-	_, err = jp.writer.Write(r)
-
-	return err
+	return json.NewEncoder(jp.writer).Encode(reportWithSeverity)
 }
 
 func convertToPackageScores(packageScores map[string]*imageprinter.PackageScore) map[string]*reportsummary.PackageSummary {

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -1,9 +1,11 @@
 package resultshandling
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"fmt"
 	"slices"
 
@@ -81,8 +83,8 @@ func (rh *ResultsHandler) GetReporter() reporter.IReport {
 	return rh.ReporterObj
 }
 
-// ToJson returns the results in the JSON format
-func (rh *ResultsHandler) ToJson() ([]byte, error) {
+// WriteJson streams the results in JSON format directly to the given writer
+func (rh *ResultsHandler) WriteJson(w io.Writer) error {
 	finalizedReport := printerv2.FinalizeResults(rh.ScanData)
 	enrichedReport := printerv2.ConvertToPostureReportWithSeverityLabelsAndCoverage(
 		finalizedReport,
@@ -131,7 +133,14 @@ func (rh *ResultsHandler) ToJson() ([]byte, error) {
 		ExceptionAudit: rh.ScanData.ExceptionAudit,
 	}
 
-	return json.Marshal(&output)
+	return json.NewEncoder(w).Encode(&output)
+}
+
+// ToJson returns the results in the JSON format
+func (rh *ResultsHandler) ToJson() ([]byte, error) {
+	var buf bytes.Buffer
+	err := rh.WriteJson(&buf)
+	return buf.Bytes(), err
 }
 
 // GetResults returns the results

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -140,7 +140,11 @@ func (rh *ResultsHandler) WriteJson(w io.Writer) error {
 func (rh *ResultsHandler) ToJson() ([]byte, error) {
 	var buf bytes.Buffer
 	err := rh.WriteJson(&buf)
-	return buf.Bytes(), err
+	res := buf.Bytes()
+		if len(res) > 0 && res[len(res)-1] == '\n' {
+		res = res[:len(res)-1]
+	}
+	return res, err
 }
 
 // GetResults returns the results

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"fmt"
+	"io"
 	"slices"
 
 	"github.com/kubescape/go-logger"
@@ -141,7 +141,7 @@ func (rh *ResultsHandler) ToJson() ([]byte, error) {
 	var buf bytes.Buffer
 	err := rh.WriteJson(&buf)
 	res := buf.Bytes()
-		if len(res) > 0 && res[len(res)-1] == '\n' {
+	if len(res) > 0 && res[len(res)-1] == '\n' {
 		res = res[:len(res)-1]
 	}
 	return res, err

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -254,11 +254,12 @@ func persistCanonicalResult(result *resultshandling.ResultsHandler, scanID strin
 	if err != nil {
 		return fmt.Errorf("failed to persist canonical scan results: invalid scan ID: %w", err)
 	}
-	data, err := result.ToJson()
+	f, err := os.Create(filepath.Join(OutputDir, parsedUUID.String()))
 	if err != nil {
-		return fmt.Errorf("failed to marshal canonical scan results: %w", err)
+		return fmt.Errorf("failed to create canonical scan results file: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(OutputDir, parsedUUID.String()), data, 0o600); err != nil {
+	defer f.Close()
+	if err := result.WriteJson(f); err != nil {
 		return fmt.Errorf("failed to persist canonical scan results: %w", err)
 	}
 	return nil

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -254,7 +254,7 @@ func persistCanonicalResult(result *resultshandling.ResultsHandler, scanID strin
 	if parseErr != nil {
 		return fmt.Errorf("failed to persist canonical scan results: invalid scan ID: %w", parseErr)
 	}
-	f, createErr := os.Create(filepath.Join(OutputDir, parsedUUID.String()))
+	f, createErr := os.OpenFile(filepath.Join(OutputDir, parsedUUID.String()), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if createErr != nil {
 		return fmt.Errorf("failed to create canonical scan results file: %w", createErr)
 	}

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -249,18 +249,23 @@ func shouldPersistCanonicalResult(ctx context.Context, scanInfo *cautils.ScanInf
 	return true
 }
 
-func persistCanonicalResult(result *resultshandling.ResultsHandler, scanID string) error {
-	parsedUUID, err := uuid.Parse(scanID)
-	if err != nil {
-		return fmt.Errorf("failed to persist canonical scan results: invalid scan ID: %w", err)
+func persistCanonicalResult(result *resultshandling.ResultsHandler, scanID string) (err error) {
+	parsedUUID, parseErr := uuid.Parse(scanID)
+	if parseErr != nil {
+		return fmt.Errorf("failed to persist canonical scan results: invalid scan ID: %w", parseErr)
 	}
-	f, err := os.Create(filepath.Join(OutputDir, parsedUUID.String()))
-	if err != nil {
-		return fmt.Errorf("failed to create canonical scan results file: %w", err)
+	f, createErr := os.Create(filepath.Join(OutputDir, parsedUUID.String()))
+	if createErr != nil {
+		return fmt.Errorf("failed to create canonical scan results file: %w", createErr)
 	}
-	defer f.Close()
-	if err := result.WriteJson(f); err != nil {
-		return fmt.Errorf("failed to persist canonical scan results: %w", err)
+	defer func() {
+		closeErr := f.Close()
+		if err == nil && closeErr != nil {
+			err = fmt.Errorf("failed to close canonical scan results file: %w", closeErr)
+		}
+	}()
+	if writeErr := result.WriteJson(f); writeErr != nil {
+		return fmt.Errorf("failed to persist canonical scan results: %w", writeErr)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR replaces json.Marshal on large posture report structs with json.Encoder, effectively streaming the JSON output directly to the file/HTTP response. This eliminates massive byte array memory spikes (which lead to OOM errors on large clusters) when generating JSON outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * JSON reports are streamed during generation, reducing memory usage for large result sets.
* **Output**
  * Existing JSON output format remains unchanged.
  * Canonical result files are written efficiently without loading the complete report into memory first.
* **Reliability**
  * Errors encountered while writing or closing result files are reported more consistently.
* **Security**
  * Newly created canonical result files use restricted permissions by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->