### PR TITLE
fix(cel): honor an equivalent matchPolicy when scoping a policy to a scanned object

### DIFF
--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -26,10 +26,8 @@ import (
 // rule that fires only on other operations does not match here either. The one
 // selector NOT evaluated is namespaceSelector — its input is the namespace's
 // labels, which the scan cannot guarantee to have — so a policy narrowing with
-// it is refused at load instead (see requireSupported). matchPolicy is
-// genuinely irrelevant offline: Equivalent matching only widens a rule across
-// API conversions, and a scan never converts — the object is matched at the
-// exact group/version it was scanned at.
+// it is refused at load instead (see requireSupported). matchPolicy decides how
+// strictly a rule's apiVersions are read, see matchesAPIVersion.
 func (v *VAP) AppliesTo(obj map[string]any) bool {
 	if v.matchConstraints == nil || len(v.matchConstraints.ResourceRules) == 0 {
 		return true // no scoping info: evaluate (a malformed-policy edge)
@@ -203,8 +201,20 @@ func effectiveMatchPolicy(mr *admissionregistrationv1.MatchResources) admissionr
 }
 
 // matchesAPIVersion reports whether the rule's apiVersions admit the object's
-// version.
-func matchesAPIVersion(allowed []string, version string, _ admissionregistrationv1.MatchPolicyType) bool {
+// version. Exact matchPolicy requires the rule to name it. Equivalent (the API
+// default, which every bundle policy leaves unset) does not: the apiserver
+// converts a request into whichever version the rule names, so naming one
+// version of a group's resource covers every other version it is served at.
+// Offline there is no discovery to say which those are, so the version is
+// dropped from the comparison instead of resolved.
+//
+// The group is not widened with it. Equivalence can cross groups on a cluster,
+// but only its registry knows which pairs, and two same-named resources in
+// unrelated groups are separate storage.
+func matchesAPIVersion(allowed []string, version string, matchPolicy admissionregistrationv1.MatchPolicyType) bool {
+	if matchPolicy != admissionregistrationv1.Exact {
+		return true
+	}
 	return matchesValue(allowed, version)
 }
 

--- a/core/pkg/opaprocessor/cel/scope.go
+++ b/core/pkg/opaprocessor/cel/scope.go
@@ -40,10 +40,11 @@ func (v *VAP) AppliesTo(obj map[string]any) bool {
 	}
 	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
 	target := scopedObject{gvr: gvr, resources: resources, name: name, namespaced: isNamespaced(obj)}
+	matchPolicy := effectiveMatchPolicy(v.matchConstraints)
 
 	included := false
 	for i := range v.matchConstraints.ResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], target) {
+		if resourceRuleMatches(&v.matchConstraints.ResourceRules[i], target, matchPolicy) {
 			included = true
 			break
 		}
@@ -52,7 +53,7 @@ func (v *VAP) AppliesTo(obj map[string]any) bool {
 		return false
 	}
 	for i := range v.matchConstraints.ExcludeResourceRules {
-		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], target) {
+		if resourceRuleMatches(&v.matchConstraints.ExcludeResourceRules[i], target, matchPolicy) {
 			return false
 		}
 	}
@@ -182,13 +183,29 @@ type scopedObject struct {
 	namespaced bool
 }
 
-func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, target scopedObject) bool {
+func resourceRuleMatches(rule *admissionregistrationv1.NamedRuleWithOperations, target scopedObject, matchPolicy admissionregistrationv1.MatchPolicyType) bool {
 	return matchesOperation(rule.Operations) &&
 		matchesScope(rule.Scope, target.namespaced) &&
 		matchesValue(rule.APIGroups, target.gvr.Group) &&
-		matchesValue(rule.APIVersions, target.gvr.Version) &&
+		matchesAPIVersion(rule.APIVersions, target.gvr.Version, matchPolicy) &&
 		matchesResource(rule.Resources, target.resources) &&
 		matchesName(rule.ResourceNames, target.name)
+}
+
+// effectiveMatchPolicy resolves matchConstraints.matchPolicy, which the API
+// defaults to Equivalent when it is unset - as every policy in the bundle
+// leaves it.
+func effectiveMatchPolicy(mr *admissionregistrationv1.MatchResources) admissionregistrationv1.MatchPolicyType {
+	if mr == nil || mr.MatchPolicy == nil {
+		return admissionregistrationv1.Equivalent
+	}
+	return *mr.MatchPolicy
+}
+
+// matchesAPIVersion reports whether the rule's apiVersions admit the object's
+// version.
+func matchesAPIVersion(allowed []string, version string, _ admissionregistrationv1.MatchPolicyType) bool {
+	return matchesValue(allowed, version)
 }
 
 // matchesScope reports whether the rule's scope admits the object. nil and "*"

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -493,3 +493,58 @@ func TestVAPAppliesToKindPluralCandidates(t *testing.T) {
 		})
 	}
 }
+
+// withMatchPolicy returns constraints carrying an explicit matchPolicy, for the
+// cases that must not read the API default.
+func withMatchPolicy(policy admissionregistrationv1.MatchPolicyType, rules ...admissionregistrationv1.NamedRuleWithOperations) *VAP {
+	return &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+		MatchPolicy:   &policy,
+		ResourceRules: rules,
+	}}
+}
+
+// TestVAPAppliesToEquivalentMatchPolicy pins the version half of rule matching.
+// A group serving a resource at several versions returns the same objects at
+// each of them, and the collector keeps whichever one the API server ranks
+// highest (see resourcehandler.preferServedVersion), so requiring the rule to
+// name that exact version dropped the object from a policy admission does apply
+// under the default Equivalent matchPolicy.
+func TestVAPAppliesToEquivalentMatchPolicy(t *testing.T) {
+	sandboxes := rule([]string{"agents.x-k8s.io"}, []string{"v1alpha1"}, []string{"sandboxes"})
+
+	cases := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		want       bool
+	}{
+		{"the version the rule names", "agents.x-k8s.io/v1alpha1", "Sandbox", true},
+		{"a newer version of the same resource", "agents.x-k8s.io/v1beta1", "Sandbox", true},
+		{"another group is still out of scope", "other.io/v1alpha1", "Sandbox", false},
+		{"another resource is still out of scope", "agents.x-k8s.io/v1beta1", "SandboxTemplate", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, vapWithConstraints(sandboxes).AppliesTo(obj(tc.apiVersion, tc.kind)))
+			assert.Equal(t, tc.want, withMatchPolicy(admissionregistrationv1.Equivalent, sandboxes).AppliesTo(obj(tc.apiVersion, tc.kind)),
+				"an explicit Equivalent must read the same as the default")
+		})
+	}
+
+	t.Run("Exact matchPolicy still requires the rule to name the version", func(t *testing.T) {
+		v := withMatchPolicy(admissionregistrationv1.Exact, sandboxes)
+		assert.True(t, v.AppliesTo(obj("agents.x-k8s.io/v1alpha1", "Sandbox")))
+		assert.False(t, v.AppliesTo(obj("agents.x-k8s.io/v1beta1", "Sandbox")))
+	})
+
+	// Exclusions go through the same matcher at admission, so an exclusion
+	// naming one version exempts the resource at every other one too.
+	t.Run("an exclusion naming another version still exempts the object", func(t *testing.T) {
+		v := &VAP{matchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules:        []admissionregistrationv1.NamedRuleWithOperations{rule([]string{"*"}, []string{"*"}, []string{"*"})},
+			ExcludeResourceRules: []admissionregistrationv1.NamedRuleWithOperations{sandboxes},
+		}}
+		assert.False(t, v.AppliesTo(obj("agents.x-k8s.io/v1beta1", "Sandbox")))
+		assert.True(t, v.AppliesTo(obj("agents.x-k8s.io/v1beta1", "SandboxTemplate")))
+	})
+}

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -1,6 +1,7 @@
 package cel
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -547,4 +548,47 @@ func TestVAPAppliesToEquivalentMatchPolicy(t *testing.T) {
 		assert.False(t, v.AppliesTo(obj("agents.x-k8s.io/v1beta1", "Sandbox")))
 		assert.True(t, v.AppliesTo(obj("agents.x-k8s.io/v1beta1", "SandboxTemplate")))
 	})
+}
+
+// siblingVersion is a version no bundle rule names, standing in for the older
+// or newer version of a group a real manifest may still be written at.
+const siblingVersion = "v1beta1"
+
+// TestVAPAppliesToCoversEveryBundleKindAtAnotherVersion is
+// TestVAPAppliesToCoversEveryBundleKind asked at a version the rule does not
+// name. Every bundle policy leaves matchPolicy at its Equivalent default, so
+// admission converts such a request and applies the policy; a `make sync-vap`
+// that lands a policy pinning Exact would fail here rather than at scan time.
+func TestVAPAppliesToCoversEveryBundleKindAtAnotherVersion(t *testing.T) {
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	for name, vap := range catalog.byName {
+		if vap.matchConstraints == nil {
+			continue
+		}
+		for _, rr := range vap.matchConstraints.ResourceRules {
+			if slices.Contains(rr.APIVersions, siblingVersion) || slices.Contains(rr.APIVersions, "*") {
+				continue // the rule names it outright, so it proves nothing here
+			}
+			for _, group := range defaultIfEmpty(rr.APIGroups, "") {
+				if group == "*" {
+					group = ""
+				}
+				apiVersion := siblingVersion
+				if group != "" {
+					apiVersion = group + "/" + siblingVersion
+				}
+				for _, res := range rr.Resources {
+					if res == "*" || strings.Contains(res, "/") {
+						continue
+					}
+					kind, ok := canonicalKinds[res]
+					require.Truef(t, ok, "policy %q constrains resource %q with no canonical Kind in the test", name, res)
+					assert.Truef(t, vap.AppliesTo(obj(apiVersion, kind)),
+						"policy %q constrains %q but appliesTo rejects a %s %s; matchPolicy is Equivalent, so admission would convert and apply it", name, res, apiVersion, kind)
+				}
+			}
+		}
+	}
 }

--- a/core/pkg/opaprocessor/cel/scope_test.go
+++ b/core/pkg/opaprocessor/cel/scope_test.go
@@ -48,7 +48,7 @@ func TestVAPAppliesTo(t *testing.T) {
 		{"cronjob matches batch/cronjobs", "batch/v1", "CronJob", true},
 		{"configmap is out of scope", "v1", "ConfigMap", false},
 		{"deployment in wrong group is out of scope", "v1", "Deployment", false},
-		{"pod in wrong version is out of scope", "v2", "Pod", false},
+		{"pod at another version of its group is in scope", "v2", "Pod", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The offline CEL engine decides whether a bundled ValidatingAdmissionPolicy covers a scanned object in `core/pkg/opaprocessor/cel/scope.go`. `AppliesTo` compares the object's group, version and resource against each rule in `matchConstraints`, and it required the rule to name the object's exact API version. The doc comment justified that by saying matchPolicy is irrelevant offline, because a scan never converts an object.

That is the wrong way round. The conversion happens on the API server side, not ours. `matchResources.matchPolicy` defaults to Equivalent and every policy in the vendored library leaves it unset, so at admission a request is matched by a rule naming any version the resource is served at, converted, and then handed to the policy. Offline we were asking for an exact version match instead, and when the object arrived at a different one the policy was skipped for it. The skip is silent: the resource drops out of that control's results, so the control reads clean.

There are two ways to hit it. A CRD served at more than one version is the obvious one. The collector already collapses the copies a multi version CRD returns and keeps whichever version the API server ranks highest (`resourcehandler.preferServedVersion`), so a policy written against `agents.x-k8s.io/v1alpha1 sandboxes` stopped matching the object as soon as the CRD started serving v1beta1. The other is a file scan, where the manifest carries whatever version its author wrote: a `policy/v1beta1` PodDisruptionBudget or a `batch/v1beta1` CronJob sitting in a repo went unscanned by every CEL control that names the v1 form.

The fix reads `matchConstraints.matchPolicy` and, when it is Equivalent (or unset, which means the same), drops the version from the comparison. Exact keeps the old behavior. Group and resource are compared exactly as before.

The group is deliberately left alone. Equivalence can cross groups on a real cluster, but only the API server's own equivalence registry knows which pairs, and two same named resources in unrelated groups are separate storage, so widening there would evaluate a policy against objects admission never hands it. That case is pinned in `TestVAPAppliesToEquivalentMatchPolicy` and passes both before and after the change on purpose.

The detail most likely to regress is the exclude side. `excludeResourceRules` go through the same matcher, so an exclusion naming one version now exempts the resource at every other version too. That is what admission does, and it is the direction that narrows rather than widens, so it gets its own case in the test.

Commit 1 is plumbing with no behavior change. `TestVAPAppliesToCoversEveryBundleKindAtAnotherVersion` walks the embedded bundle and asserts every constrained kind is still in scope at a version its rule does not name; against the current library that is 413 combinations which used to be dropped, and it turns a future `make sync-vap` landing a policy pinned to Exact into a test failure rather than a quiet loss of coverage.

One existing case in `TestVAPAppliesTo` asserted the old behavior, a Pod at another version of the core group being out of scope. It now asserts the new one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offline match-constraint evaluation now respects the configured `matchPolicy`.
  * The default policy accepts equivalent served API versions when no conversion or cross-group widening is required.
  * Exact matching now requires the scanned resource to use a specifically listed API version.
  * Exclusion rules consistently apply version-matching behavior across equivalent versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->