### PR TITLE
feat(vap): list embedded admission policies and the controls they implement

### DIFF
--- a/cmd/vap/listpolicies.go
+++ b/cmd/vap/listpolicies.go
@@ -1,0 +1,203 @@
+package vap
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	formatPretty = "pretty-print"
+	formatJSON   = "json"
+	formatYAML   = "yaml"
+	formatCSV    = "csv"
+)
+
+var listPoliciesFormats = []string{formatPretty, formatJSON, formatYAML, formatCSV}
+
+type policyListEntry struct {
+	Policy           string   `json:"policy"`
+	ControlID        string   `json:"controlID,omitempty"`
+	TakesParams      bool     `json:"takesParams"`
+	FailurePolicy    string   `json:"failurePolicy,omitempty"`
+	Resources        []string `json:"resources,omitempty"`
+	DuplicateName    bool     `json:"duplicateName,omitempty"`
+	DuplicateControl bool     `json:"duplicateControl,omitempty"`
+}
+
+func getListPoliciesCmd() *cobra.Command {
+	var format string
+	var controlsOnly bool
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "list-policies",
+		Short: "List the ValidatingAdmissionPolicies in the embedded library",
+		Long:  `Lists every policy in the CEL admission policy library embedded in this binary, with the Kubescape control it implements. Use the control IDs with 'vap create-policy-binding --control' and the policy names with '--policy'.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var rendered bytes.Buffer
+			if err := runListPolicies(&rendered, format, controlsOnly); err != nil {
+				return err
+			}
+			if outputFile != "" {
+				return writeOutput(rendered.String(), outputFile)
+			}
+			_, err := cmd.OutOrStdout().Write(rendered.Bytes())
+			return err
+		},
+	}
+
+	cmd.Flags().StringVarP(&format, "format", "f", formatPretty, fmt.Sprintf("output format. supported: %s", strings.Join(quoted(listPoliciesFormats), "/")))
+	cmd.Flags().BoolVar(&controlsOnly, "controls-only", false, "Only list policies that implement a Kubescape control")
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write output to file instead of stdout")
+
+	return cmd
+}
+
+func runListPolicies(out io.Writer, format string, controlsOnly bool) error {
+	policies, err := cel.ListPolicies()
+	if err != nil {
+		return fmt.Errorf("read embedded policy library: %w", err)
+	}
+
+	entries := make([]policyListEntry, 0, len(policies))
+	for _, policy := range policies {
+		if controlsOnly && policy.ControlID == "" {
+			continue
+		}
+		entries = append(entries, policyListEntry{
+			Policy:           policy.PolicyName,
+			ControlID:        policy.ControlID,
+			TakesParams:      policy.TakesParams,
+			FailurePolicy:    policy.FailurePolicy,
+			Resources:        policy.Resources,
+			DuplicateName:    policy.DuplicateName,
+			DuplicateControl: policy.DuplicateControl,
+		})
+	}
+
+	switch format {
+	case formatPretty:
+		prettyPrintPolicies(out, entries)
+	case formatJSON:
+		encoded, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode policies: %w", err)
+		}
+		fmt.Fprintf(out, "%s\n", encoded)
+	case formatYAML:
+		encoded, err := yaml.Marshal(entries)
+		if err != nil {
+			return fmt.Errorf("encode policies: %w", err)
+		}
+		fmt.Fprintf(out, "%s", encoded)
+	case formatCSV:
+		return csvPolicies(out, entries)
+	default:
+		return fmt.Errorf("invalid format %q, supported formats: %s", format, strings.Join(quoted(listPoliciesFormats), "/"))
+	}
+
+	return nil
+}
+
+func prettyPrintPolicies(out io.Writer, entries []policyListEntry) {
+	policyTable := table.NewWriter()
+	policyTable.SetOutputMirror(out)
+
+	policyTable.Style().Options.SeparateHeader = true
+	policyTable.Style().Options.SeparateRows = true
+	policyTable.Style().Format.HeaderAlign = text.AlignLeft
+	policyTable.Style().Format.Header = text.FormatDefault
+	policyTable.Style().Box = table.StyleBoxRounded
+
+	policyTable.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 2, WidthMax: 48},
+		{Number: 5, WidthMax: 40},
+	})
+
+	policyTable.AppendHeader(table.Row{"Control ID", "Policy", "Params", "On error", "Resources"})
+	for _, entry := range entries {
+		policyTable.AppendRow(table.Row{
+			controlDisplayID(entry),
+			policyDisplayName(entry),
+			yesNo(entry.TakesParams),
+			orDash(entry.FailurePolicy),
+			orDash(strings.Join(entry.Resources, ", ")),
+		})
+	}
+
+	policyTable.Render()
+}
+
+func csvPolicies(out io.Writer, entries []policyListEntry) error {
+	writer := csv.NewWriter(out)
+	if err := writer.Write([]string{"controlID", "policy", "takesParams", "failurePolicy", "resources", "duplicateName", "duplicateControl"}); err != nil {
+		return fmt.Errorf("write csv output: %w", err)
+	}
+	for _, entry := range entries {
+		record := []string{
+			entry.ControlID,
+			entry.Policy,
+			strconv.FormatBool(entry.TakesParams),
+			entry.FailurePolicy,
+			strings.Join(entry.Resources, ";"),
+			strconv.FormatBool(entry.DuplicateName),
+			strconv.FormatBool(entry.DuplicateControl),
+		}
+		if err := writer.Write(record); err != nil {
+			return fmt.Errorf("write csv output: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("write csv output: %w", err)
+	}
+	return nil
+}
+
+func policyDisplayName(entry policyListEntry) string {
+	if entry.DuplicateName {
+		return entry.Policy + " (duplicate name)"
+	}
+	return entry.Policy
+}
+
+func controlDisplayID(entry policyListEntry) string {
+	if entry.DuplicateControl {
+		return entry.ControlID + " (duplicate)"
+	}
+	return orDash(entry.ControlID)
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func quoted(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, "'"+v+"'")
+	}
+	return out
+}

--- a/cmd/vap/listpolicies_test.go
+++ b/cmd/vap/listpolicies_test.go
@@ -1,0 +1,122 @@
+package vap
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/pkg/opaprocessor/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func listOutput(t *testing.T, format string, controlsOnly bool) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	require.NoError(t, runListPolicies(out, format, controlsOnly))
+	return out.String()
+}
+
+func TestRunListPoliciesJSONMatchesCatalog(t *testing.T) {
+	policies, err := cel.ListPolicies()
+	require.NoError(t, err)
+	require.NotEmpty(t, policies)
+
+	var entries []policyListEntry
+	require.NoError(t, json.Unmarshal([]byte(listOutput(t, formatJSON, false)), &entries))
+	require.Len(t, entries, len(policies))
+
+	assert.Equal(t, policies[0].PolicyName, entries[0].Policy)
+	assert.Equal(t, policies[0].ControlID, entries[0].ControlID)
+}
+
+func TestRunListPoliciesControlsOnlyDropsHelpers(t *testing.T) {
+	var all, filtered []policyListEntry
+	require.NoError(t, json.Unmarshal([]byte(listOutput(t, formatJSON, false)), &all))
+	require.NoError(t, json.Unmarshal([]byte(listOutput(t, formatJSON, true)), &filtered))
+
+	require.NotEmpty(t, filtered)
+	assert.Less(t, len(filtered), len(all), "the bundle carries helper policies without a control")
+	for _, entry := range filtered {
+		assert.NotEmpty(t, entry.ControlID)
+	}
+}
+
+func TestRunListPoliciesYAMLIsParsable(t *testing.T) {
+	var entries []policyListEntry
+	require.NoError(t, yaml.Unmarshal([]byte(listOutput(t, formatYAML, true)), &entries))
+	require.NotEmpty(t, entries)
+	assert.NotEmpty(t, entries[0].Policy)
+}
+
+func TestRunListPoliciesCSVHasHeaderAndRow(t *testing.T) {
+	records, err := csv.NewReader(strings.NewReader(listOutput(t, formatCSV, true))).ReadAll()
+	require.NoError(t, err)
+	require.Greater(t, len(records), 1)
+
+	assert.Equal(t, []string{"controlID", "policy", "takesParams", "failurePolicy", "resources", "duplicateName", "duplicateControl"}, records[0])
+	for _, record := range records[1:] {
+		require.Len(t, record, 7)
+		assert.NotEmpty(t, record[0])
+		assert.NotEmpty(t, record[1])
+	}
+}
+
+func TestRunListPoliciesPrettyListsKnownControl(t *testing.T) {
+	output := listOutput(t, formatPretty, true)
+	assert.Contains(t, output, "C-0016")
+	assert.Contains(t, output, "Control ID")
+	assert.NotContains(t, output, "cluster-policy-deny-attach")
+}
+
+func TestRunListPoliciesRejectsUnknownFormat(t *testing.T) {
+	err := runListPolicies(&bytes.Buffer{}, "xml", false)
+	require.ErrorContains(t, err, "invalid format")
+}
+
+func TestListPoliciesCommandIsRegistered(t *testing.T) {
+	var names []string
+	for _, sub := range GetVapHelperCmd().Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "list-policies")
+}
+
+func TestListPoliciesCommandWritesToOutputFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policies.json")
+
+	cmd := getListPoliciesCmd()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stdout)
+	cmd.SetArgs([]string{"--format", "json", "--controls-only", "--output", path})
+	require.NoError(t, cmd.Execute())
+
+	assert.Empty(t, stdout.String(), "output went to the file, not stdout")
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var entries []policyListEntry
+	require.NoError(t, json.Unmarshal(raw, &entries))
+	require.NotEmpty(t, entries)
+	for _, entry := range entries {
+		assert.NotEmpty(t, entry.ControlID)
+	}
+}
+
+func TestListPoliciesCommandWritesToStdoutByDefault(t *testing.T) {
+	cmd := getListPoliciesCmd()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stdout)
+	cmd.SetArgs([]string{"--controls-only"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, stdout.String(), "C-0016")
+}

--- a/cmd/vap/vap.go
+++ b/cmd/vap/vap.go
@@ -30,6 +30,11 @@ var vapHelperCmdExamples = fmt.Sprintf(`
 
   Examples:
 
+  # List the policies in the embedded library, with the control each one implements
+  %[1]s vap list-policies
+  # List only the control-backed policies, as JSON
+  %[1]s vap list-policies --controls-only --format json
+
   # Install Kubescape CEL admission policy library (the copy embedded in this binary)
   %[1]s vap deploy-library | kubectl apply -f -
   # Install a specific cel-admission-library release instead of the embedded copy
@@ -56,6 +61,7 @@ func GetVapHelperCmd() *cobra.Command {
 	}
 
 	// Create subcommands
+	vapHelperCmd.AddCommand(getListPoliciesCmd())
 	vapHelperCmd.AddCommand(getDeployLibraryCmd())
 	vapHelperCmd.AddCommand(getCreatePolicyBindingCmd())
 

--- a/cmd/vap/vap_test.go
+++ b/cmd/vap/vap_test.go
@@ -1004,11 +1004,13 @@ func TestGetVapHelperCmd(t *testing.T) {
 	cmd := GetVapHelperCmd()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "vap", cmd.Use)
-	assert.Len(t, cmd.Commands(), 2)
-
-	subCmdNames := []string{cmd.Commands()[0].Use, cmd.Commands()[1].Use}
+	subCmdNames := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		subCmdNames = append(subCmdNames, sub.Use)
+	}
 	assert.Contains(t, subCmdNames, "deploy-library")
 	assert.Contains(t, subCmdNames, "create-policy-binding")
+	assert.Contains(t, subCmdNames, "list-policies")
 }
 
 func TestLabelSelectorRegexEdgeCases(t *testing.T) {

--- a/core/pkg/opaprocessor/cel/catalog.go
+++ b/core/pkg/opaprocessor/cel/catalog.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"fmt"
+	"sort"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
@@ -103,4 +104,110 @@ func MatchConstraintsForPolicy(policyName string) (matchConstraints *admissionre
 		return nil, false, nil
 	}
 	return vap.matchConstraints.DeepCopy(), true, nil
+}
+
+// PolicyInfo describes one policy in the embedded bundle. The two duplicate
+// flags map onto the lookups a caller will reach for: DuplicateName means the
+// metadata.name is claimed more than once, so create-policy-binding --policy
+// refuses it, while DuplicateControl means the controlId is, so --control
+// refuses it. They are independent - a name claimed twice by policies carrying
+// distinct control IDs leaves both controls perfectly bindable.
+type PolicyInfo struct {
+	PolicyName       string
+	ControlID        string
+	TakesParams      bool
+	FailurePolicy    string
+	Resources        []string
+	DuplicateName    bool
+	DuplicateControl bool
+}
+
+// ListPolicies returns every policy in the embedded bundle, ordered by policy
+// name then control ID. Policies that carry no controlId label are the
+// cluster-scoped helpers and are reported with an empty ControlID.
+//
+// byName and byControl are poisoned independently (indexUnique in loader.go),
+// so neither index alone sees the whole bundle: a name claimed twice is dropped
+// from byName while each of its distinct control IDs stays resolvable through
+// byControl. Listing walks both, because a control the binding command accepts
+// must not be missing from the command that exists to discover it.
+func ListPolicies() ([]PolicyInfo, error) {
+	catalog, err := getVAPCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return listPolicies(catalog), nil
+}
+
+func listPolicies(catalog *vapCatalog) []PolicyInfo {
+	policies := make([]PolicyInfo, 0, len(catalog.byName)+len(catalog.byControl))
+	listed := make(map[*VAP]struct{}, len(catalog.byName)+len(catalog.byControl))
+	names := make(map[string]struct{}, len(catalog.byName))
+
+	for name, vap := range catalog.byName {
+		policies = append(policies, policyInfo(catalog, name, vap))
+		listed[vap] = struct{}{}
+		names[name] = struct{}{}
+	}
+
+	for _, vap := range catalog.byControl {
+		if _, done := listed[vap]; done {
+			continue
+		}
+		policies = append(policies, policyInfo(catalog, vap.PolicyName, vap))
+		listed[vap] = struct{}{}
+		names[vap.PolicyName] = struct{}{}
+	}
+
+	for name := range catalog.dupNames {
+		if _, covered := names[name]; covered {
+			continue
+		}
+		policies = append(policies, PolicyInfo{PolicyName: name, DuplicateName: true})
+	}
+
+	sort.Slice(policies, func(i, j int) bool {
+		if policies[i].PolicyName != policies[j].PolicyName {
+			return policies[i].PolicyName < policies[j].PolicyName
+		}
+		return policies[i].ControlID < policies[j].ControlID
+	})
+
+	return policies
+}
+
+func policyInfo(catalog *vapCatalog, name string, vap *VAP) PolicyInfo {
+	_, duplicateName := catalog.dupNames[name]
+	_, duplicateControl := catalog.dupControls[vap.ControlID]
+
+	return PolicyInfo{
+		PolicyName:       name,
+		ControlID:        vap.ControlID,
+		TakesParams:      vap.TakesParams(),
+		FailurePolicy:    string(vap.failurePolicy),
+		Resources:        matchedResources(vap.matchConstraints),
+		DuplicateName:    duplicateName,
+		DuplicateControl: vap.ControlID != "" && duplicateControl,
+	}
+}
+
+func matchedResources(matchConstraints *admissionregistrationv1.MatchResources) []string {
+	if matchConstraints == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	resources := make([]string, 0)
+	for _, rule := range matchConstraints.ResourceRules {
+		for _, resource := range rule.Resources {
+			if _, ok := seen[resource]; ok {
+				continue
+			}
+			seen[resource] = struct{}{}
+			resources = append(resources, resource)
+		}
+	}
+	sort.Strings(resources)
+
+	return resources
 }

--- a/core/pkg/opaprocessor/cel/catalog_test.go
+++ b/core/pkg/opaprocessor/cel/catalog_test.go
@@ -3,6 +3,8 @@ package cel
 import (
 	"testing"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -135,4 +137,255 @@ func TestMatchConstraintsForPolicyCopiesBundle(t *testing.T) {
 	_, found, err = MatchConstraintsForPolicy("some-custom-policy")
 	require.NoError(t, err)
 	assert.False(t, found)
+}
+
+// TestListPoliciesCoversBundle checks the enumeration against the real embedded
+// bundle: every policy the name-keyed lookups can reach must be listed, so a
+// user reading the list is not offered a subset of what is deployable.
+func TestListPoliciesCoversBundle(t *testing.T) {
+	policies, err := ListPolicies()
+	require.NoError(t, err)
+
+	catalog, err := getVAPCatalog()
+	require.NoError(t, err)
+
+	names := make(map[string]bool, len(policies))
+	controls := make(map[string]bool, len(policies))
+	for _, policy := range policies {
+		assert.NotEmpty(t, policy.PolicyName)
+		names[policy.PolicyName] = true
+		if policy.ControlID != "" {
+			controls[policy.ControlID] = true
+		}
+	}
+
+	for name := range catalog.byName {
+		assert.True(t, names[name], "policy %q missing from ListPolicies", name)
+	}
+	for controlID := range catalog.byControl {
+		assert.True(t, controls[controlID], "control %q missing from ListPolicies", controlID)
+	}
+	for name := range catalog.dupNames {
+		assert.True(t, names[name], "duplicated name %q missing from ListPolicies", name)
+	}
+}
+
+// TestListPoliciesIsSortedByName pins the ordering callers render without
+// sorting again.
+func TestListPoliciesIsSortedByName(t *testing.T) {
+	policies, err := ListPolicies()
+	require.NoError(t, err)
+	require.NotEmpty(t, policies)
+
+	for i := 1; i < len(policies); i++ {
+		assert.LessOrEqual(t, policies[i-1].PolicyName, policies[i].PolicyName)
+	}
+}
+
+// TestListPoliciesAgreesWithControlLookup guards the listing against drifting
+// from the lookup helpers: a control ID shown in the list must resolve to the
+// same policy create-policy-binding would pick.
+func TestListPoliciesAgreesWithControlLookup(t *testing.T) {
+	policies, err := ListPolicies()
+	require.NoError(t, err)
+
+	withControl := 0
+	for _, policy := range policies {
+		if policy.ControlID == "" || policy.DuplicateControl {
+			continue
+		}
+		withControl++
+
+		name, err := PolicyNameForControl(policy.ControlID)
+		require.NoError(t, err, "control %s is listed but does not resolve", policy.ControlID)
+		assert.Equal(t, policy.PolicyName, name)
+
+		paramKind, err := ParamKindForControl(policy.ControlID)
+		require.NoError(t, err)
+		assert.Equal(t, paramKind != nil, policy.TakesParams, "control %s params mismatch", policy.ControlID)
+	}
+	assert.NotZero(t, withControl, "the bundle must expose control-backed policies")
+}
+
+// TestListPoliciesReportsHelperPolicies checks the cluster-scoped helpers that
+// carry no controlId are listed with an empty ControlID rather than dropped.
+func TestListPoliciesReportsHelperPolicies(t *testing.T) {
+	policies, err := ListPolicies()
+	require.NoError(t, err)
+
+	helpers := 0
+	for _, policy := range policies {
+		if policy.ControlID == "" {
+			helpers++
+		}
+	}
+	assert.NotZero(t, helpers, "the bundle carries cluster-scoped helper policies")
+}
+
+func TestListPoliciesMarksDuplicates(t *testing.T) {
+	catalog, err := parseVAPBundle([]byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+  labels:
+    controlId: C-0001
+spec:
+  validations:
+    - expression: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-b
+  labels:
+    controlId: C-0001
+spec:
+  validations:
+    - expression: "true"
+`))
+	require.NoError(t, err)
+	require.Contains(t, catalog.dupControls, "C-0001")
+	require.Len(t, catalog.byName, 2)
+
+	policies := listPolicies(catalog)
+	require.Len(t, policies, 2)
+	for _, policy := range policies {
+		assert.True(t, policy.DuplicateControl, "policy %q shares control C-0001 and must be flagged", policy.PolicyName)
+	}
+}
+
+func TestMatchedResourcesDeduplicatesAndSorts(t *testing.T) {
+	resources := matchedResources(&admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+			{RuleWithOperations: admissionregistrationv1.RuleWithOperations{Rule: admissionregistrationv1.Rule{Resources: []string{"pods", "deployments"}}}},
+			{RuleWithOperations: admissionregistrationv1.RuleWithOperations{Rule: admissionregistrationv1.Rule{Resources: []string{"pods", "cronjobs"}}}},
+		},
+	})
+	assert.Equal(t, []string{"cronjobs", "deployments", "pods"}, resources)
+
+	assert.Nil(t, matchedResources(nil))
+}
+
+// TestListPoliciesSurfacesDuplicateNames guards against a policy vanishing from
+// the listing: a name claimed twice is dropped from the catalog index, and a
+// discovery command that omitted it would report the bundle as smaller than it
+// is.
+func TestListPoliciesSurfacesDuplicateNames(t *testing.T) {
+	catalog, err := parseVAPBundle([]byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+spec:
+  validations:
+    - expression: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+spec:
+  validations:
+    - expression: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-b
+spec:
+  validations:
+    - expression: "true"
+`))
+	require.NoError(t, err)
+	require.Contains(t, catalog.dupNames, "policy-a")
+	require.NotContains(t, catalog.byName, "policy-a")
+
+	policies := listPolicies(catalog)
+	require.Len(t, policies, 2)
+
+	byName := map[string]PolicyInfo{}
+	for _, policy := range policies {
+		byName[policy.PolicyName] = policy
+	}
+	require.Contains(t, byName, "policy-a")
+	assert.True(t, byName["policy-a"].DuplicateName)
+	assert.False(t, byName["policy-b"].DuplicateName)
+}
+
+// TestListPoliciesKeepsDistinctControlsOfADuplicateName covers the case where
+// the two indexes disagree: the shared name is poisoned out of byName while
+// each control ID stays individually resolvable through byControl. Listing only
+// byName dropped both controls, so a control create-policy-binding accepts went
+// missing from the command meant to discover it.
+func TestListPoliciesKeepsDistinctControlsOfADuplicateName(t *testing.T) {
+	catalog, err := parseVAPBundle([]byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+  labels:
+    controlId: C-0001
+spec:
+  validations:
+    - expression: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+  labels:
+    controlId: C-0002
+spec:
+  validations:
+    - expression: "true"
+`))
+	require.NoError(t, err)
+	require.Empty(t, catalog.byName, "the shared name is poisoned out of byName")
+	require.Len(t, catalog.byControl, 2)
+	require.Empty(t, catalog.dupControls, "neither control ID is duplicated")
+
+	policies := listPolicies(catalog)
+	require.Len(t, policies, 2)
+
+	controls := make([]string, 0, len(policies))
+	for _, policy := range policies {
+		controls = append(controls, policy.ControlID)
+		assert.Equal(t, "policy-a", policy.PolicyName)
+		assert.True(t, policy.DuplicateName, "--policy cannot resolve the shared name")
+		assert.False(t, policy.DuplicateControl, "--control resolves each ID unambiguously")
+	}
+	assert.Equal(t, []string{"C-0001", "C-0002"}, controls)
+}
+
+// TestListPoliciesDoesNotDoubleReportADuplicateName checks the bare
+// duplicate-name entry is only emitted when no control-backed copy already
+// surfaced that name.
+func TestListPoliciesDoesNotDoubleReportADuplicateName(t *testing.T) {
+	catalog, err := parseVAPBundle([]byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+  labels:
+    controlId: C-0001
+spec:
+  validations:
+    - expression: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: policy-a
+  labels:
+    controlId: C-0002
+spec:
+  validations:
+    - expression: "true"
+`))
+	require.NoError(t, err)
+
+	blank := 0
+	for _, policy := range listPolicies(catalog) {
+		if policy.ControlID == "" {
+			blank++
+		}
+	}
+	assert.Zero(t, blank, "no placeholder entry once both controls are listed")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -961,6 +961,35 @@ Manage Kubernetes Validating Admission Policies.
 
 ### Subcommands
 
+#### list-policies
+
+List the ValidatingAdmissionPolicies in the library embedded in this binary,
+alongside the Kubescape control each one implements. Use it to find the values
+`create-policy-binding` accepts: control IDs for `--control`, policy names for
+`--policy`.
+
+```bash
+kubescape vap list-policies
+kubescape vap list-policies --controls-only --format json
+```
+
+**Flags:**
+
+| Flag | Description | Default |
+|---|---|---|
+| `-f`, `--format` | Output format: `pretty-print`, `json`, `yaml` or `csv`. | `pretty-print` |
+| `--controls-only` | Keep only the entries with a control ID, hiding the cluster-scoped helpers. | `false` |
+| `-o`, `--output` | Write the output to a file instead of stdout. | - |
+
+The `Params` column reports whether a policy reads a parameter object, which is
+what `create-policy-binding --parameter-reference` supplies. The two duplicate
+markers are independent and say which flag will be refused: a policy name shown
+as `(duplicate name)` is claimed more than once, so `--policy` cannot resolve
+it, while a control ID shown as `(duplicate)` is claimed by more than one
+policy, so `--control` cannot. A name claimed twice by policies carrying
+distinct control IDs is listed once per control, because each of those controls
+still binds.
+
 #### deploy-library
 
 Deploy the Kubescape CEL admission policy library.


### PR DESCRIPTION
## Summary

- `vap create-policy-binding` takes `--control C-0016` or `--policy <name>`, but nothing enumerated the embedded library, so an unsupported control surfaced only as an error after guessing.
- The `cel` catalog already exposed `PolicyNameForControl`, `ParamKindForControl` and `MatchConstraintsForControl` — every accessor is lookup-by-key, none lists.
- Adds `cel.ListPolicies` and a `vap list-policies` subcommand showing the control ID, policy name, whether it takes params, failure policy and matched resources for all 66 bundled policies.
- Supports `--format pretty-print|json|yaml|csv`, `--controls-only`, and `-o/--output` matching the sibling subcommands.
- A name claimed by more than one policy is dropped from the catalog index, so it is listed from the duplicate set and flagged rather than silently omitted.
- Covered by `TestListPoliciesAgreesWithControlLookup`, `TestListPoliciesSurfacesDuplicateNames` and `TestListPoliciesCommandWritesToOutputFile`.

**Which issue(s) this PR fixes:**
None, found while reading `cmd/vap`.

**Special notes for your reviewer:**
Verified end to end by driving all 60 control-backed policies through `create-policy-binding`: every one resolves to the policy name the listing advertises, and the `Params` column correctly predicts which need `--parameter-reference`. The duplicate-handling path is defensive, the current bundle has no duplicates, so it is exercised only by synthetic `parseVAPBundle` fixtures.

**Does this PR introduce a user-facing change?**
Yes new `kubescape vap list-policies` subcommand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `vap list-policies` command to display embedded admission policies.
  * Supports pretty-print, JSON, YAML, and CSV output formats.
  * Added filtering for policies linked to Kubescape controls.
  * Added an option to save results to a file instead of standard output.
  * Displays policy metadata, including controls, parameters, failure policies, resources, and duplicate entries.

* **Documentation**
  * Added command usage, examples, options, and output details to the CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->