### PR TITLE
feat(printer): include evidence paths in GitHub Actions annotation messages

### DIFF
--- a/core/pkg/resultshandling/printer/v2/githubactionsprinter.go
+++ b/core/pkg/resultshandling/printer/v2/githubactionsprinter.go
@@ -189,6 +189,13 @@ func (gp *GitHubActionsPrinter) collectAnnotations(ctx context.Context, opaSessi
 			}
 
 			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
+			msg := fmt.Sprintf("%s severity finding on %s. Remediation: %s",
+				apis.ControlSeverityToString(ctl.GetScoreFactor()), resource.resourceID, cautils.GetControlLink(ctl.GetID()))
+			if res, ok := opaSessionObj.AllResources[resource.resourceID]; ok {
+				if paths := AssistedRemediationPathsWithCurrentValuesFiltered(&ac, res, false); len(paths) > 0 {
+					msg += "\nFailed paths:\n" + strings.Join(paths, "\n")
+				}
+			}
 			annotations = append(annotations, ghAnnotation{
 				severityRank: severityRank,
 				severity:     apis.ControlSeverityToString(ctl.GetScoreFactor()),
@@ -197,8 +204,7 @@ func (gp *GitHubActionsPrinter) collectAnnotations(ctx context.Context, opaSessi
 				file:         resource.relPath,
 				line:         location.Line,
 				title:        fmt.Sprintf("%s %s", ctl.GetID(), ctl.GetName()),
-				message: fmt.Sprintf("%s severity finding on %s. Remediation: %s",
-					apis.ControlSeverityToString(ctl.GetScoreFactor()), resource.resourceID, cautils.GetControlLink(ctl.GetID())),
+				message:      msg,
 			})
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/githubactionsprinter_test.go
@@ -149,10 +149,11 @@ func TestGitHubActionsPrinter_GoldenAnnotation(t *testing.T) {
 
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	require.NotEmpty(t, lines)
+	wantMsg := fmt.Sprintf("High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057%%0AFailed paths:%%0Aspec.template.spec.containers[0].securityContext.privileged=false")
 	assert.Equal(t,
-		fmt.Sprintf("::error file=deploy.yaml,line=%d,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057",
-			privilegedLine),
-		lines[0], "the first line must be the exact workflow command")
+		fmt.Sprintf("::error file=deploy.yaml,line=%d,title=C-0057 Privileged container::%s",
+			privilegedLine, wantMsg),
+		lines[0], "the first line must be the exact workflow command with evidence paths")
 	assert.Contains(t, output, "1 of 1 High/Critical finding(s) annotated")
 }
 
@@ -307,4 +308,47 @@ func TestEscapeAnnotationProperty(t *testing.T) {
 	assert.Equal(t, "100%25 done", escapeAnnotationProperty("100% done"))
 	assert.Equal(t, "a%2Cb%3Ac", escapeAnnotationProperty("a,b:c"))
 	assert.Equal(t, "nl%0Aend", escapeAnnotationProperty("nl\nend"))
+}
+
+// TestGitHubActionsPrinter_EvidencePathsInMessage verifies that when a
+// resource has assisted-remediation paths, they are appended to the annotation
+// message so developers see the failing field directly in the PR annotation.
+func TestGitHubActionsPrinter_EvidencePathsInMessage(t *testing.T) {
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(t.TempDir()))
+
+	session := ghSessionFixture(t, "C-0057", 8.0)
+	output := ghOutputFor(t, session)
+
+	// The fix path from the fixture is spec.template.spec.containers[0].securityContext.privileged=false.
+	// After workflow-command escaping, newlines become %0A.
+	assert.Contains(t, output, "Failed paths:%0Aspec.template.spec.containers[0].securityContext.privileged=false",
+		"annotation message must include assisted-remediation paths so the failing field is visible in the PR")
+}
+
+// TestGitHubActionsPrinter_NoEvidencePathsWhenNone verifies that when a
+// control has no fix/delete/review paths, the annotation message does not
+// contain a stray "Failed paths:" header.
+func TestGitHubActionsPrinter_NoEvidencePathsWhenNone(t *testing.T) {
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(t.TempDir()))
+
+	session := ghSessionFixture(t, "C-0057", 8.0)
+	// Remove all paths from the control so AssistedRemediationPathsWithCurrentValues returns empty.
+	resourceID := "apps/v1/Deployment/default/demo"
+	result := session.ResourcesResult[resourceID]
+	for i := range result.AssociatedControls {
+		for j := range result.AssociatedControls[i].ResourceAssociatedRules {
+			result.AssociatedControls[i].ResourceAssociatedRules[j].Paths = nil
+		}
+	}
+	session.ResourcesResult[resourceID] = result
+
+	output := ghOutputFor(t, session)
+	assert.NotContains(t, output, "Failed paths:",
+		"annotation message must not contain a paths header when there are no evidence paths")
 }


### PR DESCRIPTION
## Overview

the github-actions printer (#3637) emits workflow commands that GitHub renders as inline PR annotations. the annotation message currently shows only severity, resource ID, and a remediation link. developers then have to run a separate scan or open the full report to find which field actually failed.

this extends the message to include the assisted-remediation paths with current field values -- the same paths already surfaced by the HTML, SARIF, and GitLab SAST printers -- so the failing field is visible directly in the PR annotation.

before:

::error file=deploy.yaml,line=13,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057


after:

::error file=deploy.yaml,line=13,title=C-0057 Privileged container::High severity finding on apps/v1/Deployment/default/demo. Remediation: https://hub.armosec.io/docs/c-0057%0AFailed paths:%0Aspec.template.spec.containers[0].securityContext.privileged=true (current: true)


## changes

- `githubactionsprinter.go`: look up the resource in `AllResources` and call `AssistedRemediationPathsWithCurrentValues` -- same helper used by GitLab SAST (#3182) and SARIF -- appending paths to the message when present
- `githubactionsprinter_test.go`: update golden annotation test to include paths; add `TestGitHubActionsPrinter_EvidencePathsInMessage` and `TestGitHubActionsPrinter_NoEvidencePathsWhenNone`

## how to test

go test ./core/pkg/resultshandling/printer/v2/ -run TestGitHubActions -v


## checklist

- [x] my code follows the style guidelines of this project
- [x] i have performed a self-review of my code
- [x] i have added thorough tests
- [x] new and existing unit tests pass locally with my changes

## related

follows up on #3637 (github-actions printer) and is consistent with #3182 (gitlab-sast evidence paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub Actions annotations now include assisted-remediation evidence paths when available.
  * Annotations omit the “Failed paths” section when no evidence paths exist.
  * Updated annotation output to accurately display remediation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->