### PR TITLE
fix(exposure): model spec.externalIPs, flag unconfirmed cross-namespace backendRef as unclear

### DIFF
--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -30,7 +30,7 @@ var gatewayGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io",
 func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 	tool := mcp.NewTool(
 		"analyze_service_exposure",
-		mcp.WithDescription("Determine whether a Service (or every Service in a namespace, if service_name is omitted) is reachable from outside the cluster, and by what mechanism: the Service itself being type LoadBalancer or NodePort, a networking.k8s.io/v1 Ingress naming it as a backend, or a Gateway API HTTPRoute naming it as a backend through an attached Gateway. Existence of an exposing object is treated as intent to expose -- this does not verify an Ingress controller or Gateway implementation is actually running."),
+		mcp.WithDescription("Determine whether a Service (or every Service in a namespace, if service_name is omitted) is reachable from outside the cluster, and by what mechanism: the Service itself being type LoadBalancer or NodePort, spec.externalIPs being set, a networking.k8s.io/v1 Ingress naming it as a backend, or a Gateway API HTTPRoute naming it as a backend through an attached Gateway. Existence of an exposing object is treated as intent to expose -- this does not verify an Ingress controller or Gateway implementation is actually running. Each Service's result carries an 'unclear' note when a cross-namespace HTTPRoute backendRef (ReferenceGrant-authorized cross-namespace references are not modeled) names it, since in that case an empty paths list is not a confirmed all-clear."),
 		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace to analyze")),
 		mcp.WithString("service_name", mcp.Description("Name of a specific Service to check (optional; omit to report on every Service in the namespace)")),
 	)
@@ -85,8 +85,19 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		// The Gateway API CRDs may not be installed on this cluster at all;
 		// that is not a tool error, just an empty set of routes/gateways --
 		// every service simply reports no ExposureHTTPRoute paths.
+		//
+		// HTTPRoutes are listed cluster-wide, not scoped to namespace, same as
+		// Gateways below: a Service is exposed via any HTTPRoute naming it as
+		// a backend, including one that lives in another namespace and
+		// reaches in via a ReferenceGrant this package doesn't evaluate.
+		// Index.ServiceExposure still only builds an actual ExposurePath from
+		// a route in the Service's own namespace (that part is unaffected),
+		// but it uses this wider collection to report unclear=true when a
+		// cross-namespace backendRef exists that it cannot confirm one way or
+		// the other -- collecting only the queried namespace would make that
+		// signal silently unreachable.
 		gatewayResources := map[string]workloadinterface.IMetadata{}
-		routeList, routeErr := dynClient.Resource(httpRouteGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		routeList, routeErr := dynClient.Resource(httpRouteGVR).List(ctx, metav1.ListOptions{})
 		if routeErr != nil && !isMissingAPIErr(routeErr) {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to list HTTPRoute objects: %v", routeErr)), nil
 		}
@@ -129,8 +140,12 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 
 		findings := make(map[string]any, len(targets))
 		for _, name := range targets {
-			paths := idx.ServiceExposure(exposure.ServiceRef{Namespace: namespace, Name: name})
-			findings[name] = buildExposurePathSummaries(paths)
+			paths, unclear := idx.ServiceExposure(exposure.ServiceRef{Namespace: namespace, Name: name})
+			finding := map[string]any{"paths": buildExposurePathSummaries(paths)}
+			if unclear {
+				finding["unclear"] = "a cross-namespace Gateway API HTTPRoute backendRef references this Service; whether it is authorized by a ReferenceGrant is not modeled, so an empty paths here is not a confirmed all-clear"
+			}
+			findings[name] = finding
 		}
 
 		result := map[string]any{

--- a/cmd/mcpserver/service_exposure_test.go
+++ b/cmd/mcpserver/service_exposure_test.go
@@ -49,6 +49,25 @@ func newServiceExposureTestServer(t *testing.T, objects ...runtime.Object) *Kube
 	return ksServer
 }
 
+// findingPaths extracts the "paths" list from one service's finding in the
+// analyze_service_exposure result -- each finding is {"paths": [...],
+// "unclear": "..."} with "unclear" present only when set.
+func findingPaths(t *testing.T, services map[string]any, name string) []any {
+	t.Helper()
+	finding, ok := services[name].(map[string]any)
+	require.True(t, ok, "finding for %q must be an object", name)
+	paths, _ := finding["paths"].([]any)
+	return paths
+}
+
+func findingIsUnclear(t *testing.T, services map[string]any, name string) bool {
+	t.Helper()
+	finding, ok := services[name].(map[string]any)
+	require.True(t, ok, "finding for %q must be an object", name)
+	_, unclear := finding["unclear"]
+	return unclear
+}
+
 func unstructuredService(namespace, name, serviceType string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
@@ -82,7 +101,7 @@ func TestAnalyzeServiceExposure_LoadBalancerServiceIsExposed(t *testing.T) {
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
-	paths := services["app"].([]any)
+	paths := findingPaths(t, services, "app")
 	require.Len(t, paths, 1)
 	require.Equal(t, "LoadBalancer", paths[0].(map[string]any)["kind"])
 }
@@ -100,7 +119,8 @@ func TestAnalyzeServiceExposure_ClusterIPWithNoIngressIsNotExposed(t *testing.T)
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
-	require.Empty(t, services["app"])
+	require.Empty(t, findingPaths(t, services, "app"))
+	require.False(t, findingIsUnclear(t, services, "app"))
 }
 
 func TestAnalyzeServiceExposure_IngressExposesClusterIPService(t *testing.T) {
@@ -117,7 +137,7 @@ func TestAnalyzeServiceExposure_IngressExposesClusterIPService(t *testing.T) {
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
-	paths := services["app"].([]any)
+	paths := findingPaths(t, services, "app")
 	require.Len(t, paths, 1)
 	entry := paths[0].(map[string]any)
 	require.Equal(t, "Ingress", entry["kind"])
@@ -138,8 +158,8 @@ func TestAnalyzeServiceExposure_OmittedServiceNameReportsEveryServiceInNamespace
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
 	require.Len(t, services, 2)
-	require.Empty(t, services["app-one"])
-	require.Len(t, services["app-two"].([]any), 1)
+	require.Empty(t, findingPaths(t, services, "app-one"))
+	require.Len(t, findingPaths(t, services, "app-two"), 1)
 }
 
 func TestAnalyzeServiceExposure_MissingNamespaceReturnsError(t *testing.T) {
@@ -230,7 +250,7 @@ func TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService(t *testing
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
-	paths := services["app"].([]any)
+	paths := findingPaths(t, services, "app")
 	require.Len(t, paths, 1)
 	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
 }
@@ -281,7 +301,87 @@ func TestAnalyzeServiceExposure_CrossNamespaceGatewayWithAllowedRoutesFromAllExp
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
-	paths := services["app"].([]any)
+	paths := findingPaths(t, services, "app")
 	require.Len(t, paths, 1, "the cross-namespace Gateway in infra must be found even though the query is scoped to prod")
 	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
+}
+
+func unstructuredServiceWithExternalIPs(namespace, name, serviceType string, externalIPs ...string) *unstructured.Unstructured {
+	ips := make([]any, len(externalIPs))
+	for i, ip := range externalIPs {
+		ips[i] = ip
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"type": serviceType, "externalIPs": ips},
+	}}
+}
+
+// TestAnalyzeServiceExposure_ExternalIPsExposesClusterIPService covers
+// CVE-2020-8554: kube-proxy programs spec.externalIPs on every node
+// regardless of spec.type, so a ClusterIP Service with externalIPs set is
+// reachable from outside the cluster the same as a NodePort Service.
+func TestAnalyzeServiceExposure_ExternalIPsExposesClusterIPService(t *testing.T) {
+	svc := unstructuredServiceWithExternalIPs("prod", "app", "ClusterIP", "203.0.113.10")
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := findingPaths(t, services, "app")
+	require.Len(t, paths, 1)
+	require.Equal(t, "ExternalIP", paths[0].(map[string]any)["kind"])
+}
+
+// TestAnalyzeServiceExposure_CrossNamespaceBackendRefIsFlaggedUnclear
+// exercises the real, working topology matthyx flagged as a non-blocking
+// follow-up on #3648: an HTTPRoute living outside the queried namespace can
+// name a Service as a backend via an explicit backendRef.namespace,
+// authorized by a ReferenceGrant this package doesn't evaluate. That must
+// not silently collapse into a confirmed "not exposed" -- the finding must
+// carry an explicit unclear note.
+func TestAnalyzeServiceExposure_CrossNamespaceBackendRefIsFlaggedUnclear(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": "route", "namespace": "edge"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app", "namespace": "prod"}}}},
+		},
+	}}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "edge"},
+		"spec":       map[string]any{"listeners": []any{map[string]any{"name": "http"}}},
+	}}
+	ksServer := newServiceExposureTestServer(t, svc, route)
+
+	// See TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService for
+	// why the Gateway is added via an explicit Create against the real GVR.
+	dyn := ksServer.k8sClient.DynamicClient
+	_, err := dyn.Resource(gatewayGVR).Namespace("edge").Create(context.Background(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	require.Empty(t, findingPaths(t, services, "app"), "this package does not confirm cross-namespace backendRefs into a path")
+	require.True(t, findingIsUnclear(t, services, "app"), "an empty result here must not be read as a confirmed all-clear")
 }

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -58,23 +58,30 @@ func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, httpR
 }
 
 // ServiceExposure reports every path that exposes the named Service to
-// traffic from outside the cluster. An empty result means nothing in this
-// snapshot exposes it -- it is only reachable from inside the cluster (or
+// traffic from outside the cluster, plus whether at least one plausible but
+// unmodeled exposure path exists that this function cannot confirm either
+// way. An empty paths with unclear=false means nothing in this snapshot
+// exposes the Service -- it is only reachable from inside the cluster (or
 // not collected/does not exist at all, which this function cannot tell
-// apart from "exists but not exposed").
-func (idx *Index) ServiceExposure(ref ServiceRef) []ExposurePath {
+// apart from "exists but not exposed"). unclear=true means paths must NOT
+// be read as a confirmed all-clear: a cross-namespace HTTPRoute backendRef
+// names this Service, and whether that reference is authorized (via a
+// ReferenceGrant this package does not collect or evaluate -- see the
+// package doc comment) is genuinely unknown.
+func (idx *Index) ServiceExposure(ref ServiceRef) (paths []ExposurePath, unclear bool) {
 	svc, ok := idx.services[ref]
 	if !ok {
-		return nil
+		return nil, false
 	}
-
-	var paths []ExposurePath
 
 	switch svc.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		paths = append(paths, ExposurePath{Kind: ExposureLoadBalancer, Source: fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)})
 	case corev1.ServiceTypeNodePort:
 		paths = append(paths, ExposurePath{Kind: ExposureNodePort, Source: fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)})
+	}
+	if len(svc.Spec.ExternalIPs) > 0 {
+		paths = append(paths, ExposurePath{Kind: ExposureExternalIP, Source: fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)})
 	}
 
 	for _, ing := range idx.ingressesByNS[ref.Namespace] {
@@ -98,7 +105,35 @@ func (idx *Index) ServiceExposure(ref ServiceRef) []ExposurePath {
 		}
 	}
 
-	return paths
+	return paths, idx.crossNamespaceBackendRefIsUnmodeled(ref)
+}
+
+// crossNamespaceBackendRefIsUnmodeled reports whether some HTTPRoute this
+// Index was given, living outside ref's namespace and admitted by at least
+// one Gateway, explicitly names ref as a backend via backendRef.namespace.
+// That is a real, working, externally-reachable path when a matching
+// ReferenceGrant exists in ref's namespace -- a resource kind this package
+// does not collect or evaluate (see the package doc comment) -- so its
+// presence must not be silently folded into a confirmed "not exposed".
+func (idx *Index) crossNamespaceBackendRefIsUnmodeled(ref ServiceRef) bool {
+	for ns, routes := range idx.httpRoutesByNS {
+		if ns == ref.Namespace {
+			continue
+		}
+		for _, route := range routes {
+			if !idx.routeAttachesToAGateway(route) {
+				continue
+			}
+			for _, rule := range route.Rules {
+				for _, backend := range rule.BackendRefs {
+					if backend.Namespace != nil && *backend.Namespace == ref.Namespace && backend.Name == ref.Name {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 // ingressPathsFor returns one ExposurePath per Ingress rule (or the

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -21,21 +21,21 @@ func ref(namespace, name string) ServiceRef {
 
 func TestServiceExposure_UnknownServiceIsEmpty(t *testing.T) {
 	idx := NewIndex(nil, nil, nil, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "missing")); paths != nil {
+	if paths, _ := idx.ServiceExposure(ref("ns", "missing")); paths != nil {
 		t.Errorf("paths = %v, want nil", paths)
 	}
 }
 
 func TestServiceExposure_ClusterIPAloneIsNotExposed(t *testing.T) {
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, nil, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
 		t.Errorf("paths = %v, want empty", paths)
 	}
 }
 
 func TestServiceExposure_LoadBalancerIsExposed(t *testing.T) {
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeLoadBalancer)}, nil, nil, nil, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureLoadBalancer {
 		t.Errorf("paths = %+v, want one ExposureLoadBalancer", paths)
 	}
@@ -43,9 +43,37 @@ func TestServiceExposure_LoadBalancerIsExposed(t *testing.T) {
 
 func TestServiceExposure_NodePortIsExposed(t *testing.T) {
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeNodePort)}, nil, nil, nil, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureNodePort {
 		t.Errorf("paths = %+v, want one ExposureNodePort", paths)
+	}
+}
+
+func TestServiceExposure_ExternalIPsExposesClusterIPService(t *testing.T) {
+	s := svc("ns", "app", corev1.ServiceTypeClusterIP)
+	s.Spec.ExternalIPs = []string{"203.0.113.10"}
+	idx := NewIndex([]corev1.Service{s}, nil, nil, nil, nil)
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 1 || paths[0].Kind != ExposureExternalIP {
+		t.Errorf("paths = %+v, want one ExposureExternalIP: kube-proxy programs spec.externalIPs on every node regardless of spec.type (CVE-2020-8554)", paths)
+	}
+}
+
+func TestServiceExposure_ExternalIPsAlongsideLoadBalancerReportsBothPaths(t *testing.T) {
+	s := svc("ns", "app", corev1.ServiceTypeLoadBalancer)
+	s.Spec.ExternalIPs = []string{"203.0.113.10"}
+	idx := NewIndex([]corev1.Service{s}, nil, nil, nil, nil)
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 2 {
+		t.Errorf("paths = %+v, want two paths: LoadBalancer and ExternalIP are independent exposure mechanisms", paths)
+	}
+}
+
+func TestServiceExposure_NoExternalIPsDoesNotAddAPath(t *testing.T) {
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, nil, nil, nil)
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty", paths)
 	}
 }
 
@@ -59,7 +87,7 @@ func TestServiceExposure_IngressDefaultBackendExposesService(t *testing.T) {
 		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("app"))},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureIngress || paths[0].Source != "ns/web" || paths[0].Host != "" {
 		t.Errorf("paths = %+v, want one ExposureIngress from ns/web with empty host", paths)
 	}
@@ -80,7 +108,7 @@ func TestServiceExposure_IngressRuleExposesServiceWithHost(t *testing.T) {
 		}},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureIngress || paths[0].Host != "app.example.com" {
 		t.Errorf("paths = %+v, want one ExposureIngress with host app.example.com", paths)
 	}
@@ -92,7 +120,7 @@ func TestServiceExposure_IngressForDifferentServiceDoesNotMatch(t *testing.T) {
 		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("other"))},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
 		t.Errorf("paths = %v, want empty", paths)
 	}
 }
@@ -103,7 +131,7 @@ func TestServiceExposure_IngressInAnotherNamespaceDoesNotApply(t *testing.T) {
 		Spec:       networkingv1.IngressSpec{DefaultBackend: ptrBackend(ingressBackend("app"))},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, []networkingv1.Ingress{ing}, nil, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
 		t.Errorf("paths = %v, want empty: an Ingress can only name a Service in its own namespace", paths)
 	}
 }
@@ -120,7 +148,7 @@ func TestServiceExposure_HTTPRouteWithUncollectedGatewayStillReportsPath(t *test
 	// what was collected rather than not exist -- so it must be treated as a
 	// possible exposure, not silently dropped.
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
+	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
 		t.Errorf("paths = %v, want one path: an uncollected Gateway must be treated as a possible exposure", paths)
 	}
 }
@@ -135,7 +163,7 @@ func TestServiceExposure_HTTPRouteAttachedToGatewayExposesService(t *testing.T) 
 		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureHTTPRoute || paths[0].Source != "ns/route" || paths[0].Host != "app.example.com" {
 		t.Errorf("paths = %+v, want one ExposureHTTPRoute from ns/route with host app.example.com", paths)
 	}
@@ -150,7 +178,7 @@ func TestServiceExposure_HTTPRouteWithNoHostnamesProducesOnePathWithEmptyHost(t 
 		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	paths := idx.ServiceExposure(ref("ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Host != "" {
 		t.Errorf("paths = %+v, want one path with empty host", paths)
 	}
@@ -166,7 +194,7 @@ func TestServiceExposure_CrossNamespaceParentRefBlockedByDefaultSameNamespaceAll
 		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	paths := idx.ServiceExposure(ref("route-ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("route-ns", "app"))
 	if len(paths) != 0 {
 		t.Errorf("paths = %+v, want empty: AllowedRoutes defaults to Same, and the route's namespace differs from the Gateway's", paths)
 	}
@@ -186,7 +214,7 @@ func TestServiceExposure_CrossNamespaceParentRefAllowedByExplicitFromAll(t *test
 		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	paths := idx.ServiceExposure(ref("route-ns", "app"))
+	paths, _ := idx.ServiceExposure(ref("route-ns", "app"))
 	if len(paths) != 1 {
 		t.Errorf("paths = %+v, want one ExposureHTTPRoute: the listener explicitly allows routes from all namespaces", paths)
 	}
@@ -205,8 +233,58 @@ func TestServiceExposure_HTTPRouteBackendInAnotherNamespaceIsNotModeled(t *testi
 	// other-ns -- without a ReferenceGrant (not modeled), this must not
 	// match ns/app.
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 0 {
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
 		t.Errorf("paths = %v, want empty", paths)
+	}
+	if unclear {
+		t.Error("unclear = true, want false: the backendRef names other-ns/app, not ns/app, so it says nothing about ns/app's exposure")
+	}
+}
+
+func TestServiceExposure_UnclearWhenCrossNamespaceHTTPRouteBackendRefIsUnmodeled(t *testing.T) {
+	gw := gateway{Namespace: "edge", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	targetNS := "ns"
+	// A real, working topology: an HTTPRoute living in "edge" names ns/app as
+	// its backend via an explicit backendRef.namespace, authorized by a
+	// ReferenceGrant in ns (not modeled by this package -- see
+	// crossNamespaceBackendRefIsUnmodeled's doc comment). idx.httpRoutesByNS
+	// only looks up routes living *in* ref.Namespace when building paths, so
+	// this route is never examined there; the unclear signal exists
+	// precisely to catch what that omission would otherwise hide.
+	route := httpRoute{
+		Namespace:  "edge",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %v, want empty: this package does not confirm cross-namespace backendRefs", paths)
+	}
+	if !unclear {
+		t.Error("unclear = false, want true: a cross-namespace backendRef from an admitted HTTPRoute names this Service")
+	}
+}
+
+func TestServiceExposure_CrossNamespaceRouteWithUncollectedGatewayIsStillUnclear(t *testing.T) {
+	targetNS := "ns"
+	route := httpRoute{
+		Namespace:  "edge",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "missing-gw"}},
+		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
+	}
+	// No Gateway at all was collected, so routeAttachesToAGateway takes the
+	// conservative "uncollected Gateway" path and reports it as attached --
+	// crossNamespaceBackendRefIsUnmodeled piggybacks on that same
+	// conservative check rather than re-deriving its own, so this must still
+	// be unclear rather than silently dropped for lack of Gateway data.
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
+	_, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if !unclear {
+		t.Error("unclear = false, want true: an uncollected Gateway is conservatively treated as attached, same as routeAttachesToAGateway")
 	}
 }
 
@@ -276,7 +354,7 @@ func TestServiceExposure_HTTPRouteIndeterminateAdmissionStillReportsPath(t *test
 	// evaluated -- this must still report the path rather than silently
 	// dropping a possible exposure.
 	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
-	if paths := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
+	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
 		t.Errorf("paths = %v, want one path: an indeterminate admission must still be reported", paths)
 	}
 }

--- a/core/pkg/exposure/types.go
+++ b/core/pkg/exposure/types.go
@@ -39,6 +39,13 @@ const (
 	// whose admission can't be confirmed one way or the other is
 	// conservatively treated as admitting it.
 	ExposureHTTPRoute
+	// ExposureExternalIP means the Service has one or more spec.externalIPs
+	// set. kube-proxy programs these on every node regardless of
+	// spec.type, so a ClusterIP Service with externalIPs set is reachable
+	// from off-cluster the same as a NodePort Service -- this is the
+	// mechanism behind CVE-2020-8554 (arbitrary externalIPs hijack via a
+	// Service create/update in a namespace an attacker controls).
+	ExposureExternalIP
 )
 
 func (k ExposureKind) String() string {
@@ -51,6 +58,8 @@ func (k ExposureKind) String() string {
 		return "Ingress"
 	case ExposureHTTPRoute:
 		return "HTTPRoute"
+	case ExposureExternalIP:
+		return "ExternalIP"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
Fixes #3678, the two non-blocking follow-ups matthyx flagged during review of #3648 (`core/pkg/exposure`).

**Depends on #3648**, which is still open -- this branch is stacked on top of it, so the diff below includes #3648's commit too until that merges. Only the last commit (`feat(exposure): model spec.externalIPs, flag unconfirmed cross-namespace backendRef as unclear`) is new; that's the one to review. Happy to rebase onto master once #3648 lands, or hold this until then, whichever you prefer.

## 1. `spec.externalIPs` not modeled

A `ClusterIP` Service with `spec.externalIPs` set is programmed by kube-proxy on every node and reachable from off-cluster regardless of `spec.type` -- the mechanism behind CVE-2020-8554. `ServiceExposure` only looked at `spec.type`, so such a Service reported as internal-only.

Added an `ExposureExternalIP` `ExposureKind`, populated whenever `len(svc.Spec.ExternalIPs) > 0`, independent of (and additive to) the existing LoadBalancer/NodePort checks.

## 2. Cross-namespace `backendRef` gap reported "not exposed" instead of "unclear"

`Index.ServiceExposure` only ever looked at `idx.httpRoutesByNS[ref.Namespace]` -- an `HTTPRoute` living in another namespace and referencing this Service via an explicit `backendRef.namespace` (authorized by a `ReferenceGrant`, a resource kind this package intentionally doesn't model) was invisible, and the query result was a bare `[]`, indistinguishable from a confirmed-internal Service.

`ServiceExposure` now returns `(paths []ExposurePath, unclear bool)`. `unclear` is true when an admitted HTTPRoute outside the Service's namespace explicitly names it as a backend -- a real, plausible exposure path this package can't confirm. `analyze_service_exposure`'s JSON output surfaces this as an `"unclear"` note per Service. HTTPRoutes are now collected cluster-wide by the MCP tool (same reasoning as the Gateway fix in #3648) so this signal has cross-namespace data to actually work from.

## Testing

- New Index-level tests for both behaviors, plus end-to-end MCP-tool tests exercising the real topology (Service in `prod`, admitted HTTPRoute in `edge` referencing it via `backendRef.namespace`).
- Verified all four new/changed tests fail against the pre-fix logic and pass post-fix (temporarily reverted each fix, confirmed red, restored, confirmed green).
- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./core/pkg/exposure/... ./cmd/mcpserver/...`, full `go test ./...`, and `golangci-lint run --new-from-rev=upstream/master` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service exposure analysis through the `analyze_service_exposure` tool.
  * Reports whether services are externally reachable and identifies exposure methods, including load balancers, node ports, external IPs, Ingress, and HTTP routes.
  * Supports analyzing a specific service or all services in a namespace.
  * Includes host and source details for identified exposure paths.
  * Flags uncertain cross-namespace routing scenarios instead of reporting them as definitively safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->