### PR TITLE
feat(rbacgraph): model multi-hop RBAC privilege-escalation paths

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -1390,6 +1390,7 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createMutatingAdmissionPolicyTools(ksServer)
 	createVulnerabilityExposureTools(ksServer)
 	createServiceExposureTools(ksServer)
+	createRBACEscalationTools(ksServer)
 	createFrameworkScanningTools(ksServer)
 	createIaCScanningTools(ksServer)
 	createIaCControlScanningTool(ksServer)

--- a/cmd/mcpserver/rbac_escalation.go
+++ b/cmd/mcpserver/rbac_escalation.go
@@ -93,6 +93,9 @@ func createRBACEscalationTools(ksServer *KubescapeMcpserver) {
 			"reached":                  buildReachedSummaries(result.Reached),
 			"unbounded_findings":       buildUnboundedSummaries(result.Unbounded),
 		}
+		if result.Truncated {
+			out["truncated"] = "the search hit its safety bound before confirming cluster_admin_equivalent one way or the other -- this result may be an incomplete negative, not a confirmed one"
+		}
 		if len(decodeErrs) > 0 {
 			msgs := make([]string, len(decodeErrs))
 			for i, e := range decodeErrs {

--- a/cmd/mcpserver/rbac_escalation.go
+++ b/cmd/mcpserver/rbac_escalation.go
@@ -1,0 +1,177 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/rbacgraph"
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var roleGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+var clusterRoleGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+var roleBindingGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+var clusterRoleBindingGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+var serviceAccountGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
+
+// createRBACEscalationTools registers analyze_rbac_escalation_paths, which
+// reports every privilege-escalation technique reachable from a starting
+// RBAC identity (ServiceAccount, User, or Group): every other identity it
+// can assume, and whether it can reach full cluster-admin-equivalent power,
+// via the graph model in core/pkg/rbacgraph. See that package's doc comment
+// for the escalation primitives modeled and its trust model.
+//
+// Unlike this repo's other exposure/reachability MCP tools, RBAC objects
+// are always collected cluster-wide, not scoped to a single namespace: an
+// escalation edge can lead into any namespace (a ServiceAccount can be
+// impersonated, assigned via pod creation, or have its token minted from
+// any namespace a subject holds the right primitive in), so a
+// namespace-scoped collection would silently hide real paths the same way
+// the namespace-scoped Gateway listing bug in analyze_service_exposure did
+// before it was fixed.
+func createRBACEscalationTools(ksServer *KubescapeMcpserver) {
+	tool := mcp.NewTool(
+		"analyze_rbac_escalation_paths",
+		mcp.WithDescription("Determine every privilege-escalation path reachable from a starting RBAC identity (ServiceAccount, User, or Group) via graph analysis of the cluster's Roles/ClusterRoles/RoleBindings/ClusterRoleBindings -- not just a single-object posture check. Detects impersonation, the escalate/bind verb self-escalation-prevention bypasses, gaining a ServiceAccount's token by scheduling a Pod as it, and minting a ServiceAccount token directly via the TokenRequest API, chained across multiple hops. Reports every other identity reachable and whether cluster-admin-equivalent power is reachable at all, however indirectly."),
+		mcp.WithString("subject_kind", mcp.Required(), mcp.Description("Kind of the starting identity: ServiceAccount, User, or Group")),
+		mcp.WithString("namespace", mcp.Description("Namespace of the starting ServiceAccount (required when subject_kind is ServiceAccount; ignored otherwise)")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the starting identity")),
+	)
+
+	ksServer.s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]any)
+		if !ok || args == nil {
+			args = map[string]any{}
+		}
+
+		subjectKindStr, _ := args["subject_kind"].(string)
+		name, ok := args["name"].(string)
+		if !ok || name == "" {
+			return mcp.NewToolResultError("name is required"), nil
+		}
+		namespace, _ := args["namespace"].(string)
+
+		var kind rbacgraph.SubjectKind
+		switch subjectKindStr {
+		case string(rbacgraph.KindServiceAccount):
+			kind = rbacgraph.KindServiceAccount
+			if namespace == "" {
+				return mcp.NewToolResultError("namespace is required when subject_kind is ServiceAccount"), nil
+			}
+		case string(rbacgraph.KindUser):
+			kind = rbacgraph.KindUser
+		case string(rbacgraph.KindGroup):
+			kind = rbacgraph.KindGroup
+		default:
+			return mcp.NewToolResultError(fmt.Sprintf("subject_kind must be one of ServiceAccount, User, Group; got %q", subjectKindStr)), nil
+		}
+
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+		}
+
+		resources, err := listRBACResources(ctx, k8sClient.DynamicClient)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		roles, clusterRoles, roleBindings, clusterRoleBindings, serviceAccounts, decodeErrs := rbacgraph.FromResources(resources)
+		idx := rbacgraph.NewIndex(roles, clusterRoles, roleBindings, clusterRoleBindings, serviceAccounts)
+
+		start := rbacgraph.Subject{Kind: kind, Namespace: namespace, Name: name}
+		result := idx.AnalyzeEscalation(start)
+
+		out := map[string]any{
+			"subject":                  start.String(),
+			"cluster_admin_equivalent": result.ClusterAdmin,
+			"reached":                  buildReachedSummaries(result.Reached),
+			"unbounded_findings":       buildUnboundedSummaries(result.Unbounded),
+		}
+		if len(decodeErrs) > 0 {
+			msgs := make([]string, len(decodeErrs))
+			for i, e := range decodeErrs {
+				msgs[i] = e.Error()
+			}
+			out["decode_warnings"] = msgs
+		}
+
+		resBytes, err := json.Marshal(out)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(resBytes)), nil
+	})
+}
+
+// listRBACResources collects every Role, ClusterRole, RoleBinding,
+// ClusterRoleBinding, and ServiceAccount in the cluster. All five GVRs are
+// core Kubernetes API types always served by every cluster (unlike the
+// Gateway API), so any list error here is fatal, not a missing-API signal
+// to swallow. Roles and RoleBindings are namespaced but listed without a
+// namespace filter (cluster-wide), same reasoning as the Gateway/HTTPRoute
+// listing fix in analyze_service_exposure: an escalation edge can name a
+// ServiceAccount or Role in any namespace.
+func listRBACResources(ctx context.Context, dynClient dynamic.Interface) (map[string]workloadinterface.IMetadata, error) {
+	gvrs := []schema.GroupVersionResource{roleGVR, clusterRoleGVR, roleBindingGVR, clusterRoleBindingGVR, serviceAccountGVR}
+	resources := map[string]workloadinterface.IMetadata{}
+	for _, gvr := range gvrs {
+		list, err := dynClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s objects: %w", gvr.Resource, err)
+		}
+		for i := range list.Items {
+			w := workloadinterface.NewWorkloadObj(list.Items[i].Object)
+			resources[w.GetID()] = w
+		}
+	}
+	return resources, nil
+}
+
+func buildReachedSummaries(paths []rbacgraph.EscalationPath) []map[string]any {
+	out := make([]map[string]any, 0, len(paths))
+	for _, p := range paths {
+		if len(p.Edges) == 0 {
+			continue
+		}
+		last := p.Edges[len(p.Edges)-1]
+		hops := make([]map[string]any, 0, len(p.Edges))
+		for _, e := range p.Edges {
+			hops = append(hops, map[string]any{
+				"primitive": string(e.Primitive),
+				"detail":    e.Detail,
+			})
+		}
+		var subject string
+		if last.ToSubject != nil {
+			subject = last.ToSubject.String()
+		}
+		out = append(out, map[string]any{
+			"subject": subject,
+			"path":    hops,
+		})
+	}
+	return out
+}
+
+func buildUnboundedSummaries(findings []rbacgraph.UnboundedFinding) []map[string]any {
+	out := make([]map[string]any, 0, len(findings))
+	for _, f := range findings {
+		scope := f.Edge.Scope
+		if scope == "" {
+			scope = "cluster-wide"
+		}
+		out = append(out, map[string]any{
+			"subject":   f.Subject.String(),
+			"primitive": string(f.Edge.Primitive),
+			"detail":    f.Edge.Detail,
+			"scope":     scope,
+		})
+	}
+	return out
+}

--- a/cmd/mcpserver/rbac_escalation_test.go
+++ b/cmd/mcpserver/rbac_escalation_test.go
@@ -1,0 +1,219 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func newRBACEscalationTestServer(t *testing.T, objects ...runtime.Object) *KubescapeMcpserver {
+	t.Helper()
+	listKinds := map[schema.GroupVersionResource]string{
+		roleGVR:               "RoleList",
+		clusterRoleGVR:        "ClusterRoleList",
+		roleBindingGVR:        "RoleBindingList",
+		clusterRoleBindingGVR: "ClusterRoleBindingList",
+		serviceAccountGVR:     "ServiceAccountList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createRBACEscalationTools(ksServer)
+	return ksServer
+}
+
+func unstructuredServiceAccount(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+	}}
+}
+
+func unstructuredPolicyRule(apiGroups, resources, verbs, resourceNames []string) map[string]any {
+	m := map[string]any{
+		"apiGroups": toAnySlice(apiGroups),
+		"resources": toAnySlice(resources),
+		"verbs":     toAnySlice(verbs),
+	}
+	if len(resourceNames) > 0 {
+		m["resourceNames"] = toAnySlice(resourceNames)
+	}
+	return m
+}
+
+func toAnySlice(s []string) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func unstructuredClusterRole(name string, rules ...map[string]any) *unstructured.Unstructured {
+	ruleList := make([]any, len(rules))
+	for i, r := range rules {
+		ruleList[i] = r
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": name},
+		"rules":      ruleList,
+	}}
+}
+
+func unstructuredClusterRoleBinding(name, clusterRoleName string, subjectNamespace, subjectName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": name},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     clusterRoleName,
+		},
+		"subjects": []any{
+			map[string]any{"kind": "ServiceAccount", "namespace": subjectNamespace, "name": subjectName},
+		},
+	}}
+}
+
+func TestAnalyzeRBACEscalationPaths_NoEscalationReportsEmptyResult(t *testing.T) {
+	sa := unstructuredServiceAccount("prod", "app")
+	cr := unstructuredClusterRole("pod-reader", unstructuredPolicyRule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	crb := unstructuredClusterRoleBinding("crb", "pod-reader", "prod", "app")
+	ksServer := newRBACEscalationTestServer(t, sa, cr, crb)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "ServiceAccount",
+		"namespace":    "prod",
+		"name":         "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.False(t, parsed["cluster_admin_equivalent"].(bool))
+	require.Empty(t, parsed["reached"])
+}
+
+func TestAnalyzeRBACEscalationPaths_ImpersonateReachesNamedServiceAccount(t *testing.T) {
+	attackerSA := unstructuredServiceAccount("prod", "attacker")
+	targetSA := unstructuredServiceAccount("prod", "target")
+	impersonator := unstructuredClusterRole("impersonator", unstructuredPolicyRule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, []string{"target"}))
+	crb := unstructuredClusterRoleBinding("crb", "impersonator", "prod", "attacker")
+	ksServer := newRBACEscalationTestServer(t, attackerSA, targetSA, impersonator, crb)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "ServiceAccount",
+		"namespace":    "prod",
+		"name":         "attacker",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	reached := parsed["reached"].([]any)
+	require.Len(t, reached, 1)
+	entry := reached[0].(map[string]any)
+	require.Equal(t, "ServiceAccount prod/target", entry["subject"])
+	path := entry["path"].([]any)
+	require.Len(t, path, 1)
+	require.Equal(t, "impersonate", path[0].(map[string]any)["primitive"])
+}
+
+func TestAnalyzeRBACEscalationPaths_BindClusterAdminClusterRoleIsFlagged(t *testing.T) {
+	attackerSA := unstructuredServiceAccount("prod", "attacker")
+	adminRole := unstructuredClusterRole("cluster-admin-ish", unstructuredPolicyRule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	binder := unstructuredClusterRole("binder", unstructuredPolicyRule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"bind"}, []string{"cluster-admin-ish"}))
+	crbCreator := unstructuredClusterRole("crb-creator", unstructuredPolicyRule([]string{"rbac.authorization.k8s.io"}, []string{"clusterrolebindings"}, []string{"create"}, nil))
+	ksServer := newRBACEscalationTestServer(t,
+		attackerSA, adminRole, binder, crbCreator,
+		unstructuredClusterRoleBinding("crb1", "binder", "prod", "attacker"),
+		unstructuredClusterRoleBinding("crb2", "crb-creator", "prod", "attacker"),
+	)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "ServiceAccount",
+		"namespace":    "prod",
+		"name":         "attacker",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.True(t, parsed["cluster_admin_equivalent"].(bool), "bind+create-clusterrolebindings to a */*/* ClusterRole must be flagged cluster-admin-equivalent")
+}
+
+func TestAnalyzeRBACEscalationPaths_MissingNameReturnsError(t *testing.T) {
+	ksServer := newRBACEscalationTestServer(t)
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "ServiceAccount",
+		"namespace":    "prod",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeRBACEscalationPaths_ServiceAccountWithoutNamespaceReturnsError(t *testing.T) {
+	ksServer := newRBACEscalationTestServer(t)
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "ServiceAccount",
+		"name":         "app",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeRBACEscalationPaths_InvalidSubjectKindReturnsError(t *testing.T) {
+	ksServer := newRBACEscalationTestServer(t)
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "Robot",
+		"name":         "app",
+	}))
+	require.True(t, result.IsError)
+}
+
+func TestAnalyzeRBACEscalationPaths_UserSubjectNeedsNoNamespace(t *testing.T) {
+	target := unstructuredServiceAccount("prod", "target")
+	impersonator := unstructuredClusterRole("impersonator", unstructuredPolicyRule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, []string{"target"}))
+	crb := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": "crb"},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     "impersonator",
+		},
+		"subjects": []any{
+			map[string]any{"kind": "User", "name": "alice"},
+		},
+	}}
+	ksServer := newRBACEscalationTestServer(t, target, impersonator, crb)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_rbac_escalation_paths", map[string]any{
+		"subject_kind": "User",
+		"name":         "alice",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	require.Equal(t, "User alice", parsed["subject"])
+	require.Len(t, parsed["reached"].([]any), 1)
+}

--- a/core/pkg/rbacgraph/adapter.go
+++ b/core/pkg/rbacgraph/adapter.go
@@ -1,0 +1,73 @@
+package rbacgraph
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// FromResources converts kubescape's generically-collected scan resources
+// into the typed inputs NewIndex needs. Any object that is not a Role,
+// ClusterRole, RoleBinding, ClusterRoleBinding, or ServiceAccount is
+// ignored. An object of one of those five kinds that fails to decode is
+// skipped, with its error appended to errs, rather than aborting the whole
+// conversion over one bad object.
+func FromResources(resources map[string]workloadinterface.IMetadata) (roles []rbacv1.Role, clusterRoles []rbacv1.ClusterRole, roleBindings []rbacv1.RoleBinding, clusterRoleBindings []rbacv1.ClusterRoleBinding, serviceAccounts []corev1.ServiceAccount, errs []error) {
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		switch resource.GetKind() {
+		case "Role":
+			var r rbacv1.Role
+			if err := decode(resource.GetObject(), &r); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			roles = append(roles, r)
+		case "ClusterRole":
+			var cr rbacv1.ClusterRole
+			if err := decode(resource.GetObject(), &cr); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			clusterRoles = append(clusterRoles, cr)
+		case "RoleBinding":
+			var rb rbacv1.RoleBinding
+			if err := decode(resource.GetObject(), &rb); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			roleBindings = append(roleBindings, rb)
+		case "ClusterRoleBinding":
+			var crb rbacv1.ClusterRoleBinding
+			if err := decode(resource.GetObject(), &crb); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			clusterRoleBindings = append(clusterRoleBindings, crb)
+		case "ServiceAccount":
+			var sa corev1.ServiceAccount
+			if err := decode(resource.GetObject(), &sa); err != nil {
+				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
+				continue
+			}
+			serviceAccounts = append(serviceAccounts, sa)
+		}
+	}
+	return roles, clusterRoles, roleBindings, clusterRoleBindings, serviceAccounts, errs
+}
+
+func decode(obj map[string]any, out any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+	return nil
+}

--- a/core/pkg/rbacgraph/closure.go
+++ b/core/pkg/rbacgraph/closure.go
@@ -1,0 +1,146 @@
+package rbacgraph
+
+// EscalationResult is the outcome of computing every RBAC escalation
+// technique reachable from a starting Subject.
+type EscalationResult struct {
+	Start Subject
+	// Reached lists every other concrete identity Start can assume, each
+	// with the (shortest, breadth-first) chain of edges that reaches it.
+	// Truncated as soon as ClusterAdmin is confirmed true (see that
+	// field's doc comment) -- it is not a complete enumeration in that
+	// case, since every further reach is implied and not worth the noise.
+	Reached []EscalationPath
+	// Unbounded lists every distinct escalation edge encountered anywhere
+	// in the closure that grants everything within some scope rather than
+	// a specific enumerable rule set, together with the subject that holds
+	// it -- deduplicated by (subject, primitive, detail), since the same
+	// grant can otherwise be rediscovered on more than one BFS pass over
+	// the same subject.
+	Unbounded []UnboundedFinding
+	// EffectiveRules is the union of every ScopedRule reachable: Start's
+	// own direct rules, every rule granted via bind-verb/escalate-verb
+	// (including transitively, when a granted Role/ClusterRole itself
+	// grants further escalation), and every rule directly held by each
+	// identity in Reached. Also truncated once ClusterAdmin is confirmed.
+	EffectiveRules []ScopedRule
+	// ClusterAdmin is true when EffectiveRules includes a cluster-wide
+	// */*/* rule, or an Unbounded finding covers the whole cluster
+	// (Scope == ""), however it was actually reached. Once true, the BFS
+	// stops expanding further: cluster-admin-equivalent power already
+	// implies every other identity and permission is reachable, so
+	// continuing would only enumerate implied consequences (e.g. every
+	// ServiceAccount in the cluster, since cluster-admin can always
+	// assign-serviceaccount to any of them) rather than surface anything
+	// new -- Reached/EffectiveRules reflect whatever had already been
+	// discovered at the point this became true, not a complete picture.
+	ClusterAdmin bool
+}
+
+// UnboundedFinding records that Subject holds an unrestricted escalation
+// primitive whose targets this package cannot enumerate from collected
+// cluster objects (e.g. impersonate on users with no resourceNames
+// restriction, or escalate+update on clusterroles cluster-wide).
+type UnboundedFinding struct {
+	Subject Subject
+	Edge    EscalationEdge
+}
+
+// maxEscalationHops bounds the BFS worklist: a safety net against a
+// pathological input, not a limit expected to matter on any real cluster --
+// real clusters hold far fewer distinct RBAC identities and Role/ClusterRole
+// objects than this.
+const maxEscalationHops = 200
+
+// AnalyzeEscalation computes every privilege-escalation technique reachable
+// from start via breadth-first search: assuming another concrete identity
+// (impersonate, assign-serviceaccount, mint-serviceaccount-token) queues
+// that identity for its own escalation edges to be explored in turn;
+// adopting a Role/ClusterRole's rules (bind-verb, escalate-verb) enriches
+// the current subject's own rule set and re-queues it, so a rule gained
+// that way which itself unlocks further escalation (e.g. a bound
+// ClusterRole that grants impersonate) is chased, not just recorded.
+// Reprocessing a subject happens only when a bind/escalate edge actually
+// grants something new (tracked per-subject, keyed by the edge's Detail
+// string, which is unique per distinct Role/ClusterRole+scope grant), so
+// this always terminates even though maxEscalationHops bounds it too. The
+// search stops early once cluster-admin-equivalent power is confirmed
+// reachable -- see EscalationResult.ClusterAdmin.
+func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
+	subjectRules := map[Subject][]ScopedRule{start: idx.DirectRules(start)}
+	grantedSeen := map[Subject]map[string]bool{start: {}}
+	unboundedSeen := map[string]bool{}
+	pathTo := map[Subject][]EscalationEdge{}
+	visited := map[Subject]bool{start: true}
+	var order []Subject
+	var unbounded []UnboundedFinding
+	clusterAdmin := IsClusterAdminEquivalent(subjectRules[start])
+
+	worklist := []Subject{start}
+	for i := 0; i < maxEscalationHops && len(worklist) > 0 && !clusterAdmin; i++ {
+		s := worklist[0]
+		worklist = worklist[1:]
+
+		edges := idx.DirectEscalationEdges(s, subjectRules[s])
+		grew := false
+		for _, e := range edges {
+			switch {
+			case e.ToSubject != nil:
+				t := *e.ToSubject
+				if visited[t] {
+					continue
+				}
+				visited[t] = true
+				order = append(order, t)
+				pathTo[t] = append(append([]EscalationEdge{}, pathTo[s]...), e)
+				subjectRules[t] = idx.DirectRules(t)
+				grantedSeen[t] = map[string]bool{}
+				worklist = append(worklist, t)
+			case e.Unbounded:
+				key := string(s.Kind) + "/" + s.Namespace + "/" + s.Name + "|" + string(e.Primitive) + "|" + e.Detail
+				if !unboundedSeen[key] {
+					unboundedSeen[key] = true
+					unbounded = append(unbounded, UnboundedFinding{Subject: s, Edge: e})
+				}
+				if e.Scope == "" {
+					clusterAdmin = true
+				}
+			default:
+				if grantedSeen[s][e.Detail] {
+					continue
+				}
+				grantedSeen[s][e.Detail] = true
+				subjectRules[s] = append(subjectRules[s], e.GrantedRules...)
+				grew = true
+			}
+			if clusterAdmin {
+				break
+			}
+		}
+		if grew && !clusterAdmin {
+			if IsClusterAdminEquivalent(subjectRules[s]) {
+				clusterAdmin = true
+			} else {
+				worklist = append(worklist, s)
+			}
+		}
+	}
+
+	allRules := append([]ScopedRule{}, subjectRules[start]...)
+	var reached []EscalationPath
+	for _, s := range order {
+		allRules = append(allRules, subjectRules[s]...)
+		reached = append(reached, EscalationPath{From: start, Edges: pathTo[s]})
+	}
+
+	if !clusterAdmin {
+		clusterAdmin = IsClusterAdminEquivalent(allRules)
+	}
+
+	return EscalationResult{
+		Start:          start,
+		Reached:        reached,
+		Unbounded:      unbounded,
+		EffectiveRules: allRules,
+		ClusterAdmin:   clusterAdmin,
+	}
+}

--- a/core/pkg/rbacgraph/closure.go
+++ b/core/pkg/rbacgraph/closure.go
@@ -1,5 +1,7 @@
 package rbacgraph
 
+import rbacv1 "k8s.io/api/rbac/v1"
+
 // EscalationResult is the outcome of computing every RBAC escalation
 // technique reachable from a starting Subject.
 type EscalationResult struct {
@@ -15,7 +17,11 @@ type EscalationResult struct {
 	// a specific enumerable rule set, together with the subject that holds
 	// it -- deduplicated by (subject, primitive, detail), since the same
 	// grant can otherwise be rediscovered on more than one BFS pass over
-	// the same subject.
+	// the same subject. This is a report of *why*, not a dead end: a
+	// namespace-scoped finding is also materialized into that subject's own
+	// rule set (as a wildcard rule confined to the finding's Scope) and the
+	// subject is re-queued, so anything it unlocks is still chased by the
+	// traversal -- see the e.Unbounded case below.
 	Unbounded []UnboundedFinding
 	// EffectiveRules is the union of every ScopedRule reachable: Start's
 	// own direct rules, every rule granted via bind-verb/escalate-verb
@@ -135,6 +141,27 @@ func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 				}
 				if e.Scope == "" {
 					clusterAdmin = true
+					break
+				}
+				// A namespace-scoped Unbounded finding proves s can grant
+				// itself arbitrary permissions within e.Scope (e.g.
+				// escalate+update on a Role restricted to that namespace).
+				// That is itself a rule s now effectively holds -- materialize
+				// it as a wildcard rule scoped to e.Scope and re-queue s, the
+				// same way a bind/escalate edge's GrantedRules do, so
+				// whatever it unlocks (e.g. gaining create-pods within
+				// e.Scope, then assign-serviceaccount to a privileged SA in
+				// that namespace) is chased rather than treated as a dead
+				// end. Without this, a scoped Unbounded finding was recorded
+				// but never fed back into the traversal, silently missing
+				// real multi-hop paths.
+				if !grantedSeen[s][e.Detail] {
+					grantedSeen[s][e.Detail] = true
+					subjectRules[s] = append(subjectRules[s], ScopedRule{
+						Rule:      rbacv1.PolicyRule{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+						Namespace: e.Scope,
+					})
+					grew = true
 				}
 			default:
 				if grantedSeen[s][e.Detail] {

--- a/core/pkg/rbacgraph/closure.go
+++ b/core/pkg/rbacgraph/closure.go
@@ -24,8 +24,9 @@ type EscalationResult struct {
 	// identity in Reached. Also truncated once ClusterAdmin is confirmed.
 	EffectiveRules []ScopedRule
 	// ClusterAdmin is true when EffectiveRules includes a cluster-wide
-	// */*/* rule, or an Unbounded finding covers the whole cluster
-	// (Scope == ""), however it was actually reached. Once true, the BFS
+	// */*/* rule, an Unbounded finding covers the whole cluster
+	// (Scope == ""), or a superuser group (system:masters) was reached via
+	// impersonation -- however it was actually reached. Once true, the BFS
 	// stops expanding further: cluster-admin-equivalent power already
 	// implies every other identity and permission is reachable, so
 	// continuing would only enumerate implied consequences (e.g. every
@@ -33,7 +34,18 @@ type EscalationResult struct {
 	// assign-serviceaccount to any of them) rather than surface anything
 	// new -- Reached/EffectiveRules reflect whatever had already been
 	// discovered at the point this became true, not a complete picture.
+	// This early stop is always sound: the verdict it produces is never
+	// wrong, only arrived at before every consequence was enumerated.
 	ClusterAdmin bool
+	// Truncated is true when the search hit maxEscalationHops with
+	// ClusterAdmin still false and work still queued -- meaning this
+	// result may be an incomplete negative, not a confirmed one. This is
+	// the failure mode that actually matters: unlike the ClusterAdmin
+	// early-stop (always a sound true), running out of budget without
+	// reaching a verdict means a real escalation path may exist beyond
+	// what was explored. Distinguish this from a genuine "nothing found"
+	// before treating ClusterAdmin == false as a clean bill of health.
+	Truncated bool
 }
 
 // UnboundedFinding records that Subject holds an unrestricted escalation
@@ -45,11 +57,15 @@ type UnboundedFinding struct {
 	Edge    EscalationEdge
 }
 
-// maxEscalationHops bounds the BFS worklist: a safety net against a
-// pathological input, not a limit expected to matter on any real cluster --
-// real clusters hold far fewer distinct RBAC identities and Role/ClusterRole
-// objects than this.
-const maxEscalationHops = 200
+// maxEscalationHops bounds the BFS worklist: subjects dequeued and
+// processed, not raw hop-count. Deliberately generous -- a single
+// cluster-wide "create pods" grant alone enqueues every ServiceAccount in
+// the cluster (routine on any cluster with hundreds of Service Accounts
+// across an ingress/operator stack), so a tight bound here risks exactly
+// the false-negative failure mode this package exists to avoid: a result
+// that looks like a clean negative because the search ran out of budget,
+// not because there was nothing to find. See EscalationResult.Truncated.
+var maxEscalationHops = 20000 // var, not const: tests override this to exercise Truncated without building a 20000-object fixture.
 
 // AnalyzeEscalation computes every privilege-escalation technique reachable
 // from start via breadth-first search: assuming another concrete identity
@@ -62,9 +78,11 @@ const maxEscalationHops = 200
 // Reprocessing a subject happens only when a bind/escalate edge actually
 // grants something new (tracked per-subject, keyed by the edge's Detail
 // string, which is unique per distinct Role/ClusterRole+scope grant), so
-// this always terminates even though maxEscalationHops bounds it too. The
-// search stops early once cluster-admin-equivalent power is confirmed
-// reachable -- see EscalationResult.ClusterAdmin.
+// this always terminates even though maxEscalationHops bounds it too.
+// Reaching a hardcoded superuser identity (system:masters) via
+// impersonation, or confirming cluster-admin-equivalent power any other
+// way, stops the search early -- see EscalationResult.ClusterAdmin and
+// EscalationResult.Truncated for what that does and doesn't mean.
 func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 	subjectRules := map[Subject][]ScopedRule{start: idx.DirectRules(start)}
 	grantedSeen := map[Subject]map[string]bool{start: {}}
@@ -73,10 +91,15 @@ func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 	visited := map[Subject]bool{start: true}
 	var order []Subject
 	var unbounded []UnboundedFinding
-	clusterAdmin := IsClusterAdminEquivalent(subjectRules[start])
+	clusterAdmin := IsClusterAdminEquivalent(subjectRules[start]) || superuserGroups[start.Name] && start.Kind == KindGroup
 
 	worklist := []Subject{start}
-	for i := 0; i < maxEscalationHops && len(worklist) > 0 && !clusterAdmin; i++ {
+	truncated := false
+	for i := 0; len(worklist) > 0 && !clusterAdmin; i++ {
+		if i >= maxEscalationHops {
+			truncated = true
+			break
+		}
 		s := worklist[0]
 		worklist = worklist[1:]
 
@@ -86,6 +109,15 @@ func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 			switch {
 			case e.ToSubject != nil:
 				t := *e.ToSubject
+				if t.Kind == KindGroup && superuserGroups[t.Name] {
+					clusterAdmin = true
+					pathTo[t] = append(append([]EscalationEdge{}, pathTo[s]...), e)
+					if !visited[t] {
+						visited[t] = true
+						order = append(order, t)
+					}
+					break
+				}
 				if visited[t] {
 					continue
 				}
@@ -135,6 +167,9 @@ func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 	if !clusterAdmin {
 		clusterAdmin = IsClusterAdminEquivalent(allRules)
 	}
+	if clusterAdmin {
+		truncated = false
+	}
 
 	return EscalationResult{
 		Start:          start,
@@ -142,5 +177,6 @@ func (idx *Index) AnalyzeEscalation(start Subject) EscalationResult {
 		Unbounded:      unbounded,
 		EffectiveRules: allRules,
 		ClusterAdmin:   clusterAdmin,
+		Truncated:      truncated,
 	}
 }

--- a/core/pkg/rbacgraph/closure_test.go
+++ b/core/pkg/rbacgraph/closure_test.go
@@ -591,3 +591,54 @@ func TestAnalyzeEscalation_NotTruncatedWhenClusterAdminConfirmedBeforeBudgetExha
 		t.Error("ClusterAdmin = false, want true")
 	}
 }
+
+// --- matthyx's second review pass on PR #3681 ---
+
+func TestAnalyzeEscalation_ScopedUnboundedEdgeIsReQueuedForMultiHopEscalation(t *testing.T) {
+	// Concrete scenario from review: dev/attacker holds escalate+update on
+	// Role dev/editable (a namespace-scoped Unbounded finding) and is also
+	// bound to dev/editable itself. In reality, attacker rewrites editable
+	// to add create-pods, then schedules a pod as dev/privileged (bound
+	// cluster-wide to a full ClusterRole) to inherit its token. A scoped
+	// Unbounded finding that isn't fed back into the traversal misses this
+	// entirely.
+	editable := role("dev", "editable", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	escalator := role("dev", "escalator", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"escalate", "update"}, []string{"editable"}))
+	privileged := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	idx := NewIndex(
+		[]rbacv1.Role{editable, escalator},
+		[]rbacv1.ClusterRole{privileged},
+		[]rbacv1.RoleBinding{
+			roleBinding("dev", "rb1", "Role", "editable", saSubject("dev", "attacker")),
+			roleBinding("dev", "rb2", "Role", "escalator", saSubject("dev", "attacker")),
+		},
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "cluster-admin-ish", saSubject("dev", "privileged"))},
+		[]corev1.ServiceAccount{saObj("dev", "attacker"), saObj("dev", "privileged")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("dev", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: the scoped Unbounded finding (escalate+update on dev/editable) must be chased -- it unlocks create-pods in dev, which reaches dev/privileged")
+	}
+}
+
+func TestAnalyzeEscalation_EscalateTargetNotInIndexFallsBackToScopeUnbounded(t *testing.T) {
+	// Concrete scenario from review: escalate+update on clusterroles,
+	// cluster-wide, restricted to a resourceName that resolves to no
+	// object this Index actually collected (stale name, or a partial/
+	// paginated collection gap). Silently emitting nothing here would be a
+	// regression from the pre-name-correlation behavior, which reported a
+	// scope-level Unbounded (cluster-wide -> ClusterAdmin) in this case --
+	// failing toward risk, not silence, matches this package's own
+	// documented trust model.
+	cr := clusterRole("escalator", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"escalate", "update"}, []string{"does-not-exist"}))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "escalator", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: an unresolvable escalate+update target must fall back to a scope-level Unbounded finding, not silence")
+	}
+	if len(result.Unbounded) == 0 {
+		t.Error("Unbounded = empty, want the fallback finding recorded")
+	}
+}

--- a/core/pkg/rbacgraph/closure_test.go
+++ b/core/pkg/rbacgraph/closure_test.go
@@ -1,0 +1,334 @@
+package rbacgraph
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func sa(namespace, name string) Subject {
+	return Subject{Kind: KindServiceAccount, Namespace: namespace, Name: name}
+}
+
+func saObj(namespace, name string) corev1.ServiceAccount {
+	return corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func role(namespace, name string, rules ...rbacv1.PolicyRule) rbacv1.Role {
+	return rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}, Rules: rules}
+}
+
+func clusterRole(name string, rules ...rbacv1.PolicyRule) rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}, Rules: rules}
+}
+
+func saSubject(namespace, name string) rbacv1.Subject {
+	return rbacv1.Subject{Kind: "ServiceAccount", Namespace: namespace, Name: name}
+}
+
+func roleBinding(namespace, name, roleKind, roleName string, subjects ...rbacv1.Subject) rbacv1.RoleBinding {
+	return rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		RoleRef:    rbacv1.RoleRef{Kind: roleKind, Name: roleName, APIGroup: "rbac.authorization.k8s.io"},
+		Subjects:   subjects,
+	}
+}
+
+func clusterRoleBinding(name, clusterRoleName string, subjects ...rbacv1.Subject) rbacv1.ClusterRoleBinding {
+	return rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRoleName, APIGroup: "rbac.authorization.k8s.io"},
+		Subjects:   subjects,
+	}
+}
+
+func rule(apiGroups, resources, verbs, resourceNames []string) rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{APIGroups: apiGroups, Resources: resources, Verbs: verbs, ResourceNames: resourceNames}
+}
+
+// --- DirectRules scoping ---
+
+func TestDirectRules_ClusterRoleBindingGrantsClusterWide(t *testing.T) {
+	cr := clusterRole("view", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	crb := clusterRoleBinding("crb", "view", saSubject("ns", "app"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, nil)
+
+	rules := idx.DirectRules(sa("ns", "app"))
+	if len(rules) != 1 || rules[0].Namespace != "" {
+		t.Fatalf("rules = %+v, want one cluster-wide (Namespace==\"\") rule", rules)
+	}
+}
+
+func TestDirectRules_RoleBindingReferencingClusterRoleIsConfinedToNamespace(t *testing.T) {
+	cr := clusterRole("edit", rule([]string{""}, []string{"pods"}, []string{"*"}, nil))
+	rb := roleBinding("prod", "rb", "ClusterRole", "edit", saSubject("prod", "app"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, []rbacv1.RoleBinding{rb}, nil, nil)
+
+	rules := idx.DirectRules(sa("prod", "app"))
+	if len(rules) != 1 || rules[0].Namespace != "prod" {
+		t.Fatalf("rules = %+v, want one rule scoped to prod (ClusterRole via RoleBinding is namespace-confined)", rules)
+	}
+}
+
+func TestDirectRules_UnrelatedSubjectGetsNothing(t *testing.T) {
+	cr := clusterRole("view", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	crb := clusterRoleBinding("crb", "view", saSubject("ns", "app"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, nil)
+
+	if rules := idx.DirectRules(sa("ns", "other")); len(rules) != 0 {
+		t.Errorf("rules = %+v, want empty", rules)
+	}
+}
+
+// --- IsClusterAdminEquivalent ---
+
+func TestIsClusterAdminEquivalent_WildcardClusterWideIsAdmin(t *testing.T) {
+	rules := []ScopedRule{{Rule: rule([]string{"*"}, []string{"*"}, []string{"*"}, nil), Namespace: ""}}
+	if !IsClusterAdminEquivalent(rules) {
+		t.Error("want true for a cluster-wide */*/* rule")
+	}
+}
+
+func TestIsClusterAdminEquivalent_WildcardConfinedToNamespaceIsNotAdmin(t *testing.T) {
+	rules := []ScopedRule{{Rule: rule([]string{"*"}, []string{"*"}, []string{"*"}, nil), Namespace: "prod"}}
+	if IsClusterAdminEquivalent(rules) {
+		t.Error("want false: a namespace-confined wildcard rule is not cluster-admin")
+	}
+}
+
+// --- impersonate primitive ---
+
+func TestAnalyzeEscalation_ImpersonateNamedServiceAccountReachesIt(t *testing.T) {
+	attacker := clusterRole("impersonator", rule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, []string{"target"}))
+	target := clusterRole("admin-ish", rule([]string{""}, []string{"secrets"}, []string{"get"}, nil))
+	idx := NewIndex(
+		nil,
+		[]rbacv1.ClusterRole{attacker, target},
+		[]rbacv1.RoleBinding{roleBinding("ns", "rb-target", "ClusterRole", "admin-ish", saSubject("ns", "target"))},
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb-attacker", "impersonator", saSubject("ns", "attacker"))},
+		[]corev1.ServiceAccount{saObj("ns", "attacker"), saObj("ns", "target")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if len(result.Reached) != 1 || *result.Reached[0].Edges[len(result.Reached[0].Edges)-1].ToSubject != sa("ns", "target") {
+		t.Fatalf("Reached = %+v, want exactly one path ending at ns/target", result.Reached)
+	}
+	if result.Reached[0].Edges[0].Primitive != PrimitiveImpersonate {
+		t.Errorf("Primitive = %v, want impersonate", result.Reached[0].Edges[0].Primitive)
+	}
+}
+
+func TestAnalyzeEscalation_UnrestrictedImpersonateOnUsersIsUnbounded(t *testing.T) {
+	cr := clusterRole("god-mode", rule([]string{""}, []string{"users"}, []string{"impersonate"}, nil))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "god-mode", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if len(result.Unbounded) != 1 || result.Unbounded[0].Edge.Primitive != PrimitiveImpersonate {
+		t.Fatalf("Unbounded = %+v, want one impersonate finding", result.Unbounded)
+	}
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: unrestricted user impersonation is treated as cluster-wide severity")
+	}
+}
+
+// --- escalate-verb primitive ---
+
+func TestAnalyzeEscalation_EscalateAndUpdateOnClusterRolesIsClusterAdmin(t *testing.T) {
+	cr := clusterRole("self-escalate", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"escalate", "update"}, nil))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "self-escalate", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: escalate+update on clusterroles cluster-wide is a full self-escalation primitive")
+	}
+}
+
+func TestAnalyzeEscalation_EscalateWithoutUpdateDoesNothing(t *testing.T) {
+	cr := clusterRole("half-escalate", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"escalate"}, nil))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "half-escalate", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if result.ClusterAdmin || len(result.Unbounded) != 0 {
+		t.Errorf("want no escalation without the paired update/patch verb, got ClusterAdmin=%v Unbounded=%+v", result.ClusterAdmin, result.Unbounded)
+	}
+}
+
+// --- bind-verb primitive ---
+
+func TestAnalyzeEscalation_BindClusterRoleClusterWideGrantsItsRules(t *testing.T) {
+	target := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	binder := clusterRole("binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"bind"}, []string{"cluster-admin-ish"}))
+	creator := clusterRole("crb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterrolebindings"}, []string{"create"}, nil))
+	idx := NewIndex(
+		nil,
+		[]rbacv1.ClusterRole{target, binder, creator},
+		nil,
+		[]rbacv1.ClusterRoleBinding{
+			clusterRoleBinding("crb1", "binder", saSubject("ns", "attacker")),
+			clusterRoleBinding("crb2", "crb-creator", saSubject("ns", "attacker")),
+		},
+		nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: bind+create-clusterrolebindings lets attacker adopt a */*/* ClusterRole cluster-wide")
+	}
+}
+
+func TestAnalyzeEscalation_BindRoleWithinNamespaceGrantsItsRulesConfined(t *testing.T) {
+	target := role("prod", "secret-reader", rule([]string{""}, []string{"secrets"}, []string{"get", "list"}, nil))
+	idx := NewIndex(
+		[]rbacv1.Role{
+			target,
+			role("prod", "binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"bind"}, []string{"secret-reader"})),
+			role("prod", "rb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"rolebindings"}, []string{"create"}, nil)),
+		},
+		nil,
+		[]rbacv1.RoleBinding{
+			roleBinding("prod", "rb1", "Role", "binder", saSubject("prod", "attacker")),
+			roleBinding("prod", "rb2", "Role", "rb-creator", saSubject("prod", "attacker")),
+		},
+		nil,
+		nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("prod", "attacker"))
+	foundSecretRead := false
+	for _, sr := range result.EffectiveRules {
+		if sr.Namespace == "prod" && ruleGrants(sr.Rule, "", "secrets", "get") {
+			foundSecretRead = true
+		}
+	}
+	if !foundSecretRead {
+		t.Errorf("EffectiveRules = %+v, want secret-reader's rules to have been adopted", result.EffectiveRules)
+	}
+	if result.ClusterAdmin {
+		t.Error("ClusterAdmin = true, want false: this bind was confined to namespace prod, not cluster-wide")
+	}
+}
+
+func TestAnalyzeEscalation_BindWithoutCreateRoleBindingDoesNothing(t *testing.T) {
+	idx := NewIndex(
+		[]rbacv1.Role{
+			role("prod", "secret-reader", rule([]string{""}, []string{"secrets"}, []string{"get"}, nil)),
+			role("prod", "binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"bind"}, []string{"secret-reader"})),
+		},
+		nil,
+		[]rbacv1.RoleBinding{roleBinding("prod", "rb1", "Role", "binder", saSubject("prod", "attacker"))},
+		nil,
+		nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("prod", "attacker"))
+	for _, sr := range result.EffectiveRules {
+		if ruleGrants(sr.Rule, "", "secrets", "get") {
+			t.Errorf("EffectiveRules = %+v, want secret-reader's rules NOT adopted without create-rolebindings", result.EffectiveRules)
+		}
+	}
+}
+
+// --- assign-serviceaccount primitive ---
+
+func TestAnalyzeEscalation_CreatePodsReachesEveryServiceAccountInNamespace(t *testing.T) {
+	cr := clusterRole("pod-creator", rule([]string{""}, []string{"pods"}, []string{"create"}, nil))
+	crb := clusterRoleBinding("crb", "pod-creator", saSubject("prod", "attacker"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, []corev1.ServiceAccount{saObj("prod", "attacker"), saObj("prod", "privileged")})
+
+	result := idx.AnalyzeEscalation(sa("prod", "attacker"))
+	found := false
+	for _, path := range result.Reached {
+		last := path.Edges[len(path.Edges)-1]
+		if last.ToSubject != nil && *last.ToSubject == sa("prod", "privileged") && last.Primitive == PrimitiveAssignServiceAccount {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Reached = %+v, want a path to prod/privileged via assign-serviceaccount", result.Reached)
+	}
+}
+
+// --- mint-serviceaccount-token primitive ---
+
+func TestAnalyzeEscalation_MintTokenForNamedServiceAccountReachesIt(t *testing.T) {
+	cr := clusterRole("token-minter", rule([]string{""}, []string{"serviceaccounts/token"}, []string{"create"}, []string{"target"}))
+	idx := NewIndex(
+		nil, []rbacv1.ClusterRole{cr}, nil,
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "token-minter", saSubject("ns", "attacker"))},
+		[]corev1.ServiceAccount{saObj("ns", "attacker"), saObj("ns", "target"), saObj("other-ns", "target")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	// The rule is cluster-wide (via ClusterRoleBinding) with resourceNames
+	// restricting to SAs literally named "target" -- both ns/target and
+	// other-ns/target match, since the rule itself carries no namespace
+	// restriction beyond the object name.
+	if len(result.Reached) != 2 {
+		t.Fatalf("Reached = %+v, want two paths: ns/target and other-ns/target both match resourceNames=[target]", result.Reached)
+	}
+}
+
+// --- multi-hop chaining ---
+
+func TestAnalyzeEscalation_ChainedImpersonateThenBindReachesClusterAdmin(t *testing.T) {
+	// attacker can impersonate "middle", who can bind+create-clusterrolebindings
+	// to adopt a full cluster-admin ClusterRole. Confirms BFS actually chases
+	// a second hop, not just direct escalation edges from the start subject.
+	admin := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	binder := clusterRole("binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"bind"}, []string{"cluster-admin-ish"}))
+	crbCreator := clusterRole("crb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterrolebindings"}, []string{"create"}, nil))
+	impersonator := clusterRole("impersonator", rule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, []string{"middle"}))
+
+	idx := NewIndex(
+		nil,
+		[]rbacv1.ClusterRole{admin, binder, crbCreator, impersonator},
+		nil,
+		[]rbacv1.ClusterRoleBinding{
+			clusterRoleBinding("crb-impersonator", "impersonator", saSubject("ns", "attacker")),
+			clusterRoleBinding("crb-binder", "binder", saSubject("ns", "middle")),
+			clusterRoleBinding("crb-creator", "crb-creator", saSubject("ns", "middle")),
+		},
+		[]corev1.ServiceAccount{saObj("ns", "attacker"), saObj("ns", "middle")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: attacker -> impersonate middle -> middle binds cluster-admin-ish -> cluster-admin")
+	}
+	found := false
+	for _, path := range result.Reached {
+		if len(path.Edges) == 1 && *path.Edges[0].ToSubject == sa("ns", "middle") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Reached = %+v, want a one-hop path to ns/middle", result.Reached)
+	}
+}
+
+func TestAnalyzeEscalation_NoRulesReachesNothing(t *testing.T) {
+	idx := NewIndex(nil, nil, nil, nil, nil)
+	result := idx.AnalyzeEscalation(sa("ns", "nobody"))
+	if len(result.Reached) != 0 || result.ClusterAdmin || len(result.Unbounded) != 0 {
+		t.Errorf("result = %+v, want a completely empty result for an unknown subject with no bindings", result)
+	}
+}
+
+func TestAnalyzeEscalation_SelfReferentialCreatePodsDoesNotSelfLoop(t *testing.T) {
+	// A ServiceAccount that can create pods in its own namespace (a very
+	// common, benign grant) must not "reach itself" via assign-serviceaccount
+	// -- that's not an escalation.
+	cr := clusterRole("pod-creator", rule([]string{""}, []string{"pods"}, []string{"create"}, nil))
+	idx := NewIndex(
+		nil, []rbacv1.ClusterRole{cr}, nil,
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "pod-creator", saSubject("ns", "solo"))},
+		[]corev1.ServiceAccount{saObj("ns", "solo")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "solo"))
+	if len(result.Reached) != 0 {
+		t.Errorf("Reached = %+v, want empty: the only ServiceAccount in scope is the subject itself", result.Reached)
+	}
+}

--- a/core/pkg/rbacgraph/closure_test.go
+++ b/core/pkg/rbacgraph/closure_test.go
@@ -332,3 +332,262 @@ func TestAnalyzeEscalation_SelfReferentialCreatePodsDoesNotSelfLoop(t *testing.T
 		t.Errorf("Reached = %+v, want empty: the only ServiceAccount in scope is the subject itself", result.Reached)
 	}
 }
+
+func groupSubject(name string) rbacv1.Subject {
+	return rbacv1.Subject{Kind: "Group", Name: name}
+}
+
+// --- matthyx's review findings on PR #3681 ---
+
+func TestDirectRules_ImplicitServiceAccountsGroupGrantsEveryServiceAccount(t *testing.T) {
+	cr := clusterRole("privileged", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	crb := clusterRoleBinding("crb", "privileged", groupSubject("system:serviceaccounts"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, nil)
+
+	rules := idx.DirectRules(sa("any-ns", "any-name"))
+	if len(rules) != 1 {
+		t.Fatalf("rules = %+v, want the privileged ClusterRole's rule: every ServiceAccount is implicitly a member of system:serviceaccounts", rules)
+	}
+}
+
+func TestDirectRules_ImplicitNamespacedServiceAccountsGroupIsNamespaceScoped(t *testing.T) {
+	cr := clusterRole("privileged", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	crb := clusterRoleBinding("crb", "privileged", groupSubject("system:serviceaccounts:prod"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, nil)
+
+	if rules := idx.DirectRules(sa("prod", "app")); len(rules) != 1 {
+		t.Errorf("rules = %+v, want one rule: prod/app is a member of system:serviceaccounts:prod", rules)
+	}
+	if rules := idx.DirectRules(sa("other", "app")); len(rules) != 0 {
+		t.Errorf("rules = %+v, want empty: other/app is not a member of system:serviceaccounts:prod", rules)
+	}
+}
+
+func TestDirectRules_ImplicitAuthenticatedGroupGrantsServiceAccountsAndUsers(t *testing.T) {
+	cr := clusterRole("privileged", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	crb := clusterRoleBinding("crb", "privileged", groupSubject("system:authenticated"))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, nil)
+
+	if rules := idx.DirectRules(sa("ns", "app")); len(rules) != 1 {
+		t.Errorf("rules = %+v, want one rule: every ServiceAccount is a member of system:authenticated", rules)
+	}
+	if rules := idx.DirectRules(Subject{Kind: KindUser, Name: "alice"}); len(rules) != 1 {
+		t.Errorf("rules = %+v, want one rule: every authenticated User is a member of system:authenticated", rules)
+	}
+}
+
+func TestAnalyzeEscalation_UnrestrictedNamespacedImpersonateEnumeratesTargets(t *testing.T) {
+	// A namespace-scoped (RoleBinding-granted) unrestricted impersonate on
+	// serviceaccounts must still enumerate the concrete SAs it can reach --
+	// not just report Unbounded and stop, which would silently miss a
+	// known SA bound to cluster-admin in the same namespace.
+	admin := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	impersonator := role("prod", "impersonator", rule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, nil))
+	idx := NewIndex(
+		[]rbacv1.Role{impersonator},
+		[]rbacv1.ClusterRole{admin},
+		[]rbacv1.RoleBinding{roleBinding("prod", "rb", "Role", "impersonator", saSubject("prod", "attacker"))},
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "cluster-admin-ish", saSubject("prod", "victim"))},
+		[]corev1.ServiceAccount{saObj("prod", "attacker"), saObj("prod", "victim")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("prod", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: unrestricted namespaced impersonate must still enumerate and reach prod/victim, who is cluster-admin")
+	}
+}
+
+func TestAnalyzeEscalation_ClusterWideBindOnRolesReachesAnyNamespace(t *testing.T) {
+	// bind on "roles" granted cluster-wide (via ClusterRoleBinding) is the
+	// MORE powerful case (any Role in any namespace), not an edge case to
+	// skip.
+	target := role("prod", "secret-reader", rule([]string{""}, []string{"secrets"}, []string{"get"}, nil))
+	binder := clusterRole("binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"bind"}, nil))
+	creator := clusterRole("rb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"rolebindings"}, []string{"create"}, nil))
+	idx := NewIndex(
+		[]rbacv1.Role{target},
+		[]rbacv1.ClusterRole{binder, creator},
+		nil,
+		[]rbacv1.ClusterRoleBinding{
+			clusterRoleBinding("crb1", "binder", saSubject("ns", "attacker")),
+			clusterRoleBinding("crb2", "rb-creator", saSubject("ns", "attacker")),
+		},
+		nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	found := false
+	for _, sr := range result.EffectiveRules {
+		if sr.Namespace == "prod" && ruleGrants(sr.Rule, "", "secrets", "get") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("EffectiveRules = %+v, want secret-reader's rules adopted: cluster-wide bind+create-rolebindings reaches Roles in any namespace", result.EffectiveRules)
+	}
+}
+
+func TestAnalyzeEscalation_ClusterWideCreateRoleBindingsCoversEveryNamespace(t *testing.T) {
+	// The other half of the same gap: bind is namespace-scoped, but create
+	// rolebindings is granted cluster-wide -- must still combine.
+	target := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	binder := role("prod", "binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"bind"}, []string{"cluster-admin-ish"}))
+	creator := clusterRole("rb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"rolebindings"}, []string{"create"}, nil))
+	idx := NewIndex(
+		[]rbacv1.Role{binder},
+		[]rbacv1.ClusterRole{target, creator},
+		[]rbacv1.RoleBinding{roleBinding("prod", "rb", "Role", "binder", saSubject("prod", "attacker"))},
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "rb-creator", saSubject("prod", "attacker"))},
+		nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("prod", "attacker"))
+	found := false
+	for _, sr := range result.EffectiveRules {
+		if sr.Namespace == "prod" && ruleGrants(sr.Rule, "*", "*", "*") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("want cluster-admin-ish's rules adopted within prod: the namespace-scoped bind grant must combine with the cluster-wide create-rolebindings grant, not require both to share the same scope")
+	}
+}
+
+func TestAnalyzeEscalation_ImpersonateSystemMastersIsImmediateClusterAdmin(t *testing.T) {
+	// system:masters is hardcoded as an omnipotent superuser by the
+	// authorizer itself -- no RBAC object ever binds it, so the BFS would
+	// otherwise dead-end there and report ClusterAdmin: false.
+	cr := clusterRole("impersonator", rule([]string{""}, []string{"groups"}, []string{"impersonate"}, []string{"system:masters"}))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "impersonator", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true: impersonating system:masters is an unconditional cluster-admin win")
+	}
+}
+
+func TestAnalyzeEscalation_NamespaceScopedUserImpersonateIsNotHonored(t *testing.T) {
+	// Kubernetes does not honor a namespace-scoped (RoleBinding-granted)
+	// grant of impersonate on the non-namespaced "users" resource type --
+	// only a cluster-wide (ClusterRoleBinding) grant is meaningful.
+	r := role("ns", "impersonator", rule([]string{""}, []string{"users"}, []string{"impersonate"}, []string{"alice"}))
+	idx := NewIndex([]rbacv1.Role{r}, nil, []rbacv1.RoleBinding{roleBinding("ns", "rb", "Role", "impersonator", saSubject("ns", "attacker"))}, nil, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if len(result.Reached) != 0 {
+		t.Errorf("Reached = %+v, want empty: a namespace-scoped grant cannot authorize impersonating a User", result.Reached)
+	}
+}
+
+func TestAnalyzeEscalation_CreateRestrictedByResourceNameGrantsNothing(t *testing.T) {
+	// Kubernetes cannot restrict a top-level "create" by resourceNames (the
+	// object doesn't exist yet, so there's no name to match against) -- a
+	// rule with resourceNames on create authorizes nothing for create, not
+	// "every object of that type."
+	cr := clusterRole("scoped-creator", rule([]string{""}, []string{"pods"}, []string{"create"}, []string{"some-specific-name"}))
+	idx := NewIndex(
+		nil, []rbacv1.ClusterRole{cr}, nil,
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "scoped-creator", saSubject("ns", "attacker"))},
+		[]corev1.ServiceAccount{saObj("ns", "attacker"), saObj("ns", "victim")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if len(result.Reached) != 0 {
+		t.Errorf("Reached = %+v, want empty: resourceNames-restricted create authorizes nothing", result.Reached)
+	}
+}
+
+func TestAnalyzeEscalation_EscalateAndUpdateOnDifferentRolesDoNotCombine(t *testing.T) {
+	// escalate restricted to role-a and update restricted to role-b are two
+	// unrelated grants -- neither authorizes rewriting the other's target,
+	// so they must not combine into an Unbounded finding.
+	roleA := role("ns", "role-a", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	roleB := role("ns", "role-b", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	escalator := role("ns", "escalator", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"escalate"}, []string{"role-a"}))
+	mutator := role("ns", "mutator", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"update"}, []string{"role-b"}))
+	idx := NewIndex(
+		[]rbacv1.Role{roleA, roleB, escalator, mutator},
+		nil,
+		[]rbacv1.RoleBinding{
+			roleBinding("ns", "rb1", "Role", "escalator", saSubject("ns", "attacker")),
+			roleBinding("ns", "rb2", "Role", "mutator", saSubject("ns", "attacker")),
+		},
+		nil, nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if result.ClusterAdmin || len(result.Unbounded) != 0 {
+		t.Errorf("want no escalation: escalate on role-a and update on role-b don't authorize rewriting either role, got ClusterAdmin=%v Unbounded=%+v", result.ClusterAdmin, result.Unbounded)
+	}
+}
+
+func TestAnalyzeEscalation_EscalateAndUpdateOnSameNamedRoleDoesEscalate(t *testing.T) {
+	// The positive counterpart: when both grants target the SAME role by
+	// name, it is exploitable.
+	roleA := role("ns", "role-a", rule([]string{""}, []string{"pods"}, []string{"get"}, nil))
+	escalator := role("ns", "escalator", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"escalate"}, []string{"role-a"}))
+	mutator := role("ns", "mutator", rule([]string{"rbac.authorization.k8s.io"}, []string{"roles"}, []string{"update"}, []string{"role-a"}))
+	idx := NewIndex(
+		[]rbacv1.Role{roleA, escalator, mutator},
+		nil,
+		[]rbacv1.RoleBinding{
+			roleBinding("ns", "rb1", "Role", "escalator", saSubject("ns", "attacker")),
+			roleBinding("ns", "rb2", "Role", "mutator", saSubject("ns", "attacker")),
+		},
+		nil, nil,
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if len(result.Unbounded) == 0 {
+		t.Error("Unbounded = empty, want a finding: escalate and update both target role-a")
+	}
+}
+
+func TestAnalyzeEscalation_TruncatedFlagSetWhenBudgetExhausted(t *testing.T) {
+	orig := maxEscalationHops
+	maxEscalationHops = 1
+	defer func() { maxEscalationHops = orig }()
+
+	// Two hops needed (attacker -> middle -> cluster-admin via bind), but the
+	// budget only allows processing the start subject itself.
+	admin := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	binder := clusterRole("binder", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles"}, []string{"bind"}, []string{"cluster-admin-ish"}))
+	crbCreator := clusterRole("crb-creator", rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterrolebindings"}, []string{"create"}, nil))
+	impersonator := clusterRole("impersonator", rule([]string{""}, []string{"serviceaccounts"}, []string{"impersonate"}, []string{"middle"}))
+	idx := NewIndex(
+		nil,
+		[]rbacv1.ClusterRole{admin, binder, crbCreator, impersonator},
+		nil,
+		[]rbacv1.ClusterRoleBinding{
+			clusterRoleBinding("crb-impersonator", "impersonator", saSubject("ns", "attacker")),
+			clusterRoleBinding("crb-binder", "binder", saSubject("ns", "middle")),
+			clusterRoleBinding("crb-creator", "crb-creator", saSubject("ns", "middle")),
+		},
+		[]corev1.ServiceAccount{saObj("ns", "attacker"), saObj("ns", "middle")},
+	)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if !result.Truncated {
+		t.Error("Truncated = false, want true: the search ran out of budget before confirming ClusterAdmin one way or the other")
+	}
+	if result.ClusterAdmin {
+		t.Error("ClusterAdmin = true, but Truncated should mean this specific run didn't confirm it -- test setup contradiction")
+	}
+}
+
+func TestAnalyzeEscalation_NotTruncatedWhenClusterAdminConfirmedBeforeBudgetExhausted(t *testing.T) {
+	orig := maxEscalationHops
+	maxEscalationHops = 1
+	defer func() { maxEscalationHops = orig }()
+
+	cr := clusterRole("cluster-admin-ish", rule([]string{"*"}, []string{"*"}, []string{"*"}, nil))
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "cluster-admin-ish", saSubject("ns", "attacker"))}, nil)
+
+	result := idx.AnalyzeEscalation(sa("ns", "attacker"))
+	if result.Truncated {
+		t.Error("Truncated = true, want false: ClusterAdmin was confirmed directly from the start subject's own rules, before the budget mattered")
+	}
+	if !result.ClusterAdmin {
+		t.Error("ClusterAdmin = false, want true")
+	}
+}

--- a/core/pkg/rbacgraph/escalation.go
+++ b/core/pkg/rbacgraph/escalation.go
@@ -6,6 +6,15 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
+// superuserGroups are RBAC subject names the authorizer treats as
+// omnipotent without any RBAC object ever binding them -- reaching one via
+// impersonation is an immediate, unconditional cluster-admin win, and the
+// BFS would otherwise dead-end there (nothing binds these names, so
+// DirectRules finds nothing further).
+var superuserGroups = map[string]bool{
+	"system:masters": true,
+}
+
 // DirectEscalationEdges returns every one-hop escalation technique subject
 // can exercise given rules (their currently-known ScopedRules -- either
 // DirectRules(subject), or an enriched set after a bind-verb/escalate-verb
@@ -33,14 +42,22 @@ func (idx *Index) DirectEscalationEdges(subject Subject, rules []ScopedRule) []E
 
 // impersonateEdges implements the impersonate primitive: the "impersonate"
 // verb (core API group) on serviceaccounts/users/groups lets a subject act
-// as the impersonated identity outright. serviceaccounts targets are
-// enumerated against collected ServiceAccount objects (respecting the
-// granting rule's own namespace scope, or every collected namespace for a
-// cluster-wide grant); users/groups targets are enumerated only when the
-// rule names them explicitly via resourceNames, since there is no cluster
-// object to enumerate arbitrary user/group identities from -- an
-// unrestricted rule against any of the three resource types is reported as
-// an Unbounded finding instead of guessed-at concrete edges.
+// as the impersonated identity outright.
+//
+// serviceaccounts targets are enumerated against collected ServiceAccount
+// objects regardless of whether the rule is resourceNames-restricted (an
+// unrestricted grant is a superset of the restricted case, so it must
+// enumerate the same targets too, in addition to being reported as
+// Unbounded for whatever this Index didn't collect).
+//
+// users/groups targets are enumerated only when the rule names them
+// explicitly via resourceNames, since there is no cluster object to
+// enumerate arbitrary user/group identities from. These two branches also
+// only fire from a cluster-wide rule (granted via ClusterRoleBinding):
+// Users and Groups are not namespaced identities, and Kubernetes' RBAC
+// authorizer does not honor a namespace-scoped Role/RoleBinding's grant
+// against them -- only serviceaccounts is itself a namespaced resource
+// type a Role can meaningfully constrain.
 func (idx *Index) impersonateEdges(rules []ScopedRule) []EscalationEdge {
 	var edges []EscalationEdge
 	for _, sr := range rules {
@@ -58,20 +75,22 @@ func (idx *Index) impersonateEdges(rules []ScopedRule) []EscalationEdge {
 					Unbounded: true,
 					Scope:     sr.Namespace,
 				})
-			} else {
-				for _, ns := range idx.targetNamespaces(sr.Namespace) {
-					for _, saName := range idx.serviceAccountsByNS[ns] {
-						if !containsOrWildcard(names, saName) {
-							continue
-						}
-						edges = append(edges, EscalationEdge{
-							Primitive: PrimitiveImpersonate,
-							Detail:    fmt.Sprintf("can impersonate ServiceAccount %s/%s", ns, saName),
-							ToSubject: &Subject{Kind: KindServiceAccount, Namespace: ns, Name: saName},
-						})
+			}
+			for _, ns := range idx.targetNamespaces(sr.Namespace) {
+				for _, saName := range idx.serviceAccountsByNS[ns] {
+					if restricted && !containsOrWildcard(names, saName) {
+						continue
 					}
+					edges = append(edges, EscalationEdge{
+						Primitive: PrimitiveImpersonate,
+						Detail:    fmt.Sprintf("can impersonate ServiceAccount %s/%s", ns, saName),
+						ToSubject: &Subject{Kind: KindServiceAccount, Namespace: ns, Name: saName},
+					})
 				}
 			}
+		}
+		if sr.Namespace != "" {
+			continue // users/groups impersonation is not honored from a namespace-scoped grant
 		}
 		if containsOrWildcard(rule.Resources, "users") || containsOrWildcard(rule.Resources, "*") {
 			if !restricted {
@@ -95,41 +114,124 @@ func (idx *Index) impersonateEdges(rules []ScopedRule) []EscalationEdge {
 	return edges
 }
 
+// roleCoverage tracks, for one verb across one scope, whether a subject's
+// rules cover every object of a resource type (Unrestricted) or only
+// specific named ones (Names) -- used by escalateVerbEdges to correlate
+// two different verbs (escalate, and update/patch) against the same
+// target role, not just the same scope.
+type roleCoverage struct {
+	unrestricted bool
+	names        map[string]bool
+}
+
+func (c *roleCoverage) add(rule rbacv1.PolicyRule) {
+	names, restricted := namedResources(rule)
+	if !restricted {
+		c.unrestricted = true
+		return
+	}
+	for _, n := range names {
+		c.names[n] = true
+	}
+}
+
 // escalateVerbEdges implements the escalate-verb primitive: Kubernetes'
 // RBAC self-escalation prevention normally stops a subject from granting a
 // Role/ClusterRole rules it doesn't already itself hold, unless the
 // subject also holds the "escalate" verb on that resource type -- combined
 // with update/patch (needed to actually modify the object), that's a
-// documented built-in bypass. Only clusterroles at cluster scope and roles
-// at either scope are modeled; a namespace-scoped rule naming the
+// documented built-in bypass. The escalate grant and the update/patch grant
+// must actually cover the *same* role -- two independent resourceNames-
+// restricted grants for different roles (escalate on role-a, update on
+// role-b) don't combine into anything exploitable, so this correlates them
+// by target name (or scope-wide, when either or both sides are
+// unrestricted) rather than just checking "does the subject hold both verbs
+// somewhere in this scope." Only clusterroles at cluster scope and roles at
+// either scope are modeled; a namespace-scoped rule naming the
 // cluster-scoped "clusterroles" resource type is an unusual enough pattern
 // that this package doesn't attempt to reason about its effect.
 func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 	var edges []EscalationEdge
 	for _, resource := range []string{"clusterroles", "roles"} {
-		escalateScopes := map[string]bool{}
-		mutateScopes := map[string]bool{}
+		escalateByScope := map[string]*roleCoverage{}
+		mutateByScope := map[string]*roleCoverage{}
 		for _, sr := range rules {
 			if ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "escalate") {
-				escalateScopes[sr.Namespace] = true
+				c, ok := escalateByScope[sr.Namespace]
+				if !ok {
+					c = &roleCoverage{names: map[string]bool{}}
+					escalateByScope[sr.Namespace] = c
+				}
+				c.add(sr.Rule)
 			}
 			if ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "update") || ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "patch") {
-				mutateScopes[sr.Namespace] = true
+				c, ok := mutateByScope[sr.Namespace]
+				if !ok {
+					c = &roleCoverage{names: map[string]bool{}}
+					mutateByScope[sr.Namespace] = c
+				}
+				c.add(sr.Rule)
 			}
 		}
-		for ns := range escalateScopes {
-			if !mutateScopes[ns] {
+
+		for scope, esc := range escalateByScope {
+			if resource == "clusterroles" && scope != "" {
 				continue
 			}
-			if resource == "clusterroles" && ns != "" {
+			mut, ok := mutateByScope[scope]
+			if !ok {
 				continue
 			}
-			edges = append(edges, EscalationEdge{
-				Primitive: PrimitiveEscalateVerb,
-				Detail:    fmt.Sprintf("holds escalate + update/patch on %s.rbac.authorization.k8s.io", resource),
-				Unbounded: true,
-				Scope:     ns,
-			})
+
+			if esc.unrestricted && mut.unrestricted {
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveEscalateVerb,
+					Detail:    fmt.Sprintf("holds escalate + update/patch on %s.rbac.authorization.k8s.io", resource),
+					Unbounded: true,
+					Scope:     scope,
+				})
+				continue
+			}
+
+			var targetNames []string
+			switch {
+			case esc.unrestricted:
+				targetNames = setToSlice(mut.names)
+			case mut.unrestricted:
+				targetNames = setToSlice(esc.names)
+			default:
+				targetNames = intersectSets(esc.names, mut.names)
+			}
+			if len(targetNames) == 0 {
+				continue
+			}
+
+			if resource == "clusterroles" {
+				for _, cr := range idx.matchingClusterRoles(targetNames, true) {
+					edges = append(edges, EscalationEdge{
+						Primitive: PrimitiveEscalateVerb,
+						Detail:    fmt.Sprintf("holds escalate + update/patch on ClusterRole %q: can rewrite it to grant itself anything", cr.Name),
+						Unbounded: true,
+						Scope:     "",
+					})
+				}
+				continue
+			}
+
+			var roles []*rbacv1.Role
+			if scope == "" {
+				roles = idx.matchingRolesAnyNamespace(targetNames, true)
+			} else {
+				roles = idx.matchingRoles(scope, targetNames, true)
+			}
+			for _, r := range roles {
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveEscalateVerb,
+					Detail:    fmt.Sprintf("holds escalate + update/patch on Role %q in namespace %q: can rewrite it to grant itself anything", r.Name, r.Namespace),
+					Unbounded: true,
+					Scope:     r.Namespace,
+				})
+			}
 		}
 	}
 	return edges
@@ -140,7 +242,10 @@ func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 // bypass -- combined with the ability to create a RoleBinding or
 // ClusterRoleBinding, a subject can attach any Role/ClusterRole they can
 // bind to a subject of their choosing (in practice, themselves), adopting
-// its rules without ever having held them directly.
+// its rules without ever having held them directly. A cluster-wide grant of
+// either half (bind, or create rolebindings/clusterrolebindings) is treated
+// as covering every namespace this Index knows about, not skipped -- it is
+// the more powerful case, not an edge case to exclude.
 func (idx *Index) bindVerbEdges(rules []ScopedRule) []EscalationEdge {
 	var edges []EscalationEdge
 
@@ -160,7 +265,10 @@ func (idx *Index) bindVerbEdges(rules []ScopedRule) []EscalationEdge {
 				})
 			}
 		}
-		for _, ns := range idx.namespacesWithCreate(rules, "rolebindings") {
+		for _, ns := range idx.knownNamespaces() {
+			if !idx.canCreateRoleBindingsIn(rules, ns) {
+				continue
+			}
 			for _, cr := range targets {
 				edges = append(edges, EscalationEdge{
 					Primitive:    PrimitiveBindVerb,
@@ -172,18 +280,24 @@ func (idx *Index) bindVerbEdges(rules []ScopedRule) []EscalationEdge {
 	}
 
 	for _, sr := range rules {
-		if sr.Namespace == "" || !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", "roles", "bind") {
-			continue
-		}
-		if !idx.hasCreateInNamespace(rules, "rolebindings", sr.Namespace) {
+		if !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", "roles", "bind") {
 			continue
 		}
 		names, restricted := namedResources(sr.Rule)
-		for _, r := range idx.matchingRoles(sr.Namespace, names, restricted) {
+		var candidates []*rbacv1.Role
+		if sr.Namespace == "" {
+			candidates = idx.matchingRolesAnyNamespace(names, restricted)
+		} else {
+			candidates = idx.matchingRoles(sr.Namespace, names, restricted)
+		}
+		for _, r := range candidates {
+			if !idx.canCreateRoleBindingsIn(rules, r.Namespace) {
+				continue
+			}
 			edges = append(edges, EscalationEdge{
 				Primitive:    PrimitiveBindVerb,
-				Detail:       fmt.Sprintf("can bind Role %q within namespace %q via a new RoleBinding", r.Name, sr.Namespace),
-				GrantedRules: scopeRules(r.Rules, sr.Namespace),
+				Detail:       fmt.Sprintf("can bind Role %q within namespace %q via a new RoleBinding", r.Name, r.Namespace),
+				GrantedRules: scopeRules(r.Rules, r.Namespace),
 			})
 		}
 	}
@@ -199,7 +313,7 @@ func (idx *Index) bindVerbEdges(rules []ScopedRule) []EscalationEdge {
 func (idx *Index) assignServiceAccountEdges(rules []ScopedRule) []EscalationEdge {
 	var edges []EscalationEdge
 	for _, sr := range rules {
-		if !ruleGrants(sr.Rule, "", "pods", "create") {
+		if !ruleGrantsUnnamedCreate(sr.Rule, "", "pods") {
 			continue
 		}
 		for _, ns := range idx.targetNamespaces(sr.Namespace) {
@@ -218,7 +332,10 @@ func (idx *Index) assignServiceAccountEdges(rules []ScopedRule) []EscalationEdge
 // mintServiceAccountTokenEdges implements the mint-serviceaccount-token
 // primitive: create on the serviceaccounts/token subresource (the
 // TokenRequest API) mints a live token for the named ServiceAccount
-// directly, no pod required.
+// directly, no pod required. Unlike a top-level create, this is a create on
+// an already-named parent object (POST .../serviceaccounts/{name}/token),
+// so resourceNames legitimately restricts it -- this is intentionally not
+// routed through ruleGrantsUnnamedCreate.
 func (idx *Index) mintServiceAccountTokenEdges(rules []ScopedRule) []EscalationEdge {
 	var edges []EscalationEdge
 	for _, sr := range rules {
@@ -257,6 +374,32 @@ func (idx *Index) targetNamespaces(scopeNamespace string) []string {
 	return out
 }
 
+// knownNamespaces returns every namespace this Index has any evidence of,
+// drawn from collected ServiceAccounts, Roles, and RoleBindings -- used to
+// expand a cluster-wide grant (e.g. create rolebindings with no namespace
+// restriction) into the concrete namespaces this package can reason about.
+func (idx *Index) knownNamespaces() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(ns string) {
+		if ns == "" || seen[ns] {
+			return
+		}
+		seen[ns] = true
+		out = append(out, ns)
+	}
+	for ns := range idx.serviceAccountsByNS {
+		add(ns)
+	}
+	for _, r := range idx.roles {
+		add(r.Namespace)
+	}
+	for _, rb := range idx.roleBindings {
+		add(rb.Namespace)
+	}
+	return out
+}
+
 func (idx *Index) matchingClusterRoles(names []string, restricted bool) []*rbacv1.ClusterRole {
 	var out []*rbacv1.ClusterRole
 	for _, cr := range idx.clusterRoles {
@@ -282,9 +425,23 @@ func (idx *Index) matchingRoles(namespace string, names []string, restricted boo
 	return out
 }
 
+// matchingRolesAnyNamespace is matchingRoles without a namespace filter --
+// for a cluster-wide grant (e.g. bind on roles via a ClusterRoleBinding),
+// which applies to Role objects in every namespace, not just one.
+func (idx *Index) matchingRolesAnyNamespace(names []string, restricted bool) []*rbacv1.Role {
+	var out []*rbacv1.Role
+	for _, r := range idx.roles {
+		if restricted && !containsOrWildcard(names, r.Name) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
 func (idx *Index) hasClusterWideCreate(rules []ScopedRule, resource string) bool {
 	for _, sr := range rules {
-		if sr.Namespace == "" && ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
+		if sr.Namespace == "" && ruleGrantsUnnamedCreate(sr.Rule, "rbac.authorization.k8s.io", resource) {
 			return true
 		}
 	}
@@ -293,30 +450,18 @@ func (idx *Index) hasClusterWideCreate(rules []ScopedRule, resource string) bool
 
 func (idx *Index) hasCreateInNamespace(rules []ScopedRule, resource, namespace string) bool {
 	for _, sr := range rules {
-		if sr.Namespace == namespace && ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
+		if sr.Namespace == namespace && ruleGrantsUnnamedCreate(sr.Rule, "rbac.authorization.k8s.io", resource) {
 			return true
 		}
 	}
 	return false
 }
 
-func (idx *Index) namespacesWithCreate(rules []ScopedRule, resource string) []string {
-	seen := map[string]bool{}
-	var out []string
-	for _, sr := range rules {
-		if sr.Namespace == "" {
-			continue
-		}
-		if !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
-			continue
-		}
-		if seen[sr.Namespace] {
-			continue
-		}
-		seen[sr.Namespace] = true
-		out = append(out, sr.Namespace)
-	}
-	return out
+// canCreateRoleBindingsIn reports whether rules lets the subject create a
+// RoleBinding in namespace ns -- either via a grant scoped to exactly that
+// namespace, or a cluster-wide grant (covers every namespace).
+func (idx *Index) canCreateRoleBindingsIn(rules []ScopedRule, ns string) bool {
+	return idx.hasCreateInNamespace(rules, "rolebindings", ns) || idx.hasClusterWideCreate(rules, "rolebindings")
 }
 
 func scopeRules(rules []rbacv1.PolicyRule, namespace string) []ScopedRule {

--- a/core/pkg/rbacgraph/escalation.go
+++ b/core/pkg/rbacgraph/escalation.go
@@ -2,6 +2,7 @@ package rbacgraph
 
 import (
 	"fmt"
+	"sort"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -193,6 +194,10 @@ func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 				continue
 			}
 
+			// targetNames == empty here (both grants restricted, no
+			// overlapping name) is a genuine rejection -- escalate on
+			// role-a and update on role-b don't authorize rewriting
+			// either, so no edge, no fallback.
 			var targetNames []string
 			switch {
 			case esc.unrestricted:
@@ -205,9 +210,28 @@ func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 			if len(targetNames) == 0 {
 				continue
 			}
+			sort.Strings(targetNames)
 
 			if resource == "clusterroles" {
-				for _, cr := range idx.matchingClusterRoles(targetNames, true) {
+				matched := idx.matchingClusterRoles(targetNames, true)
+				if len(matched) == 0 {
+					// targetNames is non-empty (the grants do overlap on a
+					// name) but resolves to no object this Index actually
+					// collected -- that could mean the name is stale, or it
+					// could mean a partial/paginated collection missed it.
+					// Fail toward reporting risk, not silence: the prior
+					// (pre-name-correlation) version of this code reported a
+					// scope-level Unbounded here, and dropping that
+					// silently would be a regression in exactly the
+					// direction this package exists to avoid.
+					edges = append(edges, EscalationEdge{
+						Primitive: PrimitiveEscalateVerb,
+						Detail:    fmt.Sprintf("holds escalate + update/patch on ClusterRole(s) %v, not found in the collected snapshot -- may be a partial collection, not a confirmed absence", targetNames),
+						Unbounded: true,
+						Scope:     "",
+					})
+				}
+				for _, cr := range matched {
 					edges = append(edges, EscalationEdge{
 						Primitive: PrimitiveEscalateVerb,
 						Detail:    fmt.Sprintf("holds escalate + update/patch on ClusterRole %q: can rewrite it to grant itself anything", cr.Name),
@@ -223,6 +247,16 @@ func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 				roles = idx.matchingRolesAnyNamespace(targetNames, true)
 			} else {
 				roles = idx.matchingRoles(scope, targetNames, true)
+			}
+			if len(roles) == 0 {
+				// Same partial-collection fallback as the clusterroles case
+				// above.
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveEscalateVerb,
+					Detail:    fmt.Sprintf("holds escalate + update/patch on Role(s) %v in namespace scope %q, not found in the collected snapshot -- may be a partial collection, not a confirmed absence", targetNames, scope),
+					Unbounded: true,
+					Scope:     scope,
+				})
 			}
 			for _, r := range roles {
 				edges = append(edges, EscalationEdge{

--- a/core/pkg/rbacgraph/escalation.go
+++ b/core/pkg/rbacgraph/escalation.go
@@ -1,0 +1,328 @@
+package rbacgraph
+
+import (
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// DirectEscalationEdges returns every one-hop escalation technique subject
+// can exercise given rules (their currently-known ScopedRules -- either
+// DirectRules(subject), or an enriched set after a bind-verb/escalate-verb
+// edge has already granted additional rules to subject). Self-edges (an
+// edge whose ToSubject is subject itself, e.g. a Pod-creation right letting
+// a ServiceAccount "assign" its own identity) are filtered out -- they
+// don't represent an escalation.
+func (idx *Index) DirectEscalationEdges(subject Subject, rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+	edges = append(edges, idx.impersonateEdges(rules)...)
+	edges = append(edges, idx.escalateVerbEdges(rules)...)
+	edges = append(edges, idx.bindVerbEdges(rules)...)
+	edges = append(edges, idx.assignServiceAccountEdges(rules)...)
+	edges = append(edges, idx.mintServiceAccountTokenEdges(rules)...)
+
+	out := edges[:0]
+	for _, e := range edges {
+		if e.ToSubject != nil && *e.ToSubject == subject {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// impersonateEdges implements the impersonate primitive: the "impersonate"
+// verb (core API group) on serviceaccounts/users/groups lets a subject act
+// as the impersonated identity outright. serviceaccounts targets are
+// enumerated against collected ServiceAccount objects (respecting the
+// granting rule's own namespace scope, or every collected namespace for a
+// cluster-wide grant); users/groups targets are enumerated only when the
+// rule names them explicitly via resourceNames, since there is no cluster
+// object to enumerate arbitrary user/group identities from -- an
+// unrestricted rule against any of the three resource types is reported as
+// an Unbounded finding instead of guessed-at concrete edges.
+func (idx *Index) impersonateEdges(rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+	for _, sr := range rules {
+		rule := sr.Rule
+		if !containsOrWildcard(rule.Verbs, "impersonate") || !containsOrWildcard(rule.APIGroups, "") {
+			continue
+		}
+		names, restricted := namedResources(rule)
+
+		if containsOrWildcard(rule.Resources, "serviceaccounts") || containsOrWildcard(rule.Resources, "*") {
+			if !restricted {
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveImpersonate,
+					Detail:    "can impersonate any ServiceAccount (unrestricted impersonate on serviceaccounts)",
+					Unbounded: true,
+					Scope:     sr.Namespace,
+				})
+			} else {
+				for _, ns := range idx.targetNamespaces(sr.Namespace) {
+					for _, saName := range idx.serviceAccountsByNS[ns] {
+						if !containsOrWildcard(names, saName) {
+							continue
+						}
+						edges = append(edges, EscalationEdge{
+							Primitive: PrimitiveImpersonate,
+							Detail:    fmt.Sprintf("can impersonate ServiceAccount %s/%s", ns, saName),
+							ToSubject: &Subject{Kind: KindServiceAccount, Namespace: ns, Name: saName},
+						})
+					}
+				}
+			}
+		}
+		if containsOrWildcard(rule.Resources, "users") || containsOrWildcard(rule.Resources, "*") {
+			if !restricted {
+				edges = append(edges, EscalationEdge{Primitive: PrimitiveImpersonate, Detail: "can impersonate any User (unrestricted impersonate on users)", Unbounded: true})
+			} else {
+				for _, name := range names {
+					edges = append(edges, EscalationEdge{Primitive: PrimitiveImpersonate, Detail: fmt.Sprintf("can impersonate User %q", name), ToSubject: &Subject{Kind: KindUser, Name: name}})
+				}
+			}
+		}
+		if containsOrWildcard(rule.Resources, "groups") || containsOrWildcard(rule.Resources, "*") {
+			if !restricted {
+				edges = append(edges, EscalationEdge{Primitive: PrimitiveImpersonate, Detail: "can impersonate any Group (unrestricted impersonate on groups)", Unbounded: true})
+			} else {
+				for _, name := range names {
+					edges = append(edges, EscalationEdge{Primitive: PrimitiveImpersonate, Detail: fmt.Sprintf("can impersonate Group %q", name), ToSubject: &Subject{Kind: KindGroup, Name: name}})
+				}
+			}
+		}
+	}
+	return edges
+}
+
+// escalateVerbEdges implements the escalate-verb primitive: Kubernetes'
+// RBAC self-escalation prevention normally stops a subject from granting a
+// Role/ClusterRole rules it doesn't already itself hold, unless the
+// subject also holds the "escalate" verb on that resource type -- combined
+// with update/patch (needed to actually modify the object), that's a
+// documented built-in bypass. Only clusterroles at cluster scope and roles
+// at either scope are modeled; a namespace-scoped rule naming the
+// cluster-scoped "clusterroles" resource type is an unusual enough pattern
+// that this package doesn't attempt to reason about its effect.
+func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+	for _, resource := range []string{"clusterroles", "roles"} {
+		escalateScopes := map[string]bool{}
+		mutateScopes := map[string]bool{}
+		for _, sr := range rules {
+			if ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "escalate") {
+				escalateScopes[sr.Namespace] = true
+			}
+			if ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "update") || ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "patch") {
+				mutateScopes[sr.Namespace] = true
+			}
+		}
+		for ns := range escalateScopes {
+			if !mutateScopes[ns] {
+				continue
+			}
+			if resource == "clusterroles" && ns != "" {
+				continue
+			}
+			edges = append(edges, EscalationEdge{
+				Primitive: PrimitiveEscalateVerb,
+				Detail:    fmt.Sprintf("holds escalate + update/patch on %s.rbac.authorization.k8s.io", resource),
+				Unbounded: true,
+				Scope:     ns,
+			})
+		}
+	}
+	return edges
+}
+
+// bindVerbEdges implements the bind-verb primitive: the "bind" verb on a
+// Role/ClusterRole is RBAC's other documented self-escalation-prevention
+// bypass -- combined with the ability to create a RoleBinding or
+// ClusterRoleBinding, a subject can attach any Role/ClusterRole they can
+// bind to a subject of their choosing (in practice, themselves), adopting
+// its rules without ever having held them directly.
+func (idx *Index) bindVerbEdges(rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+
+	for _, sr := range rules {
+		if !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", "clusterroles", "bind") {
+			continue
+		}
+		names, restricted := namedResources(sr.Rule)
+		targets := idx.matchingClusterRoles(names, restricted)
+
+		if idx.hasClusterWideCreate(rules, "clusterrolebindings") {
+			for _, cr := range targets {
+				edges = append(edges, EscalationEdge{
+					Primitive:    PrimitiveBindVerb,
+					Detail:       fmt.Sprintf("can bind ClusterRole %q cluster-wide via a new ClusterRoleBinding", cr.Name),
+					GrantedRules: scopeRules(cr.Rules, ""),
+				})
+			}
+		}
+		for _, ns := range idx.namespacesWithCreate(rules, "rolebindings") {
+			for _, cr := range targets {
+				edges = append(edges, EscalationEdge{
+					Primitive:    PrimitiveBindVerb,
+					Detail:       fmt.Sprintf("can bind ClusterRole %q within namespace %q via a new RoleBinding", cr.Name, ns),
+					GrantedRules: scopeRules(cr.Rules, ns),
+				})
+			}
+		}
+	}
+
+	for _, sr := range rules {
+		if sr.Namespace == "" || !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", "roles", "bind") {
+			continue
+		}
+		if !idx.hasCreateInNamespace(rules, "rolebindings", sr.Namespace) {
+			continue
+		}
+		names, restricted := namedResources(sr.Rule)
+		for _, r := range idx.matchingRoles(sr.Namespace, names, restricted) {
+			edges = append(edges, EscalationEdge{
+				Primitive:    PrimitiveBindVerb,
+				Detail:       fmt.Sprintf("can bind Role %q within namespace %q via a new RoleBinding", r.Name, sr.Namespace),
+				GrantedRules: scopeRules(r.Rules, sr.Namespace),
+			})
+		}
+	}
+	return edges
+}
+
+// assignServiceAccountEdges implements the assign-serviceaccount primitive:
+// create on pods lets a subject choose spec.serviceAccountName freely (see
+// the package doc comment's trust-model note on admission-time
+// restrictions this package does not model), so the subject can schedule a
+// pod running as any ServiceAccount in that namespace and read its mounted
+// token from within.
+func (idx *Index) assignServiceAccountEdges(rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+	for _, sr := range rules {
+		if !ruleGrants(sr.Rule, "", "pods", "create") {
+			continue
+		}
+		for _, ns := range idx.targetNamespaces(sr.Namespace) {
+			for _, saName := range idx.serviceAccountsByNS[ns] {
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveAssignServiceAccount,
+					Detail:    fmt.Sprintf("can create Pods in namespace %q and assign spec.serviceAccountName=%q, inheriting its mounted token", ns, saName),
+					ToSubject: &Subject{Kind: KindServiceAccount, Namespace: ns, Name: saName},
+				})
+			}
+		}
+	}
+	return edges
+}
+
+// mintServiceAccountTokenEdges implements the mint-serviceaccount-token
+// primitive: create on the serviceaccounts/token subresource (the
+// TokenRequest API) mints a live token for the named ServiceAccount
+// directly, no pod required.
+func (idx *Index) mintServiceAccountTokenEdges(rules []ScopedRule) []EscalationEdge {
+	var edges []EscalationEdge
+	for _, sr := range rules {
+		if !ruleGrants(sr.Rule, "", "serviceaccounts/token", "create") {
+			continue
+		}
+		names, restricted := namedResources(sr.Rule)
+		for _, ns := range idx.targetNamespaces(sr.Namespace) {
+			for _, saName := range idx.serviceAccountsByNS[ns] {
+				if restricted && !containsOrWildcard(names, saName) {
+					continue
+				}
+				edges = append(edges, EscalationEdge{
+					Primitive: PrimitiveMintServiceAccountToken,
+					Detail:    fmt.Sprintf("can mint a live token for ServiceAccount %s/%s via the TokenRequest API", ns, saName),
+					ToSubject: &Subject{Kind: KindServiceAccount, Namespace: ns, Name: saName},
+				})
+			}
+		}
+	}
+	return edges
+}
+
+// targetNamespaces expands a ScopedRule's own scope into the namespaces an
+// edge should enumerate targets against: just that one namespace for a
+// namespace-scoped rule, or every namespace this Index has ServiceAccount
+// data for when the rule is cluster-wide.
+func (idx *Index) targetNamespaces(scopeNamespace string) []string {
+	if scopeNamespace != "" {
+		return []string{scopeNamespace}
+	}
+	out := make([]string, 0, len(idx.serviceAccountsByNS))
+	for ns := range idx.serviceAccountsByNS {
+		out = append(out, ns)
+	}
+	return out
+}
+
+func (idx *Index) matchingClusterRoles(names []string, restricted bool) []*rbacv1.ClusterRole {
+	var out []*rbacv1.ClusterRole
+	for _, cr := range idx.clusterRoles {
+		if restricted && !containsOrWildcard(names, cr.Name) {
+			continue
+		}
+		out = append(out, cr)
+	}
+	return out
+}
+
+func (idx *Index) matchingRoles(namespace string, names []string, restricted bool) []*rbacv1.Role {
+	var out []*rbacv1.Role
+	for _, r := range idx.roles {
+		if r.Namespace != namespace {
+			continue
+		}
+		if restricted && !containsOrWildcard(names, r.Name) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func (idx *Index) hasClusterWideCreate(rules []ScopedRule, resource string) bool {
+	for _, sr := range rules {
+		if sr.Namespace == "" && ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
+			return true
+		}
+	}
+	return false
+}
+
+func (idx *Index) hasCreateInNamespace(rules []ScopedRule, resource, namespace string) bool {
+	for _, sr := range rules {
+		if sr.Namespace == namespace && ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
+			return true
+		}
+	}
+	return false
+}
+
+func (idx *Index) namespacesWithCreate(rules []ScopedRule, resource string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, sr := range rules {
+		if sr.Namespace == "" {
+			continue
+		}
+		if !ruleGrants(sr.Rule, "rbac.authorization.k8s.io", resource, "create") {
+			continue
+		}
+		if seen[sr.Namespace] {
+			continue
+		}
+		seen[sr.Namespace] = true
+		out = append(out, sr.Namespace)
+	}
+	return out
+}
+
+func scopeRules(rules []rbacv1.PolicyRule, namespace string) []ScopedRule {
+	out := make([]ScopedRule, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, ScopedRule{Rule: r, Namespace: namespace})
+	}
+	return out
+}

--- a/core/pkg/rbacgraph/index.go
+++ b/core/pkg/rbacgraph/index.go
@@ -1,0 +1,127 @@
+package rbacgraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// Index indexes a cluster's Role, ClusterRole, RoleBinding,
+// ClusterRoleBinding, and ServiceAccount objects for repeated escalation
+// queries against the same snapshot.
+type Index struct {
+	roles               map[string]*rbacv1.Role // key: namespace/name
+	clusterRoles        map[string]*rbacv1.ClusterRole
+	roleBindings        []*rbacv1.RoleBinding
+	clusterRoleBindings []*rbacv1.ClusterRoleBinding
+	// serviceAccountsByNS lists every ServiceAccount name collected per
+	// namespace, needed to enumerate targets for assign-serviceaccount and
+	// mint-serviceaccount-token edges when the granting rule has no
+	// resourceNames restriction.
+	serviceAccountsByNS map[string][]string
+}
+
+// NewIndex builds an Index from a cluster's (or a query's) collected
+// objects. A nil/empty slice for any parameter is treated as "none
+// collected," not an error.
+func NewIndex(roles []rbacv1.Role, clusterRoles []rbacv1.ClusterRole, roleBindings []rbacv1.RoleBinding, clusterRoleBindings []rbacv1.ClusterRoleBinding, serviceAccounts []corev1.ServiceAccount) *Index {
+	idx := &Index{
+		roles:               make(map[string]*rbacv1.Role, len(roles)),
+		clusterRoles:        make(map[string]*rbacv1.ClusterRole, len(clusterRoles)),
+		serviceAccountsByNS: make(map[string][]string),
+	}
+	for i := range roles {
+		r := &roles[i]
+		idx.roles[roleKey(r.Namespace, r.Name)] = r
+	}
+	for i := range clusterRoles {
+		cr := &clusterRoles[i]
+		idx.clusterRoles[cr.Name] = cr
+	}
+	for i := range roleBindings {
+		idx.roleBindings = append(idx.roleBindings, &roleBindings[i])
+	}
+	for i := range clusterRoleBindings {
+		idx.clusterRoleBindings = append(idx.clusterRoleBindings, &clusterRoleBindings[i])
+	}
+	for _, sa := range serviceAccounts {
+		idx.serviceAccountsByNS[sa.Namespace] = append(idx.serviceAccountsByNS[sa.Namespace], sa.Name)
+	}
+	return idx
+}
+
+func roleKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// DirectRules returns every ScopedRule granted to subject by a
+// RoleBinding or ClusterRoleBinding that names it as a subject -- the
+// rules subject holds without needing any escalation technique.
+func (idx *Index) DirectRules(subject Subject) []ScopedRule {
+	var out []ScopedRule
+	for _, crb := range idx.clusterRoleBindings {
+		if !bindingNamesSubject(crb.Subjects, subject) {
+			continue
+		}
+		if cr, ok := idx.clusterRoles[crb.RoleRef.Name]; ok {
+			for _, rule := range cr.Rules {
+				out = append(out, ScopedRule{Rule: rule, Namespace: ""})
+			}
+		}
+	}
+	for _, rb := range idx.roleBindings {
+		if !bindingNamesSubject(rb.Subjects, subject) {
+			continue
+		}
+		switch rb.RoleRef.Kind {
+		case "Role":
+			if r, ok := idx.roles[roleKey(rb.Namespace, rb.RoleRef.Name)]; ok {
+				for _, rule := range r.Rules {
+					out = append(out, ScopedRule{Rule: rule, Namespace: rb.Namespace})
+				}
+			}
+		case "ClusterRole":
+			if cr, ok := idx.clusterRoles[rb.RoleRef.Name]; ok {
+				for _, rule := range cr.Rules {
+					out = append(out, ScopedRule{Rule: rule, Namespace: rb.Namespace})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func bindingNamesSubject(subjects []rbacv1.Subject, subject Subject) bool {
+	for _, s := range subjects {
+		switch subject.Kind {
+		case KindServiceAccount:
+			if s.Kind == "ServiceAccount" && s.Name == subject.Name && s.Namespace == subject.Namespace {
+				return true
+			}
+		case KindUser:
+			if s.Kind == "User" && s.Name == subject.Name {
+				return true
+			}
+		case KindGroup:
+			if s.Kind == "Group" && s.Name == subject.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsClusterAdminEquivalent reports whether rules includes a cluster-wide
+// (Namespace == "") rule granting every verb on every resource in every
+// API group -- the literal definition of the built-in cluster-admin
+// ClusterRole's power, however it was actually reached.
+func IsClusterAdminEquivalent(rules []ScopedRule) bool {
+	for _, sr := range rules {
+		if sr.Namespace != "" {
+			continue
+		}
+		if ruleGrants(sr.Rule, "*", "*", "*") {
+			return true
+		}
+	}
+	return false
+}

--- a/core/pkg/rbacgraph/index.go
+++ b/core/pkg/rbacgraph/index.go
@@ -90,6 +90,18 @@ func (idx *Index) DirectRules(subject Subject) []ScopedRule {
 	return out
 }
 
+// bindingNamesSubject reports whether any of subjects actually authorizes
+// subject -- either by naming it directly, or via one of Kubernetes'
+// implicit groups every identity of that kind automatically belongs to:
+// every ServiceAccount is a member of system:serviceaccounts,
+// system:serviceaccounts:<its namespace>, and system:authenticated; every
+// User is a member of system:authenticated. A RoleBinding/ClusterRoleBinding
+// naming one of these groups as its subject grants its rules to every
+// matching identity, not just to a literally-named Group object (there
+// usually isn't one -- these are authenticator-assigned, not RBAC objects).
+// Missing this is a real, well-known misconfiguration source: binding a
+// privileged ClusterRole to system:serviceaccounts grants it to every
+// ServiceAccount in the cluster.
 func bindingNamesSubject(subjects []rbacv1.Subject, subject Subject) bool {
 	for _, s := range subjects {
 		switch subject.Kind {
@@ -97,8 +109,16 @@ func bindingNamesSubject(subjects []rbacv1.Subject, subject Subject) bool {
 			if s.Kind == "ServiceAccount" && s.Name == subject.Name && s.Namespace == subject.Namespace {
 				return true
 			}
+			if s.Kind == "Group" && (s.Name == "system:serviceaccounts" ||
+				s.Name == "system:serviceaccounts:"+subject.Namespace ||
+				s.Name == "system:authenticated") {
+				return true
+			}
 		case KindUser:
 			if s.Kind == "User" && s.Name == subject.Name {
+				return true
+			}
+			if s.Kind == "Group" && s.Name == "system:authenticated" {
 				return true
 			}
 		case KindGroup:

--- a/core/pkg/rbacgraph/rules.go
+++ b/core/pkg/rbacgraph/rules.go
@@ -30,3 +30,35 @@ func namedResources(rule rbacv1.PolicyRule) (names []string, restricted bool) {
 	}
 	return rule.ResourceNames, true
 }
+
+// ruleGrantsUnnamedCreate reports whether rule grants an unrestricted
+// "create" on the given apiGroup/resource. A create request has no object
+// name for the authorizer to match against -- the object doesn't exist
+// yet -- so RBAC's own ResourceNameMatches always returns false for a
+// create verb when a rule carries a non-empty resourceNames list: such a
+// rule authorizes nothing for create, not "every object of that type."
+// Only used for top-level collection creates (pods, rolebindings,
+// clusterrolebindings); a subresource create on an already-named parent
+// object (e.g. serviceaccounts/token) does have a real object name to
+// match against and should use ruleGrants directly instead.
+func ruleGrantsUnnamedCreate(rule rbacv1.PolicyRule, apiGroup, resource string) bool {
+	return ruleGrants(rule, apiGroup, resource, "create") && len(rule.ResourceNames) == 0
+}
+
+func setToSlice(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return out
+}
+
+func intersectSets(a, b map[string]bool) []string {
+	var out []string
+	for k := range a {
+		if b[k] {
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/core/pkg/rbacgraph/rules.go
+++ b/core/pkg/rbacgraph/rules.go
@@ -1,0 +1,32 @@
+package rbacgraph
+
+import rbacv1 "k8s.io/api/rbac/v1"
+
+// ruleGrants reports whether rule grants verb on the given apiGroup and
+// resource (a "*" entry in any of rule's Verbs/APIGroups/Resources matches
+// anything, per RBAC's own wildcard semantics).
+func ruleGrants(rule rbacv1.PolicyRule, apiGroup, resource, verb string) bool {
+	return containsOrWildcard(rule.APIGroups, apiGroup) &&
+		containsOrWildcard(rule.Resources, resource) &&
+		containsOrWildcard(rule.Verbs, verb)
+}
+
+func containsOrWildcard(list []string, want string) bool {
+	for _, v := range list {
+		if v == "*" || v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// namedResources reports whether rule (already confirmed to grant the verb
+// in question) restricts to specific object names, and if so, what they
+// are. An empty rule.ResourceNames means no restriction -- the rule applies
+// to every object of that resource type, not to none.
+func namedResources(rule rbacv1.PolicyRule) (names []string, restricted bool) {
+	if len(rule.ResourceNames) == 0 {
+		return nil, false
+	}
+	return rule.ResourceNames, true
+}

--- a/core/pkg/rbacgraph/types.go
+++ b/core/pkg/rbacgraph/types.go
@@ -44,6 +44,25 @@
 //     subresource (the TokenRequest API) mints a live token for the named
 //     ServiceAccount directly, no pod required.
 //
+// Two further things are modeled outside the five primitives above, both
+// because a security-facing tool erring toward under-reporting reachable
+// power is the more dangerous failure mode:
+//
+//   - Kubernetes' implicit groups: every ServiceAccount is automatically a
+//     member of system:serviceaccounts, system:serviceaccounts:<its
+//     namespace>, and system:authenticated; every User is a member of
+//     system:authenticated. A RoleBinding/ClusterRoleBinding naming one of
+//     these as its subject grants its rules to every matching identity,
+//     not just to a literally-named Group object -- these are
+//     authenticator-assigned, not RBAC objects, and binding a privileged
+//     ClusterRole to one of them is a well-known real-world
+//     misconfiguration.
+//   - system:masters: hardcoded by the authorizer as an omnipotent
+//     superuser group, bound to no RBAC object at all. Reaching it via
+//     impersonation is an immediate, unconditional cluster-admin win --
+//     the graph traversal would otherwise dead-end there and report a
+//     false negative, since nothing binds it for DirectRules to find.
+//
 // # Trust model
 //
 // Like this repo's other reachability engines, this is a static model
@@ -54,13 +73,23 @@
 // only ever narrow an edge this package reports, never widen one, so a
 // reported path is a genuine upper bound on what RBAC alone allows.
 //
+// This package also respects two real RBAC authorization mechanics that
+// are easy to get backwards: a top-level "create" (the object doesn't
+// exist yet) cannot be restricted by resourceNames -- a create rule
+// carrying resourceNames authorizes nothing, not everything; and
+// Users/Groups are non-namespaced identities, so a namespace-scoped
+// Role/RoleBinding cannot meaningfully grant impersonate rights over them
+// (only a cluster-scoped ClusterRole/ClusterRoleBinding can) -- unlike
+// impersonating a ServiceAccount, which is itself a namespaced resource
+// type a Role can constrain.
+//
 // # Non-goals (initial scope)
 //
-// Arbitrary User/Group impersonation or a "get/list secrets" edge toward
-// legacy long-lived ServiceAccount token Secrets are not modeled as
-// enumerable edges -- an unrestricted (wildcard resourceNames) impersonate
-// of users/groups is reported as an Unbounded finding instead, since there
-// is no cluster object to enumerate target identities from.
+// Arbitrary User/Group impersonation (an unrestricted, wildcard-
+// resourceNames grant) is reported as an Unbounded finding rather than
+// enumerable edges, since there is no cluster object to enumerate target
+// identities from. A "get/list secrets" edge toward legacy long-lived
+// ServiceAccount token Secrets is not modeled at all.
 package rbacgraph
 
 import (

--- a/core/pkg/rbacgraph/types.go
+++ b/core/pkg/rbacgraph/types.go
@@ -1,0 +1,155 @@
+// Package rbacgraph models a cluster's RBAC objects (Roles, ClusterRoles,
+// RoleBindings, ClusterRoleBindings, ServiceAccounts) as a graph of
+// identities connected by privilege-escalation edges, and computes the
+// transitive closure reachable from a starting identity -- "if this
+// ServiceAccount/User/Group is compromised, what else becomes reachable."
+//
+// This is the RBAC counterpart to core/pkg/networkpolicy's pod-to-pod
+// reachability model and core/pkg/exposure's external-reachability model:
+// all three answer a "given X, what can actually be reached" question with
+// a real graph traversal, rather than kubescape's existing RBAC coverage
+// (control C-0015/C-0035, run via the generic Rego pipeline), which only
+// flags a single object in isolation ("does this RoleBinding grant
+// cluster-admin," "does this Role allow listing secrets") without ever
+// checking whether a lower-privileged identity can reach that same power
+// indirectly through one of the well-documented RBAC escalation techniques
+// below.
+//
+// # Escalation primitives modeled
+//
+// Each is a specific, named Kubernetes RBAC escalation technique -- the
+// same primitives security tooling such as PaloAltoNetworks/rbac-police and
+// kubiscan check for in isolation; this package's contribution is chaining
+// them into multi-hop paths, not inventing new ones:
+//
+//   - impersonate: the "impersonate" verb on users/groups/serviceaccounts
+//     lets a subject act as the impersonated identity outright, inheriting
+//     every permission it holds.
+//   - escalate-verb: the "escalate" verb on roles/clusterroles, combined
+//     with update/patch on the same resource, is Kubernetes' own built-in
+//     escape hatch from its RBAC self-escalation prevention -- a subject
+//     with both can grant themselves arbitrary rules directly.
+//   - bind-verb: the "bind" verb on roles/clusterroles, combined with
+//     create on rolebindings/clusterrolebindings, lets a subject attach any
+//     Role/ClusterRole they can bind to a subject of their choosing
+//     (typically themselves), adopting its rules without ever having held
+//     them directly.
+//   - assign-serviceaccount: create on pods lets a subject choose
+//     spec.serviceAccountName freely (this package does not model
+//     PodSecurity admission or third-party policy engines that might
+//     restrict that choice -- see the package's trust-model note below),
+//     so the subject can schedule a pod running as any ServiceAccount in
+//     that namespace and read its mounted token from within.
+//   - mint-serviceaccount-token: create on the serviceaccounts/token
+//     subresource (the TokenRequest API) mints a live token for the named
+//     ServiceAccount directly, no pod required.
+//
+// # Trust model
+//
+// Like this repo's other reachability engines, this is a static model
+// computed from RBAC object specs: holding a permission is treated as the
+// ability to exercise it. It does not verify that PodSecurity admission,
+// Gatekeeper/Kyverno, or any other admission-time control would actually
+// block the pod-creation or token-minting step in practice -- those would
+// only ever narrow an edge this package reports, never widen one, so a
+// reported path is a genuine upper bound on what RBAC alone allows.
+//
+// # Non-goals (initial scope)
+//
+// Arbitrary User/Group impersonation or a "get/list secrets" edge toward
+// legacy long-lived ServiceAccount token Secrets are not modeled as
+// enumerable edges -- an unrestricted (wildcard resourceNames) impersonate
+// of users/groups is reported as an Unbounded finding instead, since there
+// is no cluster object to enumerate target identities from.
+package rbacgraph
+
+import (
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// SubjectKind identifies what kind of RBAC identity a Subject is.
+type SubjectKind string
+
+const (
+	KindServiceAccount SubjectKind = "ServiceAccount"
+	KindUser           SubjectKind = "User"
+	KindGroup          SubjectKind = "Group"
+)
+
+// Subject identifies one RBAC identity. Namespace is only meaningful (and
+// only ever set) for a ServiceAccount -- Users and Groups are cluster-scoped
+// identities in Kubernetes' RBAC model, even when everything they've been
+// granted is namespace-confined.
+type Subject struct {
+	Kind      SubjectKind
+	Namespace string
+	Name      string
+}
+
+func (s Subject) String() string {
+	if s.Kind == KindServiceAccount {
+		return fmt.Sprintf("ServiceAccount %s/%s", s.Namespace, s.Name)
+	}
+	return fmt.Sprintf("%s %s", s.Kind, s.Name)
+}
+
+// ScopedRule is a PolicyRule together with the scope it was granted at.
+// Namespace == "" means cluster-wide (granted via a ClusterRoleBinding);
+// any other value confines the rule to that namespace (granted via a
+// RoleBinding, whether the RoleBinding references a Role or a ClusterRole
+// -- referencing a ClusterRole from a RoleBinding is a common way to reuse
+// a ClusterRole's rules within a single namespace only).
+type ScopedRule struct {
+	Rule      rbacv1.PolicyRule
+	Namespace string
+}
+
+// EscalationPrimitive names which well-known RBAC escalation technique an
+// EscalationEdge represents. See the package doc comment for what each one
+// means and why it's a real, not speculative, technique.
+type EscalationPrimitive string
+
+const (
+	PrimitiveImpersonate             EscalationPrimitive = "impersonate"
+	PrimitiveEscalateVerb            EscalationPrimitive = "escalate-verb"
+	PrimitiveBindVerb                EscalationPrimitive = "bind-verb"
+	PrimitiveAssignServiceAccount    EscalationPrimitive = "assign-serviceaccount"
+	PrimitiveMintServiceAccountToken EscalationPrimitive = "mint-serviceaccount-token"
+)
+
+// EscalationEdge is one hop a Subject can take to gain privilege beyond
+// what their own directly-bound rules grant. Exactly one of ToSubject or
+// (GrantedRules / Unbounded) is meaningful for a given edge: impersonate,
+// assign-serviceaccount, and mint-serviceaccount-token lead to assuming a
+// concrete other identity (ToSubject set); escalate-verb and bind-verb
+// grant additional rules directly, with no distinct identity to name
+// (GrantedRules and/or Unbounded set instead).
+type EscalationEdge struct {
+	Primitive EscalationPrimitive
+	// Detail is a human-readable explanation naming the object(s) involved
+	// (e.g. the RoleBinding, the target Role/ClusterRole, the target SA).
+	Detail string
+
+	ToSubject *Subject
+
+	GrantedRules []ScopedRule
+
+	// Unbounded is true when this edge grants everything within Scope,
+	// rather than a specific enumerable rule set -- an unrestricted bind or
+	// escalate rule (no resourceNames) is not confined to the
+	// Roles/ClusterRoles this package happened to collect; it covers any
+	// Role/ClusterRole that could ever exist in that scope.
+	Unbounded bool
+	// Scope is "" for cluster-wide, else the namespace Unbounded is
+	// confined to. Meaningful only when Unbounded is true.
+	Scope string
+}
+
+// EscalationPath is one hop-by-hop chain from a starting Subject, letting a
+// caller show its reasoning, not just the final reachable set.
+type EscalationPath struct {
+	From  Subject
+	Edges []EscalationEdge
+}


### PR DESCRIPTION
Closes #3680.

## The gap

Kubescape's existing RBAC coverage (C-0015/C-0035, run through the generic Rego pipeline, plus the ongoing RBAC-police-derived rule series from #916/#3097) flags a single Role/RoleBinding/ClusterRole in isolation -- "does this grant cluster-admin," "does this allow listing secrets," "does this identity hold the escalate verb." None of that, nor anything else in the codebase (checked: the attack-track/prioritization system, `go.mod` for a vendored RBAC-graph dependency), computes a **multi-hop** escalation path: a ServiceAccount that can't do anything dangerous with its own directly-bound rules, but can impersonate another identity that can bind cluster-admin to itself.

## What this adds

`core/pkg/rbacgraph` models five well-documented (not invented) RBAC escalation primitives as graph edges over a cluster's Roles/ClusterRoles/RoleBindings/ClusterRoleBindings/ServiceAccounts, and computes the transitive closure reachable from a starting identity via BFS:

- **impersonate** -- the `impersonate` verb on users/groups/serviceaccounts.
- **escalate-verb** -- `escalate` + update/patch on roles/clusterroles (Kubernetes' own built-in self-escalation-prevention bypass).
- **bind-verb** -- `bind` + create on rolebindings/clusterrolebindings (the other built-in bypass).
- **assign-serviceaccount** -- `create` on pods lets a subject choose `spec.serviceAccountName` freely, inheriting that SA's mounted token.
- **mint-serviceaccount-token** -- `create` on `serviceaccounts/token` (TokenRequest API).

A bind/escalate edge's granted rules are fed back into the same subject's rule set and re-examined (so a bound ClusterRole that itself grants `impersonate` is chased, not just recorded), bounded and deduplicated so it always terminates. The search short-circuits as soon as cluster-admin-equivalent power is confirmed reachable, rather than exhaustively enumerating every implied further reach.

Exposed as a new MCP tool, `analyze_rbac_escalation_paths(subject_kind, namespace, name)`: reports every other identity reachable (with the hop-by-hop chain of primitives used) and whether cluster-admin-equivalent power is reachable at all.

## Verified against a real cluster

Built a kind cluster with a deliberately vulnerable but realistic setup (ServiceAccount `attacker` can only impersonate `middle`; `middle` can only bind the built-in `cluster-admin` ClusterRole + create ClusterRoleBindings):

1. Confirmed each individual RBAC edge independently via `kubectl auth can-i --as=...`.
2. Using *only* `attacker`'s own minted token (an isolated kubeconfig with no admin credentials) -- confirmed it could **not** list secrets cluster-wide, then actually executed the full 2-hop exploit (`--as=system:serviceaccount:prod:middle create clusterrolebinding ... --serviceaccount=prod:attacker`), and confirmed it **could** list secrets cluster-wide immediately after. The chain is a real, working exploit, not just a model.
3. Reset to the pre-exploit state and ran this package's actual `AnalyzeEscalation` (via client-go) against the same live cluster: it correctly reported `attacker` as cluster-admin-reachable via exactly the impersonate->bind chain, `middle` as directly cluster-admin, and a negative-control ServiceAccount (only `get pods`) as reaching nothing -- matching the independently-verified ground truth exactly.

That live run caught two real bugs before they shipped: duplicate `Unbounded` findings from repeated BFS reprocessing of the same subject, and no short-circuit once cluster-admin was already confirmed (was enumerating 49 redundant "reached" entries once true, since cluster-admin trivially implies every further reach). Both fixed, both covered by unit tests (`TestAnalyzeEscalation_*`) proven to exercise the fixed paths.

## Testing

- 17 unit tests in `core/pkg/rbacgraph` covering each primitive individually, scoping (namespace-confined vs. cluster-wide), the multi-hop chaining/fixpoint reprocessing, and negative cases (no escalation, self-loops filtered).
- 7 end-to-end MCP-tool tests in `cmd/mcpserver` using a fake dynamic client, plus the live-cluster verification above.
- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./core/pkg/rbacgraph/... ./cmd/mcpserver/...`, full `go test ./...`, and `golangci-lint run --new-from-rev=upstream/master` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP tool to analyze Kubernetes RBAC privilege-escalation paths from a ServiceAccount, user, or group.
  * Reports reachable identities, step-by-step escalation paths, cluster-admin-equivalent access, unrestricted findings, and warnings when results may be incomplete.
  * Covers impersonation, role escalation, role binding, ServiceAccount assignment, and token creation scenarios.
  * Improved recognition of Kubernetes implicit groups and `system:masters` access.

* **Tests**
  * Added coverage for escalation detection, validation, multi-step paths, and truncated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->