### PR TITLE
feat(scan): scan multiple images in one run sharing the vulnerability database

### DIFF
--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -15,10 +15,16 @@ import (
 // TODO(vladklokun): document image scanning on the Kubescape Docs Hub?
 var (
 	imageExample = fmt.Sprintf(`
-  Scan an image for vulnerabilities. 
+  Scan one or more images for vulnerabilities. 
 
   # Scan the 'nginx' image
   %[1]s scan image "nginx"
+
+  # Scan several images in a single run, sharing one vulnerability database load
+  %[1]s scan image "nginx:1.27" "redis:7" "postgres:16"
+
+  # Scan several images with four concurrent workers
+  %[1]s scan image "nginx:1.27" "redis:7" --image-scan-concurrency 4
 
   # Scan the 'nginx' image and see the full report 
   %[1]s scan image "nginx" -v
@@ -35,21 +41,18 @@ var (
 // getImageCmd returns the scan image command
 func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "image <image>:<tag> [flags]",
-		Short:   "Scan an image for vulnerabilities",
+		Use:     "image <image>:<tag> [<image>:<tag>...] [flags]",
+		Short:   "Scan one or more images for vulnerabilities",
 		Example: imageExample,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("the command takes exactly one image name as an argument")
-			}
-			return nil
+			return validateImageArgs(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := deriveTimeoutContext(scanInfo, ks)
 			defer cancel()
 
-			if len(args) != 1 {
-				return fmt.Errorf("the command takes exactly one image name as an argument")
+			if err := validateImageArgs(args); err != nil {
+				return err
 			}
 
 			if err := shared.ValidateCommonScanFlags(cmd, scanInfo, shared.ImageScanFormats); err != nil {
@@ -77,16 +80,9 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				return err
 			}
 
-			imageName := args[0]
-			if strings.HasSuffix(imageName, ".tar") && !strings.HasPrefix(imageName, "docker-archive:") && !strings.HasPrefix(imageName, "oci-archive:") {
-				if _, err := os.Stat(imageName); err == nil {
-					imageName = "docker-archive:" + imageName
-				}
-			}
-
 			imgScanInfo := &metav1.ImageScanInfo{
 				Authority:          credentials.Authority,
-				Image:              imageName,
+				Images:             normalizeImageArgs(args),
 				Platform:           scanInfo.ImagePlatform,
 				Username:           credentials.Username,
 				Password:           credentials.Password,
@@ -113,4 +109,40 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 	cmd.PersistentFlags().StringVar(&scanInfo.ImagePlatform, "platform", "", "OCI platform to scan, for example linux/amd64 or linux/arm64/v8")
 
 	return cmd
+}
+
+func validateImageArgs(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("the command takes at least one image name as an argument")
+	}
+	for _, arg := range args {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("image name cannot be empty")
+		}
+	}
+	return nil
+}
+
+func normalizeImageArgs(args []string) []string {
+	images := make([]string, 0, len(args))
+	seen := make(map[string]struct{}, len(args))
+	for _, arg := range args {
+		image := localArchiveReference(strings.TrimSpace(arg))
+		if _, duplicate := seen[image]; duplicate {
+			continue
+		}
+		seen[image] = struct{}{}
+		images = append(images, image)
+	}
+	return images
+}
+
+func localArchiveReference(image string) string {
+	if !strings.HasSuffix(image, ".tar") || strings.HasPrefix(image, "docker-archive:") || strings.HasPrefix(image, "oci-archive:") {
+		return image
+	}
+	if _, err := os.Stat(image); err != nil {
+		return image
+	}
+	return "docker-archive:" + image
 }

--- a/cmd/scan/image_test.go
+++ b/cmd/scan/image_test.go
@@ -53,12 +53,12 @@ func TestGetImageCmd(t *testing.T) {
 	parentCmd.AddCommand(cmd)
 
 	// Verify the command name and short description
-	assert.Equal(t, "image <image>:<tag> [flags]", cmd.Use)
-	assert.Equal(t, "Scan an image for vulnerabilities", cmd.Short)
+	assert.Equal(t, "image <image>:<tag> [<image>:<tag>...] [flags]", cmd.Use)
+	assert.Equal(t, "Scan one or more images for vulnerabilities", cmd.Short)
 	assert.Equal(t, imageExample, cmd.Example)
 
 	err := cmd.Args(&cobra.Command{}, []string{})
-	expectedErrorMessage := "the command takes exactly one image name as an argument"
+	expectedErrorMessage := "the command takes at least one image name as an argument"
 	assert.Equal(t, expectedErrorMessage, err.Error())
 
 	err = cmd.Args(&cobra.Command{}, []string{"nginx"})
@@ -191,7 +191,7 @@ func TestGetImageCmd_RunE_ForwardsRegistryTokenCredentials(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
 	assert.Equal(t, "token", mockKubescape.imgScanInfo.Token)
-	assert.Equal(t, "registry.example.com/app:tag", mockKubescape.imgScanInfo.Image)
+	assert.Equal(t, []string{"registry.example.com/app:tag"}, mockKubescape.imgScanInfo.Images)
 }
 
 func TestGetImageCmd_RunE_ForwardsCanonicalPlatform(t *testing.T) {
@@ -377,7 +377,7 @@ func TestGetScanCommand_ImageRegistryTokenAndAuthorityReachImageScan(t *testing.
 	assert.NoError(t, err)
 	assert.Equal(t, "registry.example.com", mockKubescape.imgScanInfo.Authority)
 	assert.Equal(t, "token", mockKubescape.imgScanInfo.Token)
-	assert.Equal(t, "registry.example.com/app:tag", mockKubescape.imgScanInfo.Image)
+	assert.Equal(t, []string{"registry.example.com/app:tag"}, mockKubescape.imgScanInfo.Images)
 }
 
 func TestGetImageCmd_RunE_ForwardsLocalTarball(t *testing.T) {
@@ -397,5 +397,60 @@ func TestGetImageCmd_RunE_ForwardsLocalTarball(t *testing.T) {
 
 	err = cmd.RunE(cmd, []string{tmpFile.Name()})
 	assert.NoError(t, err)
-	assert.Equal(t, "docker-archive:"+tmpFile.Name(), mockKubescape.imgScanInfo.Image)
+	assert.Equal(t, []string{"docker-archive:" + tmpFile.Name()}, mockKubescape.imgScanInfo.Images)
+}
+
+func TestGetImageCmd_ArgsAcceptsSeveralImages(t *testing.T) {
+	cmd := getImageCmd(&mocks.MockIKubescape{}, &cautils.ScanInfo{})
+
+	assert.NoError(t, cmd.Args(cmd, []string{"nginx:1.27", "redis:7", "postgres:16"}))
+	assert.EqualError(t, cmd.Args(cmd, []string{}), "the command takes at least one image name as an argument")
+	assert.EqualError(t, cmd.Args(cmd, []string{"nginx", "  "}), "image name cannot be empty")
+}
+
+func TestGetImageCmd_RunE_ForwardsEveryImageInOrder(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	err := cmd.RunE(cmd, []string{"nginx:1.27", "redis:7", "postgres:16"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"nginx:1.27", "redis:7", "postgres:16"}, mockKubescape.imgScanInfo.Images)
+}
+
+func TestGetImageCmd_RunE_ScansRepeatedImageOnce(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	err := cmd.RunE(cmd, []string{"nginx:1.27", " nginx:1.27 ", "redis:7"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"nginx:1.27", "redis:7"}, mockKubescape.imgScanInfo.Images)
+}
+
+func TestGetImageCmd_RunE_ForwardsMixedTarballAndRegistryImages(t *testing.T) {
+	mockKubescape := &imageScanCaptureKubescape{}
+	scanInfo := cautils.ScanInfo{}
+
+	cmd := getImageCmd(mockKubescape, &scanInfo)
+	parentCmd := &cobra.Command{Use: "scan"}
+	parentCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", "")
+	parentCmd.AddCommand(cmd)
+
+	tmpFile, err := os.CreateTemp("", "dummy-*.tar")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	err = cmd.RunE(cmd, []string{tmpFile.Name(), "nginx:1.27"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"docker-archive:" + tmpFile.Name(), "nginx:1.27"}, mockKubescape.imgScanInfo.Images)
 }

--- a/core/core/image_scan.go
+++ b/core/core/image_scan.go
@@ -365,16 +365,23 @@ func (ks *Kubescape) ScanImage(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *ca
 	return ks.ScanImageContext(ks.Context(), imgScanInfo, scanInfo)
 }
 
-// ScanImageContext scans imgScanInfo.Image bound to the given ctx for its
-// complete execution, rather than re-reading ks.Context() at each stage as
-// ScanImage's predecessor did (matching Kubescape.Scan's own ScanContext
-// migration, #3237). Callers that need a deadline or cancellation should
-// derive ctx themselves and pass it in directly, instead of calling
+// ScanImageContext scans every image in imgScanInfo.Images bound to the given
+// ctx for its complete execution, rather than re-reading ks.Context() at each
+// stage as ScanImage's predecessor did (matching Kubescape.Scan's own
+// ScanContext migration, #3237). Callers that need a deadline or cancellation
+// should derive ctx themselves and pass it in directly, instead of calling
 // ks.SetContext beforehand: mutating the shared *Kubescape's context is not
 // safe if the instance is reused or another operation could run
-// concurrently against it.
+// concurrently against it. The images share one vulnerability database load
+// and the worker pool the cluster scan already uses, so an image that fails
+// never hides the results of the ones that succeeded.
 func (ks *Kubescape) ScanImageContext(ctx context.Context, imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo) (bool, error) {
-	logger.L().Start(fmt.Sprintf("Scanning image %s...", imgScanInfo.Image))
+	images := imgScanInfo.Images
+	if len(images) == 0 {
+		return false, fmt.Errorf("no image provided to scan")
+	}
+
+	logger.L().Start(imageScanStartMessage(images))
 
 	distCfg, installCfg, shouldUpdate, err := imagescan.NewDefaultDBConfig(scanInfo.ListingURL, scanInfo.SkipDBUpdate)
 	if err != nil {
@@ -388,6 +395,50 @@ func (ks *Kubescape) ScanImageContext(ctx context.Context, imgScanInfo *ksmetav1
 	}
 	defer svc.Close()
 
+	var exceptionPolicies []VulnerabilitiesIgnorePolicy
+	if imgScanInfo.Exceptions != "" {
+		exceptionPolicies, err = GetImageExceptionsFromFile(imgScanInfo.Exceptions)
+		if err != nil {
+			logger.L().StopError(fmt.Sprintf("Failed to load exceptions from file: %s", imgScanInfo.Exceptions))
+			return false, err
+		}
+	}
+
+	jobs := buildImageScanJobs(imgScanInfo, scanInfo, exceptionPolicies)
+
+	resultsHandler := resultshandling.NewResultsHandler(nil, nil, nil)
+	scanErr := scanImageJobs(ctx, svc, scanInfo.ImageScanConcurrency, jobs, resultsHandler)
+	scanErr = unwrapSingleImageError(scanErr)
+	if len(resultsHandler.ImageScanData) == 0 {
+		logger.L().StopError(imageScanFailureMessage(images))
+		return false, scanErr
+	}
+	logger.L().StopSuccess(imageScanSuccessMessage(images, resultsHandler.ImageScanData))
+
+	scanInfo.SetScanType(cautils.ScanTypeImage)
+
+	// Printers open their output files on construction, so they are built only
+	// once at least one image has produced results.
+	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, "")
+	if err != nil {
+		return false, errors.Join(scanErr, err)
+	}
+	resultsHandler.PrinterObjs = outputPrinters
+	resultsHandler.UiPrinter = GetUIPrinter(ctx, scanInfo, "")
+
+	threshold := imagescan.ParseSeverity(scanInfo.FailThresholdSeverity)
+	exceedsSeverityThreshold := false
+	for i := range resultsHandler.ImageScanData {
+		if svc.ExceedsSeverityThreshold(threshold, resultsHandler.ImageScanData[i].Matches, scanInfo.OnlyFixable) {
+			exceedsSeverityThreshold = true
+			break
+		}
+	}
+
+	return exceedsSeverityThreshold, errors.Join(scanErr, resultsHandler.HandleResults(ctx, scanInfo))
+}
+
+func buildImageScanJobs(imgScanInfo *ksmetav1.ImageScanInfo, scanInfo *cautils.ScanInfo, exceptionPolicies []VulnerabilitiesIgnorePolicy) []ImageScanJob {
 	creds := imagescan.RegistryCredentials{
 		Authority: imgScanInfo.Authority,
 		Username:  imgScanInfo.Username,
@@ -395,43 +446,75 @@ func (ks *Kubescape) ScanImageContext(ctx context.Context, imgScanInfo *ksmetav1
 		Token:     imgScanInfo.Token,
 	}
 
-	var vulnerabilityExceptions []string
-	var severityExceptions []string
-	if imgScanInfo.Exceptions != "" {
-		exceptionPolicies, err := GetImageExceptionsFromFile(imgScanInfo.Exceptions)
-		if err != nil {
-			logger.L().StopError(fmt.Sprintf("Failed to load exceptions from file: %s", imgScanInfo.Exceptions))
-			return false, err
+	jobs := make([]ImageScanJob, 0, len(imgScanInfo.Images))
+	for _, image := range imgScanInfo.Images {
+		// Resolving exceptions parses the image as a registry reference, which
+		// archive and directory references are not, so it stays behind the
+		// check for configured policies.
+		var vulnerabilityExceptions, severityExceptions []string
+		if len(exceptionPolicies) > 0 {
+			vulnerabilityExceptions, severityExceptions = getUniqueVulnerabilitiesAndSeverities(exceptionPolicies, image)
 		}
-
-		vulnerabilityExceptions, severityExceptions = getUniqueVulnerabilitiesAndSeverities(exceptionPolicies, imgScanInfo.Image)
+		jobs = append(jobs, ImageScanJob{
+			Image:                   image,
+			Platform:                imgScanInfo.Platform,
+			RegistryCredentials:     []imagescan.RegistryCredentials{creds},
+			VulnerabilityExceptions: vulnerabilityExceptions,
+			SeverityExceptions:      severityExceptions,
+			RegistryMapping:         scanInfo.RegistryMapping,
+		})
 	}
+	return jobs
+}
 
-	imageScanData, err := scanWithRegistryMapping(
-		ctx, svc, imgScanInfo.Image, []imagescan.RegistryCredentials{creds},
-		scanInfo.RegistryMapping, vulnerabilityExceptions, severityExceptions, imgScanInfo.Platform,
-	)
-	if err != nil {
-		logger.L().StopError(fmt.Sprintf("Failed to scan image %s: %s", imgScanInfo.Image, err))
-		return false, err
+func imageScanStartMessage(images []string) string {
+	if len(images) == 1 {
+		return fmt.Sprintf("Scanning image %s...", images[0])
 	}
+	return fmt.Sprintf("Scanning %s...", countedNoun(len(images), "image"))
+}
 
-	logger.L().StopSuccess(fmt.Sprintf("Successfully scanned image: %s", imgScanInfo.Image))
-
-	scanInfo.SetScanType(cautils.ScanTypeImage)
-
-	outputPrinters, err := GetOutputPrinters(scanInfo, ctx, "")
-	if err != nil {
-		return false, err
+// unwrapSingleImageError reports the cause directly when an aggregate holds a
+// single image failure, so scanning one image keeps the plain error it
+// reported before the command grew multi-image support.
+func unwrapSingleImageError(err error) error {
+	var aggregated *ScanErrorAggregator
+	if !errors.As(err, &aggregated) {
+		return err
 	}
+	failure, ok := aggregated.SingleError()
+	if !ok {
+		return err
+	}
+	return fmt.Errorf("failed to scan image %s: %w", failure.Image, failure.Err)
+}
 
-	uiPrinter := GetUIPrinter(ctx, scanInfo, "")
+// imageScanFailureMessage carries no cause: scanImageJobs has already logged
+// every per-image error, and the failure itself is returned to the caller to
+// be reported once more.
+func imageScanFailureMessage(images []string) string {
+	if len(images) == 1 {
+		return fmt.Sprintf("Failed to scan image %s", images[0])
+	}
+	return fmt.Sprintf("Failed to scan %s", countedNoun(len(images), "image"))
+}
 
-	resultsHandler := resultshandling.NewResultsHandler(nil, outputPrinters, uiPrinter)
+func imageScanSuccessMessage(images []string, scanned []cautils.ImageScanData) string {
+	switch {
+	case len(images) == 1:
+		return fmt.Sprintf("Successfully scanned image: %s", images[0])
+	case len(scanned) < len(images):
+		return fmt.Sprintf("Successfully scanned %d of %s", len(scanned), countedNoun(len(images), "image"))
+	default:
+		return fmt.Sprintf("Successfully scanned %s", countedNoun(len(images), "image"))
+	}
+}
 
-	resultsHandler.ImageScanData = []cautils.ImageScanData{*imageScanData}
-
-	return svc.ExceedsSeverityThreshold(imagescan.ParseSeverity(scanInfo.FailThresholdSeverity), imageScanData.Matches, scanInfo.OnlyFixable), resultsHandler.HandleResults(ctx, scanInfo)
+func countedNoun(n int, singular string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %ss", n, singular)
 }
 
 // ScanErrorCategory defines distinct vulnerability scan failure categories.
@@ -521,6 +604,17 @@ func (a *ScanErrorAggregator) Summary() map[ScanErrorCategory]int {
 	return summary
 }
 
+// SingleError returns the only collected failure when exactly one was recorded,
+// letting callers that scanned a single image report its cause directly.
+func (a *ScanErrorAggregator) SingleError() (CategorizedScanError, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.Errors) != 1 {
+		return CategorizedScanError{}, false
+	}
+	return a.Errors[0], true
+}
+
 // HasErrors indicates whether any scan errors occurred.
 func (a *ScanErrorAggregator) HasErrors() bool {
 	a.mu.Lock()
@@ -574,6 +668,15 @@ func imageScanTarget(image, platform string) string {
 	return cautils.ImageScanTarget(image, platform)
 }
 
+const defaultImageScanConcurrency = 5
+
+func imageScanWorkers(concurrency int) int {
+	if concurrency <= 0 {
+		return defaultImageScanConcurrency
+	}
+	return concurrency
+}
+
 // ImageScanOrchestrator coordinates concurrent image scan execution across a worker pool.
 type ImageScanOrchestrator struct {
 	concurrency     int
@@ -583,11 +686,8 @@ type ImageScanOrchestrator struct {
 
 // NewImageScanOrchestrator instantiates an orchestrator with a worker pool size.
 func NewImageScanOrchestrator(svc imageScanService, concurrency int) *ImageScanOrchestrator {
-	if concurrency <= 0 {
-		concurrency = 5
-	}
 	return &ImageScanOrchestrator{
-		concurrency:     concurrency,
+		concurrency:     imageScanWorkers(concurrency),
 		svc:             svc,
 		errorAggregator: NewScanErrorAggregator(),
 	}

--- a/core/core/image_scan_multi_test.go
+++ b/core/core/image_scan_multi_test.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	ksmetav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v4/pkg/imagescan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildImageScanJobsCarriesScanSettingsToEveryImage(t *testing.T) {
+	imgScanInfo := &ksmetav1.ImageScanInfo{
+		Images:    []string{"nginx:1.27", "redis:7"},
+		Platform:  "linux/arm64",
+		Authority: "registry.example.com",
+		Username:  "user",
+		Password:  "pass",
+	}
+	scanInfo := &cautils.ScanInfo{RegistryMapping: map[string]string{"docker.io": "mirror.example.com"}}
+
+	jobs := buildImageScanJobs(imgScanInfo, scanInfo, nil)
+
+	require.Len(t, jobs, 2)
+	assert.Equal(t, "nginx:1.27", jobs[0].Image)
+	assert.Equal(t, "redis:7", jobs[1].Image)
+	for _, job := range jobs {
+		assert.Equal(t, "linux/arm64", job.Platform)
+		assert.Equal(t, scanInfo.RegistryMapping, job.RegistryMapping)
+		require.Equal(t, []imagescan.RegistryCredentials{{
+			Authority: "registry.example.com",
+			Username:  "user",
+			Password:  "pass",
+		}}, job.RegistryCredentials)
+	}
+}
+
+func TestBuildImageScanJobsResolvesExceptionsPerImage(t *testing.T) {
+	policies := []VulnerabilitiesIgnorePolicy{
+		{
+			Metadata:        Metadata{Name: "nginx-only"},
+			Targets:         []Target{{Attributes: Attributes{ImageName: "nginx"}}},
+			Vulnerabilities: []string{"CVE-2024-0001"},
+			Severities:      []string{"Low"},
+		},
+	}
+	imgScanInfo := &ksmetav1.ImageScanInfo{Images: []string{"nginx:1.27", "redis:7"}}
+
+	jobs := buildImageScanJobs(imgScanInfo, &cautils.ScanInfo{}, policies)
+
+	require.Len(t, jobs, 2)
+	assert.Contains(t, jobs[0].VulnerabilityExceptions, "CVE-2024-0001")
+	assert.Equal(t, []string{"LOW"}, jobs[0].SeverityExceptions)
+	assert.Empty(t, jobs[1].VulnerabilityExceptions, "an exception targeting nginx must not reach redis")
+	assert.Empty(t, jobs[1].SeverityExceptions)
+}
+
+func TestImageScanWorkersFallsBackToDefault(t *testing.T) {
+	assert.Equal(t, defaultImageScanConcurrency, imageScanWorkers(0))
+	assert.Equal(t, defaultImageScanConcurrency, imageScanWorkers(-3))
+	assert.Equal(t, 1, imageScanWorkers(1))
+	assert.Equal(t, 8, imageScanWorkers(8))
+}
+
+func TestImageScanProgressMessages(t *testing.T) {
+	single := []string{"nginx:1.27"}
+	many := []string{"nginx:1.27", "redis:7", "postgres:16"}
+
+	assert.Equal(t, "Scanning image nginx:1.27...", imageScanStartMessage(single))
+	assert.Equal(t, "Scanning 3 images...", imageScanStartMessage(many))
+
+	assert.Equal(t, "Successfully scanned image: nginx:1.27", imageScanSuccessMessage(single, make([]cautils.ImageScanData, 1)))
+	assert.Equal(t, "Successfully scanned 3 images", imageScanSuccessMessage(many, make([]cautils.ImageScanData, 3)))
+	assert.Equal(t, "Successfully scanned 2 of 3 images", imageScanSuccessMessage(many, make([]cautils.ImageScanData, 2)))
+
+	assert.Equal(t, "Failed to scan image nginx:1.27", imageScanFailureMessage(single))
+	assert.Equal(t, "Failed to scan 3 images", imageScanFailureMessage(many))
+}
+
+// An archive reference is not a parseable registry reference, so resolving
+// exceptions against one logs a spurious attribute failure. It must not run
+// when no exception policies are configured.
+func TestBuildImageScanJobsSkipsExceptionResolutionWithoutPolicies(t *testing.T) {
+	imgScanInfo := &ksmetav1.ImageScanInfo{Images: []string{"docker-archive:/tmp/image.tar"}}
+
+	jobs := buildImageScanJobs(imgScanInfo, &cautils.ScanInfo{}, nil)
+
+	require.Len(t, jobs, 1)
+	assert.Nil(t, jobs[0].VulnerabilityExceptions)
+	assert.Nil(t, jobs[0].SeverityExceptions)
+}
+
+func TestUnwrapSingleImageErrorReportsTheCauseDirectly(t *testing.T) {
+	cause := errors.New("unauthorized: authentication required")
+	aggregated := NewScanErrorAggregator()
+	aggregated.Add("private.example/app:latest", cause)
+
+	unwrapped := unwrapSingleImageError(aggregated)
+
+	assert.EqualError(t, unwrapped, "failed to scan image private.example/app:latest: unauthorized: authentication required")
+	assert.ErrorIs(t, unwrapped, cause)
+}
+
+func TestUnwrapSingleImageErrorKeepsAggregateForSeveralFailures(t *testing.T) {
+	aggregated := NewScanErrorAggregator()
+	aggregated.Add("first:latest", errors.New("boom"))
+	aggregated.Add("second:latest", errors.New("bang"))
+
+	assert.Same(t, aggregated, unwrapSingleImageError(aggregated))
+	assert.Nil(t, unwrapSingleImageError(nil))
+}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -600,7 +600,7 @@ func scanImageJobsWithDiscoveryErrors(ctx context.Context, svc imageScanService,
 }
 
 func scanImageJobs(ctx context.Context, svc imageScanService, concurrency int, jobs []ImageScanJob, resultsHandling *resultshandling.ResultsHandler) error {
-	logger.L().Info(fmt.Sprintf("Scanning %d images concurrently with %d workers...", len(jobs), concurrency))
+	logger.L().Info(fmt.Sprintf("Scanning %s with %s...", countedNoun(len(jobs), "image"), countedNoun(imageScanWorkers(concurrency), "worker")))
 	orchestrator := NewImageScanOrchestrator(svc, concurrency)
 	results := orchestrator.ScanImages(ctx, jobs)
 	sort.Slice(results, func(i, j int) bool {

--- a/core/meta/datastructures/v1/image_scan.go
+++ b/core/meta/datastructures/v1/image_scan.go
@@ -5,7 +5,7 @@ type ImageScanInfo struct {
 	Username           string
 	Password           string
 	Token              string
-	Image              string
+	Images             []string
 	Platform           string
 	Exceptions         string
 	UseDefaultMatchers bool

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -1,9 +1,11 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/anchore/clio"
@@ -59,12 +61,7 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	if opaSessionObj != nil {
 		err = printConfigurationsScanning(opaSessionObj, imageScanData, jp)
 	} else if len(imageScanData) > 0 {
-		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
-			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
-		if err2 != nil {
-			return fmt.Errorf("failed to create document: %w", err2)
-		}
-		err = grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: imageScanData[0].SBOM}).Present(jp.writer)
+		err = printImageScanning(imageScanData, jp)
 	} else {
 		err = fmt.Errorf("no data provided")
 	}
@@ -76,6 +73,39 @@ func (jp *JsonPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 
 	printer.LogOutputFile(jp.writer.Name())
 	return nil
+}
+
+// printImageScanning keeps grype's bare document shape for a single image and
+// wraps several in an array, as the CycloneDX and SPDX printers already do.
+func printImageScanning(imageScanData []cautils.ImageScanData, jp *JsonPrinter) error {
+	if len(imageScanData) == 1 {
+		return presentImageScan(imageScanData[0], jp.writer)
+	}
+
+	documents := make([]json.RawMessage, 0, len(imageScanData))
+	for i := range imageScanData {
+		var buf bytes.Buffer
+		if err := presentImageScan(imageScanData[i], &buf); err != nil {
+			return err
+		}
+		documents = append(documents, json.RawMessage(bytes.TrimSpace(buf.Bytes())))
+	}
+
+	encoded, err := json.MarshalIndent(documents, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal multi-image json output: %w", err)
+	}
+	_, err = jp.writer.Write(append(encoded, '\n'))
+	return err
+}
+
+func presentImageScan(imageScanData cautils.ImageScanData, w io.Writer) error {
+	model, err := models.NewDocument(clio.Identification{}, imageScanData.Packages, imageScanData.Context,
+		imageScanData.Matches, imageScanData.IgnoredMatches, imageScanData.VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
+	if err != nil {
+		return fmt.Errorf("failed to create document: %w", err)
+	}
+	return grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: imageScanData.SBOM}).Present(w)
 }
 
 func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, jp *JsonPrinter) error {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_imagescan_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_imagescan_test.go
@@ -1,0 +1,66 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeImageScanJSON(t *testing.T, imageScanData []cautils.ImageScanData) []byte {
+	t.Helper()
+
+	tmp, err := os.CreateTemp("", "json-image-scan-*.json")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, tmp.Close())
+		assert.NoError(t, os.Remove(tmp.Name()))
+	}()
+
+	jp := NewJsonPrinter()
+	jp.writer = tmp
+	require.NoError(t, jp.ActionPrint(context.Background(), nil, imageScanData))
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return raw
+}
+
+func TestJsonPrinter_ImageScan_SingleImageKeepsBareDocument(t *testing.T) {
+	raw := writeImageScanJSON(t, []cautils.ImageScanData{buildSeverityExceptionImageScanData()})
+
+	var doc map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	assert.Contains(t, doc, "matches")
+}
+
+func TestJsonPrinter_ImageScan_ReportsEveryImage(t *testing.T) {
+	first := buildSeverityExceptionImageScanData()
+	first.Image = "first-image:latest"
+	second := buildSeverityExceptionImageScanData()
+	second.Image = "second-image:latest"
+
+	raw := writeImageScanJSON(t, []cautils.ImageScanData{first, second})
+
+	var documents []struct {
+		Matches []struct {
+			Vulnerability struct {
+				ID string `json:"id"`
+			} `json:"vulnerability"`
+		} `json:"matches"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &documents))
+	require.Len(t, documents, 2, "every scanned image must reach the json report")
+
+	for _, doc := range documents {
+		var ids []string
+		for _, m := range doc.Matches {
+			ids = append(ids, m.Vulnerability.ID)
+		}
+		assert.Contains(t, ids, "CVE-KEPT")
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -529,30 +529,58 @@ kubescape scan workload Deployment/nginx --chart-path ./chart --file-path ./char
 
 ## kubescape scan image
 
-Scan a container image for vulnerabilities.
+Scan one or more container images for vulnerabilities.
 
 ### Synopsis
 
 ```bash
-kubescape scan image <image>:<tag> [flags]
+kubescape scan image <image>:<tag> [<image>:<tag>...] [flags]
 ```
 
 ### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--exceptions <path>` | Path to exceptions file |
+| `--exceptions <path>` | Path to exceptions file. Targets are matched per image, so one file can carry rules for every image in the run |
 | `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `yaml`, `markdown`, `cyclonedx-json`, `spdx-json` |
+| `--image-scan-concurrency <n>` | Number of images scanned in parallel (default `1`) |
 | `-p, --password <pass>` | Registry password |
-| `--platform <platform>` | OCI platform to scan, for example `linux/amd64`, `linux/arm64/v8`, or `windows/amd64` |
+| `--platform <platform>` | OCI platform to scan, for example `linux/amd64`, `linux/arm64/v8`, or `windows/amd64`. Applies to every image in the run |
 | `-u, --username <user>` | Registry username |
 | `--use-default-matchers` | Use default vulnerability matchers | `true` |
+
+### Scanning several images at once
+
+Passing several images scans them in a single run: the vulnerability database is
+loaded and updated once instead of once per image, and every image lands in one
+report. Repeated arguments are scanned once.
+
+Credentials, `--platform` and `--exceptions` apply to the whole run, so images
+that need different registry credentials still need separate invocations.
+
+An image that cannot be scanned — an unreachable registry, a bad reference — does
+not abort the run: the remaining images are still scanned and reported, the
+failures are summarized at the end, and the command exits non-zero. The severity
+threshold is evaluated across all images, so `--severity-threshold` fails the run
+when any single image crosses it.
+
+Output formats behave as follows for a multi-image run: `json`, `cyclonedx-json`
+and `spdx-json` emit a JSON array with one document per image (a single image
+keeps the bare document shape), while the table, HTML, PDF, markdown, SARIF,
+GitLab SAST, JUnit and Prometheus outputs report every image in one document.
 
 ### Examples
 
 ```bash
 # Scan public image
 kubescape scan image nginx:1.21
+
+# Scan several images in one run
+kubescape scan image nginx:1.27 redis:7 postgres:16
+
+# Scan several images four at a time and write one SARIF report
+kubescape scan image nginx:1.27 redis:7 postgres:16 \
+  --image-scan-concurrency 4 --format sarif --output images.sarif
 
 # Scan with verbose output
 kubescape scan image nginx:1.21 -v


### PR DESCRIPTION
## Summary

- `scan image` accepted exactly one argument, so scanning N images meant N processes, N Grype DB loads and N unmergeable reports even though the report printers were already made multi-image capable (#3396, #3400).
- Several images now run through the existing `ImageScanOrchestrator` (honors `--image-scan-concurrency`) on a single shared DB load, with `--exceptions` resolved per image; a failed image no longer aborts the run, and `--severity-threshold` is evaluated across all of them.
- `jsonprinter.go` reported only `imageScanData[0]` and now emits every image — an array for several, the bare grype document for one, matching the CycloneDX/SPDX printers.
- Tested by `TestGetImageCmd_RunE_ForwardsEveryImageInOrder`, `TestBuildImageScanJobsResolvesExceptionsPerImage`, `TestJsonPrinter_ImageScan_ReportsEveryImage` and `TestUnwrapSingleImageErrorReportsTheCauseDirectly`, plus live runs against `alpine:3.19` + `busybox:1.36`.

**Which issue(s) this PR fixes:**
N/A, found while reading the image scan path; no open or closed issue/PR covers it.

**Special notes for your reviewer:**
`ImageScanInfo.Image` becomes `Images []string`, a compile-time break for code constructing it, though the `IKubescape` signature is unchanged. Single-image runs are otherwise unchanged: same progress messages, same bare JSON document, same plain error.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan image` takes multiple images and reports them in one document; a run where some images fail now reports the successful ones and exits non-zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scan multiple container images in a single command.
  - Support configurable concurrent image scanning.
  - Automatically normalize duplicate, whitespace-padded, and local archive image references.
  - Apply credentials, platform settings, and exceptions across the full scan.
  - Include results for every scanned image in JSON output.

- **Bug Fixes**
  - Improved handling and reporting of single- and multi-image scan failures.

- **Documentation**
  - Updated CLI reference with multi-image usage, concurrency options, output formats, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->