### PR TITLE
feat(resourcehandler): collect via namespaced endpoints under --include-namespaces

### DIFF
--- a/core/pkg/resourcehandler/crd_scan_contract_test.go
+++ b/core/pkg/resourcehandler/crd_scan_contract_test.go
@@ -447,6 +447,7 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 
 	var actualQueries []string
 	seenSelectors := map[schema.GroupVersionResource]string{}
+	seenNamespaces := map[schema.GroupVersionResource]string{}
 	for _, action := range dynamicClient.Actions() {
 		if action.GetVerb() == "list" {
 			gvr := action.GetResource()
@@ -454,6 +455,7 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 			listAction, ok := action.(k8stesting.ListAction)
 			require.True(t, ok)
 			seenSelectors[gvr] = listAction.GetListRestrictions().Fields.String()
+			seenNamespaces[gvr] = action.GetNamespace()
 		}
 	}
 	var expectedQueries []string
@@ -464,7 +466,10 @@ func TestK8sResourceHandlerUsesDiscoveredGVRsAndNamespaceScope(t *testing.T) {
 	sort.Strings(expectedQueries)
 	assert.Equal(t, expectedQueries, actualQueries)
 	for _, gvr := range expectedGVRs {
-		assert.Equal(t, "metadata.namespace=agents", seenSelectors[gvr])
+		// These CRDs are namespaced, so the included namespace scopes the query
+		// through the namespaced endpoint rather than a field selector.
+		assert.Equal(t, "agents", seenNamespaces[gvr])
+		assert.Empty(t, seenSelectors[gvr])
 		assert.Contains(t, resources, k8sinterface.GroupVersionResourceToString(&gvr))
 	}
 }

--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -35,6 +35,14 @@ func splitNamespaces(s string) []string {
 
 type IFieldSelector interface {
 	GetNamespacesSelectors(*schema.GroupVersionResource, *bool) []string
+	// GetNamespaceScopedQueries returns the namespaces whose namespaced
+	// collection endpoint the scan may address directly for this resource,
+	// or nil when collection must stay cluster-scoped. Addressing
+	// /apis/<gv>/namespaces/<ns>/<resource> returns the same objects a
+	// cluster-scoped LIST filtered by metadata.namespace does, but Kubernetes
+	// authorizes it against a namespaced Role rather than requiring a
+	// ClusterRole.
+	GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string
 	GetClusterScope(*schema.GroupVersionResource) bool
 }
 
@@ -43,6 +51,10 @@ type EmptySelector struct {
 
 func (es *EmptySelector) GetNamespacesSelectors(resource *schema.GroupVersionResource, namespaced *bool) []string {
 	return []string{""} //
+}
+
+func (es *EmptySelector) GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string {
+	return nil
 }
 
 func (es *EmptySelector) GetClusterScope(*schema.GroupVersionResource) bool {
@@ -62,6 +74,13 @@ func (es *ExcludeSelector) GetClusterScope(resource *schema.GroupVersionResource
 	return resource.Resource == "namespaces"
 }
 
+// GetNamespaceScopedQueries always returns nil: excluding namespaces means
+// collecting every other one, which needs the cluster-scoped collection and so
+// cannot be expressed as a bounded set of namespaced queries.
+func (es *ExcludeSelector) GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string {
+	return nil
+}
+
 type IncludeSelector struct {
 	namespace string
 }
@@ -73,6 +92,32 @@ func NewIncludeSelector(ns string) *IncludeSelector {
 func (is *IncludeSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
 	// for selector, 'namespace' is in Namespaced scope
 	return resource.Resource == "namespaces"
+}
+
+// GetNamespaceScopedQueries returns the included namespaces when the resource is
+// namespaced, so collection can address each namespace's own endpoint. A
+// cluster-scoped resource, and the Namespace kind itself (which the include
+// selector narrows by metadata.name on a cluster-scoped collection), keep the
+// cluster-scoped query and return nil.
+func (is *IncludeSelector) GetNamespaceScopedQueries(resource *schema.GroupVersionResource, namespaced *bool) []string {
+	if !isNamespacedTarget(resource, namespaced) {
+		return nil
+	}
+	return splitNamespaces(is.namespace)
+}
+
+// isNamespacedTarget reports whether resource is served under a namespaced
+// endpoint, preferring the scope discovery reported and falling back to
+// k8s-interface's static table when it did not, mirroring
+// getNamespacesSelectorWithOptionalScope.
+func isNamespacedTarget(resource *schema.GroupVersionResource, namespaced *bool) bool {
+	if resource.Resource == "namespaces" {
+		return false
+	}
+	if namespaced != nil {
+		return *namespaced
+	}
+	return k8sinterface.IsResourceInNamespaceScope(resource.Resource)
 }
 
 func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource, namespaced *bool) []string {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/pager"
 )
 
@@ -1082,7 +1083,15 @@ func (k8sHandler *K8sResourceHandler) pullSingleResource(ctx context.Context, re
 func (k8sHandler *K8sResourceHandler) pullSingleResourceInto(ctx context.Context, resource *schema.GroupVersionResource, labelSelector string, fields string, fieldSelector IFieldSelector, namespaced *bool, sink resourceSink) []selectorFailure {
 	var selectorErrs []selectorFailure
 
-	fieldSelectors := fieldSelector.GetNamespacesSelectors(resource, namespaced)
+	// A namespaced query addresses the namespace's own endpoint, which already
+	// restricts the result set, so it carries no metadata.namespace selector of
+	// its own. When there are none, collection stays cluster-scoped and narrows
+	// by field selector as before.
+	queryNamespaces := fieldSelector.GetNamespaceScopedQueries(resource, namespaced)
+	fieldSelectors := make([]string, len(queryNamespaces))
+	if len(queryNamespaces) == 0 {
+		fieldSelectors = fieldSelector.GetNamespacesSelectors(resource, namespaced)
+	}
 
 	for i := range fieldSelectors {
 		listOptions := metav1.ListOptions{}
@@ -1099,7 +1108,10 @@ func (k8sHandler *K8sResourceHandler) pullSingleResourceInto(ctx context.Context
 			listOptions.FieldSelector = ""
 		}
 
-		clientResource := k8sHandler.k8s.DynamicClient.Resource(*resource)
+		var clientResource dynamic.ResourceInterface = k8sHandler.k8s.DynamicClient.Resource(*resource)
+		if len(queryNamespaces) > 0 {
+			clientResource = k8sHandler.k8s.DynamicClient.Resource(*resource).Namespace(queryNamespaces[i])
+		}
 
 		collected := 0
 

--- a/core/pkg/resourcehandler/namespacedcollection_test.go
+++ b/core/pkg/resourcehandler/namespacedcollection_test.go
@@ -1,0 +1,183 @@
+package resourcehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var namespacedPodsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// clusterScopeForbidden is the error a real API server returns for a
+// cluster-scoped LIST from a caller holding only a namespaced Role.
+type clusterScopeForbidden struct{}
+
+func (clusterScopeForbidden) Error() string {
+	return `User "system:serviceaccount:team-a:scanner" cannot list resource "pods" in API group "" at the cluster scope`
+}
+
+// namespaceScopedRBACReactor models a caller holding only a Role+RoleBinding in
+// "team-a", exactly as the Kubernetes RBAC authorizer behaves:
+//
+//   - a request to the cluster-scoped collection endpoint (GET /api/v1/pods)
+//     resolves with requestInfo.Namespace == "", so only ClusterRoleBindings are
+//     consulted and it is denied. The fieldSelector on the request is applied
+//     after authorization and never enters the decision.
+//   - a request to the namespaced endpoint (GET /api/v1/namespaces/team-a/pods)
+//     resolves with requestInfo.Namespace == "team-a" and the Role allows it.
+func namespaceScopedRBACReactor(endpoints *[]string) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ns := action.GetNamespace()
+		*endpoints = append(*endpoints, ns)
+		if ns != "team-a" {
+			return true, nil, apierrors.NewForbidden(namespacedPodsGVR.GroupResource(), "", clusterScopeForbidden{})
+		}
+		return true, &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata":   map[string]any{"name": "api", "namespace": "team-a"},
+			"spec":       map[string]any{"hostNetwork": true},
+		}}}}, nil
+	}
+}
+
+// TestIncludeNamespacesIssuesNamespacedList pins that --include-namespaces
+// addresses each namespace's own collection endpoint, which Kubernetes
+// authorizes against a namespaced Role, instead of narrowing a cluster-scoped
+// LIST by field selector. The endpoint already restricts the result set, so the
+// query carries no metadata.namespace selector of its own.
+func TestIncludeNamespacesIssuesNamespacedList(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	type observed struct{ ns, field string }
+	var seen []observed
+
+	handler := newHandlerWithReactor(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if la, ok := action.(k8stesting.ListAction); ok {
+			seen = append(seen, observed{action.GetNamespace(), la.GetListRestrictions().Fields.String()})
+		}
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+
+	namespaced := true
+	handler.pullSingleResource(context.Background(), &namespacedPodsGVR, "", "", NewIncludeSelector("team-a,team-b"), &namespaced)
+
+	require.Len(t, seen, 2, "one query per included namespace")
+	for _, o := range seen {
+		t.Logf("LIST -> endpoint namespace=%q fieldSelector=%q", o.ns, o.field)
+		assert.Empty(t, o.field, "the namespaced endpoint already scopes the query")
+	}
+	assert.Equal(t, "team-a", seen[0].ns)
+	assert.Equal(t, "team-b", seen[1].ns)
+}
+
+// TestNamespaceScopedRBACCollectsResources is the reason this exists: a caller
+// holding only a Role in team-a, scanning exactly team-a, collects its
+// resources. Against the same simulated RBAC a cluster-scoped LIST is denied.
+func TestNamespaceScopedRBACCollectsResources(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	var endpoints []string
+	handler := newHandlerWithReactor(t, namespaceScopedRBACReactor(&endpoints))
+
+	namespaced := true
+	collected, errs := handler.pullSingleResource(
+		context.Background(), &namespacedPodsGVR, "", "", NewIncludeSelector("team-a"), &namespaced)
+
+	t.Logf("endpoint namespaces hit: %q", endpoints)
+	t.Logf("resources collected: %d, selector failures: %d", len(collected), len(errs))
+	for _, e := range errs {
+		t.Logf("failure: %v", e.err)
+	}
+
+	require.Empty(t, errs, "the namespaced endpoint is authorized by the Role")
+	require.Len(t, collected, 1)
+	assert.Equal(t, []string{"team-a"}, endpoints)
+	assert.Equal(t, "api", collected[0].GetName())
+}
+
+// TestPreflightReviewsRequestedNamespace pins that --dry-run reviews access at
+// the scope collection will use, so a caller who can list pods in the namespace
+// they asked to scan is reported as allowed.
+func TestPreflightReviewsRequestedNamespace(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	var reviewedNamespaces []string
+	client := fakeclientset.NewClientset()
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ssar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		reviewedNamespaces = append(reviewedNamespaces, ssar.Spec.ResourceAttributes.Namespace)
+		// The caller holds a Role in team-a only: allowed there, denied cluster-wide.
+		allowed := ssar.Spec.ResourceAttributes.Namespace == "team-a"
+		ssar.Status = authorizationv1.SubjectAccessReviewStatus{
+			Allowed: allowed,
+			Denied:  !allowed,
+			Reason:  "no ClusterRoleBinding grants cluster-scoped list",
+		}
+		return true, ssar, nil
+	})
+
+	handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{
+		KubernetesClient: client,
+		DiscoveryClient:  client.Discovery(),
+		Context:          context.Background(),
+	}}
+
+	check := handler.checkListAccess(context.Background(), "/v1/pods", []string{"team-a"}, nil)
+
+	t.Logf("SelfSubjectAccessReview namespaces reviewed: %q", reviewedNamespaces)
+	t.Logf("preflight verdict for /v1/pods -> allowed=%v reason=%q", check.Allowed, check.Reason)
+
+	require.Equal(t, []string{"team-a"}, reviewedNamespaces)
+	assert.True(t, check.Allowed, "the namespace the scan will address is allowed")
+
+	clusterCheck := handler.checkListAccess(context.Background(), "/v1/pods", nil, nil)
+	assert.False(t, clusterCheck.Allowed, "cluster scope stays denied for the same caller")
+}
+
+// TestGetResourcesSucceedsUnderNamespaceScopedRBAC is the scan-level outcome: a
+// full collection pass for a framework that needs Pods, run by a caller holding
+// only a Role in team-a and asking to scan team-a, completes and collects the
+// namespace's resources.
+func TestGetResourcesSucceedsUnderNamespaceScopedRBAC(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+
+	var endpoints []string
+	handler := newHandlerWithReactor(t, namespaceScopedRBACReactor(&endpoints))
+
+	podMatch := reporthandling.RuleMatchObjects{
+		APIGroups:   []string{""},
+		APIVersions: []string{"v1"},
+		Resources:   []string{"Pod"},
+	}
+	rule := mockRule("rule-a", []reporthandling.RuleMatchObjects{podMatch}, "")
+	control := mockControl("control-1", []reporthandling.PolicyRule{rule})
+	framework := mockFramework("test", []reporthandling.Control{control})
+
+	scanInfo := &cautils.ScanInfo{IncludeNamespaces: "team-a"}
+	sessionObj := cautils.NewOPASessionObj(context.Background(), nil, nil, scanInfo, nil)
+	sessionObj.Policies = append(sessionObj.Policies, *framework)
+
+	_, allResources, _, _, err := handler.GetResources(context.Background(), sessionObj, scanInfo)
+
+	t.Logf("endpoint namespaces hit: %q", endpoints)
+	t.Logf("resources collected: %d", len(allResources))
+
+	require.NoError(t, err, "the scan proceeds under namespace-scoped RBAC")
+	require.NotEmpty(t, allResources)
+	for _, ns := range endpoints {
+		assert.Equal(t, "team-a", ns, "every query addresses the requested namespace")
+	}
+}

--- a/core/pkg/resourcehandler/preflight.go
+++ b/core/pkg/resourcehandler/preflight.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GVRCheck is the preflight result for a single resource type the scan needs to list.
@@ -65,14 +66,14 @@ var ErrPreflightNotSupported = errors.New("dry-run RBAC preflight is only suppor
 // Preflight resolves the resource types the given policies require and
 // checks, via SelfSubjectAccessReview, whether the current credentials can
 // list each one, without collecting any resources. Kubescape lists every
-// resource type with a single cluster-wide LIST (namespace filtering happens
-// against the returned items, not via a namespaced list call), so a
-// cluster-wide "list" access review is the same check the real collection
-// would need to pass, regardless of --include-namespaces/--exclude-namespaces.
+// resource type at the scope collection will address it: namespaced when
+// --include-namespaces names the namespaces a namespaced resource is collected
+// from, cluster-wide otherwise. That is the same check the real collection
+// would need to pass.
 //
-// --include-kinds/--exclude-kinds are honored, unlike the namespace filters:
-// they decide which resource types get listed at all, so reviewing access to an
-// excluded kind would fail the dry-run over a listing that never happens.
+// --include-kinds/--exclude-kinds are honored too: they decide which resource
+// types get listed at all, so reviewing access to an excluded kind would fail
+// the dry-run over a listing that never happens.
 func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj *cautils.OPASessionObj, scanInfo *cautils.ScanInfo) (*PreflightResult, error) {
 	resolver, discoveryFailures := newDiscoveryResourceResolver(k8sHandler.k8s.DiscoveryClient)
 
@@ -81,6 +82,8 @@ func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj 
 	queryableResources, _ := getQueryableResourceMapFromPolicies(sessionObj.Policies, sessionObj.SingleResourceScan, scanningScope, resolver)
 	filterQueryableResourcesByKind(queryableResources, scanInfo)
 	setKSResourceMap(sessionObj.Policies, resourceToControl, resolver)
+
+	globalFieldSelectors := getFieldSelectorFromScanInfo(scanInfo)
 
 	result := &PreflightResult{DiscoveryFailures: discoveryFailures}
 	seen := make(map[string]struct{}, len(queryableResources))
@@ -96,36 +99,58 @@ func (k8sHandler *K8sResourceHandler) Preflight(ctx context.Context, sessionObj 
 		}
 		seen[qr.GroupVersionResourceTriplet] = struct{}{}
 
-		result.Checks = append(result.Checks, k8sHandler.checkListAccess(ctx, qr.GroupVersionResourceTriplet, resourceToControl[qr.GroupVersionResourceTriplet]))
+		apiGroup, apiVersion, resource := k8sinterface.StringToResourceGroup(qr.GroupVersionResourceTriplet)
+		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
+		namespaces := globalFieldSelectors.GetNamespaceScopedQueries(&gvr, qr.Namespaced)
+
+		result.Checks = append(result.Checks, k8sHandler.checkListAccess(ctx, qr.GroupVersionResourceTriplet, namespaces, resourceToControl[qr.GroupVersionResourceTriplet]))
 	}
 
 	sort.Slice(result.Checks, func(i, j int) bool { return result.Checks[i].GVR < result.Checks[j].GVR })
 	return result, nil
 }
 
-func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTriplet string, affectedControls []string) GVRCheck {
+// checkListAccess reviews "list" access to gvrTriplet. namespaces are the
+// namespaces collection will address the resource in; an empty slice reviews
+// cluster scope. Every namespace must be allowed for the check to pass, since
+// collection queries all of them, and the first one that is not decides the
+// reported outcome.
+func (k8sHandler *K8sResourceHandler) checkListAccess(ctx context.Context, gvrTriplet string, namespaces []string, affectedControls []string) GVRCheck {
 	group, version, resource := k8sinterface.StringToResourceGroup(gvrTriplet)
+
+	scopes := namespaces
+	if len(scopes) == 0 {
+		scopes = []string{""}
+	}
+
 	check := GVRCheck{GVR: gvrTriplet, AffectedControls: affectedControls}
-
-	ssar := &authorizationv1.SelfSubjectAccessReview{
-		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationv1.ResourceAttributes{
-				Verb:     "list",
-				Group:    group,
-				Version:  version,
-				Resource: resource,
+	for _, namespace := range scopes {
+		ssar := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:      "list",
+					Group:     group,
+					Version:   version,
+					Resource:  resource,
+					Namespace: namespace,
+				},
 			},
-		},
+		}
+
+		check = GVRCheck{GVR: gvrTriplet, AffectedControls: affectedControls}
+		resp, err := k8sHandler.k8s.KubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
+		if err != nil {
+			check.Errored = true
+			check.Reason = err.Error()
+			return check
+		}
+
+		applyAccessReviewStatus(&check, resp.Status)
+		if !check.Allowed {
+			return check
+		}
 	}
 
-	resp, err := k8sHandler.k8s.KubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
-	if err != nil {
-		check.Errored = true
-		check.Reason = err.Error()
-		return check
-	}
-
-	applyAccessReviewStatus(&check, resp.Status)
 	return check
 }
 

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -25,11 +25,15 @@ import (
 )
 
 type staticFieldSelector struct {
-	selectors []string
+	selectors  []string
+	namespaces []string
 }
 
 func (s *staticFieldSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource, namespaced *bool) []string {
 	return s.selectors
+}
+func (s *staticFieldSelector) GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string {
+	return s.namespaces
 }
 func (s *staticFieldSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
 	return false


### PR DESCRIPTION
I found that --include-namespaces cannot actually be used with a namespaced Role. Collection narrows the query with a metadata.namespace field selector, but it still issues the request against the cluster-scoped collection endpoint (GET /api/v1/pods). Kubernetes resolves that path with an empty namespace in the request info, so only ClusterRoleBindings are consulted, and the field selector never enters the authorization decision. A caller who holds only a Role in the namespace they asked to scan gets a 403 on every resource type, even though every object they need is one they can already read.

I changed collection to address each included namespace's own endpoint instead, the same way EstimateClusterSize already does for the cluster-size estimate. A namespaced resource under --include-namespaces now goes through DynamicClient.Resource(gvr).Namespace(ns).List(...), which Kubernetes authorizes against a namespaced Role. Cluster-scoped resources and the Namespace kind itself are unaffected and keep using the cluster-scoped endpoint, since that is what they actually need. --exclude-namespaces also stays as it was, since excluding some namespaces means collecting everything else, which cannot be expressed as a bounded set of namespaced queries.

I updated --dry-run to match. It now reviews access at the same scope collection will use, so a caller who can list pods in their own namespace is told that instead of being told they cannot list pods cluster-wide.

I added tests that model the real RBAC authorizer, a namespaced Role that is denied at cluster scope and allowed in its own namespace, and drove the real collection and preflight code through it end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace-aware resource scanning for included namespaces.
  * Scans can now collect resources through namespace-scoped access, supporting environments where cluster-wide permissions are unavailable.
  * Dry-run access checks now validate each requested namespace separately.

* **Bug Fixes**
  * Corrected namespaced resource queries to use namespace-specific endpoints instead of cluster-wide queries with namespace filters.
  * Improved handling of namespace permissions during preflight and resource collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->