### PR TITLE
feat(scan): emit CycloneDX and SPDX SBOMs from posture scans with --scan-images

### DIFF
--- a/core/core/sbom_output_test.go
+++ b/core/core/sbom_output_test.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSBOMOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		scanType  cautils.ScanTypes
+		scanImage bool
+		hide      bool
+		encrypt   bool
+		expectErr string
+	}{
+		{
+			name:     "non-sbom format is unaffected",
+			format:   printer.JsonFormat,
+			scanType: cautils.ScanTypeCluster,
+		},
+		{
+			name:     "image scan emits an sbom without --scan-images",
+			format:   printer.CycloneDXFormat,
+			scanType: cautils.ScanTypeImage,
+		},
+		{
+			name:      "posture scan with --scan-images emits an sbom",
+			format:    printer.CycloneDXFormat,
+			scanType:  cautils.ScanTypeCluster,
+			scanImage: true,
+		},
+		{
+			name:      "spdx follows the same rules as cyclonedx",
+			format:    printer.SPDXFormat,
+			scanType:  cautils.ScanTypeRepo,
+			scanImage: true,
+		},
+		{
+			name:      "posture scan without --scan-images is rejected",
+			format:    printer.CycloneDXFormat,
+			scanType:  cautils.ScanTypeCluster,
+			expectErr: "add --scan-images",
+		},
+		{
+			name:      "--hide is rejected because the sbom cannot be anonymized",
+			format:    printer.CycloneDXFormat,
+			scanType:  cautils.ScanTypeCluster,
+			scanImage: true,
+			hide:      true,
+			expectErr: "not supported with --hide or --encrypt",
+		},
+		{
+			name:      "--encrypt is rejected because the sbom cannot be anonymized",
+			format:    printer.SPDXFormat,
+			scanType:  cautils.ScanTypeCluster,
+			scanImage: true,
+			encrypt:   true,
+			expectErr: "not supported with --hide or --encrypt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanInfo := &cautils.ScanInfo{
+				ScanImages:        tt.scanImage,
+				Hide:              tt.hide,
+				EncryptionEnabled: tt.encrypt,
+			}
+			scanInfo.ScanType = tt.scanType
+
+			err := validateSBOMOutput(scanInfo, tt.format)
+
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectErr)
+		})
+	}
+}

--- a/core/core/scan.go
+++ b/core/core/scan.go
@@ -147,6 +147,22 @@ func getInterfaces(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdenti
 	}, nil
 }
 
+func validateSBOMOutput(scanInfo *cautils.ScanInfo, format string) error {
+	if format != printer.CycloneDXFormat && format != printer.SPDXFormat {
+		return nil
+	}
+	if scanInfo.ScanType == cautils.ScanTypeImage {
+		return nil
+	}
+	if !scanInfo.ScanImages {
+		return fmt.Errorf("format %q describes scanned images: add --scan-images, or run %q to scan an image directly", format, cautils.ExecName()+" scan image")
+	}
+	if scanInfo.Hide || scanInfo.EncryptionEnabled {
+		return fmt.Errorf("format %q is not supported with --hide or --encrypt: an SBOM is the Anchore scan document, whose package identity and relationships are keyed by content-derived IDs that anonymization cannot rewrite", format)
+	}
+	return nil
+}
+
 func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterName string) ([]printer.IPrinter, error) {
 	formats := scanInfo.Formats()
 	containPrettyPrinter := false
@@ -160,6 +176,10 @@ func GetOutputPrinters(scanInfo *cautils.ScanInfo, ctx context.Context, clusterN
 	for _, format := range formats {
 		usesPrettyPrinter, err := resultshandling.ValidatePrinter(scanInfo.ScanType, scanInfo.GetScanningContext(), format)
 		if err != nil {
+			return nil, closeConfiguredPrinters(err)
+		}
+
+		if err := validateSBOMOutput(scanInfo, format); err != nil {
 			return nil, closeConfiguredPrinters(err)
 		}
 

--- a/core/pkg/anonymizer/imagescan.go
+++ b/core/pkg/anonymizer/imagescan.go
@@ -31,11 +31,13 @@ import (
 // JSON. A partial scrub of that graph would produce a report the user believes
 // is anonymized and is not, which is worse than the leak it replaces.
 //
-// Nothing is lost by that on this path: every printer that emits the Anchore
-// graph (json, yaml, cyclonedx-json, spdx-json) does so only when
-// opaSessionObj is nil, which is the standalone `scan image` path. The
-// anonymizer never runs there, so cmd/scan/image.go rejects --hide/--encrypt
-// up front instead (shared.ValidateImageScanAnonymization).
+// Nothing is lost by that on this path: the printers that emit the Anchore
+// graph are gated so an anonymized run never reaches one. json and yaml emit it
+// only when opaSessionObj is nil, the standalone `scan image` path, which
+// cmd/scan/image.go rejects for --hide/--encrypt up front
+// (shared.ValidateImageScanAnonymization). cyclonedx-json and spdx-json also
+// emit it for a posture scan carrying --scan-images, which validateSBOMOutput
+// (core/core/scan.go) rejects for the same reason.
 func transformImageScanData(imageScanData []cautils.ImageScanData, transformer Transformer) error {
 	var err error
 

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter.go
@@ -39,15 +39,12 @@ func (cp *CycloneDXPrinter) SetWriter(ctx context.Context, outputFile string) er
 	return nil
 }
 
-// Score is a no-op: HandleResults only calls Score when opaSessionObj != nil
-// (core/pkg/resultshandling/results.go), and this printer only ever runs
-// against image scans, so it is never invoked in practice.
 func (cp *CycloneDXPrinter) Score(score float32) {}
 
 func (cp *CycloneDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
-	if opaSessionObj != nil || len(imageScanData) == 0 {
-		logger.L().Ctx(ctx).Error("cyclonedx-json output is only supported for image scans")
-		return fmt.Errorf("cyclonedx-json output is only supported for image scans")
+	if len(imageScanData) == 0 {
+		logger.L().Ctx(ctx).Error("cyclonedx-json output requires scanned images")
+		return fmt.Errorf("cyclonedx-json output requires scanned images")
 	}
 
 	encoder, err := cyclonedxjson.NewFormatEncoderWithConfig(cyclonedxjson.DefaultEncoderConfig())

--- a/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/cyclonedxprinter_test.go
@@ -63,7 +63,7 @@ func TestActionPrint_CycloneDX_ImageScan(t *testing.T) {
 	assert.Equal(t, "CycloneDX", doc["bomFormat"])
 }
 
-func TestActionPrint_CycloneDX_NonImageScan_NoOutput(t *testing.T) {
+func TestActionPrint_CycloneDX_PostureScanWithoutImages_NoOutput(t *testing.T) {
 	tmp, err := os.CreateTemp("", "cyclonedx-noimage-*.cdx.json")
 	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmp.Name()) }()
@@ -76,7 +76,7 @@ func TestActionPrint_CycloneDX_NonImageScan_NoOutput(t *testing.T) {
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
-	assert.Empty(t, raw, "cyclonedx-json must not write anything for a non-image scan")
+	assert.Empty(t, raw, "cyclonedx-json must not write anything when no image was scanned")
 }
 
 func TestActionPrint_CycloneDX_MultiImageScan(t *testing.T) {
@@ -146,4 +146,27 @@ func TestActionPrint_CycloneDX_AllNilSBOMs_ReturnsError(t *testing.T) {
 	err = cp.ActionPrint(context.Background(), nil, imageScanData)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no SBOM data available")
+}
+
+func TestActionPrint_CycloneDX_PostureScanWithImages(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		buildSeverityExceptionImageScanData(),
+		buildSeverityExceptionImageScanData(),
+	}
+
+	tmp, err := os.CreateTemp("", "cyclonedx-posture-*.cdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	cp := NewCycloneDXPrinter()
+	cp.writer = tmp
+	require.NoError(t, cp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), imageScanData))
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var documents []json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &documents))
+	assert.Len(t, documents, 2, "a posture scan with --scan-images must emit one document per scanned image")
 }

--- a/core/pkg/resultshandling/printer/v2/spdxprinter.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter.go
@@ -39,15 +39,12 @@ func (sp *SPDXPrinter) SetWriter(ctx context.Context, outputFile string) error {
 	return nil
 }
 
-// Score is a no-op: HandleResults only calls Score when opaSessionObj != nil
-// (core/pkg/resultshandling/results.go), and this printer only ever runs
-// against image scans, so it is never invoked in practice.
 func (sp *SPDXPrinter) Score(score float32) {}
 
 func (sp *SPDXPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
-	if opaSessionObj != nil || len(imageScanData) == 0 {
-		logger.L().Ctx(ctx).Error("spdx-json output is only supported for image scans")
-		return fmt.Errorf("spdx-json output is only supported for image scans")
+	if len(imageScanData) == 0 {
+		logger.L().Ctx(ctx).Error("spdx-json output requires scanned images")
+		return fmt.Errorf("spdx-json output requires scanned images")
 	}
 
 	encoder, err := spdxjson.NewFormatEncoderWithConfig(spdxjson.DefaultEncoderConfig())

--- a/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/spdxprinter_test.go
@@ -66,7 +66,7 @@ func TestActionPrint_SPDX_ImageScan(t *testing.T) {
 	assert.True(t, strings.HasPrefix(version, "SPDX-"))
 }
 
-func TestActionPrint_SPDX_NonImageScan_NoOutput(t *testing.T) {
+func TestActionPrint_SPDX_PostureScanWithoutImages_NoOutput(t *testing.T) {
 	tmp, err := os.CreateTemp("", "spdx-noimage-*.spdx.json")
 	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmp.Name()) }()
@@ -79,7 +79,7 @@ func TestActionPrint_SPDX_NonImageScan_NoOutput(t *testing.T) {
 
 	raw, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
-	assert.Empty(t, raw, "spdx-json must not write anything for a non-image scan")
+	assert.Empty(t, raw, "spdx-json must not write anything when no image was scanned")
 }
 
 func TestActionPrint_SPDX_MultiImageScan(t *testing.T) {
@@ -155,4 +155,27 @@ func TestActionPrint_SPDX_AllNilSBOMs_ReturnsError(t *testing.T) {
 	err = sp.ActionPrint(context.Background(), nil, imageScanData)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no SBOM data available")
+}
+
+func TestActionPrint_SPDX_PostureScanWithImages(t *testing.T) {
+	imageScanData := []cautils.ImageScanData{
+		buildSeverityExceptionImageScanData(),
+		buildSeverityExceptionImageScanData(),
+	}
+
+	tmp, err := os.CreateTemp("", "spdx-posture-*.spdx.json")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	sp := NewSPDXPrinter()
+	sp.writer = tmp
+	require.NoError(t, sp.ActionPrint(context.Background(), cautils.NewOPASessionObjMock(), imageScanData))
+	require.NoError(t, tmp.Close())
+
+	raw, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+
+	var documents []json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &documents))
+	assert.Len(t, documents, 2, "a posture scan with --scan-images must emit one document per scanned image")
 }

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -428,12 +428,8 @@ func ValidatePrinter(scanType cautils.ScanTypes, scanContext cautils.ScanningCon
 			return false, fmt.Errorf("format \"%s\" is only supported when scanning local files", printFormat)
 		}
 	}
-	if printFormat == printer.CycloneDXFormat || printFormat == printer.SPDXFormat {
-		return false, fmt.Errorf("format \"%s\" is only supported for image scanning", printFormat)
-	}
-
 	switch printFormat {
-	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat, printer.PolicyReportFormat, printer.ExceptionsFormat:
+	case printer.JsonFormat, printer.HtmlFormat, printer.JunitResultFormat, printer.PrometheusFormat, printer.PdfFormat, printer.YamlFormat, printer.CsvFormat, printer.MarkdownFormat, printer.PolicyReportFormat, printer.ExceptionsFormat, printer.CycloneDXFormat, printer.SPDXFormat:
 		return false, nil
 	default:
 		return true, nil

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -434,16 +434,16 @@ func TestValidatePrinter(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "cyclonedx-json format for cluster scan should return error",
+			name:      "cyclonedx-json format for cluster scan should not return error",
 			scanType:  cautils.ScanTypeCluster,
 			format:    printer.CycloneDXFormat,
-			expectErr: errors.New("format \"cyclonedx-json\" is only supported for image scanning"),
+			expectErr: nil,
 		},
 		{
-			name:      "spdx-json format for cluster scan should return error",
+			name:      "spdx-json format for cluster scan should not return error",
 			scanType:  cautils.ScanTypeCluster,
 			format:    printer.SPDXFormat,
-			expectErr: errors.New("format \"spdx-json\" is only supported for image scanning"),
+			expectErr: nil,
 		},
 		{
 			name:      "markdown format for cluster scan should not return error",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,7 +46,7 @@ kubescape scan [target] [flags]
 | `--exceptions <path>` | Path to exceptions file | - |
 | `--audit-exceptions` | Include exception usage details in supported scan outputs | `false` |
 | `--fail-coverage-below <float>` | Fail if the scan coverage score is below threshold (`0` disables). Applies in every view — see [score thresholds](#score-thresholds). | `0` |
-| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `github-actions`, `yaml`, `csv`, `markdown`, `policyreport`, `exceptions` — see [generating an exceptions baseline](#generating-an-exceptions-baseline). `github-actions` emits failed High/Critical controls as `::error` workflow commands for inline PR annotations; local file scans only, capped at GitHub's 10-annotations-per-step limit | `pretty-printer` |
+| `-f, --format <format>` | Output format: `pretty-printer`, `json`, `junit`, `prometheus`, `pdf`, `html`, `sarif`, `gitlab-sast`, `github-actions`, `yaml`, `csv`, `markdown`, `policyreport`, `exceptions`, `cyclonedx-json`, `spdx-json` — see [generating an exceptions baseline](#generating-an-exceptions-baseline) and [generating an SBOM](#generating-an-sbom). `github-actions` emits failed High/Critical controls as `::error` workflow commands for inline PR annotations; local file scans only, capped at GitHub's 10-annotations-per-step limit | `pretty-printer` |
 | `--hide` | Replace sensitive report metadata with deterministic pseudonyms. Ignored when `--encrypt` is also specified. | `false` |
 | `--host-scan` | Enable host data collection from cluster nodes for certain controls. When not set, Kubescape auto-detects node-agent CRDs and uses a CRD-based host sensor if available. Use `--host-scan=false` to disable host data collection. See the [Kubescape operator](https://github.com/kubescape/helm-charts/tree/main/charts/kubescape-operator) for a managed alternative. | auto-detect |
 | `--include-namespaces <ns>` | Namespaces to include (comma-separated) | - |
@@ -56,7 +56,7 @@ kubescape scan [target] [flags]
 | `--kubeconfig <path>` | Path to kubeconfig file | - |
 | `-o, --output <path>` | Output file path | stdout |
 | `--otel-endpoint <endpoint>` | Export scan traces and metrics to an OTLP collector — see [OpenTelemetry export](#opentelemetry-export). Accepts `host:port` (plaintext) or a `http(s)://` URL. | `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| `--scan-images` | Also scan container images for vulnerabilities | `false` |
+| `--scan-images` | Also scan container images for vulnerabilities. Required for `--format cyclonedx-json` and `--format spdx-json` — see [generating an SBOM](#generating-an-sbom) | `false` |
 | `--image-platform <platform>` | OCI platform for workload image scans, such as `linux/amd64`. Overrides platform inferred from Nodes and hard scheduling constraints | inferred |
 | `--min-severity <sev>` | Only show controls at or above this severity: `low`, `medium`, `high`, `critical`. Output-only — exit codes are computed on the full unfiltered report | - |
 | `--max-severity <sev>` | Only show controls at or below this severity. Output-only — exit codes are computed on the full unfiltered report | - |
@@ -198,6 +198,39 @@ resources from it, or widen one by replacing an escaped `name` with a regular
 expression of your own.
 
 Exceptions are posture-only and the format is rejected for `scan image`.
+
+### Generating an SBOM
+
+`--scan-images` already pulls and analyses every image a scan finds. Adding
+`--format cyclonedx-json` or `--format spdx-json` writes the software bill of
+materials that analysis produced, so one command inventories everything running
+in a cluster or referenced by a set of manifests:
+
+```bash
+# CycloneDX SBOM for every image running in the cluster
+kubescape scan --scan-images --format cyclonedx-json --output cluster.cdx.json
+
+# SPDX SBOM for the images referenced by a manifest directory
+kubescape scan ./manifests --scan-images --format spdx-json --output manifests.spdx.json
+
+# Posture report and SBOM from a single scan
+kubescape scan --scan-images --format json,cyclonedx-json --output report
+```
+
+One document is emitted per image, as a JSON array when the scan covered several
+and as the bare document when it covered one — the same shape `kubescape scan
+image` produces. The SBOM describes images only; posture results belong to the
+other formats, so pair them with `--format` when both are needed.
+
+Without `--scan-images` there is nothing to describe and the scan stops before it
+starts, rather than writing an empty file. To scan an image directly, without a
+posture scan around it, use [`kubescape scan image`](#kubescape-scan-image).
+
+`--hide` and `--encrypt` are rejected with these formats. An SBOM is the Anchore
+scan document, whose package identity and relationships are keyed by
+content-derived IDs that anonymization cannot rewrite, so it would name the
+images and packages a `--hide` run is meant to conceal. Anonymized runs keep the
+posture formats, where image references are pseudonymized.
 
 ### Custom rules
 


### PR DESCRIPTION
## Summary

- `--scan-images` already pulls and analyses every image a posture scan finds and Syft returns a full SBOM for each, but `ValidatePrinter` rejected `cyclonedx-json`/`spdx-json` outright for anything that wasn't `scan image`, so those SBOMs were computed and discarded inventorying a cluster meant rescanning each image one command at a time.
- `results.go` now accepts both formats for posture scans and the two printers no longer refuse a posture session; a new `validateSBOMOutput` in `core/core/scan.go` requires `--scan-images` and fails before collection starts rather than writing an empty file.
- `validateSBOMOutput` also rejects `--hide`/`--encrypt`: the anonymizer deliberately leaves the Anchore graph untransformed (content-derived IDs it cannot rewrite), so emitting an SBOM there would name the images and packages an anonymized run conceals - `imagescan.go`'s invariant comment is updated to match.
- Tested by `TestValidateSBOMOutput`, `TestActionPrint_{CycloneDX,SPDX}_PostureScanWithImages` and the extended `TestValidatePrinter`, plus live runs over a two-image manifest set (CycloneDX 1.6 and SPDX 2.3, and `--format json,cyclonedx-json` in one pass).

**Which issue(s) this PR fixes:**
N/A, found while reading the printer validation path; no open or closed issue/PR covers it.

**Special notes for your reviewer:**
No exported API changes, `ValidatePrinter` keeps its signature and the scanInfo-dependent rules sit in `GetOutputPrinters`, the single production path. `scan image` and `patch` set `ScanTypeImage` and take the early return, so both are untouched.

**Does this PR introduce a user-facing change?**
Yes `kubescape scan --scan-images --format cyclonedx-json|spdx-json` now writes an SBOM per scanned image (array for several, bare document for one); the formats are rejected without `--scan-images` and under `--hide`/`--encrypt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CycloneDX and SPDX JSON output support for posture and cluster scans when image scanning is enabled.
  * Multi-image scans now produce one SBOM document per image.
  * Added clear validation for required image scanning and incompatible output options.

* **Bug Fixes**
  * Improved handling of posture scans with image data for SBOM generation.

* **Documentation**
  * Updated CLI reference with SBOM formats, requirements, output behavior, and restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->