### PR TITLE
fix(score): route dead telemetry scorer output to logger.L().Debug

### DIFF
--- a/core/pkg/hostsensorutils/ebpf/tracer.go
+++ b/core/pkg/hostsensorutils/ebpf/tracer.go
@@ -2,8 +2,8 @@ package ebpf
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubescape/v4/core/pkg/hostsensorutils"
 )
 
@@ -21,7 +21,8 @@ func (t *Tracer) Start(ctx context.Context) (<-chan hostsensorutils.SyscallEvent
 		defer close(events)
 		// Stub: Load eBPF programs, attach to tracepoints, read from perf ring buffer
 		// and translate to SyscallEvent.
-		fmt.Println("eBPF tracer started (stub)")
+		// Note: Library code must never write directly to stdout as it would corrupt JSON/SARIF output.
+		logger.L().Debug("eBPF tracer started (stub)")
 		<-ctx.Done()
 	}()
 	return events, nil

--- a/core/pkg/hostsensorutils/ebpf/tracer_test.go
+++ b/core/pkg/hostsensorutils/ebpf/tracer_test.go
@@ -1,0 +1,30 @@
+package ebpf
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracer_Start(t *testing.T) {
+	tracer := NewTracer()
+	assert.NotNil(t, tracer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	events, err := tracer.Start(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, events)
+
+	// Wait for context cancellation and channel closure
+	<-ctx.Done()
+	select {
+	case _, ok := <-events:
+		assert.False(t, ok, "channel should be closed after context done")
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for events channel to close")
+	}
+}

--- a/core/pkg/score/score.go
+++ b/core/pkg/score/score.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/hostsensorutils"
 	"github.com/kubescape/opa-utils/score"
@@ -36,6 +38,8 @@ func (su *ScoreWrapper) Calculate(reportVersion PostureReportVersion) error {
 	return fmt.Errorf("unsupported score calculator")
 }
 
+// CalculateWithTelemetry dynamically adjusts scores based on eBPF telemetry events.
+// Note: Library code must never write directly to stdout as it would corrupt JSON/SARIF output.
 func (su *ScoreWrapper) CalculateWithTelemetry(ctx context.Context, reportVersion PostureReportVersion, telemetryChan <-chan hostsensorutils.SyscallEvent) error {
 	// Dynamically adjust scores based on eBPF telemetry
 	// This is a stub implementation
@@ -48,7 +52,7 @@ func (su *ScoreWrapper) CalculateWithTelemetry(ctx context.Context, reportVersio
 				// Channel closed, compute final score
 				return su.Calculate(reportVersion)
 			}
-			fmt.Printf("Received telemetry: %+v\n", event)
+			logger.L().Debug("received telemetry", helpers.Interface("event", event))
 			// Adjust su.opaSessionObj.Report scores dynamically based on utilized capabilities
 		}
 	}

--- a/core/pkg/score/score_test.go
+++ b/core/pkg/score/score_test.go
@@ -1,9 +1,12 @@
 package score
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	cautils "github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/hostsensorutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,4 +60,31 @@ func TestCalculateReturnsErrorWhenReportVersionIsNotSupported(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, "unsupported score calculator", err.Error())
+}
+
+func TestCalculateWithTelemetry_ContextDone(t *testing.T) {
+	opaSessionObj := cautils.NewOPASessionObjMock()
+	scoreWrapper := NewScoreWrapper(opaSessionObj)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	telemetryChan := make(chan hostsensorutils.SyscallEvent)
+	err := scoreWrapper.CalculateWithTelemetry(ctx, EPostureReportV2, telemetryChan)
+	assert.NoError(t, err)
+}
+
+func TestCalculateWithTelemetry_ChannelClose(t *testing.T) {
+	opaSessionObj := cautils.NewOPASessionObjMock()
+	scoreWrapper := NewScoreWrapper(opaSessionObj)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	telemetryChan := make(chan hostsensorutils.SyscallEvent, 2)
+	telemetryChan <- hostsensorutils.SyscallEvent{}
+	close(telemetryChan)
+
+	err := scoreWrapper.CalculateWithTelemetry(ctx, EPostureReportV2, telemetryChan)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Overview

This PR fixes potential `stdout` stream corruption in `CalculateWithTelemetry` (`core/pkg/score`) and `ebpf.Tracer` (`core/pkg/hostsensorutils/ebpf`) by replacing direct `fmt.Printf` / `fmt.Println` writes with `logger.L().Debug(...)`.

---

### Problem

Kubescape streams machine-readable JSON and SARIF reports to `stdout` when `--output` is unset. Any library component that writes raw text directly to `stdout` will interleave unformatted logs into the JSON/SARIF payload, causing downstream consumers and CI pipelines to fail parsing.

---

### Key Changes

1. **`core/pkg/score/score.go`**:
   - Replaced `fmt.Printf("Received telemetry: %+v\n", event)` with `logger.L().Debug("received telemetry", helpers.Interface("event", event))`.
   - Added documentation explaining the prohibition of `stdout` writes from library packages.
2. **`core/pkg/hostsensorutils/ebpf/tracer.go`**:
   - Replaced `fmt.Println("eBPF tracer started (stub)")` with `logger.L().Debug("eBPF tracer started (stub)")`.
3. **Unit Tests**:
   - Added `TestCalculateWithTelemetry_ContextDone` and `TestCalculateWithTelemetry_ChannelClose` in `core/pkg/score/score_test.go`.
   - Added `TestTracer_Start` in `core/pkg/hostsensorutils/ebpf/tracer_test.go`.

---

### How to Test

Run the unit tests:
```bash
go test -v -count=1 ./core/pkg/score/... ./core/pkg/hostsensorutils/ebpf/...
```

---

### Related Issues

* Fixes #3701

---

*Investigated and drafted with AI assistance; reviewed and tested by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for tracer startup and telemetry processing using structured logs.

* **Tests**
  * Added coverage for tracer startup, event-channel closure, canceled contexts, and completed telemetry processing.
  * Verified telemetry calculations handle shutdown scenarios without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->