### PR TITLE
feat(scan): add per-namespace compliance rollup

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -232,7 +232,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.VerboseMode, "verbose", "v", false, "Display all of the input resources and not only failed resources")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.ShowEvidence, "show-evidence", "E", false, "Show evidence paths with current field values for each failed control (pretty-printer only)")
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.ShowSecrets, "show-secrets", false, "Show secret field values in evidence output. By default secret values are redacted. Only effective with --show-evidence")
-	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.SecurityViewType))
+	scanCmd.PersistentFlags().StringVar(&scanInfo.View, "view", string(cautils.SecurityViewType), fmt.Sprintf("View results based on the %s/%s/%s/%s. default is --view=%s", cautils.ResourceViewType, cautils.ControlViewType, cautils.SecurityViewType, cautils.NamespaceViewType, cautils.SecurityViewType))
 	scanCmd.PersistentFlags().BoolVar(&scanInfo.UseDefault, "use-default", false, "Load local policy object from default path. If not used will download latest")
 	scanCmd.PersistentFlags().StringSliceVar(&scanInfo.UseFrom, "use-from", nil, "Load local policy object from specified path. If not used will download latest")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.FormatVersion, "format-version", "v2", "Output object can be different between versions, this is for maintaining backward and forward compatibility. Supported:'v1'/'v2'")

--- a/core/cautils/datastructures.go
+++ b/core/cautils/datastructures.go
@@ -107,6 +107,7 @@ type OPASessionObj struct {
 	ScanCoverage          ScanCoverage                       // runtime coverage gaps (failed GVR pulls + not-evaluated controls)
 	PartialGVRFailures    []PartialGVRPull                   // per-selector LIST failures for GVRs that were partially collected
 	UnexaminedKinds       []UnexaminedKind                   // cluster-served resource kinds no control in the policy set queried
+	NamespaceSummaries    NamespaceSummaries                 // per-namespace compliance rollup, see BuildNamespaceSummaries
 	PolicyDegradations    []PolicyDegradation                // policy inputs (control configurations, exceptions) served from a fallback
 	SkippedManifests      []SkippedManifest                  // manifest files skipped during loading (invalid YAML, missing kind, etc.)
 	SessionID             string                             // SessionID

--- a/core/cautils/namespacesummary.go
+++ b/core/cautils/namespacesummary.go
@@ -1,0 +1,114 @@
+package cautils
+
+import (
+	"sort"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+// clusterScopedNamespace buckets resources that carry no namespace
+// (cluster-scoped kinds, or a manifest that omitted one) into a single named
+// entry rather than dropping them from the rollup.
+const clusterScopedNamespace = "<cluster-scoped>"
+
+// NamespaceSummary is one namespace's compliance rollup. Every control in the
+// scan's policy set is counted toward its score -- the same convention the
+// cluster and framework scores already use -- so namespace scores stay
+// directly comparable to one another and to the cluster-wide number.
+type NamespaceSummary struct {
+	Namespace       string  `json:"namespace"`
+	ComplianceScore float32 `json:"complianceScore"`
+	FailedControls  int     `json:"failedControls"`
+	TotalControls   int     `json:"totalControls"`
+	ResourceCount   int     `json:"resourceCount"`
+}
+
+// NamespaceSummaries is sorted ascending by ComplianceScore so the worst
+// namespace leads.
+type NamespaceSummaries []NamespaceSummary
+
+// BuildNamespaceSummaries computes a per-namespace compliance rollup from the
+// finalized control summaries.
+//
+// A control with no resource in a given namespace contributes 100 to that
+// namespace's score, mirroring how a control with no resource anywhere
+// already scores 100 at the cluster level (opa-utils
+// ScoreUtil.GetControlComplianceScore). This keeps every namespace's score
+// computed over the same TotalControls denominator, which is what makes them
+// comparable to each other.
+func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResources map[string]workloadinterface.IMetadata) NamespaceSummaries {
+	if len(controls) == 0 {
+		return nil
+	}
+
+	namespaceOf := func(resourceID string) string {
+		if resource, ok := allResources[resourceID]; ok && resource.GetNamespace() != "" {
+			return resource.GetNamespace()
+		}
+		return clusterScopedNamespace
+	}
+
+	// perControlCounts[controlID][namespace] = [passed, total], computed once
+	// per control up front so every namespace this scan actually touched is
+	// known before any control's contribution is scored. A control with no
+	// resource in a given namespace must still contribute 100 to it, and that
+	// namespace must already exist in the result set for that to happen.
+	perControlCounts := make(map[string]map[string][2]int, len(controls))
+	resourcesByNamespace := make(map[string]map[string]struct{})
+	for controlID, control := range controls {
+		counts := make(map[string][2]int)
+		for resourceID, status := range control.ResourceIDs.All() {
+			namespace := namespaceOf(resourceID)
+			if resourcesByNamespace[namespace] == nil {
+				resourcesByNamespace[namespace] = make(map[string]struct{})
+			}
+			resourcesByNamespace[namespace][resourceID] = struct{}{}
+
+			c := counts[namespace]
+			c[1]++
+			if status == apis.StatusPassed {
+				c[0]++
+			}
+			counts[namespace] = c
+		}
+		perControlCounts[controlID] = counts
+	}
+
+	totalControls := len(controls)
+	summaries := make(NamespaceSummaries, 0, len(resourcesByNamespace))
+	for namespace, resources := range resourcesByNamespace {
+		var scoreSum float32
+		var failedControls int
+		for controlID := range controls {
+			passed, total := 0, 0
+			if c, ok := perControlCounts[controlID][namespace]; ok {
+				passed, total = c[0], c[1]
+			}
+			score := float32(100)
+			if total > 0 {
+				score = (float32(passed) / float32(total)) * 100
+			}
+			scoreSum += score
+			if score < 100 {
+				failedControls++
+			}
+		}
+		summaries = append(summaries, NamespaceSummary{
+			Namespace:       namespace,
+			ComplianceScore: scoreSum / float32(totalControls),
+			FailedControls:  failedControls,
+			TotalControls:   totalControls,
+			ResourceCount:   len(resources),
+		})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].ComplianceScore != summaries[j].ComplianceScore {
+			return summaries[i].ComplianceScore < summaries[j].ComplianceScore
+		}
+		return summaries[i].Namespace < summaries[j].Namespace
+	})
+	return summaries
+}

--- a/core/cautils/namespacesummary.go
+++ b/core/cautils/namespacesummary.go
@@ -22,9 +22,14 @@ const ClusterScopedNamespace = "<cluster-scoped>"
 type NamespaceSummary struct {
 	Namespace       string  `json:"namespace"`
 	ComplianceScore float32 `json:"complianceScore"`
-	FailedControls  int     `json:"failedControls"`
-	TotalControls   int     `json:"totalControls"`
-	ResourceCount   int     `json:"resourceCount"`
+	// NonCompliantControls counts controls that did not score a clean 100 in
+	// this namespace. It is not the same as apis.StatusFailed: a control that
+	// is merely partially passing, or entirely skipped/action-required here,
+	// also counts, so this figure does not reconcile with the cluster
+	// summary's failed-control counter.
+	NonCompliantControls int `json:"nonCompliantControls"`
+	TotalControls        int `json:"totalControls"`
+	ResourceCount        int `json:"resourceCount"`
 }
 
 // NamespaceSummaries is sorted ascending by ComplianceScore so the worst
@@ -32,14 +37,17 @@ type NamespaceSummary struct {
 type NamespaceSummaries []NamespaceSummary
 
 // BuildNamespaceSummaries computes a per-namespace compliance rollup from the
-// finalized control summaries.
-//
-// A control with no resource in a given namespace contributes 100 to that
-// namespace's score, mirroring how a control with no resource anywhere
-// already scores 100 at the cluster level (opa-utils
-// ScoreUtil.GetControlComplianceScore). This keeps every namespace's score
-// computed over the same TotalControls denominator, which is what makes them
-// comparable to each other.
+// finalized control summaries. It must run after the score wrapper has set
+// ControlSummary.ComplianceScore for every control (see the callers in
+// processorhandler.go): a control with no resource in a given namespace
+// contributes that already-computed score to the namespace, whatever it is,
+// rather than assuming 100. This matters because opa-utils'
+// GetControlComplianceScore only returns 100 for a zero-resource control that
+// is also Passed (a control the cluster genuinely never needed); a control
+// that could not be evaluated (RBAC-restricted collection, a timeout) is
+// zero-resource too but scores 0, and namespaces must inherit that same 0,
+// not a free 100, to stay comparable to the cluster number sitting next to
+// them in the same report.
 func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResources map[string]workloadinterface.IMetadata) NamespaceSummaries {
 	if len(controls) == 0 {
 		return nil
@@ -54,8 +62,8 @@ func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResourc
 
 	// resourcesByNamespace is seeded from every scanned resource, not just
 	// ones a control matched, so a namespace holding only resources no
-	// control examines still gets a summary (scoring 100 on every control)
-	// instead of being silently absent from the rollup.
+	// control examines still gets a summary instead of being silently absent
+	// from the rollup.
 	resourcesByNamespace := make(map[string]map[string]struct{})
 	for resourceID := range allResources {
 		namespace := namespaceOf(resourceID)
@@ -65,13 +73,24 @@ func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResourc
 		resourcesByNamespace[namespace][resourceID] = struct{}{}
 	}
 
+	// controlIDs is sorted once and reused for every namespace below, so
+	// scoreSum always accumulates in the same order across runs. float32
+	// addition is not associative, and ranging a map iterates in randomized
+	// order, so without this the same input could produce a ComplianceScore
+	// that differs by a ULP between two runs -- and with it, defeat the exact
+	// tie-break the final sort below relies on.
+	controlIDs := make([]string, 0, len(controls))
+	for controlID := range controls {
+		controlIDs = append(controlIDs, controlID)
+	}
+	sort.Strings(controlIDs)
+
 	// perControlCounts[controlID][namespace] = [passed, total], computed once
 	// per control up front so every namespace this scan actually touched is
-	// known before any control's contribution is scored. A control with no
-	// resource in a given namespace must still contribute 100 to it, and that
-	// namespace must already exist in the result set for that to happen.
+	// known before any control's contribution is scored.
 	perControlCounts := make(map[string]map[string][2]int, len(controls))
-	for controlID, control := range controls {
+	for _, controlID := range controlIDs {
+		control := controls[controlID]
 		counts := make(map[string][2]int)
 		for resourceID, status := range control.ResourceIDs.All() {
 			namespace := namespaceOf(resourceID)
@@ -93,39 +112,54 @@ func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResourc
 		perControlCounts[controlID] = counts
 	}
 
+	namespaces := make([]string, 0, len(resourcesByNamespace))
+	for namespace := range resourcesByNamespace {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+
 	totalControls := len(controls)
-	summaries := make(NamespaceSummaries, 0, len(resourcesByNamespace))
-	for namespace, resources := range resourcesByNamespace {
-		var scoreSum float32
-		var failedControls int
-		for controlID := range controls {
-			passed, total := 0, 0
-			if c, ok := perControlCounts[controlID][namespace]; ok {
-				passed, total = c[0], c[1]
-			}
-			score := float32(100)
-			if total > 0 {
+	summaries := make(NamespaceSummaries, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		var scoreSum float64
+		var nonCompliantControls int
+		for _, controlID := range controlIDs {
+			var score float32
+			if c, ok := perControlCounts[controlID][namespace]; ok && c[1] > 0 {
+				passed, total := c[0], c[1]
 				score = (float32(passed) / float32(total)) * 100
+			} else {
+				// No resource of this control's in this namespace: inherit
+				// the control's own cluster-computed score rather than
+				// assuming 100 (see the function doc comment).
+				control := controls[controlID]
+				score = control.GetComplianceScore()
+				if score < 0 {
+					// Defensive fallback for a caller that runs this before
+					// the score wrapper: mirrors opa-utils' own zero-resource
+					// default so behavior degrades to the old approximation
+					// rather than a negative score.
+					score = 100
+				}
 			}
-			scoreSum += score
+			scoreSum += float64(score)
 			if score < 100 {
-				failedControls++
+				nonCompliantControls++
 			}
 		}
 		summaries = append(summaries, NamespaceSummary{
-			Namespace:       namespace,
-			ComplianceScore: scoreSum / float32(totalControls),
-			FailedControls:  failedControls,
-			TotalControls:   totalControls,
-			ResourceCount:   len(resources),
+			Namespace:            namespace,
+			ComplianceScore:      float32(scoreSum / float64(totalControls)),
+			NonCompliantControls: nonCompliantControls,
+			TotalControls:        totalControls,
+			ResourceCount:        len(resourcesByNamespace[namespace]),
 		})
 	}
 
-	sort.Slice(summaries, func(i, j int) bool {
-		if summaries[i].ComplianceScore != summaries[j].ComplianceScore {
-			return summaries[i].ComplianceScore < summaries[j].ComplianceScore
-		}
-		return summaries[i].Namespace < summaries[j].Namespace
+	// namespaces was built in sorted order, so a stable sort by score alone
+	// keeps ties in that same alphabetical order without a second comparison.
+	sort.SliceStable(summaries, func(i, j int) bool {
+		return summaries[i].ComplianceScore < summaries[j].ComplianceScore
 	})
 	return summaries
 }

--- a/core/cautils/namespacesummary.go
+++ b/core/cautils/namespacesummary.go
@@ -8,10 +8,12 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 )
 
-// clusterScopedNamespace buckets resources that carry no namespace
+// ClusterScopedNamespace buckets resources that carry no namespace
 // (cluster-scoped kinds, or a manifest that omitted one) into a single named
-// entry rather than dropping them from the rollup.
-const clusterScopedNamespace = "<cluster-scoped>"
+// entry rather than dropping them from the rollup. It is not a real
+// Kubernetes namespace, so callers must not treat it as user data (the
+// anonymizer skips it for that reason).
+const ClusterScopedNamespace = "<cluster-scoped>"
 
 // NamespaceSummary is one namespace's compliance rollup. Every control in the
 // scan's policy set is counted toward its score -- the same convention the
@@ -47,7 +49,20 @@ func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResourc
 		if resource, ok := allResources[resourceID]; ok && resource.GetNamespace() != "" {
 			return resource.GetNamespace()
 		}
-		return clusterScopedNamespace
+		return ClusterScopedNamespace
+	}
+
+	// resourcesByNamespace is seeded from every scanned resource, not just
+	// ones a control matched, so a namespace holding only resources no
+	// control examines still gets a summary (scoring 100 on every control)
+	// instead of being silently absent from the rollup.
+	resourcesByNamespace := make(map[string]map[string]struct{})
+	for resourceID := range allResources {
+		namespace := namespaceOf(resourceID)
+		if resourcesByNamespace[namespace] == nil {
+			resourcesByNamespace[namespace] = make(map[string]struct{})
+		}
+		resourcesByNamespace[namespace][resourceID] = struct{}{}
 	}
 
 	// perControlCounts[controlID][namespace] = [passed, total], computed once
@@ -56,11 +71,13 @@ func BuildNamespaceSummaries(controls reportsummary.ControlSummaries, allResourc
 	// resource in a given namespace must still contribute 100 to it, and that
 	// namespace must already exist in the result set for that to happen.
 	perControlCounts := make(map[string]map[string][2]int, len(controls))
-	resourcesByNamespace := make(map[string]map[string]struct{})
 	for controlID, control := range controls {
 		counts := make(map[string][2]int)
 		for resourceID, status := range control.ResourceIDs.All() {
 			namespace := namespaceOf(resourceID)
+			// Usually already seeded from allResources above; kept here too
+			// so a control's resource ID that is missing from allResources
+			// still lands in the rollup instead of being silently dropped.
 			if resourcesByNamespace[namespace] == nil {
 				resourcesByNamespace[namespace] = make(map[string]struct{})
 			}

--- a/core/cautils/namespacesummary_test.go
+++ b/core/cautils/namespacesummary_test.go
@@ -92,7 +92,7 @@ func TestBuildNamespaceSummaries_ClusterScopedBucket(t *testing.T) {
 
 	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-NODE": failed}, allResources)
 	require.Len(t, summaries, 1)
-	assert.Equal(t, clusterScopedNamespace, summaries[0].Namespace)
+	assert.Equal(t, ClusterScopedNamespace, summaries[0].Namespace)
 	assert.Equal(t, float32(0), summaries[0].ComplianceScore)
 	assert.Equal(t, 1, summaries[0].ResourceCount)
 }
@@ -106,5 +106,33 @@ func TestBuildNamespaceSummaries_UnknownResourceIDFallsBackToClusterScoped(t *te
 
 	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-X": ctrl}, map[string]workloadinterface.IMetadata{})
 	require.Len(t, summaries, 1)
-	assert.Equal(t, clusterScopedNamespace, summaries[0].Namespace)
+	assert.Equal(t, ClusterScopedNamespace, summaries[0].Namespace)
+}
+
+// TestBuildNamespaceSummaries_NamespaceWithNoMatchedResourceStillScores
+// covers a namespace holding resources that no control's ResourceIDs ever
+// reference (every control simply does not apply to them). It must still
+// produce a summary, scoring 100 on every control, instead of being silently
+// absent from the rollup.
+func TestBuildNamespaceSummaries_NamespaceWithNoMatchedResourceStillScores(t *testing.T) {
+	untouchedPod := namespacedPod("configmap-only", "quiet-ns")
+	allResources := map[string]workloadinterface.IMetadata{untouchedPod.GetID(): untouchedPod}
+
+	// C-OTHER has resources, but none of them live in quiet-ns.
+	other := reportsummary.ControlSummary{ControlID: "C-OTHER"}
+	other.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, "some-other-resource-id")
+
+	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-OTHER": other}, allResources)
+
+	byNamespace := make(map[string]NamespaceSummary, len(summaries))
+	for _, s := range summaries {
+		byNamespace[s.Namespace] = s
+	}
+
+	quiet, ok := byNamespace["quiet-ns"]
+	require.True(t, ok, "a namespace with a resource must appear even if no control matched a resource in it")
+	assert.Equal(t, float32(100), quiet.ComplianceScore)
+	assert.Equal(t, 1, quiet.TotalControls)
+	assert.Equal(t, 0, quiet.FailedControls)
+	assert.Equal(t, 1, quiet.ResourceCount)
 }

--- a/core/cautils/namespacesummary_test.go
+++ b/core/cautils/namespacesummary_test.go
@@ -1,0 +1,110 @@
+package cautils
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func namespacedPod(id, namespace string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": id, "namespace": namespace},
+	})
+}
+
+func clusterScopedNode(id string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata":   map[string]any{"name": id},
+	})
+}
+
+// TestBuildNamespaceSummaries_EmptyControlsReturnsNil covers the no-op input:
+// no policy set means nothing to score.
+func TestBuildNamespaceSummaries_EmptyControlsReturnsNil(t *testing.T) {
+	assert.Nil(t, BuildNamespaceSummaries(nil, nil))
+}
+
+// TestBuildNamespaceSummaries_CountsEveryControl pins the approved
+// convention: a control with no resource in a namespace still counts toward
+// that namespace's score at 100, so every namespace divides by the same
+// TotalControls and stays comparable to the others.
+func TestBuildNamespaceSummaries_CountsEveryControl(t *testing.T) {
+	prodPod := namespacedPod("prod-pod", "prod")
+	devPod := namespacedPod("dev-pod", "dev")
+
+	allResources := map[string]workloadinterface.IMetadata{
+		prodPod.GetID(): prodPod,
+		devPod.GetID():  devPod,
+	}
+
+	// C-FAIL fails in dev only, passes in prod.
+	failInDev := reportsummary.ControlSummary{ControlID: "C-FAIL"}
+	failInDev.Append(&apis.StatusInfo{InnerStatus: apis.StatusPassed}, prodPod.GetID())
+	failInDev.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, devPod.GetID())
+
+	// C-EMPTY has no matching resource anywhere in the cluster, so it must
+	// still contribute 100 to both namespaces' scores.
+	empty := reportsummary.ControlSummary{ControlID: "C-EMPTY"}
+
+	controls := reportsummary.ControlSummaries{"C-FAIL": failInDev, "C-EMPTY": empty}
+
+	summaries := BuildNamespaceSummaries(controls, allResources)
+	require.Len(t, summaries, 2)
+
+	byNamespace := make(map[string]NamespaceSummary, len(summaries))
+	for _, s := range summaries {
+		byNamespace[s.Namespace] = s
+	}
+
+	prod := byNamespace["prod"]
+	require.Equal(t, 2, prod.TotalControls)
+	assert.Equal(t, float32(100), prod.ComplianceScore, "C-FAIL passed and C-EMPTY has no resource here, both score 100")
+	assert.Equal(t, 0, prod.FailedControls)
+	assert.Equal(t, 1, prod.ResourceCount)
+
+	dev := byNamespace["dev"]
+	require.Equal(t, 2, dev.TotalControls)
+	assert.Equal(t, float32(50), dev.ComplianceScore, "C-FAIL failed (0%) and C-EMPTY has no resource here (100%), averaged over 2 controls")
+	assert.Equal(t, 1, dev.FailedControls)
+	assert.Equal(t, 1, dev.ResourceCount)
+
+	// worst namespace first
+	require.Equal(t, "dev", summaries[0].Namespace)
+	require.Equal(t, "prod", summaries[1].Namespace)
+}
+
+// TestBuildNamespaceSummaries_ClusterScopedBucket verifies a resource with no
+// namespace is grouped under the cluster-scoped bucket rather than dropped.
+func TestBuildNamespaceSummaries_ClusterScopedBucket(t *testing.T) {
+	node := clusterScopedNode("node-1")
+	allResources := map[string]workloadinterface.IMetadata{node.GetID(): node}
+
+	failed := reportsummary.ControlSummary{ControlID: "C-NODE"}
+	failed.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, node.GetID())
+
+	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-NODE": failed}, allResources)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, clusterScopedNamespace, summaries[0].Namespace)
+	assert.Equal(t, float32(0), summaries[0].ComplianceScore)
+	assert.Equal(t, 1, summaries[0].ResourceCount)
+}
+
+// TestBuildNamespaceSummaries_UnknownResourceIDFallsBackToClusterScoped covers
+// a resource ID present on a control but absent from AllResources (e.g. a
+// resource evaluated in an earlier scope and later dropped from the map).
+func TestBuildNamespaceSummaries_UnknownResourceIDFallsBackToClusterScoped(t *testing.T) {
+	ctrl := reportsummary.ControlSummary{ControlID: "C-X"}
+	ctrl.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, "unknown-id")
+
+	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-X": ctrl}, map[string]workloadinterface.IMetadata{})
+	require.Len(t, summaries, 1)
+	assert.Equal(t, clusterScopedNamespace, summaries[0].Namespace)
+}

--- a/core/cautils/namespacesummary_test.go
+++ b/core/cautils/namespacesummary_test.go
@@ -26,6 +26,11 @@ func clusterScopedNode(id string) workloadinterface.IMetadata {
 	})
 }
 
+func withComplianceScore(ctrl reportsummary.ControlSummary, score float32) reportsummary.ControlSummary {
+	ctrl.ComplianceScore = &score
+	return ctrl
+}
+
 // TestBuildNamespaceSummaries_EmptyControlsReturnsNil covers the no-op input:
 // no policy set means nothing to score.
 func TestBuildNamespaceSummaries_EmptyControlsReturnsNil(t *testing.T) {
@@ -34,8 +39,9 @@ func TestBuildNamespaceSummaries_EmptyControlsReturnsNil(t *testing.T) {
 
 // TestBuildNamespaceSummaries_CountsEveryControl pins the approved
 // convention: a control with no resource in a namespace still counts toward
-// that namespace's score at 100, so every namespace divides by the same
-// TotalControls and stays comparable to the others.
+// that namespace's score, using the control's own already-computed
+// ComplianceScore, so every namespace divides by the same TotalControls and
+// stays comparable to the others.
 func TestBuildNamespaceSummaries_CountsEveryControl(t *testing.T) {
 	prodPod := namespacedPod("prod-pod", "prod")
 	devPod := namespacedPod("dev-pod", "dev")
@@ -50,9 +56,10 @@ func TestBuildNamespaceSummaries_CountsEveryControl(t *testing.T) {
 	failInDev.Append(&apis.StatusInfo{InnerStatus: apis.StatusPassed}, prodPod.GetID())
 	failInDev.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, devPod.GetID())
 
-	// C-EMPTY has no matching resource anywhere in the cluster, so it must
-	// still contribute 100 to both namespaces' scores.
-	empty := reportsummary.ControlSummary{ControlID: "C-EMPTY"}
+	// C-EMPTY has no matching resource anywhere in the cluster. It is
+	// genuinely irrelevant (Passed with zero resources), so the score
+	// wrapper would give it 100, and both namespaces must inherit that.
+	empty := withComplianceScore(reportsummary.ControlSummary{ControlID: "C-EMPTY"}, 100)
 
 	controls := reportsummary.ControlSummaries{"C-FAIL": failInDev, "C-EMPTY": empty}
 
@@ -67,18 +74,50 @@ func TestBuildNamespaceSummaries_CountsEveryControl(t *testing.T) {
 	prod := byNamespace["prod"]
 	require.Equal(t, 2, prod.TotalControls)
 	assert.Equal(t, float32(100), prod.ComplianceScore, "C-FAIL passed and C-EMPTY has no resource here, both score 100")
-	assert.Equal(t, 0, prod.FailedControls)
+	assert.Equal(t, 0, prod.NonCompliantControls)
 	assert.Equal(t, 1, prod.ResourceCount)
 
 	dev := byNamespace["dev"]
 	require.Equal(t, 2, dev.TotalControls)
 	assert.Equal(t, float32(50), dev.ComplianceScore, "C-FAIL failed (0%) and C-EMPTY has no resource here (100%), averaged over 2 controls")
-	assert.Equal(t, 1, dev.FailedControls)
+	assert.Equal(t, 1, dev.NonCompliantControls)
 	assert.Equal(t, 1, dev.ResourceCount)
 
 	// worst namespace first
 	require.Equal(t, "dev", summaries[0].Namespace)
 	require.Equal(t, "prod", summaries[1].Namespace)
+}
+
+// TestBuildNamespaceSummaries_NotEvaluatedControlScoresZero is the regression
+// test for the blocker: opa-utils' GetControlComplianceScore only returns 100
+// for a zero-resource control that is also Passed. A control that could not
+// be evaluated (RBAC-restricted collection, a timeout) is zero-resource too
+// but scores 0 at the cluster level. Every namespace must inherit that same
+// 0, not a free 100, or the namespace view silently hides the coverage gap
+// the cluster score is reporting right next to it.
+func TestBuildNamespaceSummaries_NotEvaluatedControlScoresZero(t *testing.T) {
+	pod := namespacedPod("some-pod", "prod")
+	allResources := map[string]workloadinterface.IMetadata{pod.GetID(): pod}
+
+	// C-OK passes cleanly in prod.
+	ok := reportsummary.ControlSummary{ControlID: "C-OK"}
+	ok.Append(&apis.StatusInfo{InnerStatus: apis.StatusPassed}, pod.GetID())
+
+	// C-NOTEVAL could not be evaluated anywhere (e.g. its resource type
+	// failed to collect): zero resources, status Skipped/NotEvaluated, so
+	// GetControlComplianceScore returns 0, not 100.
+	notEvaluated := withComplianceScore(reportsummary.ControlSummary{
+		ControlID: "C-NOTEVAL",
+		Status:    apis.StatusSkipped,
+	}, 0)
+
+	controls := reportsummary.ControlSummaries{"C-OK": ok, "C-NOTEVAL": notEvaluated}
+	summaries := BuildNamespaceSummaries(controls, allResources)
+
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "prod", summaries[0].Namespace)
+	assert.Equal(t, float32(50), summaries[0].ComplianceScore, "C-OK scores 100, C-NOTEVAL must contribute 0, not 100")
+	assert.Equal(t, 1, summaries[0].NonCompliantControls)
 }
 
 // TestBuildNamespaceSummaries_ClusterScopedBucket verifies a resource with no
@@ -112,14 +151,18 @@ func TestBuildNamespaceSummaries_UnknownResourceIDFallsBackToClusterScoped(t *te
 // TestBuildNamespaceSummaries_NamespaceWithNoMatchedResourceStillScores
 // covers a namespace holding resources that no control's ResourceIDs ever
 // reference (every control simply does not apply to them). It must still
-// produce a summary, scoring 100 on every control, instead of being silently
-// absent from the rollup.
+// produce a summary instead of being silently absent from the rollup, and
+// since the report has only this one, globally-failing control, the
+// namespace inherits that same score -- consistent with the cluster number,
+// which is the design goal, even though this namespace has no resource of
+// its own involved in the failure.
 func TestBuildNamespaceSummaries_NamespaceWithNoMatchedResourceStillScores(t *testing.T) {
 	untouchedPod := namespacedPod("configmap-only", "quiet-ns")
 	allResources := map[string]workloadinterface.IMetadata{untouchedPod.GetID(): untouchedPod}
 
-	// C-OTHER has resources, but none of them live in quiet-ns.
-	other := reportsummary.ControlSummary{ControlID: "C-OTHER"}
+	// C-OTHER has a resource, but not in quiet-ns, and that resource fails --
+	// its cluster-wide ComplianceScore is 0.
+	other := withComplianceScore(reportsummary.ControlSummary{ControlID: "C-OTHER"}, 0)
 	other.Append(&apis.StatusInfo{InnerStatus: apis.StatusFailed}, "some-other-resource-id")
 
 	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-OTHER": other}, allResources)
@@ -131,8 +174,24 @@ func TestBuildNamespaceSummaries_NamespaceWithNoMatchedResourceStillScores(t *te
 
 	quiet, ok := byNamespace["quiet-ns"]
 	require.True(t, ok, "a namespace with a resource must appear even if no control matched a resource in it")
-	assert.Equal(t, float32(100), quiet.ComplianceScore)
+	assert.Equal(t, float32(0), quiet.ComplianceScore)
 	assert.Equal(t, 1, quiet.TotalControls)
-	assert.Equal(t, 0, quiet.FailedControls)
+	assert.Equal(t, 1, quiet.NonCompliantControls)
 	assert.Equal(t, 1, quiet.ResourceCount)
+}
+
+// TestBuildNamespaceSummaries_UnsetComplianceScoreFallsBackTo100 covers a
+// caller that runs BuildNamespaceSummaries before the score wrapper has set
+// ControlSummary.ComplianceScore. GetComplianceScore then returns -1, which
+// must not leak into the report as a negative score.
+func TestBuildNamespaceSummaries_UnsetComplianceScoreFallsBackTo100(t *testing.T) {
+	pod := namespacedPod("pod", "prod")
+	allResources := map[string]workloadinterface.IMetadata{pod.GetID(): pod}
+
+	// C-ELSEWHERE has no resource in prod and no ComplianceScore set.
+	elsewhere := reportsummary.ControlSummary{ControlID: "C-ELSEWHERE"}
+
+	summaries := BuildNamespaceSummaries(reportsummary.ControlSummaries{"C-ELSEWHERE": elsewhere}, allResources)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, float32(100), summaries[0].ComplianceScore)
 }

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -106,6 +106,12 @@ const (
 	// action-required resources are always listed, and passed resources are
 	// listed in verbose mode.
 	ControlViewType ViewTypes = "control"
+
+	// NamespaceViewType prints the per-namespace compliance rollup: every
+	// control in the scan's policy set is counted toward each namespace's
+	// score, so namespaces are ranked worst-first and stay comparable to one
+	// another and to the cluster-wide score.
+	NamespaceViewType ViewTypes = "namespace"
 )
 
 type PolicyIdentifier struct {

--- a/core/pkg/anonymizer/session.go
+++ b/core/pkg/anonymizer/session.go
@@ -227,6 +227,30 @@ func transformSession(session *cautils.OPASessionObj, _ *Mapping, transformer Tr
 			session.Report.SummaryDetails.Controls[controlID] = control
 		}
 	}
+
+	if err := transformNamespaceSummaries(session.NamespaceSummaries, transformer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// transformNamespaceSummaries anonymizes the namespace name in each
+// NamespaceSummary in place. It reuses the "ns" prefix transformResourceMetadata
+// uses for a resource's own namespace, so a namespace gets the same pseudonym
+// here as everywhere else in the report. ClusterScopedNamespace is a
+// Kubescape-internal marker, not a real namespace, so it is left untouched.
+func transformNamespaceSummaries(summaries cautils.NamespaceSummaries, transformer Transformer) error {
+	for i := range summaries {
+		if summaries[i].Namespace == cautils.ClusterScopedNamespace {
+			continue
+		}
+		namespace, err := transformValue(transformer, "ns", summaries[i].Namespace)
+		if err != nil {
+			return err
+		}
+		summaries[i].Namespace = namespace
+	}
 	return nil
 }
 

--- a/core/pkg/anonymizer/session_test.go
+++ b/core/pkg/anonymizer/session_test.go
@@ -152,6 +152,60 @@ func TestTransformSession_NamesAndNamespacesReplaced(t *testing.T) {
 	}
 }
 
+// TestTransformSession_NamespaceSummariesRedacted covers a gap that would
+// otherwise leak the real namespace name: --hide/--encrypt transform a
+// resource's own namespace field, but NamespaceSummaries is a separate report
+// section that must be redacted independently, and it must get the exact
+// same pseudonym as the resource it summarizes so the two stay joinable. The
+// cluster-scoped bucket is not a real namespace and must survive untouched.
+func TestTransformSession_NamespaceSummariesRedacted(t *testing.T) {
+	pod := workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "my-secret-pod",
+			"namespace": "my-secret-ns",
+		},
+	})
+	oldID := pod.GetID()
+
+	session := &cautils.OPASessionObj{
+		AllResources:         map[string]workloadinterface.IMetadata{oldID: pod},
+		ResourcesResult:      make(map[string]resourcesresults.Result),
+		ResourceSource:       make(map[string]reporthandling.Source),
+		ResourcesPrioritized: make(map[string]prioritization.PrioritizedResource),
+		ResourceAttackTracks: make(map[string][]v1alpha1.IAttackTrack),
+		NamespaceSummaries: cautils.NamespaceSummaries{
+			{Namespace: "my-secret-ns", ComplianceScore: 80},
+			{Namespace: cautils.ClusterScopedNamespace, ComplianceScore: 95},
+		},
+	}
+
+	err := transformSession(session, NewMapping(), NewMappingTransformer())
+	require.NoError(t, err)
+
+	var transformedNs, clusterScoped string
+	for _, s := range session.NamespaceSummaries {
+		switch s.ComplianceScore {
+		case 80:
+			transformedNs = s.Namespace
+		case 95:
+			clusterScoped = s.Namespace
+		}
+	}
+
+	assert.NotEqual(t, "my-secret-ns", transformedNs)
+	assert.Contains(t, transformedNs, "ns-")
+
+	var resourceNs string
+	for _, resource := range session.AllResources {
+		resourceNs = resource.GetNamespace()
+	}
+	assert.Equal(t, resourceNs, transformedNs, "the namespace summary must carry the same pseudonym as the resource")
+
+	assert.Equal(t, cautils.ClusterScopedNamespace, clusterScoped, "the cluster-scoped marker must not be pseudonymized")
+}
+
 // TestTransformSession_CollidingNamesKeepDistinctResources covers what a
 // pseudonym collision costs at session level, which is more than a confusing
 // report: transformSession rebuilds AllResources and ResourcesResult keyed by

--- a/core/pkg/opaprocessor/namespacesummary_streaming_test.go
+++ b/core/pkg/opaprocessor/namespacesummary_streaming_test.go
@@ -1,0 +1,50 @@
+package opaprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNamespaceSummaries_EagerMatchesStreaming runs the eager and streaming
+// pipelines over the same manifests and asserts they build identical
+// NamespaceSummaries. Both ProcessRulesListener and ProcessWithStreaming call
+// cautils.BuildNamespaceSummaries independently; --skip-controls was found
+// wired into only one of these two paths, so this is exactly the class of
+// divergence a namespace-scoped feature added here must be tested against.
+func TestNamespaceSummaries_EagerMatchesStreaming(t *testing.T) {
+	t.Setenv("LARGE_CLUSTER_SIZE", "10000") // eager and streaming both evaluate as one scope
+
+	dir := t.TempDir()
+	writeFixtureManifests(t, dir)
+
+	scanInfo := &cautils.ScanInfo{InputPatterns: []string{dir}}
+	handler := resourcehandler.NewFileResourceHandler()
+	frameworks := parityFrameworks(true)
+
+	eagerSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
+	eagerSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+	require.NoError(t, resourcehandler.CollectResources(context.Background(), handler, eagerSession, scanInfo))
+
+	eager := NewOPAProcessor(eagerSession, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	require.NoError(t, eager.ProcessRulesListener(context.Background(), cautils.NewProgressHandler("")))
+	require.NotEmpty(t, eager.NamespaceSummaries, "the fixture has namespaced resources with failures, so summaries must be built")
+
+	streamingSession := cautils.NewOPASessionObj(context.Background(), frameworks, nil, scanInfo, nil)
+	streamingSession.Metadata.ContextMetadata.ClusterContextMetadata = &reporthandlingv2.ClusterMetadata{}
+
+	batchChan, errChan, expectedBatches, err := handler.StreamResourcesBatches(context.Background(), streamingSession, scanInfo)
+	require.NoError(t, err)
+
+	streaming := NewOPAProcessor(streamingSession, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	streaming.SetInitialResourceCount(0) // file scans never estimate cluster size
+	require.NoError(t, streaming.ProcessWithStreaming(context.Background(), batchChan, errChan, cautils.NewProgressHandler(""), expectedBatches))
+
+	assert.Equal(t, eager.NamespaceSummaries, streaming.NamespaceSummaries)
+}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -276,12 +276,16 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
-	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
 		logger.L().Ctx(ctx).Warning("failed to calculate score", helpers.Error(err))
 	}
+
+	// BuildNamespaceSummaries relies on ControlSummary.ComplianceScore for
+	// controls it has no resource for in a given namespace, so it must run
+	// after scorewrapper.Calculate has populated that field.
+	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	opap.reweightComplianceScores()
 
@@ -472,12 +476,16 @@ done:
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
-	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
 		logger.L().Ctx(ctx).Warning("failed to calculate score", helpers.Error(err))
 	}
+
+	// BuildNamespaceSummaries relies on ControlSummary.ComplianceScore for
+	// controls it has no resource for in a given namespace, so it must run
+	// after scorewrapper.Calculate has populated that field.
+	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	opap.reweightComplianceScores()
 

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -276,6 +276,7 @@ func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressList
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
+	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {
@@ -471,6 +472,7 @@ done:
 	opap.markNotEvaluatedControlsSkipped()
 	opap.ScanCoverage.VacuousFrameworks = cautils.DetectVacuousFrameworks(opap.Report.SummaryDetails.Frameworks)
 	opap.ScanCoverage.UnexaminedKinds = opap.UnexaminedKinds
+	opap.NamespaceSummaries = cautils.BuildNamespaceSummaries(opap.Report.SummaryDetails.Controls, opap.AllResources)
 
 	scorewrapper := score.NewScoreWrapper(opap.OPASessionObj)
 	if err := scorewrapper.Calculate(score.EPostureReportV2); err != nil {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -127,6 +127,7 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 	// extract specified labels from workloads, and attach scan coverage gaps.
 	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
 	reportWithSeverity.ExceptionAudit = opaSessionObj.ExceptionAudit
+	reportWithSeverity.NamespaceSummaries = opaSessionObj.NamespaceSummaries
 
 	r, err := json.Marshal(reportWithSeverity)
 	if err != nil {

--- a/core/pkg/resultshandling/printer/v2/namespacetable.go
+++ b/core/pkg/resultshandling/printer/v2/namespacetable.go
@@ -1,0 +1,46 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+)
+
+const (
+	namespaceColumnName = iota
+	namespaceColumnScore
+	namespaceColumnFailedControls
+	namespaceColumnResources
+)
+
+// printNamespaceSummaries renders the per-namespace compliance rollup as a
+// table, worst-scoring namespace first (see cautils.BuildNamespaceSummaries).
+func printNamespaceSummaries(writer io.Writer, summaries cautils.NamespaceSummaries) {
+	if len(summaries) == 0 {
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(writer)
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Number: namespaceColumnName + 1, Align: text.AlignLeft},
+		{Number: namespaceColumnScore + 1, Align: text.AlignCenter},
+		{Number: namespaceColumnFailedControls + 1, Align: text.AlignCenter},
+		{Number: namespaceColumnResources + 1, Align: text.AlignCenter},
+	})
+	t.AppendHeader(table.Row{"Namespace", "Compliance Score", "Failed Controls", "Resources"})
+
+	for _, summary := range summaries {
+		t.AppendRow(table.Row{
+			summary.Namespace,
+			fmt.Sprintf("%d%%", cautils.ComplianceScoreToInt(summary.ComplianceScore)),
+			fmt.Sprintf("%d/%d", summary.FailedControls, summary.TotalControls),
+			summary.ResourceCount,
+		})
+	}
+
+	t.Render()
+}

--- a/core/pkg/resultshandling/printer/v2/namespacetable.go
+++ b/core/pkg/resultshandling/printer/v2/namespacetable.go
@@ -12,7 +12,7 @@ import (
 const (
 	namespaceColumnName = iota
 	namespaceColumnScore
-	namespaceColumnFailedControls
+	namespaceColumnNonCompliantControls
 	namespaceColumnResources
 )
 
@@ -28,16 +28,16 @@ func printNamespaceSummaries(writer io.Writer, summaries cautils.NamespaceSummar
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: namespaceColumnName + 1, Align: text.AlignLeft},
 		{Number: namespaceColumnScore + 1, Align: text.AlignCenter},
-		{Number: namespaceColumnFailedControls + 1, Align: text.AlignCenter},
+		{Number: namespaceColumnNonCompliantControls + 1, Align: text.AlignCenter},
 		{Number: namespaceColumnResources + 1, Align: text.AlignCenter},
 	})
-	t.AppendHeader(table.Row{"Namespace", "Compliance Score", "Failed Controls", "Resources"})
+	t.AppendHeader(table.Row{"Namespace", "Compliance Score", "Non-Compliant Controls", "Resources"})
 
 	for _, summary := range summaries {
 		t.AppendRow(table.Row{
 			summary.Namespace,
 			fmt.Sprintf("%d%%", cautils.ComplianceScoreToInt(summary.ComplianceScore)),
-			fmt.Sprintf("%d/%d", summary.FailedControls, summary.TotalControls),
+			fmt.Sprintf("%d/%d", summary.NonCompliantControls, summary.TotalControls),
 			summary.ResourceCount,
 		})
 	}

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -101,6 +101,8 @@ func (pp *PrettyPrinter) ActionPrint(_ context.Context, opaSessionObj *cautils.O
 			if pp.verboseMode {
 				pp.resourceTable(opaSessionObj)
 			}
+		case cautils.NamespaceViewType:
+			printNamespaceSummaries(pp.writer, opaSessionObj.NamespaceSummaries)
 		}
 
 		pp.printOverview(opaSessionObj, pp.verboseMode)

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -71,6 +71,7 @@ type PostureReportWithSeverity struct {
 	ResourceLabels       map[string]map[string]string      `json:"resourceLabels,omitempty"` // map[resourceID]map[labelKey]labelValue - extracted labels from workloads
 	ScanCoverage         *cautils.ScanCoverage             `json:"scanCoverage,omitempty"`
 	ExceptionAudit       *cautils.ExceptionAudit           `json:"exceptionAudit,omitempty"`
+	NamespaceSummaries   cautils.NamespaceSummaries        `json:"namespaceSummaries,omitempty"`
 }
 
 // enrichControlsWithSeverity adds severity field to controls based on scoreFactor

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -114,21 +114,23 @@ func (rh *ResultsHandler) ToJson() ([]byte, error) {
 
 	output := struct {
 		*reporthandlingv2.PostureReport
-		SummaryDetails summaryWithEnrichment        `json:"summaryDetails,omitempty"`
-		Results        []resultWithEnrichment       `json:"results,omitempty"`
-		ResourceLabels map[string]map[string]string `json:"resourceLabels,omitempty"`
-		ScanCoverage   *cautils.ScanCoverage        `json:"scanCoverage,omitempty"`
-		ExceptionAudit *cautils.ExceptionAudit      `json:"exceptionAudit,omitempty"`
+		SummaryDetails     summaryWithEnrichment        `json:"summaryDetails,omitempty"`
+		Results            []resultWithEnrichment       `json:"results,omitempty"`
+		ResourceLabels     map[string]map[string]string `json:"resourceLabels,omitempty"`
+		ScanCoverage       *cautils.ScanCoverage        `json:"scanCoverage,omitempty"`
+		ExceptionAudit     *cautils.ExceptionAudit      `json:"exceptionAudit,omitempty"`
+		NamespaceSummaries cautils.NamespaceSummaries   `json:"namespaceSummaries,omitempty"`
 	}{
 		PostureReport: finalizedReport,
 		SummaryDetails: summaryWithEnrichment{
 			SummaryDetails: finalizedReport.SummaryDetails,
 			Controls:       enrichedReport.SummaryDetails.Controls,
 		},
-		Results:        results,
-		ResourceLabels: enrichedReport.ResourceLabels,
-		ScanCoverage:   enrichedReport.ScanCoverage,
-		ExceptionAudit: rh.ScanData.ExceptionAudit,
+		Results:            results,
+		ResourceLabels:     enrichedReport.ResourceLabels,
+		ScanCoverage:       enrichedReport.ScanCoverage,
+		ExceptionAudit:     rh.ScanData.ExceptionAudit,
+		NamespaceSummaries: rh.ScanData.NamespaceSummaries,
 	}
 
 	return json.Marshal(&output)


### PR DESCRIPTION
I kept running into the same gap when scanning multi-tenant clusters. Kubescape gives you one cluster-wide compliance score, but there is no way to see how a single namespace is doing on its own. A team scanning a 180-namespace cluster has no way to tell whether their score is dragged down by one bad namespace or spread evenly, without writing a script that reimplements Kubescape's own scoring math.

This adds a namespaceSummaries section to the report and a --view namespace table that ranks namespaces worst first, so you can see which ones need attention.

I went with the convention that every control counts toward every namespace's score. If a control has no matching resource in a namespace it still contributes 100 there, the same way a control with no resource anywhere already scores 100 at the cluster level. This keeps every namespace's score computed over the same total control count, so they stay comparable to each other and to the cluster number. Cluster-scoped resources get their own bucket instead of being dropped.

The rollup is built independently on the eager and streaming scan paths, since a cluster can flip between them depending on size, and I added a test asserting both produce identical results for the same input.

I tested it end to end on a fixture with two namespaces and confirmed the pretty-printer table and the JSON output agree, and that the per-control math matches what the cluster score already reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a namespace view for scan results, showing compliance scores, non-compliant controls, and resource counts by namespace.
  - Included cluster-scoped resources in a dedicated summary category.
  - Added namespace compliance summaries to JSON output.
  - Updated scan command help to list namespace views as a supported option.
  - Preserved namespace summary privacy in anonymized reports.

- **Tests**
  - Added coverage for namespace scoring, cluster-scoped resources, anonymization, and consistency across processing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->