### PR TITLE
fix(printer): include the scanned platform in GitLab finding ids

### DIFF
--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -248,7 +248,7 @@ func toGitLabImageVulnerability(image, platform string, cve imageprinter.CVE) gi
 	}
 
 	return gitLabVulnerability{
-		ID:          gitLabImageVulnerabilityID(image, cve.Package, cve.Version, cve.ID),
+		ID:          gitLabImageVulnerabilityID(image, cve.Package, cve.Version, cve.ID, platform),
 		Category:    "dependency_scanning",
 		Name:        message,
 		Message:     message,
@@ -273,9 +273,17 @@ func toGitLabImageVulnerability(image, platform string, cve imageprinter.CVE) gi
 	}
 }
 
-// gitLabImageVulnerabilityID returns a stable id so GitLab can track a CVE finding across scans for triage and dismissal
-func gitLabImageVulnerabilityID(image, pkg, version, cveID string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(image+"/"+pkg+"/"+version+"/"+cveID)))
+// gitLabImageVulnerabilityID returns a stable id so GitLab can track a CVE finding across scans for triage and dismissal.
+// The platform is part of that identity: one image reference can be scanned for several platforms, and a finding
+// dismissed on one is not thereby dismissed on another. It is appended only when a platform was requested, so ids
+// for scans that do not pass --platform stay as they were.
+func gitLabImageVulnerabilityID(image, pkg, version, cveID, platform string) string {
+	id := image + "/" + pkg + "/" + version + "/" + cveID
+	if platform != "" {
+		id += "/" + platform
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(id)))
 }
 
 // printConfigurationScan maps each failed control on each failed resource to a GitLab SAST vulnerability and writes the report

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -2,7 +2,9 @@ package printer
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +15,7 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
@@ -355,6 +358,88 @@ func TestGitLabVulnerabilityID(t *testing.T) {
 		"a different resource must produce a different id")
 }
 
+func TestGitLabImageVulnerabilityID(t *testing.T) {
+	const (
+		image   = "docker.io/library/nginx:1.25"
+		pkg     = "zlib1g"
+		version = "1.2.13"
+		cveID   = "CVE-2023-45853"
+	)
+
+	first := gitLabImageVulnerabilityID(image, pkg, version, cveID, "linux/amd64")
+
+	assert.Equal(t, first, gitLabImageVulnerabilityID(image, pkg, version, cveID, "linux/amd64"),
+		"the same finding must keep a stable id so GitLab can track it across scans")
+	assert.NotEqual(t, first, gitLabImageVulnerabilityID(image, pkg, version, cveID, "linux/arm64"),
+		"a different platform must produce a different id")
+	assert.NotEqual(t, first, gitLabImageVulnerabilityID(image, pkg, version, cveID, ""),
+		"a platform-specific scan must not collide with an unspecified one")
+	assert.NotEqual(t, first, gitLabImageVulnerabilityID(image, "openssl", version, cveID, "linux/amd64"),
+		"a different package must produce a different id")
+	assert.NotEqual(t, first, gitLabImageVulnerabilityID(image, pkg, "1.3.0", cveID, "linux/amd64"),
+		"a different version must produce a different id")
+	assert.NotEqual(t, first, gitLabImageVulnerabilityID(image, pkg, version, "CVE-2024-0001", "linux/amd64"),
+		"a different CVE must produce a different id")
+}
+
+// TestGitLabImageVulnerabilityID_UnspecifiedPlatformIsUnchanged pins the migration guarantee.
+// Adding the platform to the id would otherwise renumber every existing finding and drop the
+// dismissals GitLab has recorded against them. Appending it only when a platform was requested
+// keeps ids identical for everyone who does not pass --platform.
+func TestGitLabImageVulnerabilityID_UnspecifiedPlatformIsUnchanged(t *testing.T) {
+	sum := sha256.Sum256([]byte("docker.io/library/nginx:1.25/zlib1g/1.2.13/CVE-2023-45853"))
+
+	assert.Equal(t, fmt.Sprintf("%x", sum),
+		gitLabImageVulnerabilityID("docker.io/library/nginx:1.25", "zlib1g", "1.2.13", "CVE-2023-45853", ""))
+}
+
+// TestGitLabImageVulnerability_PlatformIsPartOfIdentity checks the mapper passes the platform
+// through to the id. It reports the platform in the description, so without this the same CVE
+// on the same package and version across two platform scans of a multi-arch image produced one
+// id, and dismissing it on one platform dismissed it on the other.
+func TestGitLabImageVulnerability_PlatformIsPartOfIdentity(t *testing.T) {
+	cve := imageprinter.CVE{
+		ID:       "CVE-2023-45853",
+		Package:  "zlib1g",
+		Version:  "1.2.13",
+		Severity: "High",
+	}
+	const image = "docker.io/library/nginx:1.25"
+
+	amd64 := toGitLabImageVulnerability(image, "linux/amd64", cve)
+	arm64 := toGitLabImageVulnerability(image, "linux/arm64", cve)
+
+	assert.NotEqual(t, amd64.ID, arm64.ID,
+		"two platform scans of the same image must not share a finding id")
+	assert.Contains(t, amd64.Description, "linux/amd64")
+	assert.Contains(t, arm64.Description, "linux/arm64")
+}
+
+// TestGitLabImageScan_PlatformVariantsGetDistinctIDs covers the case #3345 introduced when it
+// scanned every observed platform for a workload that can run across a heterogeneous cluster.
+// Both variants land in one report, so identifying them without the platform put two entries
+// with the same id in a single document.
+func TestGitLabImageScan_PlatformVariantsGetDistinctIDs(t *testing.T) {
+	variant := func(platform string) cautils.ImageScanData {
+		return cautils.ImageScanData{
+			Image:    "nginx:1.25",
+			Platform: platform,
+			Matches: match.NewMatches(match.Match{
+				Package: grypepkg.Package{ID: "pkg-1", Name: "openssl", Version: "3.0.0"},
+				Vulnerability: vulnerability.Vulnerability{
+					Metadata: &vulnerability.Metadata{ID: "CVE-2026-0001", Severity: "High"},
+				},
+			}),
+		}
+	}
+
+	report := gitLabImageReportFor(t, []cautils.ImageScanData{variant("linux/amd64"), variant("linux/arm64")})
+	require.Len(t, report.Vulnerabilities, 2)
+
+	assert.NotEqual(t, report.Vulnerabilities[0].ID, report.Vulnerabilities[1].ID,
+		"two platform variants of one image must not share an id within a single report")
+}
+
 // gitLabImageReportFor runs the printer against image scan data and returns the decoded report
 func gitLabImageReportFor(t *testing.T, imageScanData []cautils.ImageScanData) gitLabSASTReport {
 	t.Helper()
@@ -409,8 +494,8 @@ func TestGitLabImageScan_LocationHasFile(t *testing.T) {
 	withoutPlatform[0].Platform = ""
 	legacyReport := gitLabImageReportFor(t, withoutPlatform)
 	require.Len(t, legacyReport.Vulnerabilities, 1)
-	assert.Equal(t, legacyReport.Vulnerabilities[0].ID, report.Vulnerabilities[0].ID,
-		"adding platform metadata must not change GitLab's vulnerability fingerprint")
+	assert.NotEqual(t, legacyReport.Vulnerabilities[0].ID, report.Vulnerabilities[0].ID,
+		"a platform-specific finding must not share an id with an unspecified one")
 }
 
 // TestGitLabImageScan_VersionKeyAlwaysPresent guards against #2782's schema violation:


### PR DESCRIPTION
Resolved #3712.

## The problem

#3345 scans every observed platform when a workload can run across a heterogeneous cluster, and each variant becomes its own entry in the same GitLab report. `gitLabImageVulnerabilityID` builds the id from image, package, version and CVE, so those variants share one id.

Two entries, one document, same id, told apart only by the platform sentence in their descriptions:

```
id=cdb85e00a01fbfc9  ... CVE-2026-0001 ... Scanned platform: linux/amd64.
id=cdb85e00a01fbfc9  ... CVE-2026-0001 ... Scanned platform: linux/arm64.
```

Across separate scans the same collision means a dismissal recorded on one platform silently covers the other, which is the tracking the function's own comment describes.

## The awkward part, stated plainly

#3345 added an assertion that adding platform metadata must not change the fingerprint, and this PR reverses it. That decision was reasonable: it kept ids stable for anyone who started passing `--platform` for an image they had already scanned. But it is what puts duplicate ids in a single report, and it means the platform is reported as distinguishing while not distinguishing anything.

Appending the platform only when one was requested keeps most of that intent. Anyone not passing `--platform` keeps byte-identical ids and their recorded dismissals, pinned by `TestGitLabImageVulnerabilityID_UnspecifiedPlatformIsUnchanged` against the literal pre-existing hash. Only scans that name a platform get a new id, once.

If you would rather keep the existing assertion, the alternative is dropping the platform sentence from the description so the report stops implying a distinction it does not make. Happy to switch to that instead.

## Tests

- `TestGitLabImageScan_PlatformVariantsGetDistinctIDs`, the case above, two variants in one report
- `TestGitLabImageVulnerability_PlatformIsPartOfIdentity`, that the mapper passes the platform through
- `TestGitLabImageVulnerabilityID`, stability and each component's contribution
- `TestGitLabImageVulnerabilityID_UnspecifiedPlatformIsUnchanged`, the migration guarantee
- `TestGitLabImageScan_LocationHasFile`, its trailing platform assertion updated to match

`gitLabImageVulnerabilityID` had no tests before this. Excluding the platform from the id again fails all of them except the migration guarantee, which is meant to hold either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image vulnerability findings now receive distinct tracking IDs for different scan platforms.
  * Platform information is included in vulnerability descriptions when available.
  * Existing IDs remain unchanged for scans without a specified platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->