### PR TITLE
feat(fix): select which controls to remediate with --include-controls and --skip-controls

### DIFF
--- a/cmd/fix/fix.go
+++ b/cmd/fix/fix.go
@@ -3,6 +3,7 @@ package fix
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/meta"
@@ -62,6 +63,10 @@ func GetFixCmd(ks meta.IKubescape) *cobra.Command {
 			}
 			fixInfo.ReportFile = args[0]
 
+			if err := validateControlSelection(&fixInfo); err != nil {
+				return err
+			}
+
 			return ks.Fix(&fixInfo)
 		},
 	}
@@ -71,7 +76,26 @@ func GetFixCmd(ks meta.IKubescape) *cobra.Command {
 	fixCmd.PersistentFlags().BoolVar(&fixInfo.SkipUserValues, "skip-user-values", true, "Changes which involve user-defined values will be skipped")
 	fixCmd.PersistentFlags().StringVar(&fixInfo.BasePath, "base-path", "", "Restrict fixes to this directory: the report's own recorded scan location must resolve inside it. Use this when the report file comes from a source you don't fully trust (e.g. a shared CI artifact); without it, the report's recorded location is trusted as-is")
 	fixCmd.PersistentFlags().StringVar(&fixInfo.ContainerProfilePath, "container-profile", "", "Path to a JSON file containing a ContainerProfile to use for drift detection")
+	fixCmd.PersistentFlags().StringSliceVar(&fixInfo.IncludeControls, "include-controls", nil, "Remediate only these control IDs (comma-separated, case-insensitive). Controls outside the list are left untouched and are not reported as unfixed; disables --container-profile drift remediation")
+	fixCmd.PersistentFlags().StringSliceVar(&fixInfo.SkipControls, "skip-controls", nil, "Leave these control IDs untouched (comma-separated, case-insensitive). Takes precedence over --include-controls; disables --container-profile drift remediation")
 	fixCmd.PersistentFlags().StringVar(&fixInfo.OutputDir, "output-dir", "", "Cluster scans only: write one patched manifest per resource into this directory instead of printing them to stdout. Ignored for file-based reports, which are fixed in place")
 
 	return fixCmd
+}
+
+func validateControlSelection(fixInfo *metav1.FixInfo) error {
+	for _, selection := range []struct {
+		flag     string
+		controls []string
+	}{
+		{"--include-controls", fixInfo.IncludeControls},
+		{"--skip-controls", fixInfo.SkipControls},
+	} {
+		for _, control := range selection.controls {
+			if strings.TrimSpace(control) == "" {
+				return fmt.Errorf("%s contains an empty control identifier", selection.flag)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/fix/fix_test.go
+++ b/cmd/fix/fix_test.go
@@ -3,6 +3,7 @@ package fix
 import (
 	"testing"
 
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -27,4 +28,28 @@ func TestGetFixCmd(t *testing.T) {
 
 	err = fixCmd.RunE(&cobra.Command{}, []string{"random-file.json"})
 	assert.Nil(t, err)
+}
+
+func TestValidateControlSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixInfo metav1.FixInfo
+		wantErr string
+	}{
+		{name: "no filters", fixInfo: metav1.FixInfo{}},
+		{name: "populated filters", fixInfo: metav1.FixInfo{IncludeControls: []string{"C-0016"}, SkipControls: []string{"C-0017"}}},
+		{name: "empty include entry", fixInfo: metav1.FixInfo{IncludeControls: []string{"C-0016", " "}}, wantErr: "--include-controls contains an empty control identifier"},
+		{name: "empty skip entry", fixInfo: metav1.FixInfo{SkipControls: []string{""}}, wantErr: "--skip-controls contains an empty control identifier"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateControlSelection(&tt.fixInfo)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
 }

--- a/core/meta/datastructures/v1/fix.go
+++ b/core/meta/datastructures/v1/fix.go
@@ -13,6 +13,12 @@ type FixInfo struct {
 	// as-is, as it always has been.
 	BasePath             string
 	ContainerProfilePath string // Path to an optional ContainerProfile JSON file
+	// IncludeControls and SkipControls narrow which failed controls are
+	// remediated. Matching is case-insensitive on the control ID, and
+	// SkipControls wins over IncludeControls, mirroring the scan-side
+	// --include-controls/--skip-controls pair.
+	IncludeControls []string
+	SkipControls    []string
 	// OutputDir applies only to cluster scan reports, which have no manifests
 	// to rewrite. When set, one patched manifest per resource is written there;
 	// when empty, the manifests are printed to stdout. It is ignored for

--- a/core/pkg/fixhandler/controlselector.go
+++ b/core/pkg/fixhandler/controlselector.go
@@ -1,0 +1,61 @@
+package fixhandler
+
+import "strings"
+
+// controlSelector decides which failed controls a fix run remediates. A nil
+// include set selects every control; skip always wins over include, matching
+// the scan-side --include-controls/--skip-controls precedence.
+type controlSelector struct {
+	include map[string]struct{}
+	skip    map[string]struct{}
+}
+
+func newControlSelector(include, skip []string) controlSelector {
+	return controlSelector{
+		include: normalizeControlIDs(include),
+		skip:    normalizeControlIDs(skip),
+	}
+}
+
+func normalizeControlIDs(ids []string) map[string]struct{} {
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if token := strings.ToLower(strings.TrimSpace(id)); token != "" {
+			set[token] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+func (cs controlSelector) selects(controlID string) bool {
+	token := strings.ToLower(strings.TrimSpace(controlID))
+	if _, skipped := cs.skip[token]; skipped {
+		return false
+	}
+	if cs.include == nil {
+		return true
+	}
+	_, included := cs.include[token]
+	return included
+}
+
+func (cs controlSelector) active() bool {
+	return cs.include != nil || cs.skip != nil
+}
+
+func (cs controlSelector) describe() string {
+	switch {
+	case cs.include != nil && cs.skip != nil:
+		return "--include-controls/--skip-controls"
+	case cs.include != nil:
+		return "--include-controls"
+	default:
+		return "--skip-controls"
+	}
+}

--- a/core/pkg/fixhandler/controlselector_test.go
+++ b/core/pkg/fixhandler/controlselector_test.go
@@ -1,0 +1,288 @@
+package fixhandler
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControlSelector_Selects(t *testing.T) {
+	tests := []struct {
+		name      string
+		include   []string
+		skip      []string
+		controlID string
+		want      bool
+	}{
+		{name: "no filters selects everything", controlID: "C-0016", want: true},
+		{name: "include matches", include: []string{"C-0016"}, controlID: "C-0016", want: true},
+		{name: "include excludes everything else", include: []string{"C-0016"}, controlID: "C-0017", want: false},
+		{name: "include is case-insensitive", include: []string{"c-0016"}, controlID: "C-0016", want: true},
+		{name: "include tolerates surrounding space", include: []string{"  C-0016 "}, controlID: "C-0016", want: true},
+		{name: "skip drops the control", skip: []string{"C-0016"}, controlID: "C-0016", want: false},
+		{name: "skip leaves others alone", skip: []string{"C-0016"}, controlID: "C-0017", want: true},
+		{name: "skip is case-insensitive", skip: []string{"C-0016"}, controlID: "c-0016", want: false},
+		{name: "skip wins over include", include: []string{"C-0016"}, skip: []string{"C-0016"}, controlID: "C-0016", want: false},
+		{name: "blank-only include behaves as no filter", include: []string{"", "   "}, controlID: "C-0016", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, newControlSelector(tt.include, tt.skip).selects(tt.controlID))
+		})
+	}
+}
+
+func TestPrepareResourcesToFix_HonorsControlSelection(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, err := filepath.Rel(dir, manifest)
+	assert.NoError(t, err)
+
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged container",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+				),
+				failedControl("C-0017", "Immutable container filesystem",
+					failedRuleWithFix("spec.containers[0].securityContext.readOnlyRootFilesystem", "true"),
+				),
+				failedControl("C-0041", "HostNetwork access", failedRuleNoFix()),
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		include      []string
+		skip         []string
+		wantFixed    int
+		wantUnfixed  []string
+		wantResource int
+	}{
+		{name: "no selection fixes both fixable controls", wantFixed: 2, wantUnfixed: []string{"C-0041"}, wantResource: 1},
+		{name: "include narrows to one control", include: []string{"C-0057"}, wantFixed: 1, wantResource: 1},
+		{name: "skip drops one fixable control", skip: []string{"C-0057"}, wantFixed: 1, wantUnfixed: []string{"C-0041"}, wantResource: 1},
+		{name: "skipped unfixable control is not reported", skip: []string{"C-0041"}, wantFixed: 2, wantResource: 1},
+		{name: "selecting nothing leaves the resource alone", include: []string{"C-9999"}, wantFixed: 0, wantResource: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandlerForResources(dir, results, nil, false)
+			h.controls = newControlSelector(tt.include, tt.skip)
+
+			rtf := h.PrepareResourcesToFix(context.Background())
+
+			assert.Len(t, rtf, tt.wantResource)
+			assert.Equal(t, tt.wantFixed, h.FixedControlsCount())
+
+			unfixed := make([]string, 0, len(h.UnfixedControls()))
+			for _, u := range h.UnfixedControls() {
+				unfixed = append(unfixed, u.ControlID)
+			}
+			assert.ElementsMatch(t, tt.wantUnfixed, unfixed)
+		})
+	}
+}
+
+func TestControlSelector_ActiveAndDescribe(t *testing.T) {
+	assert.False(t, newControlSelector(nil, nil).active())
+	assert.False(t, newControlSelector([]string{" "}, nil).active())
+	assert.True(t, newControlSelector([]string{"C-0016"}, nil).active())
+
+	assert.Equal(t, "--include-controls", newControlSelector([]string{"C-0016"}, nil).describe())
+	assert.Equal(t, "--skip-controls", newControlSelector(nil, []string{"C-0016"}).describe())
+	assert.Equal(t, "--include-controls/--skip-controls", newControlSelector([]string{"C-0016"}, []string{"C-0017"}).describe())
+}
+
+func TestControlSelectionCounts(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", "apiVersion: apps/v1\nkind: Deployment\n")
+	rel, err := filepath.Rel(dir, manifest)
+	assert.NoError(t, err)
+
+	res := buildResource(t, dir, rel, "Deployment", "demo", 0)
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged container",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+				),
+				failedControl("C-0017", "Immutable container filesystem",
+					failedRuleWithFix("spec.containers[0].securityContext.readOnlyRootFilesystem", "true"),
+				),
+				{
+					ControlID: "C-9998",
+					Name:      "passed control",
+					Status:    apis.StatusInfo{InnerStatus: apis.StatusPassed},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		include      []string
+		skip         []string
+		wantSelected int
+	}{
+		{name: "no selection keeps every failed control", wantSelected: 2},
+		{name: "include keeps one", include: []string{"C-0057"}, wantSelected: 1},
+		{name: "skip drops one", skip: []string{"C-0057"}, wantSelected: 1},
+		{name: "unmatched include keeps nothing", include: []string{"C-9999"}, wantSelected: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandlerForResources(dir, results, nil, false)
+			h.controls = newControlSelector(tt.include, tt.skip)
+
+			selected, total := h.controlSelectionCounts()
+
+			assert.Equal(t, tt.wantSelected, selected)
+			assert.Equal(t, 2, total, "passed controls are never counted")
+		})
+	}
+}
+
+// buildWorkloadResource mirrors buildResource but records a container, which
+// profile drift detection needs to produce any fix at all.
+func buildWorkloadResource(t *testing.T, baseDir, filename, name, container string, documentIndex int) *reporthandling.Resource {
+	t.Helper()
+	obj := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": container, "image": "nginx"},
+					},
+				},
+			},
+		},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath(filename + ":" + itoa(documentIndex))
+
+	return &reporthandling.Resource{
+		ResourceID: lw.GetID(),
+		Object:     lw.GetObject(),
+		Source:     &reporthandling.Source{FileType: reporthandling.SourceTypeYaml, Path: baseDir},
+	}
+}
+
+func writeContainerProfile(t *testing.T, dir, kind, name, namespace, container string) string {
+	t.Helper()
+	profile := map[string]any{
+		"metadata": map[string]any{
+			"name": "profile",
+			"labels": map[string]string{
+				"kubescape.io/workload-kind":           kind,
+				"kubescape.io/workload-name":           name,
+				"kubescape.io/workload-namespace":      namespace,
+				"kubescape.io/workload-container-name": container,
+			},
+		},
+		"spec": map[string]any{},
+	}
+	raw, err := json.Marshal(profile)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "profile.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+// A control selection must not be quietly widened by --container-profile:
+// drift fixes carry no control, so applying them under a selection would edit
+// the manifest for controls the user excluded (review of #3707).
+func TestPrepareResourcesToFix_ContainerProfileRespectsControlSelection(t *testing.T) {
+	dir := t.TempDir()
+	manifest := writeManifest(t, dir, "deploy.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: nginx
+`)
+	rel, err := filepath.Rel(dir, manifest)
+	require.NoError(t, err)
+
+	res := buildWorkloadResource(t, dir, rel, "demo", "app", 0)
+	results := []resourcesresults.Result{
+		{
+			ResourceID:  res.GetID(),
+			RawResource: res,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				failedControl("C-0057", "Privileged container",
+					failedRuleWithFix("spec.containers[0].securityContext.privileged", "false"),
+				),
+			},
+		},
+	}
+	profilePath := writeContainerProfile(t, dir, "Deployment", "demo", "default", "app")
+
+	tests := []struct {
+		name         string
+		include      []string
+		wantResource int
+		wantDrift    bool
+	}{
+		{name: "no selection still applies profile drift", wantResource: 1, wantDrift: true},
+		{name: "selection matching no control applies nothing", include: []string{"C-9999"}, wantResource: 0},
+		{name: "selection matching a control applies only its fix", include: []string{"C-0057"}, wantResource: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandlerForResources(dir, results, nil, false)
+			h.fixInfo.ContainerProfilePath = profilePath
+			h.controls = newControlSelector(tt.include, nil)
+
+			rtf := h.PrepareResourcesToFix(context.Background())
+
+			require.Len(t, rtf, tt.wantResource)
+			if tt.wantResource == 0 {
+				return
+			}
+
+			var drift int
+			for expression := range rtf[0].YamlExpressions {
+				if strings.Contains(expression, "readOnlyRootFilesystem") || strings.Contains(expression, "capabilities.drop") {
+					drift++
+				}
+			}
+			if tt.wantDrift {
+				assert.NotZero(t, drift, "profile drift must still apply when no control is selected")
+				return
+			}
+			assert.Zero(t, drift, "profile drift must not bypass an active control selection")
+		})
+	}
+}

--- a/core/pkg/fixhandler/datastructures.go
+++ b/core/pkg/fixhandler/datastructures.go
@@ -16,6 +16,7 @@ type FixHandler struct {
 	fixInfo       *metav1.FixInfo
 	reportObj     *reporthandlingv2.PostureReport
 	localBasePath string
+	controls      controlSelector
 
 	// unfixedControls is populated by PrepareResourcesToFix with every failed
 	// (resource, control) tuple that the fixer cannot or will not auto-remediate.

--- a/core/pkg/fixhandler/fixhandler.go
+++ b/core/pkg/fixhandler/fixhandler.go
@@ -113,6 +113,7 @@ func NewFixHandler(fixInfo *metav1.FixInfo) (*FixHandler, error) {
 		fixInfo:       fixInfo,
 		reportObj:     &reportObj,
 		localBasePath: localPath,
+		controls:      newControlSelector(fixInfo.IncludeControls, fixInfo.SkipControls),
 	}, nil
 }
 
@@ -261,6 +262,42 @@ func getLocalPath(report *reporthandlingv2.PostureReport) string {
 // would resolve against the process working directory rather than anything in the report.
 // Reports without a usable root (cloned repos, older reports) keep using the report-wide
 // path. Traversal is contained where it can actually occur, on the join in
+// reportControlSelection states how much of the report a control selection
+// leaves in scope. Selecting nothing is not an error - a targeted control can
+// legitimately have passed - but it is indistinguishable from a mistyped ID
+// without saying so.
+func (h *FixHandler) reportControlSelection(ctx context.Context) {
+	selected, total := h.controlSelectionCounts()
+
+	if selected == 0 {
+		logger.L().Ctx(ctx).Warning(fmt.Sprintf("%s excluded all %d flagged control instances; nothing will be remediated",
+			h.controls.describe(), total))
+		return
+	}
+	logger.L().Info(fmt.Sprintf("%s selected %d of %d flagged control instances", h.controls.describe(), selected, total))
+}
+
+// controlSelectionCounts reports how many of the report's failed
+// (resource, control) tuples the current selection keeps.
+func (h *FixHandler) controlSelectionCounts() (selected, total int) {
+	for _, result := range h.reportObj.Results {
+		if !result.GetStatus(nil).IsFailed() {
+			continue
+		}
+		for i := range result.AssociatedControls {
+			ac := &result.AssociatedControls[i]
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+			total++
+			if h.controls.selects(ac.GetID()) {
+				selected++
+			}
+		}
+	}
+	return selected, total
+}
+
 // PrepareResourcesToFix.
 //
 // Source.Path is as report-supplied as the report-wide path, so --base-path has to
@@ -568,6 +605,10 @@ func (h *FixHandler) resolveResourceSource(ctx context.Context, resourceObj *rep
 func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInfo {
 	resourceIdToResource := h.buildResourcesMap()
 
+	if h.controls.active() {
+		h.reportControlSelection(ctx)
+	}
+
 	resourcesToFix := make([]ResourceFixInfo, 0)
 	resourcesPerFile := h.countResourcesPerFile(resourceIdToResource)
 	h.unfixedControls = h.unfixedControls[:0]
@@ -588,6 +629,15 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		}
 	}
 
+	// Profile drift fixes are derived from observed runtime behaviour, not from
+	// a control, so nothing attributes them to a selected one. Applying them
+	// under a selection would edit the manifest for controls the user excluded.
+	if containerProfile != nil && h.controls.active() {
+		logger.L().Ctx(ctx).Warning(fmt.Sprintf("--container-profile drift remediation is skipped while %s is set: profile fixes belong to no control and cannot be selected",
+			h.controls.describe()))
+		containerProfile = nil
+	}
+
 	for _, result := range h.reportObj.Results {
 		if !result.GetStatus(nil).IsFailed() {
 			continue
@@ -602,7 +652,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 			logger.L().Ctx(ctx).Warning("Skipping result with no resource data in report: " + sanitizeForLog(resourceID))
 			for i := range result.AssociatedControls {
 				ac := &result.AssociatedControls[i]
-				if !ac.GetStatus(nil).IsFailed() {
+				if !ac.GetStatus(nil).IsFailed() || !h.controls.selects(ac.GetID()) {
 					continue
 				}
 				h.unfixedControls = append(h.unfixedControls, UnfixedControl{
@@ -619,7 +669,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 		if src.skipReason != "" {
 			for i := range result.AssociatedControls {
 				ac := &result.AssociatedControls[i]
-				if !ac.GetStatus(nil).IsFailed() {
+				if !ac.GetStatus(nil).IsFailed() || !h.controls.selects(ac.GetID()) {
 					continue
 				}
 				h.unfixedControls = append(h.unfixedControls, UnfixedControl{
@@ -663,7 +713,7 @@ func (h *FixHandler) PrepareResourcesToFix(ctx context.Context) []ResourceFixInf
 
 		for i := range result.AssociatedControls {
 			ac := &result.AssociatedControls[i]
-			if !ac.GetStatus(nil).IsFailed() {
+			if !ac.GetStatus(nil).IsFailed() || !h.controls.selects(ac.GetID()) {
 				continue
 			}
 
@@ -851,7 +901,7 @@ func (h *FixHandler) PrepareHelmSuggestions(ctx context.Context) []HelmFixSugges
 		var fixPaths []armotypes.FixPath
 		for i := range result.AssociatedControls {
 			ac := &result.AssociatedControls[i]
-			if !ac.GetStatus(nil).IsFailed() {
+			if !ac.GetStatus(nil).IsFailed() || !h.controls.selects(ac.GetID()) {
 				continue
 			}
 			for _, rule := range ac.ResourceAssociatedRules {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -738,6 +738,51 @@ a config omits, so the live `envFrom` survives.
 | `--no-confirm` | Apply without confirmation | `false` |
 | `--skip-user-values` | Skip changes requiring user values | `true` |
 | `--output-dir` | Cluster scans only: write one patched manifest per resource here instead of printing them | *(print to stdout)* |
+| `--include-controls` | Remediate only these control IDs (comma-separated, case-insensitive). Disables `--container-profile` drift remediation — see [selecting controls to fix](#selecting-controls-to-fix) | *(all)* |
+| `--skip-controls` | Leave these control IDs untouched (comma-separated, case-insensitive). Takes precedence over `--include-controls`, and disables `--container-profile` drift remediation | - |
+
+### Selecting controls to fix
+
+By default `kubescape fix` remediates every failed control it can. In a pipeline
+that is rarely what you want: some remediations are safe to apply unattended,
+others need a human. `--include-controls` and `--skip-controls` narrow the run to
+the controls you trust:
+
+```bash
+# Only apply the two remediations this pipeline has signed off on
+kubescape fix results.json --no-confirm --include-controls C-0016,C-0017
+
+# Apply everything except the one that breaks this workload
+kubescape fix results.json --no-confirm --skip-controls C-0055
+```
+
+Matching is case-insensitive on the control ID, and `--skip-controls` wins when a
+control appears in both. Controls outside the selection are left untouched and
+are not listed as unfixed, so the run's counts describe only what you asked for.
+
+A field can be remediated by more than one control, so skipping a control does
+not always leave its field unchanged — another selected control may still set it.
+
+Each run reports how much of the report the selection kept, so the later
+"Fixed N of M" counts are read against the right total:
+
+```
+--include-controls selected 1 of 22 flagged control instances
+Fixed 1 of 1 flagged control instances across 1 file(s).
+```
+
+`--container-profile` drift remediation is skipped while a selection is active,
+and says so. Those fixes come from observed runtime behaviour rather than from a
+control, so nothing attributes them to a selected one — applying them anyway
+would edit the manifest for controls you excluded. Drop the selection flags to
+get profile drift remediation back; behaviour without them is unchanged.
+
+A selection that matches nothing warns rather than fails, since a targeted
+control can legitimately have passed in that report:
+
+```
+--include-controls excluded all 22 flagged control instances; nothing will be remediated
+```
 
 ### Examples
 


### PR DESCRIPTION
## Summary

- `kubescape fix` was all-or-nothing: `scan` has `--include-controls`, `--skip-controls` and `--exclude-controls`, but the remediation side had no way to narrow what it applies, so a pipeline that had signed off on two safe fixes either applied every one or hand-edited the manifests afterwards.
- A single selector in `core/pkg/fixhandler` now gates all four places failed controls are iterated the main fix loop, the Helm suggestion path, and both unfixable-resource reporting paths - so file scans, cluster reports (`--output-dir`) and Helm suggestions behave identically. Matching mirrors `scan`: case-insensitive on control ID, `--skip-controls` wins over `--include-controls`.
- Controls outside the selection are left untouched and are not listed as unfixed, so each run first reports what the selection kept (`--include-controls selected 1 of 22 flagged control instances`), which anchors the later `Fixed 1 of 1` counts. A selection matching nothing warns rather than fails, since a targeted control can legitimately have passed in that report.
- Tested by `TestControlSelector_Selects`, `TestControlSelector_ActiveAndDescribe`, `TestControlSelectionCounts`, `TestPrepareResourcesToFix_HonorsControlSelection` and `TestValidateControlSelection`, plus live runs over a generated report (no filter 6/22, `--include-controls C-0016` 1/1, `--skip-controls C-0016` 5/21, lowercase IDs accepted).

**Which issue(s) this PR fixes:**
N/A, found while reading the remediation path; no open or closed issue/PR covers control selection in `fix`.

**Special notes for your reviewer:**
Matching is on control ID only, a report carries `controlID` and `name` but not `Control_ID`, so CIS section numbers can't resolve here the way they do in `scan`. Also note a field can be remediated by more than one control, so skipping C-0016 still leaves `allowPrivilegeEscalation` set via C-0211; that's documented rather than special-cased.

**Does this PR introduce a user-facing change?**
Yes `kubescape fix` gains `--include-controls` and `--skip-controls`, and prints one line describing the selection when either is used. Runs without them are unchanged, including their output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--include-controls` and `--skip-controls` options to restrict remediation by control ID.
  * Control matching is case-insensitive and ignores surrounding whitespace.
  * Excluded controls take precedence when both filters overlap.
  * Fix results now indicate how many controls were selected for remediation.

* **Bug Fixes**
  * Invalid empty control identifiers are rejected before remediation begins.

* **Documentation**
  * Added CLI guidance and examples for selecting controls to fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->