### PR TITLE
fix: do not print scan usage when --severity-threshold fails (#3716)

### DIFF
--- a/cmd/scan/control.go
+++ b/cmd/scan/control.go
@@ -91,6 +91,10 @@ func getControlCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comman
 				return err
 			}
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err

--- a/cmd/scan/framework.go
+++ b/cmd/scan/framework.go
@@ -110,6 +110,10 @@ func getFrameworkCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comm
 
 			policyIdentifiers := cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework)
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err

--- a/cmd/scan/image.go
+++ b/cmd/scan/image.go
@@ -91,6 +91,10 @@ func getImageCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command 
 				UseDefaultMatchers: scanInfo.UseDefaultMatchers,
 			}
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			exceedsSeverityThreshold, err := ks.ScanImageContext(ctx, imgScanInfo, scanInfo)
 			if err != nil {
 				return err

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -142,6 +142,10 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 
 			scanInfo.View = requestedView
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			if policyIdentifiers := contractPolicyIdentifiers(selectedContract); len(policyIdentifiers) > 0 {
 				setContractScanTarget(args, &scanInfo)
 				return securityScan(scanInfo, ks, policyIdentifiers)

--- a/cmd/scan/scan_usage_test.go
+++ b/cmd/scan/scan_usage_test.go
@@ -1,0 +1,93 @@
+package scan
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/kubescape/v4/core/meta"
+	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitHub #3716: Cobra prints UsageString on RunE errors unless SilenceUsage is set
+// after a valid invocation. These tests must not preset cmd.SilenceUsage.
+
+type usageTestPrinter struct{}
+
+func (usageTestPrinter) ActionPrint(context.Context, *cautils.OPASessionObj, []cautils.ImageScanData) error {
+	return nil
+}
+func (usageTestPrinter) PrintNextSteps()                         {}
+func (usageTestPrinter) Score(float32)                           {}
+func (usageTestPrinter) SetWriter(context.Context, string) error { return nil }
+
+type usageThresholdKubescape struct {
+	mocks.MockIKubescape
+}
+
+func (m *usageThresholdKubescape) ScanContext(_ context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+	results := resultshandling.NewResultsHandler(nil, nil, usageTestPrinter{})
+	data := cautils.NewOPASessionObjMock()
+	data.Report.SummaryDetails.ResourcesSeverityCounters = reportsummary.SeverityCounters{LowSeverityCounter: 1}
+	results.SetData(data)
+	return results, nil
+}
+
+func (m *usageThresholdKubescape) ScanImageContext(_ context.Context, _ *metav1.ImageScanInfo, _ *cautils.ScanInfo) (bool, error) {
+	return true, nil
+}
+
+func newKubescapeRootWithScan(ks meta.IKubescape) (*cobra.Command, *bytes.Buffer) {
+	root := &cobra.Command{Use: "kubescape"}
+	root.AddCommand(GetScanCommand(ks))
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	return root, &buf
+}
+
+func TestScanSeverityThresholdFailureDoesNotPrintUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "security view scan", args: []string{"scan", ".", "--severity-threshold", "low"}},
+		{name: "framework", args: []string{"scan", "framework", "nsa", "--severity-threshold", "low"}},
+		{name: "control", args: []string{"scan", "control", "C-0058", "--severity-threshold", "low"}},
+		{name: "workload", args: []string{"scan", "workload", "Deployment/nginx", "--severity-threshold", "low"}},
+		{name: "image", args: []string{"scan", "image", "nginx", "--severity-threshold", "high"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := &usageThresholdKubescape{}
+			root, buf := newKubescapeRootWithScan(ks)
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "severity threshold")
+			assert.NotContains(t, buf.String(), "Usage:", "threshold failure must not dump command usage")
+		})
+	}
+}
+
+func TestScanValidationErrorStillPrintsUsage(t *testing.T) {
+	ks := &usageThresholdKubescape{}
+	root, buf := newKubescapeRootWithScan(ks)
+	root.SetArgs([]string{"scan", "--format-version=v3"})
+
+	err := root.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --format-version")
+	assert.Contains(t, buf.String(), "Usage:")
+}

--- a/cmd/scan/scan_usage_test.go
+++ b/cmd/scan/scan_usage_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
-	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/kubescape/kubescape/v4/core/meta"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
+	"github.com/kubescape/kubescape/v4/core/mocks"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/spf13/cobra"

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -105,6 +105,10 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 				return err
 			}
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Overview

When `kubescape scan` completes and a result gate such as `--severity-threshold` fails, Cobra v1.10.2 prints the full command usage (`kubescape scan --help`) in addition to the error line. That makes CI output noisy and confusing, especially when the scan report (including excepted findings) has already been printed.

This PR sets `cmd.SilenceUsage = true` **after** all argument, flag, and input validation succeed, and **before** runtime scan work begins. The boundary is:

- **Invalid CLI input** → usage is still shown (e.g. bad `--format-version`)
- **Valid invocation, runtime/result-gate failure** → only the error line is printed (e.g. threshold exceeded)

Changes are scoped to `kubescape scan` and its subcommands (`framework`, `control`, `workload`, `image`). `patch` and `diff` have the same class of behavior but are out of scope for this issue.

## Additional Information

- Root cause: Cobra prints `UsageString()` on any `RunE` error unless `SilenceUsage` is enabled on the executed command.
- Issue repro: `kubescape scan tmp/ --severity-threshold low` on a manifest that fails low-severity controls.
- The reporter’s “exceptions” refers to excepted findings in the scan report (`w/exceptions`), not a separate trigger for the usage dump.
- No changes to threshold calculations, exception logic, or result printers.

## Related issues

* Resolves #3716


## How to Test

**Unit tests:**

```bash
go test ./cmd/scan \
  -run 'TestScanSeverityThresholdFailureDoesNotPrintUsage|TestScanValidationErrorStillPrintsUsage' \
  -count=1 -v
  
 ```
 
 **Test Ran Locally :**
<img width="1356" height="777" alt="image" src="https://github.com/user-attachments/assets/cc18cfbb-653e-4d9a-a915-5ff5ee6cfede" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan commands no longer display usage text for runtime or result-threshold failures after valid input is provided.
  * Invalid arguments, flags, and fleet scan combinations continue to display usage guidance.
  * Consistent behavior now applies across contract policy, security, framework, image, workload, and fleet scans.

* **Tests**
  * Added coverage across scan modes for usage output on validation errors and threshold failures.
  * Added coverage for invalid fleet scan options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->