### PR TITLE
feat(list): add --framework and --search filters to list controls 

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -101,11 +101,20 @@ func flagValidationList(listPolicies *v1.ListPolicies) error {
 }
 
 func validateControlListFilters(target string, filters v1.ControlListFilters) error {
-	if strings.TrimSpace(filters.Framework) == "" && strings.TrimSpace(filters.Search) == "" {
+	hasFramework := strings.TrimSpace(filters.Framework) != ""
+	hasSearch := strings.TrimSpace(filters.Search) != ""
+
+	if !hasFramework && !hasSearch {
 		return nil
 	}
 	if target != "controls" {
-		return fmt.Errorf("--framework and --search can only be used with 'list controls'")
+		if hasFramework && hasSearch {
+			return fmt.Errorf("--framework and --search can only be used with 'list controls'")
+		}
+		if hasFramework {
+			return fmt.Errorf("--framework can only be used with 'list controls'")
+		}
+		return fmt.Errorf("--search can only be used with 'list controls'")
 	}
 	return nil
 }

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -72,14 +72,71 @@ func TestGetListCmd_ControlFilterFlags(t *testing.T) {
 }
 
 func TestGetListCmd_ControlFilterFlagsRejectNonControlsTarget(t *testing.T) {
-	listCmd := GetListCmd(&recordingListKubescape{})
-	listCmd.SilenceUsage = true
-	listCmd.SilenceErrors = true
-	listCmd.SetArgs([]string{"frameworks", "--framework", "NSA"})
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "framework flag only",
+			args:    []string{"frameworks", "--framework", "NSA"},
+			wantErr: "--framework can only be used with 'list controls'",
+		},
+		{
+			name:    "search flag only",
+			args:    []string{"frameworks", "--search", "container"},
+			wantErr: "--search can only be used with 'list controls'",
+		},
+		{
+			name:    "both framework and search flags",
+			args:    []string{"frameworks", "--framework", "NSA", "--search", "container"},
+			wantErr: "--framework and --search can only be used with 'list controls'",
+		},
+	}
 
-	err := listCmd.Execute()
-	require.Error(t, err)
-	assert.EqualError(t, err, "--framework and --search can only be used with 'list controls'")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listCmd := GetListCmd(&recordingListKubescape{})
+			listCmd.SilenceUsage = true
+			listCmd.SilenceErrors = true
+			listCmd.SetArgs(tt.args)
+
+			err := listCmd.Execute()
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestGetListCmd_ControlFilterFlagsAllowsNonControlsWhenUnsetOrWhitespace(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "no filter flags passed",
+			args: []string{"frameworks"},
+		},
+		{
+			name: "whitespace framework and search flags passed",
+			args: []string{"frameworks", "--framework", "   ", "--search", "\t"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &recordingListKubescape{}
+			listCmd := GetListCmd(recorder)
+			listCmd.SilenceUsage = true
+			listCmd.SilenceErrors = true
+			listCmd.SetArgs(tt.args)
+
+			err := listCmd.Execute()
+			require.NoError(t, err)
+			require.NotNil(t, recorder.received)
+			assert.Equal(t, "frameworks", recorder.received.Target)
+		})
+	}
 }
 
 func TestGetListCmd_ControlFilterFlagMetadata(t *testing.T) {


### PR DESCRIPTION
## Overview
Introduces `--framework` and `--search` filtering flags to `kubescape list controls` (#3623) to enable targeted control discovery in CI/CD and automation workflows.

### Summary of Implementation
- **Data Model & Flag Wiring**: Added `ControlListFilters` to `ListPolicies` (`v1`) data structures and registered `--framework` and `--search` flags on the `list` command.
- **Filtering Logic**:
  - `--framework`: Performs exact, case-insensitive matching (`strings.EqualFold`) against control framework membership.
  - `--search`: Performs case-insensitive substring matching (`strings.Contains`) across control ID, name, and frameworks.
  - Composed filters apply with logical **AND** evaluation.
- **Pre-Render Filtering**: Filters control entries prior to output rendering in `PrintListResult`, automatically supporting all output formats (`pretty-print`, `json`, `yaml`, `csv`).
- **Target Validation**: Restricts filter flags to `list controls` with granular error messages, while allowing unset or whitespace-only flags on other targets as no-ops.

## Additional Information
- Complete unit test coverage added for flag binding, target validation, exact framework matching, text search, whitespace handling, and composed filtering.

## How to Test
1. List controls filtered by framework:
   ```bash
   kubescape list controls --framework NSA

2. Search controls by text:

   ```bash
   kubescape list controls --search container
   ```

3. Combine framework and search filters across output formats:

   ```bash
   kubescape list controls --framework NSA --search container --format json
   ```

4. Verify rejection on unsupported targets:

   ```bash
   kubescape list frameworks --framework NSA
   ```

## Related issues/PRs

* Resolved #3623

## Checklist before requesting a review

* [x] My code follows the style guidelines of this project
* [x] I have commented on my code, particularly in hard-to-understand areas
* [x] I have performed a self-review of my code
* [x] If it is a core feature, I have added thorough tests.
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation messages when `--framework` or `--search` is used with a target other than `controls`.
  * Whitespace-only filter values are now handled like unset filters, allowing valid non-controls targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->