### PR TITLE
fix(git): use hex encoding for hashRepoURL instead of raw bytes

### DIFF
--- a/core/cautils/remotegitutils.go
+++ b/core/cautils/remotegitutils.go
@@ -2,6 +2,7 @@ package cautils
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	nethttp "net/http"
@@ -31,10 +32,11 @@ var (
 	gitTransportOnce sync.Once
 )
 
+// hashRepoURL returns a hex-encoded SHA-256 digest of the given repository URL.
 func hashRepoURL(repoURL string) string {
 	h := sha256.New()
 	h.Write([]byte(repoURL))
-	return string(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func repoWorkspaceKey(gitURL giturl.IGitAPI) string {

--- a/core/cautils/remotegitutils_test.go
+++ b/core/cautils/remotegitutils_test.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -154,4 +155,23 @@ func TestGetDirPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHashRepoURL verifies that hashRepoURL returns a valid 64-character hex-encoded
+// SHA-256 digest that is deterministic and unique per URL.
+func TestHashRepoURL(t *testing.T) {
+	url := "https://github.com/kubescape/kubescape.git"
+	hash := hashRepoURL(url)
+
+	assert.Len(t, hash, 64)
+	decoded, err := hex.DecodeString(hash)
+	require.NoError(t, err, "hash must be valid hexadecimal")
+	assert.Len(t, decoded, 32, "decoded hash must be 32 bytes")
+
+	// Ensure determinism
+	assert.Equal(t, hash, hashRepoURL(url))
+
+	// Ensure different URLs produce different hashes
+	otherHash := hashRepoURL("https://github.com/kubescape/other.git")
+	assert.NotEqual(t, hash, otherHash)
 }


### PR DESCRIPTION
## Overview

`hashRepoURL()` in `core/cautils/remotegitutils.go` previously returned `string(h.Sum(nil))`, casting raw SHA-256 digest bytes directly into a Go string. This produced 32-byte strings containing control characters, non-printable characters, invalid UTF-8 bytes, and potentially null bytes used as map keys in `tmpDirPaths`, `tmpDirRefs`, and `cloneGroup`.

This PR updates `hashRepoURL()` to return `hex.EncodeToString(h.Sum(nil))`, producing a clean, deterministic 64-character hex-encoded string. It also adds a unit test (`TestHashRepoURL`) in `remotegitutils_test.go` to assert valid hex formatting, correct byte length, determinism, and uniqueness.

## How to Test

Run the unit tests in `core/cautils`:
```bash
go test -v ./core/cautils -run "TestHashRepoURL|Test.*Git.*|TestGetClonedPath|TestGetDirPath"
```

All existing tests and the new test pass locally.

## Related issues/PRs:

* Resolved #3719

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of repository-based workspace cache identifiers.
  * Cache keys derived from repository URLs now use a stable, standardized hexadecimal format, helping ensure reliable cache behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->