### PR TITLE
fix(resourcehandler): retrieve single workload via Get instead of List

### DIFF
--- a/core/pkg/resourcehandler/fieldselector.go
+++ b/core/pkg/resourcehandler/fieldselector.go
@@ -44,6 +44,11 @@ type IFieldSelector interface {
 	// ClusterRole.
 	GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string
 	GetClusterScope(*schema.GroupVersionResource) bool
+	// AllowsNamespace reports whether the given resource identity and namespace
+	// are permitted by the selector. For cluster-scoped resources, it returns true
+	// (except for the "namespaces" resource itself, where namespace/name is filtered).
+	// For namespaced resources, it checks whether the namespace is allowed.
+	AllowsNamespace(resource *schema.GroupVersionResource, namespace string, namespaced *bool) bool
 }
 
 type EmptySelector struct {
@@ -58,6 +63,10 @@ func (es *EmptySelector) GetNamespaceScopedQueries(*schema.GroupVersionResource,
 }
 
 func (es *EmptySelector) GetClusterScope(*schema.GroupVersionResource) bool {
+	return true
+}
+
+func (es *EmptySelector) AllowsNamespace(resource *schema.GroupVersionResource, namespace string, namespaced *bool) bool {
 	return true
 }
 
@@ -79,6 +88,30 @@ func (es *ExcludeSelector) GetClusterScope(resource *schema.GroupVersionResource
 // cannot be expressed as a bounded set of namespaced queries.
 func (es *ExcludeSelector) GetNamespaceScopedQueries(*schema.GroupVersionResource, *bool) []string {
 	return nil
+}
+
+func (es *ExcludeSelector) AllowsNamespace(resource *schema.GroupVersionResource, namespace string, namespaced *bool) bool {
+	excluded := splitNamespaces(es.namespace)
+	if len(excluded) == 0 {
+		return true
+	}
+	if resource != nil && resource.Resource == "namespaces" {
+		for _, ex := range excluded {
+			if namespace == ex {
+				return false
+			}
+		}
+		return true
+	}
+	if !isNamespacedTarget(resource, namespaced) {
+		return true
+	}
+	for _, ex := range excluded {
+		if namespace == ex {
+			return false
+		}
+	}
+	return true
 }
 
 type IncludeSelector struct {
@@ -106,18 +139,45 @@ func (is *IncludeSelector) GetNamespaceScopedQueries(resource *schema.GroupVersi
 	return splitNamespaces(is.namespace)
 }
 
+func (is *IncludeSelector) AllowsNamespace(resource *schema.GroupVersionResource, namespace string, namespaced *bool) bool {
+	included := splitNamespaces(is.namespace)
+	if len(included) == 0 {
+		return true
+	}
+	if resource != nil && resource.Resource == "namespaces" {
+		for _, inc := range included {
+			if namespace == inc {
+				return true
+			}
+		}
+		return false
+	}
+	if !isNamespacedTarget(resource, namespaced) {
+		return true
+	}
+	for _, inc := range included {
+		if namespace == inc {
+			return true
+		}
+	}
+	return false
+}
+
 // isNamespacedTarget reports whether resource is served under a namespaced
 // endpoint, preferring the scope discovery reported and falling back to
 // k8s-interface's static table when it did not, mirroring
 // getNamespacesSelectorWithOptionalScope.
 func isNamespacedTarget(resource *schema.GroupVersionResource, namespaced *bool) bool {
-	if resource.Resource == "namespaces" {
+	if resource != nil && resource.Resource == "namespaces" {
 		return false
 	}
 	if namespaced != nil {
 		return *namespaced
 	}
-	return k8sinterface.IsResourceInNamespaceScope(resource.Resource)
+	if resource != nil {
+		return k8sinterface.IsResourceInNamespaceScope(resource.Resource)
+	}
+	return false
 }
 
 func (es *ExcludeSelector) GetNamespacesSelectors(resource *schema.GroupVersionResource, namespaced *bool) []string {

--- a/core/pkg/resourcehandler/fieldselector_test.go
+++ b/core/pkg/resourcehandler/fieldselector_test.go
@@ -80,3 +80,70 @@ func TestIncludeNamespacesSelectors(t *testing.T) {
 	assert.Equal(t, "metadata.namespace==ns1", malformedSelectors[0])
 	assert.Equal(t, "metadata.namespace==ns3", malformedSelectors[1])
 }
+
+func TestAllowsNamespace(t *testing.T) {
+	k8sinterface.InitializeMapResourcesMock()
+	podGVR := &schema.GroupVersionResource{Resource: "pods"}
+	nodeGVR := &schema.GroupVersionResource{Resource: "nodes"}
+	nsGVR := &schema.GroupVersionResource{Resource: "namespaces"}
+
+	trueVal := true
+	falseVal := false
+
+	t.Run("empty selector allows everything", func(t *testing.T) {
+		es := &EmptySelector{}
+		assert.True(t, es.AllowsNamespace(podGVR, "default", nil))
+		assert.True(t, es.AllowsNamespace(podGVR, "kube-system", nil))
+		assert.True(t, es.AllowsNamespace(nodeGVR, "", nil))
+		assert.True(t, es.AllowsNamespace(nsGVR, "default", nil))
+	})
+
+	t.Run("exclude selector", func(t *testing.T) {
+		es := NewExcludeSelector("dev,staging")
+		// excluded namespaces
+		assert.False(t, es.AllowsNamespace(podGVR, "dev", nil))
+		assert.False(t, es.AllowsNamespace(podGVR, "staging", nil))
+		// allowed namespace
+		assert.True(t, es.AllowsNamespace(podGVR, "prod", nil))
+		assert.True(t, es.AllowsNamespace(podGVR, "default", nil))
+		// cluster-scoped resources are allowed
+		assert.True(t, es.AllowsNamespace(nodeGVR, "", nil))
+		assert.True(t, es.AllowsNamespace(nodeGVR, "dev", &falseVal))
+		// namespaces resource checked by name
+		assert.False(t, es.AllowsNamespace(nsGVR, "dev", nil))
+		assert.True(t, es.AllowsNamespace(nsGVR, "prod", nil))
+		// explicit namespaced override
+		assert.False(t, es.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "dev", &trueVal))
+		assert.True(t, es.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "prod", &trueVal))
+		assert.True(t, es.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "dev", &falseVal))
+
+		// empty exclude selector allows everything
+		emptyExclude := NewExcludeSelector("")
+		assert.True(t, emptyExclude.AllowsNamespace(podGVR, "dev", nil))
+	})
+
+	t.Run("include selector", func(t *testing.T) {
+		is := NewIncludeSelector("prod,staging")
+		// included namespaces
+		assert.True(t, is.AllowsNamespace(podGVR, "prod", nil))
+		assert.True(t, is.AllowsNamespace(podGVR, "staging", nil))
+		// non-included namespaces
+		assert.False(t, is.AllowsNamespace(podGVR, "dev", nil))
+		assert.False(t, is.AllowsNamespace(podGVR, "default", nil))
+		assert.False(t, is.AllowsNamespace(podGVR, "", nil))
+		// cluster-scoped resources are allowed
+		assert.True(t, is.AllowsNamespace(nodeGVR, "", nil))
+		assert.True(t, is.AllowsNamespace(nodeGVR, "dev", &falseVal))
+		// namespaces resource checked by name
+		assert.True(t, is.AllowsNamespace(nsGVR, "prod", nil))
+		assert.False(t, is.AllowsNamespace(nsGVR, "dev", nil))
+		// explicit namespaced override
+		assert.True(t, is.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "prod", &trueVal))
+		assert.False(t, is.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "dev", &trueVal))
+		assert.True(t, is.AllowsNamespace(&schema.GroupVersionResource{Resource: "customresources"}, "dev", &falseVal))
+
+		// empty include selector allows everything
+		emptyInclude := NewIncludeSelector("")
+		assert.True(t, emptyInclude.AllowsNamespace(podGVR, "dev", nil))
+	})
+}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -650,9 +650,58 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", getReadableID(resource))
 	}
 	gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resourceName}
+	isNamespaced := (resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))
 
+	// When the target resource's namespace is known (or the resource is cluster-scoped),
+	// retrieve it directly via Get. This adheres to least-privilege RBAC (requires only 'get',
+	// not 'list') and respects RBAC resourceNames restrictions.
+	if !isNamespaced || resource.GetNamespace() != "" {
+		targetNS := resource.GetNamespace()
+		if targetNS == "" && gvr.Resource == "namespaces" {
+			targetNS = resource.GetName()
+		}
+		if globalFieldSelector != nil && !globalFieldSelector.AllowsNamespace(&gvr, targetNS, resolved[0].namespaced) {
+			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+		}
+
+		var clientResource dynamic.ResourceInterface = k8sHandler.k8s.DynamicClient.Resource(gvr)
+		if isNamespaced {
+			clientResource = k8sHandler.k8s.DynamicClient.Resource(gvr).Namespace(resource.GetNamespace())
+		}
+		uObj, err := clientResource.Get(ctx, resource.GetName(), metav1.GetOptions{})
+		if err == nil {
+			if globalFieldSelector != nil {
+				objNS := uObj.GetNamespace()
+				if objNS == "" && gvr.Resource == "namespaces" {
+					objNS = uObj.GetName()
+				}
+				if !globalFieldSelector.AllowsNamespace(&gvr, objNS, resolved[0].namespaced) {
+					return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+				}
+			}
+			if k8sinterface.IsTypeWorkload(uObj.Object) && k8sinterface.WorkloadHasParent(workloadinterface.NewWorkloadObj(uObj.Object)) {
+				return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+			}
+			if !k8sinterface.IsTypeWorkload(uObj.Object) {
+				return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
+			}
+			return workloadinterface.NewWorkloadObj(uObj.Object), nil
+		}
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+		}
+		// If Get failed with another error (e.g. Forbidden if the account was granted
+		// 'list' but not 'get', or an unexpected API issue), log and fall back to
+		// pullSingleResource for backwards compatibility.
+		logger.L().Debug("direct get failed, falling back to list",
+			helpers.String("resource", getReadableID(resource)),
+			helpers.Error(err))
+	}
+
+	// For namespaced resources where namespace is omitted (cluster-wide search across all namespaces),
+	// or as a fallback if Get failed, search via List using field selectors.
 	fieldSelectors := getNameFieldSelectorString(resource.GetName(), FieldSelectorsEqualsOperator)
-	if resource.GetNamespace() != "" && ((resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))) {
+	if resource.GetNamespace() != "" && isNamespaced {
 		fieldSelectors = combineFieldSelectors(fieldSelectors, getNamespaceFieldSelectorString(resource.GetNamespace(), FieldSelectorsEqualsOperator))
 	}
 	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, "", fieldSelectors, globalFieldSelector, resolved[0].namespaced)

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,12 +44,32 @@ func unstructuredResource(apiVersion, kind, namespace, name string) *unstructure
 	}}
 }
 
+func unstructuredResourceWithParent(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+			"ownerReferences": []any{
+				map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"name":       "parent-deploy",
+				},
+			},
+		},
+	}}
+}
+
 func TestFindScanObjectResourceDataDriven(t *testing.T) {
 	k8sinterface.InitializeMapResourcesMock()
 	deploymentGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	replicaSetGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
 	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	listKinds := map[schema.GroupVersionResource]string{
 		deploymentGVR: "DeploymentList",
+		replicaSetGVR: "ReplicaSetList",
 		// Secrets are registered so the fake client is genuinely able to serve
 		// them. Without this the client cannot list secrets at all and the
 		// "no API calls were issued" assertion below would hold even for an
@@ -64,6 +85,8 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 		wantError        string
 		wantNil          bool
 		wantNoAPIActions bool
+		listForbidden    bool
+		selector         IFieldSelector
 	}{
 		{name: "nil request is not a single-resource scan", request: nil, wantNil: true},
 		{
@@ -73,16 +96,37 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			wantName: "checkout",
 		},
 		{
+			name:          "deployment is returned via get when list is forbidden",
+			request:       scanObject("apps/v1", "Deployment", "shop", "checkout"),
+			objects:       []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			wantName:      "checkout",
+			listForbidden: true,
+		},
+		{
+			name:      "workload with parent cannot be scanned",
+			request:   scanObject("apps/v1", "ReplicaSet", "shop", "checkout-rs"),
+			objects:   []runtime.Object{unstructuredResourceWithParent("apps/v1", "ReplicaSet", "shop", "checkout-rs")},
+			wantError: "has a parent and cannot be scanned",
+		},
+		{
+			// When namespace is omitted, cluster-wide list is used; pullSingleResourceInto
+			// filters out workloads with parents, returning not found rather than parent error.
+			name:      "workload with parent and omitted namespace reports not found",
+			request:   scanObject("apps/v1", "ReplicaSet", "", "checkout-rs"),
+			objects:   []runtime.Object{unstructuredResourceWithParent("apps/v1", "ReplicaSet", "shop", "checkout-rs")},
+			wantError: "was not found",
+		},
+		{
 			name:      "missing deployment reports the requested identity",
 			request:   scanObject("apps/v1", "Deployment", "shop", "missing"),
 			wantError: "was not found",
 		},
 		{
 			name:    "ambiguous result is rejected",
-			request: scanObject("apps/v1", "Deployment", "shop", "checkout"),
+			request: scanObject("apps/v1", "Deployment", "", "checkout"),
 			objects: []runtime.Object{
 				unstructuredResource("apps/v1", "Deployment", "shop", "checkout"),
-				unstructuredResource("apps/v1", "Deployment", "shop", "checkout-copy"),
+				unstructuredResource("apps/v1", "Deployment", "staging", "checkout"),
 			},
 			wantError: "more than one resource found",
 		},
@@ -100,10 +144,8 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			// Defense in depth: a Secret is not a useful single-resource scan
 			// target, so it must be rejected before retrieval rather than
 			// fetched and then sanitized downstream. Rejecting early also
-			// avoids an unnecessary Kubernetes API call. The Secret exists in
-			// the fake client here, so the rejection is proven to be a policy
-			// decision and not a lookup miss.
-			name:             "secret is rejected even when it exists",
+			// avoids the need for Secret-reading RBAC permissions.
+			name:             "secret is rejected before API retrieval",
 			request:          scanObject("v1", "Secret", "shop", "db-creds"),
 			objects:          []runtime.Object{unstructuredResource("v1", "Secret", "shop", "db-creds")},
 			wantError:        "scanning Secret resources via single resource scan is not supported",
@@ -116,16 +158,63 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			wantError:        "scanning Secret resources via single resource scan is not supported",
 			wantNoAPIActions: true,
 		},
+		{
+			name:             "workload in excluded namespace is rejected without API call",
+			request:          scanObject("apps/v1", "Deployment", "dev", "checkout"),
+			objects:          []runtime.Object{unstructuredResource("apps/v1", "Deployment", "dev", "checkout")},
+			selector:         NewExcludeSelector("dev"),
+			wantError:        "was not found",
+			wantNoAPIActions: true,
+		},
+		{
+			name:     "workload in non-excluded namespace is returned via get",
+			request:  scanObject("apps/v1", "Deployment", "shop", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			selector: NewExcludeSelector("dev"),
+			wantName: "checkout",
+		},
+		{
+			name:     "workload in included namespace is returned via get",
+			request:  scanObject("apps/v1", "Deployment", "shop", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			selector: NewIncludeSelector("shop,staging"),
+			wantName: "checkout",
+		},
+		{
+			name:             "workload not in included namespace is rejected without API call",
+			request:          scanObject("apps/v1", "Deployment", "dev", "checkout"),
+			objects:          []runtime.Object{unstructuredResource("apps/v1", "Deployment", "dev", "checkout")},
+			selector:         NewIncludeSelector("shop"),
+			wantError:        "was not found",
+			wantNoAPIActions: true,
+		},
+		{
+			name:          "workload in included namespace is returned via get when list is forbidden",
+			request:       scanObject("apps/v1", "Deployment", "shop", "checkout"),
+			objects:       []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			selector:      NewIncludeSelector("shop"),
+			wantName:      "checkout",
+			listForbidden: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, test.objects...)
+			if test.listForbidden {
+				dynamicClient.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "deployments"}, "", errors.New("cannot list resource"))
+				})
+			}
 			handler := &K8sResourceHandler{k8s: &k8sinterface.KubernetesApi{DynamicClient: dynamicClient}}
 			resolver, discoveryFailures := newDiscoveryResourceResolver(nil)
 			require.Empty(t, discoveryFailures)
 
-			workload, err := handler.findScanObjectResource(context.Background(), test.request, &EmptySelector{}, resolver)
+			selector := test.selector
+			if selector == nil {
+				selector = &EmptySelector{}
+			}
+			workload, err := handler.findScanObjectResource(context.Background(), test.request, selector, resolver)
 			if test.wantNoAPIActions {
 				// Defense in depth: the rejection must happen before the live
 				// API pull, so no Kubernetes API/RBAC operation is issued for a

--- a/core/pkg/resourcehandler/k8sresources_pull_test.go
+++ b/core/pkg/resourcehandler/k8sresources_pull_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -23,23 +24,46 @@ import (
 type mockDynamicClient struct {
 	dynamic.Interface
 	listFunc func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	getFunc  func(ctx context.Context, namespace, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
 }
 
 func (m *mockDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
-	return &mockNamespaceableResourceClient{listFunc: m.listFunc}
+	return &mockNamespaceableResourceClient{listFunc: m.listFunc, getFunc: m.getFunc}
 }
 
 type mockNamespaceableResourceClient struct {
 	dynamic.NamespaceableResourceInterface
-	listFunc func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	namespace string
+	listFunc  func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	getFunc   func(ctx context.Context, namespace, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
 }
 
 func (m *mockNamespaceableResourceClient) Namespace(s string) dynamic.ResourceInterface {
-	return m
+	clone := *m
+	clone.namespace = s
+	return &clone
 }
 
 func (m *mockNamespaceableResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	return m.listFunc(ctx, opts)
+}
+
+func (m *mockNamespaceableResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, m.namespace, name, opts, subresources...)
+	}
+	if m.listFunc != nil {
+		list, err := m.listFunc(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		for i := range list.Items {
+			if list.Items[i].GetName() == name && (m.namespace == "" || list.Items[i].GetNamespace() == "" || list.Items[i].GetNamespace() == m.namespace) {
+				return &list.Items[i], nil
+			}
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 func TestPullResources_PartialFailureSurface(t *testing.T) {

--- a/core/pkg/resourcehandler/pullresources_test.go
+++ b/core/pkg/resourcehandler/pullresources_test.go
@@ -38,6 +38,17 @@ func (s *staticFieldSelector) GetNamespaceScopedQueries(*schema.GroupVersionReso
 func (s *staticFieldSelector) GetClusterScope(resource *schema.GroupVersionResource) bool {
 	return false
 }
+func (s *staticFieldSelector) AllowsNamespace(resource *schema.GroupVersionResource, namespace string, namespaced *bool) bool {
+	if len(s.namespaces) > 0 {
+		for _, ns := range s.namespaces {
+			if ns == namespace {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
 func TestPullSingleResource_FieldSelectorDoesNotLeakAcrossIterations(t *testing.T) {
 	var capturedSelectors []string
 


### PR DESCRIPTION
## Overview

When scanning an individual Kubernetes workload via `kubescape scan workload <workload>` or the `scan_workload` MCP tool, Kubescape resolves the target resource from the cluster using `pullSingleResource`. This executes a `List` request against the collection endpoint filtered with a `metadata.name=<name>` field selector.

In Kubernetes RBAC, filtering a `List` request by field selector still requires the `list` verb on the resource collection. Consequently, service accounts or users operating under least-privilege RBAC (with only `get` permission on the resource, or scoped to specific resources via `resourceNames`) fail with an HTTP 403 Forbidden error (`cannot list resource "deployments"`).

### Future Behavior

`findScanObjectResource` now retrieves the target workload using a direct Kubernetes `Get` request whenever the namespace is known (or when the resource is cluster-scoped):

- Issues `clientResource.Get(name)`, requiring only the `get` RBAC verb and allowing `resourceNames` restrictions to work as expected.
- If `Get` fails with a non-404 error (e.g., if a legacy role only granted `list` and denied `get`), it falls back to `pullSingleResource` (`List`) for backwards compatibility.
- Retains cluster-wide `List` search across all namespaces when `namespace` is omitted.

---

## Additional Information

- **RBAC `resourceNames` Scoping:** In Kubernetes RBAC, `resourceNames` restrictions only apply to `get`, `update`, `patch`, and `delete` verbs; the Kubernetes API server ignores `resourceNames` on `list` requests. Switching to direct `Get` enables administrators to grant Kubescape read access restricted to specific workload names.

- **Parent Resource & Secret Protection:** Preserves existing defense-in-depth checks: `Secret` resources are still blocked prior to issuing any API call, and workloads managed by parent controllers (`ReplicaSet`, `Job`, `Pod`) continue to be rejected with guidance to scan the parent controller instead.

---

## How to Test

### Automated Unit Tests

```bash
go test -v -run TestFindScanObjectResourceDataDriven ./core/pkg/resourcehandler
```

### Manual Verification

1. Create a ServiceAccount and Role granting only get-only permission scoped to a specific deployment:

   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
     namespace: default
     name: workload-get-only
   rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames: ["nginx"]
     verbs: ["get"]
   ```

2. Bind the Role and grant read access to contextual resources required by controls (e.g., view ClusterRole):

   ```bash
   kubectl create rolebinding workload-get-binding --role=workload-get-only --serviceaccount=default:get-only-sa -n default
   kubectl create clusterrolebinding get-only-view --clusterrole=view --serviceaccount=default:get-only-sa
   ```

3. Run the scan as the service account:

   ```bash
   kubescape scan workload Deployment/nginx -n default
   ```

4. Verify that the scan successfully evaluates the deployment without failing with `deployments.apps "nginx" is forbidden: User ... cannot list resource "deployments"`.

---

## Related Issues/PRs

- Resolves #3721

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved single-resource Kubernetes scans for namespaces and cluster-scoped resources.
* Added validation for parent workload ownership and expected workload types.
* Enforced namespace field selectors during resource lookups.
* Improved missing-resource errors with clearer feedback.
* Lookups now fall back to alternative discovery when direct retrieval is unavailable or encounters an error.
* Namespace-omitted lookups continue searching across the cluster while correctly handling duplicate names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->