### PR TITLE
feat(rules): detect Azure AKS Workload Identity in provider-iam-assum…

### DIFF
--- a/rules/provider-iam-assumption-v1/raw.rego
+++ b/rules/provider-iam-assumption-v1/raw.rego
@@ -15,6 +15,7 @@ deny contains msga if {
 	provider := [
 		{"annotation": "eks.amazonaws.com/role-arn", "description": "AWS IAM role"},
 		{"annotation": "iam.gke.io/gcp-service-account", "description": "GCP service account"},
+		{"annotation": "azure.workload.identity/client-id", "description": "Azure workload identity client ID"},
 	][_]
 
 	identity := sa.metadata.annotations[provider.annotation]

--- a/rules/provider-iam-assumption-v1/test/azure-workload-identity/expected.json
+++ b/rules/provider-iam-assumption-v1/test/azure-workload-identity/expected.json
@@ -1,0 +1,30 @@
+[
+    {
+        "alertMessage": "ServiceAccount: blob-reader is assigned the Azure workload identity client ID 00000000-0000-0000-0000-000000000000",
+        "failedPaths": [
+            "metadata.annotations[azure.workload.identity/client-id]"
+        ],
+        "reviewPaths": [
+            "metadata.annotations[azure.workload.identity/client-id]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 3,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ServiceAccount",
+                    "metadata": {
+                        "annotations": {
+                            "azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "name": "blob-reader",
+                        "namespace": "data"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/provider-iam-assumption-v1/test/azure-workload-identity/input/serviceaccount.yaml
+++ b/rules/provider-iam-assumption-v1/test/azure-workload-identity/input/serviceaccount.yaml
@@ -1,0 +1,7 @@
+﻿apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blob-reader
+  namespace: data
+  annotations:
+    azure.workload.identity/client-id: "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
Ⅰ. Describe what this PR does

provider-iam-assumption-v1 flags ServiceAccounts annotated for cloud IAM role assumption, but only checked AWS IRSA (eks.amazonaws.com/role-arn) and GCP Workload Identity (iam.gke.io/gcp-service-account). Azure AKS Workload Identity Federation — the GA successor to aad-pod-identity, generally available since AKS 1.22+ — uses the azure.workload.identity/client-id annotation and grants the same class of risk (a projected token exchangeable for cloud credentials), but was not detected.

This PR adds a third entry to the rule's provider list for the Azure annotation, matching the existing AWS/GCP pattern.

Ⅱ. Does this pull request fix one issue?

Fixes #3723

Ⅲ. List the added test cases

New azure-workload-identity fixture under rules/provider-iam-assumption-v1/test/, mirroring the existing eks-role-arn/gke-workload-identity cases (ServiceAccount annotated with azure.workload.identity/client-id → expected alert).

Ⅳ. Describe how to verify it

kubescape policy test rules/provider-iam-assumption-v1 — 4/4 cases pass, including the new Azure case. Full rules suite (kubescape policy test rules) — 106/106 cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Azure Workload Identity client ID annotations are now recognized when identifying ServiceAccounts assigned cloud-provider identities.

* **Tests**
  * Added coverage for Azure Workload Identity ServiceAccounts, including expected alerts and annotation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->