### PR TITLE
fix(resultshandling): rebuild namespace rollup after severity filtering

### DIFF
--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -173,6 +173,9 @@ type reportSnapshot struct {
 	status                     apis.ScanningStatus
 	frameworksStatusCounters   []reportsummary.StatusCounters
 	frameworksStatuses         []apis.ScanningStatus
+	// The per-namespace rollup is replaced (not mutated) by ApplySeverityFilters,
+	// so capturing the slice header is enough to restore the pre-filter rollup.
+	namespaceSummaries cautils.NamespaceSummaries
 }
 
 func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
@@ -216,6 +219,7 @@ func snapshotReport(sessionObj *cautils.OPASessionObj) reportSnapshot {
 		status:                     sessionObj.Report.SummaryDetails.Status,
 		frameworksStatusCounters:   fwStatusCounters,
 		frameworksStatuses:         fwStatuses,
+		namespaceSummaries:         sessionObj.NamespaceSummaries,
 	}
 }
 
@@ -247,6 +251,7 @@ func restoreReport(sessionObj *cautils.OPASessionObj, snap reportSnapshot) {
 			sessionObj.ResourcesResult[id] = result
 		}
 	}
+	sessionObj.NamespaceSummaries = snap.namespaceSummaries
 }
 
 // HandleResults handles all necessary actions for the scan results

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -1099,6 +1099,26 @@ func makeFilteredSession() *cautils.OPASessionObj {
 	}
 }
 
+// TestSnapshotRestoreReport_NamespaceSummaries verifies the namespace rollup
+// follows the same output-only contract as the rest of the report: severity
+// filtering may replace it for printers and submission, and restoreReport must
+// put the pre-filter rollup back for the caller's threshold evaluation.
+func TestSnapshotRestoreReport_NamespaceSummaries(t *testing.T) {
+	sessionObj := &cautils.OPASessionObj{Report: &reporthandlingv2.PostureReport{}}
+	original := cautils.NamespaceSummaries{{Namespace: "app", ComplianceScore: 100, TotalControls: 1}}
+	sessionObj.NamespaceSummaries = original
+
+	snap := snapshotReport(sessionObj)
+
+	filtered := cautils.NamespaceSummaries{{Namespace: "app", ComplianceScore: 50, TotalControls: 1}}
+	sessionObj.NamespaceSummaries = filtered
+	require.Equal(t, filtered, sessionObj.NamespaceSummaries)
+
+	restoreReport(sessionObj, snap)
+	assert.Equal(t, original, sessionObj.NamespaceSummaries,
+		"restoreReport must put back the pre-filter namespace rollup")
+}
+
 // TestHandleResults_RestoresReportOnPrinterError verifies that the deferred
 // restoreReport fires even when a printer close fails and HandleResults returns
 // an error, so rh.ScanData.Report is never left permanently filtered.

--- a/core/pkg/resultshandling/severity_filter.go
+++ b/core/pkg/resultshandling/severity_filter.go
@@ -13,7 +13,9 @@ import (
 // ApplySeverityFilters removes controls from the OPASessionObj that fall outside the
 // [minSeverity, maxSeverity] range. Both bounds are inclusive. An empty string
 // disables that bound. Controls removed here are also removed from every
-// per-resource associated-control list so the report stays consistent.
+// per-resource associated-control list so the report stays consistent, and the
+// per-namespace rollup is rebuilt from the retained controls so the namespace
+// view agrees with the recomputed cluster and framework scores.
 func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSeverity string) {
 	if sessionObj == nil || sessionObj.Report == nil {
 		return
@@ -64,6 +66,13 @@ func ApplySeverityFilters(sessionObj *cautils.OPASessionObj, minSeverity, maxSev
 	}
 
 	recomputeSummaryDetails(sessionObj)
+
+	// NamespaceSummaries was built during policy processing over the full
+	// control set; rebuild it from the retained controls so the namespace
+	// table no longer counts controls the filtered report no longer contains.
+	// The rebuild inherits each control's final cluster-computed score as-is,
+	// keeping the timed-out-control semantics agreed in #2424 unchanged.
+	sessionObj.NamespaceSummaries = cautils.BuildNamespaceSummaries(sessionObj.Report.SummaryDetails.Controls, sessionObj.AllResources)
 }
 
 // recomputeSummaryDetails refreshes every derived summary field that was

--- a/core/pkg/resultshandling/severity_filter_test.go
+++ b/core/pkg/resultshandling/severity_filter_test.go
@@ -3,6 +3,7 @@ package resultshandling
 import (
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -56,6 +57,63 @@ func makeFailedControl(id string, scoreFactor float32) reportsummary.ControlSumm
 	c := makeControl(id, scoreFactor)
 	c.StatusInfo = apis.StatusInfo{InnerStatus: apis.StatusFailed}
 	return c
+}
+
+func TestApplySeverityFilters_RebuildsNamespaceSummaries(t *testing.T) {
+	lowFailed := makeControlWithResources("C-low", scoreLow, apis.StatusFailed, "res-app-1")
+	highMixed := makeControlWithResources("C-high", scoreHigh, apis.StatusFailed, "res-db-1")
+	highMixed.ResourceIDs.Append(apis.StatusPassed, "res-app-2")
+
+	s := makeSessionWithControls(map[string]reportsummary.ControlSummary{
+		"C-low":  lowFailed,
+		"C-high": highMixed,
+	})
+	s.AllResources = map[string]workloadinterface.IMetadata{
+		"res-app-1": namespacedPodResource("res-app-1", "app"),
+		"res-app-2": namespacedPodResource("res-app-2", "app"),
+		"res-db-1":  namespacedPodResource("res-db-1", "db"),
+	}
+
+	// Policy processing builds the rollup over the full control set, before
+	// HandleResults applies the severity filters.
+	s.NamespaceSummaries = cautils.BuildNamespaceSummaries(s.Report.SummaryDetails.Controls, s.AllResources)
+	require.NotEmpty(t, s.NamespaceSummaries)
+	for _, ns := range s.NamespaceSummaries {
+		require.Equal(t, 2, ns.TotalControls, "pre-filter rollup must count both controls")
+	}
+
+	ApplySeverityFilters(s, "high", "")
+
+	require.Len(t, s.Report.SummaryDetails.Controls, 1)
+	for _, ns := range s.NamespaceSummaries {
+		assert.Equal(t, 1, ns.TotalControls,
+			"namespace rollup must describe only the controls the filtered report still contains")
+	}
+	assert.Equal(t,
+		cautils.BuildNamespaceSummaries(s.Report.SummaryDetails.Controls, s.AllResources),
+		s.NamespaceSummaries,
+		"namespace rollup must be rebuilt from the filtered control set")
+}
+
+func TestApplySeverityFilters_NoFiltersLeavesNamespaceSummaries(t *testing.T) {
+	s := makeSessionWithControls(map[string]reportsummary.ControlSummary{
+		"C-high": makeControl("C-high", scoreHigh),
+	})
+	pre := cautils.NamespaceSummaries{{Namespace: "app", ComplianceScore: 50, TotalControls: 1}}
+	s.NamespaceSummaries = pre
+
+	ApplySeverityFilters(s, "", "")
+
+	assert.Equal(t, pre, s.NamespaceSummaries,
+		"without severity filters nothing is removed, so the rollup must stay untouched")
+}
+
+func namespacedPodResource(id, namespace string) workloadinterface.IMetadata {
+	return workloadinterface.NewWorkloadObj(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": id, "namespace": namespace},
+	})
 }
 
 func TestApplySeverityFilters_NilSessionObj(t *testing.T) {


### PR DESCRIPTION
## Overview

With `--min-severity`/`--max-severity`, the per-namespace compliance rollup kept describing controls that had been filtered out of the report, while the cluster and framework scores were recomputed over the retained set — e.g. a namespace table showing `Non-Compliant Controls: 15/45` directly below an overall cluster score showing `5/5 controls evaluated` (confirmed inconsistent by @matthyx in the community thread). The report visibly disagrees with itself in a single output.

Closes #3725

## What this PR does

- Rebuilds `NamespaceSummaries` from the retained controls at the end of `ApplySeverityFilters` (`core/pkg/resultshandling/severity_filter.go`). This is the single call site reached by both the eager and streaming paths, and it mirrors the consistency discipline the global scores received in #3434.
- Extends the existing `reportSnapshot`/`restoreReport` machinery (`core/pkg/resultshandling/results.go`) with the rollup, so severity filtering stays **output-only**: printers and submission see the consistent filtered set, while exit-code thresholds (`--compliance-threshold`, `--severity-threshold`, etc.) are still evaluated against the full restored report.
- Timed-out-control semantics are deliberately **unchanged** (agreed in #2424): the rebuild inherits each control's final cluster-computed score as-is and does not touch the pre-reweight ordering in `processorhandler.go`.

## Tests

- `TestApplySeverityFilters_RebuildsNamespaceSummaries` — red-first: builds a session whose rollup is constructed pre-filter exactly as policy processing does, applies `--min-severity high`, and asserts the rollup matches `BuildNamespaceSummaries` over the filtered control set (failed before this fix with the stale `totalControls: 2`).
- `TestSnapshotRestoreReport_NamespaceSummaries` — locks the output-only contract: `restoreReport` must put the pre-filter rollup back after printing.
- `TestApplySeverityFilters_NoFiltersLeavesNamespaceSummaries` — without severity flags the rollup is untouched (early-return path).
- Full suite: `go test ./core/... -count=1` → 5842 tests pass across 49 packages; `go test ./core/pkg/resultshandling/... -race` → 1599 tests pass; `gofmt`, `go vet`, `go build ./...` clean.

## Related issue(s)

- #3725 (this fix)
- #3434 — the global-score staleness this change extends to the namespace view
- #2424 — timed-out-control semantics, intentionally untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved complete namespace summaries after severity-filtered results are processed, ensuring downstream evaluations use the original unfiltered rollup.
  * Rebuilt namespace summaries accurately when controls are removed by severity filtering.
  * Kept existing namespace summaries unchanged when no filters are applied.

* **Tests**
  * Added coverage for namespace summary filtering, restoration, and unchanged behavior with empty filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->