### PR TITLE
fix(exposure): model GRPCRoute exposure paths with v1beta1 fallback

### DIFF
--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -11,26 +11,32 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 var serviceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 var ingressGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
 var httpRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+var httpRouteGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "httproutes"}
+var grpcRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes"}
+var grpcRouteGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "grpcroutes"}
 var gatewayGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+var gatewayGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "gateways"}
 
 // createServiceExposureTools registers analyze_service_exposure, which
 // reports whether a Service (or every Service in a namespace) is reachable
 // from outside the cluster, and by what mechanism -- a Service of type
 // LoadBalancer/NodePort directly, or a networking.k8s.io/v1 Ingress or
-// Gateway API HTTPRoute naming it as a backend. See core/pkg/exposure for
+// Gateway API HTTPRoute/GRPCRoute naming it as a backend. See core/pkg/exposure for
 // the matching model and its documented trust model (existence of an
 // exposing object is treated as intent, the same way this repo's
 // NetworkPolicy reachability engine treats a NetworkPolicy's existence).
 func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 	tool := mcp.NewTool(
 		"analyze_service_exposure",
-		mcp.WithDescription("Determine whether a Service (or every Service in a namespace, if service_name is omitted) is reachable from outside the cluster, and by what mechanism: the Service itself being type LoadBalancer or NodePort, spec.externalIPs being set, a networking.k8s.io/v1 Ingress naming it as a backend, or a Gateway API HTTPRoute naming it as a backend through an attached Gateway. Existence of an exposing object is treated as intent to expose -- this does not verify an Ingress controller or Gateway implementation is actually running. Each Service's result carries an 'unclear' note when a cross-namespace HTTPRoute backendRef (ReferenceGrant-authorized cross-namespace references are not modeled) names it, since in that case an empty paths list is not a confirmed all-clear."),
+		mcp.WithDescription("Determine whether a Service (or every Service in a namespace, if service_name is omitted) is reachable from outside the cluster, and by what mechanism: the Service itself being type LoadBalancer or NodePort, spec.externalIPs being set, a networking.k8s.io/v1 Ingress naming it as a backend, or a Gateway API HTTPRoute or GRPCRoute naming it as a backend through an attached Gateway. Existence of an exposing object is treated as intent to expose -- this does not verify an Ingress controller or Gateway implementation is actually running. Each Service's result carries an 'unclear' note when a cross-namespace HTTPRoute/GRPCRoute backendRef (ReferenceGrant-authorized cross-namespace references are not modeled) names it, since in that case an empty paths list is not a confirmed all-clear."),
 		mcp.WithString("namespace", mcp.Required(), mcp.Description("Namespace to analyze")),
 		mcp.WithString("service_name", mcp.Description("Name of a specific Service to check (optional; omit to report on every Service in the namespace)")),
 	)
@@ -84,10 +90,10 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 
 		// The Gateway API CRDs may not be installed on this cluster at all;
 		// that is not a tool error, just an empty set of routes/gateways --
-		// every service simply reports no ExposureHTTPRoute paths.
+		// every service simply reports no route paths.
 		//
-		// HTTPRoutes are listed cluster-wide, not scoped to namespace, same as
-		// Gateways below: a Service is exposed via any HTTPRoute naming it as
+		// Routes are listed cluster-wide, not scoped to namespace, same as
+		// Gateways below: a Service is exposed via any route naming it as
 		// a backend, including one that lives in another namespace and
 		// reaches in via a ReferenceGrant this package doesn't evaluate.
 		// Index.ServiceExposure still only builds an actual ExposurePath from
@@ -97,32 +103,36 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		// the other -- collecting only the queried namespace would make that
 		// signal silently unreachable.
 		gatewayResources := map[string]workloadinterface.IMetadata{}
-		routeList, routeErr := dynClient.Resource(httpRouteGVR).List(ctx, metav1.ListOptions{})
-		if routeErr != nil && !isMissingAPIErr(routeErr) {
+		routeList, routeErr := listGatewayKind(ctx, dynClient, httpRouteGVR, httpRouteGVRv1beta1)
+		if routeErr != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to list HTTPRoute objects: %v", routeErr)), nil
 		}
-		if routeErr == nil {
-			for i := range routeList.Items {
-				w := workloadinterface.NewWorkloadObj(routeList.Items[i].Object)
-				gatewayResources[w.GetID()] = w
-			}
+		for i := range routeList.Items {
+			w := workloadinterface.NewWorkloadObj(routeList.Items[i].Object)
+			gatewayResources[w.GetID()] = w
+		}
+		grpcRouteList, grpcRouteErr := listGatewayKind(ctx, dynClient, grpcRouteGVR, grpcRouteGVRv1beta1)
+		if grpcRouteErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to list GRPCRoute objects: %v", grpcRouteErr)), nil
+		}
+		for i := range grpcRouteList.Items {
+			w := workloadinterface.NewWorkloadObj(grpcRouteList.Items[i].Object)
+			gatewayResources[w.GetID()] = w
 		}
 		// Gateways are listed cluster-wide, not scoped to namespace: the
 		// dominant real-world topology puts the Gateway in an infra
-		// namespace (e.g. istio-system) with an HTTPRoute in an app
+		// namespace (e.g. istio-system) with a route in an app
 		// namespace referencing it cross-namespace via parentRefs, and
 		// AllowedRoutes deciding whether that attachment is admitted.
 		// Scoping this list to namespace would make every such Gateway
 		// invisible to idx.routeAttachesToAGateway.
-		gwList, gwErr := dynClient.Resource(gatewayGVR).List(ctx, metav1.ListOptions{})
-		if gwErr != nil && !isMissingAPIErr(gwErr) {
+		gwList, gwErr := listGatewayKind(ctx, dynClient, gatewayGVR, gatewayGVRv1beta1)
+		if gwErr != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to list Gateway objects: %v", gwErr)), nil
 		}
-		if gwErr == nil {
-			for i := range gwList.Items {
-				w := workloadinterface.NewWorkloadObj(gwList.Items[i].Object)
-				gatewayResources[w.GetID()] = w
-			}
+		for i := range gwList.Items {
+			w := workloadinterface.NewWorkloadObj(gwList.Items[i].Object)
+			gatewayResources[w.GetID()] = w
 		}
 		httpRoutes, gateways, gwDecodeErrs := exposure.FromUnstructuredGatewayAPI(gatewayResources)
 		decodeErrs = append(decodeErrs, gwDecodeErrs...)
@@ -143,7 +153,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 			paths, unclear := idx.ServiceExposure(exposure.ServiceRef{Namespace: namespace, Name: name})
 			finding := map[string]any{"paths": buildExposurePathSummaries(paths)}
 			if unclear {
-				finding["unclear"] = "a cross-namespace Gateway API HTTPRoute backendRef references this Service; whether it is authorized by a ReferenceGrant is not modeled, so an empty paths here is not a confirmed all-clear"
+				finding["unclear"] = "a cross-namespace Gateway API HTTPRoute/GRPCRoute backendRef references this Service; whether it is authorized by a ReferenceGrant is not modeled, so an empty paths here is not a confirmed all-clear"
 			}
 			findings[name] = finding
 		}
@@ -166,6 +176,30 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})
+}
+
+// listGatewayKind lists a Gateway API kind trying its candidate versions
+// in order (v1, then v1beta1 for clusters whose CRDs predate the kind's
+// graduation to v1) and returning the first list the API server actually
+// serves. Only a missing-API response moves the attempt to the next
+// candidate -- a genuine list failure (RBAC, connectivity) is returned
+// as-is rather than silently degrading. When no candidate is served at
+// all, an empty list is returned: that is the "CRDs not installed" case,
+// not an error. The decoded objects' spec shape is identical across
+// versions, so callers stay version-blind.
+func listGatewayKind(ctx context.Context, dynClient dynamic.Interface, candidates ...schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
+	for _, gvr := range candidates {
+		list, err := dynClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+		if err == nil {
+			return list, nil
+		}
+		if !isMissingAPIErr(err) {
+			return nil, err
+		}
+	}
+	// No candidate is served: the CRDs are not installed, which is the
+	// "nothing collected" case, not an error.
+	return &unstructured.UnstructuredList{}, nil
 }
 
 // isMissingAPIErr reports whether err indicates the API group/resource

--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -21,7 +21,12 @@ var ingressGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version
 var httpRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
 var httpRouteGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "httproutes"}
 var grpcRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes"}
-var grpcRouteGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "grpcroutes"}
+
+// grpcRouteGVRv1alpha2 is the legacy GRPCRoute candidate: upstream served
+// GRPCRoute as v1alpha2 through Gateway API v1.0 and promoted it directly
+// to v1 in v1.1 -- no v1beta1 GRPCRoute ever existed. HTTPRoute and Gateway
+// did serve as v1beta1 pre-v1, so their v1beta1 candidates stay.
+var grpcRouteGVRv1alpha2 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "grpcroutes"}
 var gatewayGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
 var gatewayGVRv1beta1 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "gateways"}
 
@@ -111,7 +116,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 			w := workloadinterface.NewWorkloadObj(routeList.Items[i].Object)
 			gatewayResources[w.GetID()] = w
 		}
-		grpcRouteList, grpcRouteErr := listGatewayKind(ctx, dynClient, grpcRouteGVR, grpcRouteGVRv1beta1)
+		grpcRouteList, grpcRouteErr := listGatewayKind(ctx, dynClient, grpcRouteGVR, grpcRouteGVRv1alpha2)
 		if grpcRouteErr != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to list GRPCRoute objects: %v", grpcRouteErr)), nil
 		}

--- a/cmd/mcpserver/service_exposure_test.go
+++ b/cmd/mcpserver/service_exposure_test.go
@@ -28,11 +28,15 @@ import (
 func newServiceExposureTestServer(t *testing.T, objects ...runtime.Object) *KubescapeMcpserver {
 	t.Helper()
 	listKinds := map[schema.GroupVersionResource]string{
-		serviceGVR:   "ServiceList",
-		ingressGVR:   "IngressList",
-		namespaceGVR: "NamespaceList",
-		httpRouteGVR: "HTTPRouteList",
-		gatewayGVR:   "GatewayList",
+		serviceGVR:          "ServiceList",
+		ingressGVR:          "IngressList",
+		namespaceGVR:        "NamespaceList",
+		httpRouteGVR:        "HTTPRouteList",
+		grpcRouteGVR:        "GRPCRouteList",
+		gatewayGVR:          "GatewayList",
+		httpRouteGVRv1beta1: "HTTPRouteList",
+		grpcRouteGVRv1beta1: "GRPCRouteList",
+		gatewayGVRv1beta1:   "GatewayList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
 
@@ -253,6 +257,106 @@ func TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService(t *testing
 	paths := findingPaths(t, services, "app")
 	require.Len(t, paths, 1)
 	require.Equal(t, "HTTPRoute", paths[0].(map[string]any)["kind"])
+}
+
+// TestAnalyzeServiceExposure_GRPCRouteThroughGatewayExposesService covers
+// the same topology as the HTTPRoute test above, but with a GRPCRoute --
+// the core Gateway API kind Envoy Gateway (and similar gRPC-first
+// deployments) use for their ingress paths. GRPCRoute carries the same
+// parentRefs/hostnames/backendRefs shape as HTTPRoute, so a Service whose
+// only ingress path is a GRPCRoute must report an ExposureGRPCRoute path,
+// not a confident "not exposed".
+func TestAnalyzeServiceExposure_GRPCRouteThroughGatewayExposesService(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "GRPCRoute",
+		"metadata":   map[string]any{"name": "grpc-route", "namespace": "prod"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}}},
+		},
+	}}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "prod"},
+		"spec":       map[string]any{"listeners": []any{map[string]any{"name": "grpc"}}},
+	}}
+	ksServer := newServiceExposureTestServer(t, svc, route)
+
+	// See TestAnalyzeServiceExposure_HTTPRouteThroughGatewayExposesService for
+	// why the Gateway is added via an explicit Create against the real GVR.
+	dyn := ksServer.k8sClient.DynamicClient
+	_, err := dyn.Resource(gatewayGVR).Namespace("prod").Create(context.Background(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := findingPaths(t, services, "app")
+	require.Len(t, paths, 1, "a Service exposed only via a GRPCRoute must not be reported as not exposed")
+	require.Equal(t, "GRPCRoute", paths[0].(map[string]any)["kind"])
+}
+
+// TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks covers
+// the fallback: clusters whose Gateway API CRDs predate GRPCRoute's v1
+// graduation (Gateway API v1.1) serve it as v1beta1 only. The v1 list
+// returns NotFound, the v1beta1 candidate serves the route, and the
+// exposure analysis must still find it.
+func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing.T) {
+	svc := unstructuredService("prod", "app", "ClusterIP")
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "gw", "namespace": "prod"},
+		"spec":       map[string]any{"listeners": []any{map[string]any{"name": "grpc"}}},
+	}}
+	ksServer := newServiceExposureTestServer(t, svc)
+
+	// Serve grpcroutes only under v1beta1: the reactor 404s the v1 list
+	// attempt (a real cluster without a v1 grpcroutes CRD) and falls through
+	// for v1beta1, which the fake client serves from its registered list
+	// kind.
+	dyn := ksServer.k8sClient.DynamicClient.(*dynamicfake.FakeDynamicClient)
+	dyn.PrependReactor("list", "grpcroutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Version == "v1" {
+			return true, nil, apierrors.NewNotFound(grpcRouteGVR.GroupResource(), "")
+		}
+		return false, nil, nil
+	})
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1beta1",
+		"kind":       "GRPCRoute",
+		"metadata":   map[string]any{"name": "grpc-route", "namespace": "prod"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}}},
+		},
+	}}
+	_, err := dyn.Resource(grpcRouteGVRv1beta1).Namespace("prod").Create(context.Background(), route, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = dyn.Resource(gatewayGVR).Namespace("prod").Create(context.Background(), gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_service_exposure", map[string]any{
+		"namespace":    "prod",
+		"service_name": "app",
+	}))
+	require.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
+	services := parsed["services"].(map[string]any)
+	paths := findingPaths(t, services, "app")
+	require.Len(t, paths, 1, "a v1beta1-only GRPCRoute must still be found via the fallback")
+	require.Equal(t, "GRPCRoute", paths[0].(map[string]any)["kind"])
 }
 
 // TestAnalyzeServiceExposure_CrossNamespaceGatewayWithAllowedRoutesFromAllExposesService

--- a/cmd/mcpserver/service_exposure_test.go
+++ b/cmd/mcpserver/service_exposure_test.go
@@ -28,15 +28,15 @@ import (
 func newServiceExposureTestServer(t *testing.T, objects ...runtime.Object) *KubescapeMcpserver {
 	t.Helper()
 	listKinds := map[schema.GroupVersionResource]string{
-		serviceGVR:          "ServiceList",
-		ingressGVR:          "IngressList",
-		namespaceGVR:        "NamespaceList",
-		httpRouteGVR:        "HTTPRouteList",
-		grpcRouteGVR:        "GRPCRouteList",
-		gatewayGVR:          "GatewayList",
-		httpRouteGVRv1beta1: "HTTPRouteList",
-		grpcRouteGVRv1beta1: "GRPCRouteList",
-		gatewayGVRv1beta1:   "GatewayList",
+		serviceGVR:           "ServiceList",
+		ingressGVR:           "IngressList",
+		namespaceGVR:         "NamespaceList",
+		httpRouteGVR:         "HTTPRouteList",
+		grpcRouteGVR:         "GRPCRouteList",
+		gatewayGVR:           "GatewayList",
+		httpRouteGVRv1beta1:  "HTTPRouteList",
+		grpcRouteGVRv1alpha2: "GRPCRouteList",
+		gatewayGVRv1beta1:    "GatewayList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
 
@@ -305,12 +305,13 @@ func TestAnalyzeServiceExposure_GRPCRouteThroughGatewayExposesService(t *testing
 	require.Equal(t, "GRPCRoute", paths[0].(map[string]any)["kind"])
 }
 
-// TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks covers
-// the fallback: clusters whose Gateway API CRDs predate GRPCRoute's v1
-// graduation (Gateway API v1.1) serve it as v1beta1 only. The v1 list
-// returns NotFound, the v1beta1 candidate serves the route, and the
-// exposure analysis must still find it.
-func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing.T) {
+// TestAnalyzeServiceExposure_GRPCRouteV1alpha2OnlyClusterStillWorks covers
+// the fallback against the actual legacy version: upstream served GRPCRoute
+// as v1alpha2 through Gateway API v1.0 and promoted it directly to v1 in
+// v1.1 -- no v1beta1 GRPCRoute ever existed. A cluster with a v1alpha2-only
+// grpcroutes CRD 404s the v1 list attempt, and the v1alpha1 candidate must
+// still surface the exposure path.
+func TestAnalyzeServiceExposure_GRPCRouteV1alpha2OnlyClusterStillWorks(t *testing.T) {
 	svc := unstructuredService("prod", "app", "ClusterIP")
 	gw := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "gateway.networking.k8s.io/v1",
@@ -320,10 +321,10 @@ func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing
 	}}
 	ksServer := newServiceExposureTestServer(t, svc)
 
-	// Serve grpcroutes only under v1beta1: the reactor 404s the v1 list
-	// attempt (a real cluster without a v1 grpcroutes CRD) and falls through
-	// for v1beta1, which the fake client serves from its registered list
-	// kind.
+	// Serve grpcroutes only under v1alpha2: the reactor 404s the v1 list
+	// attempt (a real cluster whose grpcroutes CRD predates the v1
+	// graduation) and falls through for v1alpha2, which the fake client
+	// serves from its registered list kind.
 	dyn := ksServer.k8sClient.DynamicClient.(*dynamicfake.FakeDynamicClient)
 	dyn.PrependReactor("list", "grpcroutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.GetResource().Version == "v1" {
@@ -332,7 +333,7 @@ func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing
 		return false, nil, nil
 	})
 	route := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "gateway.networking.k8s.io/v1beta1",
+		"apiVersion": "gateway.networking.k8s.io/v1alpha2",
 		"kind":       "GRPCRoute",
 		"metadata":   map[string]any{"name": "grpc-route", "namespace": "prod"},
 		"spec": map[string]any{
@@ -340,7 +341,7 @@ func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing
 			"rules":      []any{map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}}},
 		},
 	}}
-	_, err := dyn.Resource(grpcRouteGVRv1beta1).Namespace("prod").Create(context.Background(), route, metav1.CreateOptions{})
+	_, err := dyn.Resource(grpcRouteGVRv1alpha2).Namespace("prod").Create(context.Background(), route, metav1.CreateOptions{})
 	require.NoError(t, err)
 	_, err = dyn.Resource(gatewayGVR).Namespace("prod").Create(context.Background(), gw, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -355,7 +356,7 @@ func TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks(t *testing
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	services := parsed["services"].(map[string]any)
 	paths := findingPaths(t, services, "app")
-	require.Len(t, paths, 1, "a v1beta1-only GRPCRoute must still be found via the fallback")
+	require.Len(t, paths, 1, "a v1alpha2-only GRPCRoute must still be found via the fallback")
 	require.Equal(t, "GRPCRoute", paths[0].(map[string]any)["kind"])
 }
 

--- a/core/pkg/exposure/adapter.go
+++ b/core/pkg/exposure/adapter.go
@@ -49,26 +49,27 @@ func FromResources(resources map[string]workloadinterface.IMetadata) (services [
 	return services, ingresses, namespaces, errs
 }
 
-// FromUnstructuredGatewayAPI decodes Gateway API HTTPRoute and Gateway
-// objects from their generic unstructured representation. Kept separate
-// from FromResources because these two kinds are not part of kubescape's
-// generic scanned-resource set on every cluster (the Gateway API CRDs may
-// not even be installed) and have no typed Go representation this repo
-// already vendors to decode into. A malformed object of either kind is
-// skipped, with its error appended to errs, same as FromResources.
-func FromUnstructuredGatewayAPI(resources map[string]workloadinterface.IMetadata) (httpRoutes []httpRoute, gateways []gateway, errs []error) {
+// FromUnstructuredGatewayAPI decodes Gateway API route (HTTPRoute,
+// GRPCRoute) and Gateway objects from their generic unstructured
+// representation. Kept separate from FromResources because these kinds are
+// not part of kubescape's generic scanned-resource set on every cluster
+// (the Gateway API CRDs may not even be installed) and have no typed Go
+// representation this repo already vendors to decode into. A malformed
+// object of any of these kinds is skipped, with its error appended to
+// errs, same as FromResources.
+func FromUnstructuredGatewayAPI(resources map[string]workloadinterface.IMetadata) (routes []gatewayRoute, gateways []gateway, errs []error) {
 	for _, resource := range resources {
 		if resource == nil {
 			continue
 		}
 		switch resource.GetKind() {
-		case "HTTPRoute":
-			r, err := decodeHTTPRoute(resource.GetObject())
+		case "HTTPRoute", "GRPCRoute":
+			r, err := decodeGatewayRoute(resource.GetKind(), resource.GetObject())
 			if err != nil {
 				errs = append(errs, fmt.Errorf("resource %s: %w", resource.GetID(), err))
 				continue
 			}
-			httpRoutes = append(httpRoutes, r)
+			routes = append(routes, r)
 		case "Gateway":
 			g, err := decodeGateway(resource.GetObject())
 			if err != nil {
@@ -78,7 +79,7 @@ func FromUnstructuredGatewayAPI(resources map[string]workloadinterface.IMetadata
 			gateways = append(gateways, g)
 		}
 	}
-	return httpRoutes, gateways, errs
+	return routes, gateways, errs
 }
 
 // decode converts an unstructured object's generic map into its typed shape
@@ -96,18 +97,19 @@ func decode(obj map[string]any, out any) error {
 	return nil
 }
 
-// gatewayAPIWireShape mirrors just the fields this package reads from an
-// HTTPRoute or Gateway's spec, in their real Gateway API JSON shape
-// (camelCase, pointer-optional fields), separate from this package's own
-// internal httpRoute/gateway types so a JSON round-trip can populate it
-// directly without custom unmarshaling.
+// gatewayAPIWireShape mirrors just the fields this package reads from a
+// Gateway API route (HTTPRoute, GRPCRoute) or Gateway's spec, in their
+// real Gateway API JSON shape (camelCase, pointer-optional fields),
+// separate from this package's own internal gatewayRoute/gateway types so
+// a JSON round-trip can populate it directly without custom unmarshaling.
+// The route spec fields are identical between HTTPRoute and GRPCRoute.
 type gatewayAPIWireShape struct {
 	Metadata struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	} `json:"metadata"`
 	Spec struct {
-		// HTTPRoute fields.
+		// Route fields (HTTPRoute and GRPCRoute share this shape).
 		ParentRefs []struct {
 			Namespace *string `json:"namespace,omitempty"`
 			Name      string  `json:"name"`
@@ -139,13 +141,17 @@ type gatewayAPIWireShape struct {
 // blob into that type rather than duplicating its field shape here too.
 type unstructuredRawJSON map[string]any
 
-func decodeHTTPRoute(obj map[string]any) (httpRoute, error) {
+// decodeGatewayRoute decodes an HTTPRoute or GRPCRoute. The spec fields
+// this package reads are identical between the two kinds, so only the
+// kind attribution differs.
+func decodeGatewayRoute(kind string, obj map[string]any) (gatewayRoute, error) {
 	var wire gatewayAPIWireShape
 	if err := decode(obj, &wire); err != nil {
-		return httpRoute{}, err
+		return gatewayRoute{}, err
 	}
 
-	r := httpRoute{
+	r := gatewayRoute{
+		Kind:      kind,
 		Namespace: wire.Metadata.Namespace,
 		Name:      wire.Metadata.Name,
 		Hostnames: wire.Spec.Hostnames,
@@ -158,7 +164,7 @@ func decodeHTTPRoute(obj map[string]any) (httpRoute, error) {
 		for _, b := range rule.BackendRefs {
 			backends = append(backends, backendRef{Namespace: b.Namespace, Name: b.Name})
 		}
-		r.Rules = append(r.Rules, httpRouteRule{BackendRefs: backends})
+		r.Rules = append(r.Rules, gatewayRouteRule{BackendRefs: backends})
 	}
 	return r, nil
 }

--- a/core/pkg/exposure/adapter.go
+++ b/core/pkg/exposure/adapter.go
@@ -111,10 +111,11 @@ type gatewayAPIWireShape struct {
 	Spec struct {
 		// Route fields (HTTPRoute and GRPCRoute share this shape).
 		ParentRefs []struct {
-			Group     *string `json:"group,omitempty"`
-			Kind      *string `json:"kind,omitempty"`
-			Namespace *string `json:"namespace,omitempty"`
-			Name      string  `json:"name"`
+			Group       *string `json:"group,omitempty"`
+			Kind        *string `json:"kind,omitempty"`
+			Namespace   *string `json:"namespace,omitempty"`
+			Name        string  `json:"name"`
+			SectionName *string `json:"sectionName,omitempty"`
 		} `json:"parentRefs,omitempty"`
 		Hostnames []string `json:"hostnames,omitempty"`
 		Rules     []struct {
@@ -165,7 +166,7 @@ func decodeGatewayRoute(kind string, obj map[string]any) (gatewayRoute, error) {
 		Hostnames: wire.Spec.Hostnames,
 	}
 	for _, p := range wire.Spec.ParentRefs {
-		r.ParentRefs = append(r.ParentRefs, parentRef{Group: p.Group, Kind: p.Kind, Namespace: p.Namespace, Name: p.Name})
+		r.ParentRefs = append(r.ParentRefs, parentRef{Group: p.Group, Kind: p.Kind, Namespace: p.Namespace, Name: p.Name, SectionName: p.SectionName})
 	}
 	for _, rule := range wire.Spec.Rules {
 		var backends []backendRef

--- a/core/pkg/exposure/adapter.go
+++ b/core/pkg/exposure/adapter.go
@@ -111,12 +111,16 @@ type gatewayAPIWireShape struct {
 	Spec struct {
 		// Route fields (HTTPRoute and GRPCRoute share this shape).
 		ParentRefs []struct {
+			Group     *string `json:"group,omitempty"`
+			Kind      *string `json:"kind,omitempty"`
 			Namespace *string `json:"namespace,omitempty"`
 			Name      string  `json:"name"`
 		} `json:"parentRefs,omitempty"`
 		Hostnames []string `json:"hostnames,omitempty"`
 		Rules     []struct {
 			BackendRefs []struct {
+				Group     *string `json:"group,omitempty"`
+				Kind      *string `json:"kind,omitempty"`
 				Namespace *string `json:"namespace,omitempty"`
 				Name      string  `json:"name"`
 			} `json:"backendRefs,omitempty"`
@@ -130,6 +134,10 @@ type gatewayAPIWireShape struct {
 					From     *string              `json:"from,omitempty"`
 					Selector *unstructuredRawJSON `json:"selector,omitempty"`
 				} `json:"namespaces,omitempty"`
+				Kinds []struct {
+					Group *string `json:"group,omitempty"`
+					Kind  string  `json:"kind"`
+				} `json:"kinds,omitempty"`
 			} `json:"allowedRoutes,omitempty"`
 		} `json:"listeners,omitempty"`
 	} `json:"spec"`
@@ -157,12 +165,12 @@ func decodeGatewayRoute(kind string, obj map[string]any) (gatewayRoute, error) {
 		Hostnames: wire.Spec.Hostnames,
 	}
 	for _, p := range wire.Spec.ParentRefs {
-		r.ParentRefs = append(r.ParentRefs, parentRef{Namespace: p.Namespace, Name: p.Name})
+		r.ParentRefs = append(r.ParentRefs, parentRef{Group: p.Group, Kind: p.Kind, Namespace: p.Namespace, Name: p.Name})
 	}
 	for _, rule := range wire.Spec.Rules {
 		var backends []backendRef
 		for _, b := range rule.BackendRefs {
-			backends = append(backends, backendRef{Namespace: b.Namespace, Name: b.Name})
+			backends = append(backends, backendRef{Group: b.Group, Kind: b.Kind, Namespace: b.Namespace, Name: b.Name})
 		}
 		r.Rules = append(r.Rules, gatewayRouteRule{BackendRefs: backends})
 	}
@@ -194,6 +202,9 @@ func decodeGateway(obj map[string]any) (gateway, error) {
 					rn.Selector = sel
 				}
 				ar.Namespaces = rn
+			}
+			for _, k := range l.AllowedRoutes.Kinds {
+				ar.Kinds = append(ar.Kinds, routeGroupKind{Group: k.Group, Kind: k.Kind})
 			}
 			out.AllowedRoutes = ar
 		}

--- a/core/pkg/exposure/adapter_test.go
+++ b/core/pkg/exposure/adapter_test.go
@@ -128,15 +128,15 @@ func TestFromUnstructuredGatewayAPI_DecodesHTTPRouteAndGateway(t *testing.T) {
 		gw.GetID():    gw,
 	}
 
-	httpRoutes, gateways, errs := FromUnstructuredGatewayAPI(resources)
+	routes, gateways, errs := FromUnstructuredGatewayAPI(resources)
 
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
-	if len(httpRoutes) != 1 {
-		t.Fatalf("httpRoutes = %+v, want one", httpRoutes)
+	if len(routes) != 1 {
+		t.Fatalf("routes = %+v, want one", routes)
 	}
-	r := httpRoutes[0]
+	r := routes[0]
 	if r.Namespace != "ns" || r.Name != "route" || len(r.ParentRefs) != 1 || r.ParentRefs[0].Name != "gw" {
 		t.Errorf("route decoded incorrectly: %+v", r)
 	}
@@ -171,9 +171,52 @@ func TestFromUnstructuredGatewayAPI_IgnoresOtherKinds(t *testing.T) {
 	})
 	resources := map[string]workloadinterface.IMetadata{pod.GetID(): pod}
 
-	httpRoutes, gateways, errs := FromUnstructuredGatewayAPI(resources)
-	if len(httpRoutes) != 0 || len(gateways) != 0 || len(errs) != 0 {
-		t.Errorf("httpRoutes=%v gateways=%v errs=%v, want all empty", httpRoutes, gateways, errs)
+	routes, gateways, errs := FromUnstructuredGatewayAPI(resources)
+	if len(routes) != 0 || len(gateways) != 0 || len(errs) != 0 {
+		t.Errorf("routes=%v gateways=%v errs=%v, want all empty", routes, gateways, errs)
+	}
+}
+
+// TestFromUnstructuredGatewayAPI_DecodesGRPCRoute verifies GRPCRoute is
+// decoded through the same route model as HTTPRoute, with the kind
+// attributed so exposure paths can be labeled GRPCRoute.
+func TestFromUnstructuredGatewayAPI_DecodesGRPCRoute(t *testing.T) {
+	route := unstructuredResource(map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "GRPCRoute",
+		"metadata":   map[string]any{"name": "grpc-route", "namespace": "ns"},
+		"spec": map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"hostnames":  []any{"grpc.example.com"},
+			"rules": []any{
+				map[string]any{"backendRefs": []any{map[string]any{"name": "app"}}},
+			},
+		},
+	})
+
+	routes, gateways, errs := FromUnstructuredGatewayAPI(map[string]workloadinterface.IMetadata{route.GetID(): route})
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(gateways) != 0 {
+		t.Errorf("gateways = %+v, want none", gateways)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes = %+v, want one", routes)
+	}
+	r := routes[0]
+	if r.Kind != "GRPCRoute" {
+		t.Errorf("Kind = %q, want GRPCRoute", r.Kind)
+	}
+	if r.Namespace != "ns" || r.Name != "grpc-route" || len(r.ParentRefs) != 1 || r.ParentRefs[0].Name != "gw" {
+		t.Errorf("route decoded incorrectly: %+v", r)
+	}
+	if len(r.Hostnames) != 1 || r.Hostnames[0] != "grpc.example.com" {
+		t.Errorf("hostnames decoded incorrectly: %v", r.Hostnames)
+	}
+	if len(r.Rules) != 1 || len(r.Rules[0].BackendRefs) != 1 || r.Rules[0].BackendRefs[0].Name != "app" {
+		t.Errorf("backendRefs decoded incorrectly: %+v", r.Rules)
 	}
 }
 
@@ -197,9 +240,9 @@ func TestFromUnstructuredGatewayAPI_MalformedHTTPRouteIsSkippedNotFatal(t *testi
 		bad.GetID():  bad,
 	}
 
-	httpRoutes, _, errs := FromUnstructuredGatewayAPI(resources)
-	if len(httpRoutes) != 1 || httpRoutes[0].Name != "good" {
-		t.Fatalf("expected the well-formed HTTPRoute to still decode, got %+v", httpRoutes)
+	routes, _, errs := FromUnstructuredGatewayAPI(resources)
+	if len(routes) != 1 || routes[0].Name != "good" {
+		t.Fatalf("expected the well-formed HTTPRoute to still decode, got %+v", routes)
 	}
 	if len(errs) != 1 {
 		t.Fatalf("expected exactly one decode error, got %d: %v", len(errs), errs)

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -9,13 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// Index indexes a cluster's Service, Ingress, HTTPRoute, Gateway, and
-// Namespace objects for repeated exposure queries against the same
-// snapshot.
+// Index indexes a cluster's Service, Ingress, Gateway API route
+// (HTTPRoute/GRPCRoute), Gateway, and Namespace objects for repeated
+// exposure queries against the same snapshot.
 type Index struct {
 	services         map[ServiceRef]*corev1.Service
 	ingressesByNS    map[string][]*networkingv1.Ingress
-	httpRoutesByNS   map[string][]*httpRoute
+	routesByNS       map[string][]*gatewayRoute
 	gateways         map[ServiceRef]*gateway // keyed the same shape as ServiceRef: namespace+name
 	namespacesByName map[string]NamespaceInfo
 }
@@ -23,13 +23,13 @@ type Index struct {
 // NewIndex builds an Index from a cluster's (or a query's) collected
 // objects. A nil slice for any parameter is treated as "none collected,"
 // not an error -- a cluster without the Gateway API installed simply has no
-// httpRoutes/gateways to pass, and every query still works, just without
+// routes/gateways to pass, and every query still works, just without
 // that exposure mechanism ever matching.
-func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, httpRoutes []httpRoute, gateways []gateway, namespaces []NamespaceInfo) *Index {
+func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, routes []gatewayRoute, gateways []gateway, namespaces []NamespaceInfo) *Index {
 	idx := &Index{
 		services:         make(map[ServiceRef]*corev1.Service, len(services)),
 		ingressesByNS:    make(map[string][]*networkingv1.Ingress),
-		httpRoutesByNS:   make(map[string][]*httpRoute),
+		routesByNS:       make(map[string][]*gatewayRoute),
 		gateways:         make(map[ServiceRef]*gateway, len(gateways)),
 		namespacesByName: make(map[string]NamespaceInfo, len(namespaces)),
 	}
@@ -42,9 +42,9 @@ func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, httpR
 		ing := &ingresses[i]
 		idx.ingressesByNS[ing.Namespace] = append(idx.ingressesByNS[ing.Namespace], ing)
 	}
-	for i := range httpRoutes {
-		r := &httpRoutes[i]
-		idx.httpRoutesByNS[r.Namespace] = append(idx.httpRoutesByNS[r.Namespace], r)
+	for i := range routes {
+		r := &routes[i]
+		idx.routesByNS[r.Namespace] = append(idx.routesByNS[r.Namespace], r)
 	}
 	for i := range gateways {
 		g := &gateways[i]
@@ -64,7 +64,7 @@ func NewIndex(services []corev1.Service, ingresses []networkingv1.Ingress, httpR
 // exposes the Service -- it is only reachable from inside the cluster (or
 // not collected/does not exist at all, which this function cannot tell
 // apart from "exists but not exposed"). unclear=true means paths must NOT
-// be read as a confirmed all-clear: a cross-namespace HTTPRoute backendRef
+// be read as a confirmed all-clear: a cross-namespace route backendRef
 // names this Service, and whether that reference is authorized (via a
 // ReferenceGrant this package does not collect or evaluate -- see the
 // package doc comment) is genuinely unknown.
@@ -88,27 +88,39 @@ func (idx *Index) ServiceExposure(ref ServiceRef) (paths []ExposurePath, unclear
 		paths = append(paths, ingressPathsFor(ing, ref.Name)...)
 	}
 
-	for _, route := range idx.httpRoutesByNS[ref.Namespace] {
+	for _, route := range idx.routesByNS[ref.Namespace] {
 		if !idx.routeAttachesToAGateway(route) {
 			continue
 		}
-		if !httpRouteReferencesService(route, ref) {
+		if !routeReferencesService(route, ref) {
 			continue
 		}
 		source := fmt.Sprintf("%s/%s", route.Namespace, route.Name)
 		if len(route.Hostnames) == 0 {
-			paths = append(paths, ExposurePath{Kind: ExposureHTTPRoute, Source: source})
+			paths = append(paths, ExposurePath{Kind: routeExposureKind(route.Kind), Source: source})
 			continue
 		}
 		for _, host := range route.Hostnames {
-			paths = append(paths, ExposurePath{Kind: ExposureHTTPRoute, Source: source, Host: host})
+			paths = append(paths, ExposurePath{Kind: routeExposureKind(route.Kind), Source: source, Host: host})
 		}
 	}
 
 	return paths, idx.crossNamespaceBackendRefIsUnmodeled(ref)
 }
 
-// crossNamespaceBackendRefIsUnmodeled reports whether some HTTPRoute this
+// routeExposureKind maps a Gateway API route kind to the ExposureKind that
+// attributes its paths. Unrecognized kinds (possible only if a future
+// Gateway API route kind is decoded before this mapping learns it) fall
+// back to ExposureHTTPRoute, keeping the conservative-report-a-path
+// posture of the rest of the package.
+func routeExposureKind(routeKind string) ExposureKind {
+	if routeKind == "GRPCRoute" {
+		return ExposureGRPCRoute
+	}
+	return ExposureHTTPRoute
+}
+
+// crossNamespaceBackendRefIsUnmodeled reports whether some route this
 // Index was given, living outside ref's namespace and admitted by at least
 // one Gateway, explicitly names ref as a backend via backendRef.namespace.
 // That is a real, working, externally-reachable path when a matching
@@ -116,7 +128,7 @@ func (idx *Index) ServiceExposure(ref ServiceRef) (paths []ExposurePath, unclear
 // does not collect or evaluate (see the package doc comment) -- so its
 // presence must not be silently folded into a confirmed "not exposed".
 func (idx *Index) crossNamespaceBackendRefIsUnmodeled(ref ServiceRef) bool {
-	for ns, routes := range idx.httpRoutesByNS {
+	for ns, routes := range idx.routesByNS {
 		if ns == ref.Namespace {
 			continue
 		}
@@ -164,13 +176,13 @@ func backendNamesService(backend *networkingv1.IngressBackend, serviceName strin
 	return backend != nil && backend.Service != nil && backend.Service.Name == serviceName
 }
 
-// httpRouteReferencesService reports whether any rule in route sends
+// routeReferencesService reports whether any rule in route sends
 // traffic to ref. A backendRef with no Namespace defaults to the route's
 // own namespace, per Gateway API's own defaulting rules -- this package
 // does not model a backendRef reaching into another namespace via a
 // ReferenceGrant, since that requires collecting and evaluating a third
 // resource kind this Index is not given.
-func httpRouteReferencesService(route *httpRoute, ref ServiceRef) bool {
+func routeReferencesService(route *gatewayRoute, ref ServiceRef) bool {
 	for _, rule := range route.Rules {
 		for _, backend := range rule.BackendRefs {
 			ns := route.Namespace
@@ -198,7 +210,7 @@ func httpRouteReferencesService(route *httpRoute, ref ServiceRef) bool {
 // without RBAC to list it elsewhere) rather than not exist -- so it gets the
 // same conservative treatment rather than being silently treated as a
 // non-match.
-func (idx *Index) routeAttachesToAGateway(route *httpRoute) bool {
+func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 	for _, ref := range route.ParentRefs {
 		ns := route.Namespace
 		if ref.Namespace != nil {

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -138,6 +138,12 @@ func (idx *Index) crossNamespaceBackendRefIsUnmodeled(ref ServiceRef) bool {
 			}
 			for _, rule := range route.Rules {
 				for _, backend := range rule.BackendRefs {
+					// Only an effective core-Service backendRef names this
+					// Service; a non-Service backend sharing its name says
+					// nothing about its exposure.
+					if !isServiceBackendRef(backend) {
+						continue
+					}
 					if backend.Namespace != nil && *backend.Namespace == ref.Namespace && backend.Name == ref.Name {
 						return true
 					}
@@ -177,14 +183,20 @@ func backendNamesService(backend *networkingv1.IngressBackend, serviceName strin
 }
 
 // routeReferencesService reports whether any rule in route sends
-// traffic to ref. A backendRef with no Namespace defaults to the route's
-// own namespace, per Gateway API's own defaulting rules -- this package
-// does not model a backendRef reaching into another namespace via a
-// ReferenceGrant, since that requires collecting and evaluating a third
-// resource kind this Index is not given.
+// traffic to ref. Only effective core-Service backends count (per Gateway
+// API's group/kind defaults -- a backendRef naming another kind must not
+// produce a Service exposure path however closely its name matches). A
+// backendRef with no Namespace defaults to the route's own namespace, per
+// Gateway API's own defaulting rules -- this package does not model a
+// backendRef reaching into another namespace via a ReferenceGrant, since
+// that requires collecting and evaluating a third resource kind this Index
+// is not given.
 func routeReferencesService(route *gatewayRoute, ref ServiceRef) bool {
 	for _, rule := range route.Rules {
 		for _, backend := range rule.BackendRefs {
+			if !isServiceBackendRef(backend) {
+				continue
+			}
 			ns := route.Namespace
 			if backend.Namespace != nil {
 				ns = *backend.Namespace
@@ -197,21 +209,29 @@ func routeReferencesService(route *gatewayRoute, ref ServiceRef) bool {
 	return false
 }
 
-// routeAttachesToAGateway reports whether route is admitted by at least one
-// listener of a Gateway object this Index was given, via any of the
-// route's parentRefs. A listener whose AllowedRoutes cannot be confirmed to
-// exclude the route (a Selector needing namespace labels this Index was not
-// given) is conservatively treated as admitting it: this package errs
-// toward reporting a possible exposure rather than silently hiding one, the
-// same choice core/pkg/mapreconcile makes for its own indeterminate
-// matches. A parentRef naming a Gateway this Index has no record of at all
-// is the most indeterminate case there is -- the Gateway may simply live
-// outside what was collected (a cross-namespace reference, or a caller
-// without RBAC to list it elsewhere) rather than not exist -- so it gets the
-// same conservative treatment rather than being silently treated as a
+// routeAttachesToAGateway reports whether route is admitted by at least
+// one listener of a Gateway object this Index was given, via any of the
+// route's parentRefs. Only effective Gateway parents count (per Gateway
+// API's group/kind defaults -- a parentRef naming another kind must not
+// attach a route to a Gateway that merely shares its namespace/name), and
+// a listener must admit the route on BOTH axes: its AllowedRoutes
+// namespaces policy and its AllowedRoutes kinds policy. A listener whose
+// namespace admission cannot be confirmed to exclude the route (a Selector
+// needing namespace labels this Index was not given) is conservatively
+// treated as admitting it: this package errs toward reporting a possible
+// exposure rather than silently hiding one, the same choice
+// core/pkg/mapreconcile makes for its own indeterminate matches. A
+// parentRef naming a Gateway this Index has no record of at all is the
+// most indeterminate case there is -- the Gateway may simply live outside
+// what was collected (a cross-namespace reference, or a caller without
+// RBAC to list it elsewhere) rather than not exist -- so it gets the same
+// conservative treatment rather than being silently treated as a
 // non-match.
 func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 	for _, ref := range route.ParentRefs {
+		if !isGatewayParentRef(ref) {
+			continue
+		}
 		ns := route.Namespace
 		if ref.Namespace != nil {
 			ns = *ref.Namespace
@@ -221,6 +241,9 @@ func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 			return true
 		}
 		for _, l := range gw.Listeners {
+			if !idx.listenerAdmitsRouteKind(l, route.Kind) {
+				continue
+			}
 			admits, determinable := idx.gatewayAdmitsRouteNamespace(l, route.Namespace, gw.Namespace)
 			if admits || !determinable {
 				return true
@@ -228,6 +251,18 @@ func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 		}
 	}
 	return false
+}
+
+// listenerAdmitsRouteKind reports whether the listener's allowedRoutes
+// kinds list admits a route of the given kind. The kinds policy is always
+// determinable -- unlike the namespace policy it never depends on labels
+// this Index was not given. A listener with no allowedRoutes (or an empty
+// kinds list) admits every kind, per the Gateway API default.
+func (idx *Index) listenerAdmitsRouteKind(l listener, routeKind string) bool {
+	if l.AllowedRoutes == nil {
+		return true
+	}
+	return l.AllowedRoutes.admitsRouteKind(routeKind)
 }
 
 // gatewayAdmitsRouteNamespace evaluates one listener's AllowedRoutes against

--- a/core/pkg/exposure/index.go
+++ b/core/pkg/exposure/index.go
@@ -213,20 +213,23 @@ func routeReferencesService(route *gatewayRoute, ref ServiceRef) bool {
 // one listener of a Gateway object this Index was given, via any of the
 // route's parentRefs. Only effective Gateway parents count (per Gateway
 // API's group/kind defaults -- a parentRef naming another kind must not
-// attach a route to a Gateway that merely shares its namespace/name), and
-// a listener must admit the route on BOTH axes: its AllowedRoutes
-// namespaces policy and its AllowedRoutes kinds policy. A listener whose
-// namespace admission cannot be confirmed to exclude the route (a Selector
-// needing namespace labels this Index was not given) is conservatively
-// treated as admitting it: this package errs toward reporting a possible
-// exposure rather than silently hiding one, the same choice
-// core/pkg/mapreconcile makes for its own indeterminate matches. A
-// parentRef naming a Gateway this Index has no record of at all is the
-// most indeterminate case there is -- the Gateway may simply live outside
-// what was collected (a cross-namespace reference, or a caller without
-// RBAC to list it elsewhere) rather than not exist -- so it gets the same
-// conservative treatment rather than being silently treated as a
-// non-match.
+// attach a route to a Gateway that merely shares its namespace/name). When
+// a parentRef carries a sectionName, it pins the attachment to the one
+// listener with that name -- no other listener of the Gateway may admit
+// the route, and a sectionName naming no collected listener contributes
+// nothing. Otherwise every listener is evaluated. A listener must admit
+// the route on BOTH axes: its AllowedRoutes namespaces policy and its
+// AllowedRoutes kinds policy. A listener whose namespace admission cannot
+// be confirmed to exclude the route (a Selector needing namespace labels
+// this Index was not given) is conservatively treated as admitting it:
+// this package errs toward reporting a possible exposure rather than
+// silently hiding one, the same choice core/pkg/mapreconcile makes for its
+// own indeterminate matches. A parentRef naming a Gateway this Index has
+// no record of at all is the most indeterminate case there is -- the
+// Gateway may simply live outside what was collected (a cross-namespace
+// reference, or a caller without RBAC to list it elsewhere) rather than
+// not exist -- so it gets the same conservative treatment rather than
+// being silently treated as a non-match.
 func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 	for _, ref := range route.ParentRefs {
 		if !isGatewayParentRef(ref) {
@@ -241,6 +244,9 @@ func (idx *Index) routeAttachesToAGateway(route *gatewayRoute) bool {
 			return true
 		}
 		for _, l := range gw.Listeners {
+			if ref.SectionName != nil && l.Name != *ref.SectionName {
+				continue
+			}
 			if !idx.listenerAdmitsRouteKind(l, route.Kind) {
 				continue
 			}

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -137,17 +137,17 @@ func TestServiceExposure_IngressInAnotherNamespaceDoesNotApply(t *testing.T) {
 }
 
 func TestServiceExposure_HTTPRouteWithUncollectedGatewayStillReportsPath(t *testing.T) {
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "missing-gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	// No Gateway named missing-gw was collected. This is the most
 	// indeterminate case there is -- the Gateway could simply live outside
 	// what was collected rather than not exist -- so it must be treated as a
 	// possible exposure, not silently dropped.
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, nil, nil)
 	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
 		t.Errorf("paths = %v, want one path: an uncollected Gateway must be treated as a possible exposure", paths)
 	}
@@ -155,14 +155,14 @@ func TestServiceExposure_HTTPRouteWithUncollectedGatewayStillReportsPath(t *test
 
 func TestServiceExposure_HTTPRouteAttachedToGatewayExposesService(t *testing.T) {
 	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "gw"}},
 		Hostnames:  []string{"app.example.com"},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Kind != ExposureHTTPRoute || paths[0].Source != "ns/route" || paths[0].Host != "app.example.com" {
 		t.Errorf("paths = %+v, want one ExposureHTTPRoute from ns/route with host app.example.com", paths)
@@ -171,13 +171,13 @@ func TestServiceExposure_HTTPRouteAttachedToGatewayExposesService(t *testing.T) 
 
 func TestServiceExposure_HTTPRouteWithNoHostnamesProducesOnePathWithEmptyHost(t *testing.T) {
 	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, _ := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 1 || paths[0].Host != "" {
 		t.Errorf("paths = %+v, want one path with empty host", paths)
@@ -187,13 +187,13 @@ func TestServiceExposure_HTTPRouteWithNoHostnamesProducesOnePathWithEmptyHost(t 
 func TestServiceExposure_CrossNamespaceParentRefBlockedByDefaultSameNamespaceAllowedRoutes(t *testing.T) {
 	gw := gateway{Namespace: "gw-ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
 	gwNS := "gw-ns"
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "route-ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Namespace: &gwNS, Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
-	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, _ := idx.ServiceExposure(ref("route-ns", "app"))
 	if len(paths) != 0 {
 		t.Errorf("paths = %+v, want empty: AllowedRoutes defaults to Same, and the route's namespace differs from the Gateway's", paths)
@@ -207,13 +207,13 @@ func TestServiceExposure_CrossNamespaceParentRefAllowedByExplicitFromAll(t *test
 		Name:          "http",
 		AllowedRoutes: &allowedRoutes{Namespaces: &routeNamespaces{From: &all}},
 	}}}
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "route-ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Namespace: &gwNS, Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
-	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("route-ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, _ := idx.ServiceExposure(ref("route-ns", "app"))
 	if len(paths) != 1 {
 		t.Errorf("paths = %+v, want one ExposureHTTPRoute: the listener explicitly allows routes from all namespaces", paths)
@@ -223,16 +223,16 @@ func TestServiceExposure_CrossNamespaceParentRefAllowedByExplicitFromAll(t *test
 func TestServiceExposure_HTTPRouteBackendInAnotherNamespaceIsNotModeled(t *testing.T) {
 	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
 	otherNS := "other-ns"
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &otherNS, Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Namespace: &otherNS, Name: "app"}}}},
 	}
 	// The Service actually lives in ns, but the route's backendRef claims
 	// other-ns -- without a ReferenceGrant (not modeled), this must not
 	// match ns/app.
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 0 {
 		t.Errorf("paths = %v, want empty", paths)
@@ -248,17 +248,17 @@ func TestServiceExposure_UnclearWhenCrossNamespaceHTTPRouteBackendRefIsUnmodeled
 	// A real, working topology: an HTTPRoute living in "edge" names ns/app as
 	// its backend via an explicit backendRef.namespace, authorized by a
 	// ReferenceGrant in ns (not modeled by this package -- see
-	// crossNamespaceBackendRefIsUnmodeled's doc comment). idx.httpRoutesByNS
+	// crossNamespaceBackendRefIsUnmodeled's doc comment). idx.routesByNS
 	// only looks up routes living *in* ref.Namespace when building paths, so
 	// this route is never examined there; the unclear signal exists
 	// precisely to catch what that omission would otherwise hide.
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "edge",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
 	}
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
 	if len(paths) != 0 {
 		t.Errorf("paths = %v, want empty: this package does not confirm cross-namespace backendRefs", paths)
@@ -268,20 +268,73 @@ func TestServiceExposure_UnclearWhenCrossNamespaceHTTPRouteBackendRefIsUnmodeled
 	}
 }
 
+// TestServiceExposure_GRPCRouteBackendReportsGRPCRoutePath verifies the
+// kind attribution: a GRPCRoute naming a Service as a backend produces an
+// ExposureGRPCRoute path through the same admission logic an HTTPRoute
+// goes through.
+func TestServiceExposure_GRPCRouteBackendReportsGRPCRoutePath(t *testing.T) {
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "grpc"}}}
+	route := gatewayRoute{
+		Kind:       "GRPCRoute",
+		Namespace:  "ns",
+		Name:       "grpc-route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if unclear {
+		t.Error("unclear = true, want false: a same-namespace GRPCRoute backendRef is fully modeled")
+	}
+	if len(paths) != 1 {
+		t.Fatalf("paths = %+v, want one", paths)
+	}
+	if paths[0].Kind != ExposureGRPCRoute {
+		t.Errorf("paths[0].Kind = %v, want ExposureGRPCRoute", paths[0].Kind)
+	}
+	if paths[0].Source != "ns/grpc-route" {
+		t.Errorf("paths[0].Source = %q, want ns/grpc-route", paths[0].Source)
+	}
+}
+
+// TestServiceExposure_CrossNamespaceGRPCRouteBackendRefIsUnclear mirrors the
+// HTTPRoute cross-namespace case: a GRPCRoute living outside the queried
+// namespace can name a Service as a backend via backendRef.namespace, and
+// that must surface as unclear rather than a confirmed all-clear.
+func TestServiceExposure_CrossNamespaceGRPCRouteBackendRefIsUnclear(t *testing.T) {
+	gw := gateway{Namespace: "edge", Name: "gw", Listeners: []listener{{Name: "grpc"}}}
+	targetNS := "ns"
+	route := gatewayRoute{
+		Kind:       "GRPCRoute",
+		Namespace:  "edge",
+		Name:       "grpc-route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %v, want empty: this package does not confirm cross-namespace backendRefs", paths)
+	}
+	if !unclear {
+		t.Error("unclear = false, want true: a cross-namespace backendRef from an admitted GRPCRoute names this Service")
+	}
+}
+
 func TestServiceExposure_CrossNamespaceRouteWithUncollectedGatewayIsStillUnclear(t *testing.T) {
 	targetNS := "ns"
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "edge",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "missing-gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Namespace: &targetNS, Name: "app"}}}},
 	}
 	// No Gateway at all was collected, so routeAttachesToAGateway takes the
 	// conservative "uncollected Gateway" path and reports it as attached --
 	// crossNamespaceBackendRefIsUnmodeled piggybacks on that same
 	// conservative check rather than re-deriving its own, so this must still
 	// be unclear rather than silently dropped for lack of Gateway data.
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, nil, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, nil, nil)
 	_, unclear := idx.ServiceExposure(ref("ns", "app"))
 	if !unclear {
 		t.Error("unclear = false, want true: an uncollected Gateway is conservatively treated as attached, same as routeAttachesToAGateway")
@@ -344,16 +397,16 @@ func TestServiceExposure_HTTPRouteIndeterminateAdmissionStillReportsPath(t *test
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "payments"}},
 		}},
 	}}}
-	route := httpRoute{
+	route := gatewayRoute{Kind: "HTTPRoute",
 		Namespace:  "ns",
 		Name:       "route",
 		ParentRefs: []parentRef{{Name: "gw"}},
-		Rules:      []httpRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
 	}
 	// No NamespaceInfo for "ns" was collected, so the selector can't be
 	// evaluated -- this must still report the path rather than silently
 	// dropping a possible exposure.
-	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []httpRoute{route}, []gateway{gw}, nil)
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
 	if paths, _ := idx.ServiceExposure(ref("ns", "app")); len(paths) != 1 {
 		t.Errorf("paths = %v, want one path: an indeterminate admission must still be reported", paths)
 	}

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -347,6 +347,52 @@ func TestServiceExposure_GRPCRouteNotAdmittedByHTTPRouteOnlyListener(t *testing.
 	}
 }
 
+// TestServiceExposure_GRPCRouteSectionNamePinsAdmissionToNamedListener
+// verifies parentRefs[].sectionName semantics: a route attaching via
+// sectionName must be evaluated against that listener only -- never
+// admitted by another listener of the same Gateway that merely allows its
+// kind. The Gateway below has a kind-refusing "http" listener and a
+// permissive "grpc" listener; the route pins to "http", so it must not be
+// admitted, and pinning to "grpc" instead must be admitted.
+func TestServiceExposure_GRPCRouteSectionNamePinsAdmissionToNamedListener(t *testing.T) {
+	httpRouteKind := "HTTPRoute"
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{
+		{Name: "http", AllowedRoutes: &allowedRoutes{Kinds: []routeGroupKind{{Kind: httpRouteKind}}}},
+		{Name: "grpc"},
+	}}
+
+	pinnedToRefusing := gatewayRoute{
+		Kind:       "GRPCRoute",
+		Namespace:  "ns",
+		Name:       "grpc-route",
+		ParentRefs: []parentRef{{Name: "gw", SectionName: strPtr("http")}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{pinnedToRefusing}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty: the route attaches to section %q only, and that listener admits only HTTPRoute", paths, "http")
+	}
+	if unclear {
+		t.Error("unclear = true, want false: the same-namespace backendRef is fully evaluated, just not attached")
+	}
+
+	pinnedToPermissive := gatewayRoute{
+		Kind:       "GRPCRoute",
+		Namespace:  "ns",
+		Name:       "grpc-route",
+		ParentRefs: []parentRef{{Name: "gw", SectionName: strPtr("grpc")}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx2 := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{pinnedToPermissive}, []gateway{gw}, nil)
+	paths2, _ := idx2.ServiceExposure(ref("ns", "app"))
+	if len(paths2) != 1 || paths2[0].Kind != ExposureGRPCRoute {
+		t.Errorf("paths = %+v, want one ExposureGRPCRoute: the pinned listener admits GRPCRoute", paths2)
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
 // TestServiceExposure_NonGatewayParentDoesNotAttachToSameNameGateway
 // verifies the parentRef group/kind defaults: a parentRef naming a
 // non-Gateway parent (here a mesh Service) whose namespace/name happen to

--- a/core/pkg/exposure/index_test.go
+++ b/core/pkg/exposure/index_test.go
@@ -321,6 +321,98 @@ func TestServiceExposure_CrossNamespaceGRPCRouteBackendRefIsUnclear(t *testing.T
 	}
 }
 
+// TestServiceExposure_GRPCRouteNotAdmittedByHTTPRouteOnlyListener verifies
+// the allowedRoutes.kinds policy: a listener explicitly permitting only
+// HTTPRoute must not admit a GRPCRoute, even in the same namespace.
+func TestServiceExposure_GRPCRouteNotAdmittedByHTTPRouteOnlyListener(t *testing.T) {
+	httpRouteKind := "HTTPRoute"
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{
+		Name:          "http",
+		AllowedRoutes: &allowedRoutes{Kinds: []routeGroupKind{{Kind: httpRouteKind}}},
+	}}}
+	route := gatewayRoute{
+		Kind:       "GRPCRoute",
+		Namespace:  "ns",
+		Name:       "grpc-route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty: the listener explicitly admits only HTTPRoute", paths)
+	}
+	if unclear {
+		t.Error("unclear = true, want false: a kind-refused route names no cross-namespace backend")
+	}
+}
+
+// TestServiceExposure_NonGatewayParentDoesNotAttachToSameNameGateway
+// verifies the parentRef group/kind defaults: a parentRef naming a
+// non-Gateway parent (here a mesh Service) whose namespace/name happen to
+// match a collected Gateway must not attach the route to it.
+func TestServiceExposure_NonGatewayParentDoesNotAttachToSameNameGateway(t *testing.T) {
+	coreGroup := ""
+	serviceKind := "Service"
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	route := gatewayRoute{
+		Kind:      "HTTPRoute",
+		Namespace: "ns",
+		Name:      "route",
+		ParentRefs: []parentRef{
+			{Group: &coreGroup, Kind: &serviceKind, Name: "gw"}, // a mesh Service parent, same name as the Gateway
+		},
+		Rules: []gatewayRouteRule{{BackendRefs: []backendRef{{Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
+	paths, _ := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty: a Service parent is not the collected Gateway even though the name matches", paths)
+	}
+}
+
+// TestServiceExposure_NonServiceBackendDoesNotCreateExposurePath verifies
+// the backendRef group/kind defaults: a backendRef naming a non-Service
+// backend (e.g. a multicluster ServiceImport) whose namespace/name match a
+// collected Service must not produce an exposure path -- and a
+// cross-namespace one must not raise the unclear signal either.
+func TestServiceExposure_NonServiceBackendDoesNotCreateExposurePath(t *testing.T) {
+	multiclusterGroup := "multicluster.x-k8s.io"
+	serviceImportKind := "ServiceImport"
+	gw := gateway{Namespace: "ns", Name: "gw", Listeners: []listener{{Name: "http"}}}
+	route := gatewayRoute{
+		Kind:       "HTTPRoute",
+		Namespace:  "ns",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Group: &multiclusterGroup, Kind: &serviceImportKind, Name: "app"}}}},
+	}
+	idx := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{route}, []gateway{gw}, nil)
+	paths, unclear := idx.ServiceExposure(ref("ns", "app"))
+	if len(paths) != 0 {
+		t.Errorf("paths = %+v, want empty: a ServiceImport backend is not the Service even though the name matches", paths)
+	}
+	if unclear {
+		t.Error("unclear = true, want false: a same-namespace non-Service backendRef says nothing about the Service")
+	}
+
+	// Cross-namespace variant: the backendRef names other-ns/app, which is
+	// not the Service under query at all, so no unclear either.
+	otherNS := "other-ns"
+	crossRoute := gatewayRoute{
+		Kind:       "HTTPRoute",
+		Namespace:  "edge",
+		Name:       "route",
+		ParentRefs: []parentRef{{Name: "gw"}},
+		Rules:      []gatewayRouteRule{{BackendRefs: []backendRef{{Group: &multiclusterGroup, Kind: &serviceImportKind, Namespace: &otherNS, Name: "app"}}}},
+	}
+	idx2 := NewIndex([]corev1.Service{svc("ns", "app", corev1.ServiceTypeClusterIP)}, nil, []gatewayRoute{crossRoute}, []gateway{gw}, nil)
+	_, unclear2 := idx2.ServiceExposure(ref("ns", "app"))
+	if unclear2 {
+		t.Error("unclear = true, want false: a cross-namespace non-Service backendRef does not name this Service")
+	}
+}
+
 func TestServiceExposure_CrossNamespaceRouteWithUncollectedGatewayIsStillUnclear(t *testing.T) {
 	targetNS := "ns"
 	route := gatewayRoute{Kind: "HTTPRoute",

--- a/core/pkg/exposure/types.go
+++ b/core/pkg/exposure/types.go
@@ -1,8 +1,8 @@
 // Package exposure models which of a cluster's Service objects are reachable
 // from outside the cluster, and by what mechanism: a Service of type
 // LoadBalancer or NodePort is exposed directly; a networking.k8s.io/v1
-// Ingress or a Gateway API HTTPRoute exposes whatever Service it names as a
-// backend.
+// Ingress or a Gateway API HTTPRoute/GRPCRoute exposes whatever Service it
+// names as a backend.
 //
 // This is the "outside-in" counterpart to core/pkg/networkpolicy's
 // reachability model: that package answers "can this pod reach that pod
@@ -39,6 +39,13 @@ const (
 	// whose admission can't be confirmed one way or the other is
 	// conservatively treated as admitting it.
 	ExposureHTTPRoute
+	// ExposureGRPCRoute means a Gateway API GRPCRoute names this Service as
+	// a backend. GRPCRoute has been a v1 core Gateway API kind since
+	// Gateway API v1.1 and carries the same parentRefs/hostnames/
+	// backendRefs shape as HTTPRoute, so the same admission model applies;
+	// only the wire protocol the Gateway serves differs, which is outside
+	// this package's concern.
+	ExposureGRPCRoute
 	// ExposureExternalIP means the Service has one or more spec.externalIPs
 	// set. kube-proxy programs these on every node regardless of
 	// spec.type, so a ClusterIP Service with externalIPs set is reachable
@@ -58,6 +65,8 @@ func (k ExposureKind) String() string {
 		return "Ingress"
 	case ExposureHTTPRoute:
 		return "HTTPRoute"
+	case ExposureGRPCRoute:
+		return "GRPCRoute"
 	case ExposureExternalIP:
 		return "ExternalIP"
 	default:
@@ -69,14 +78,14 @@ func (k ExposureKind) String() string {
 // the cluster.
 type ExposurePath struct {
 	Kind ExposureKind
-	// Source names the object responsible: the Ingress/HTTPRoute
+	// Source names the object responsible: the Ingress/HTTPRoute/GRPCRoute
 	// (namespace/name) that names this Service as a backend, or the
 	// Service itself for LoadBalancer/NodePort.
 	Source string
 	// Host is the hostname traffic must arrive with to reach this path, per
-	// the responsible Ingress rule or HTTPRoute hostname. Empty means any
+	// the responsible Ingress rule or route hostname. Empty means any
 	// host (an Ingress rule/defaultBackend with no host restriction, a
-	// LoadBalancer/NodePort Service, or an HTTPRoute with no hostnames
+	// LoadBalancer/NodePort Service, or a route with no hostnames
 	// declared).
 	Host string
 }
@@ -94,21 +103,27 @@ type NamespaceInfo struct {
 	Labels map[string]string
 }
 
-// httpRoute is a minimal local mirror of gateway.networking.k8s.io/v1
-// HTTPRoute -- only the fields exposure analysis needs. Defined locally
-// rather than vendoring sigs.k8s.io/gateway-api, since decoding the handful
-// of fields used here from the same generic unstructured object this
-// package's adapter already reads for every other resource kind needs
+// gatewayRoute is a minimal local mirror of the Gateway API route kinds
+// this package models (HTTPRoute, and GRPCRoute which shares its spec
+// shape) -- only the fields exposure analysis needs, plus which kind the
+// object is so exposure paths can be attributed correctly. Defined locally
+// rather than vendoring sigs.k8s.io/gateway-api, since decoding the
+// handful of fields used here from the same generic unstructured object
+// this package's adapter already reads for every other resource kind needs
 // nothing else from that module.
-type httpRoute struct {
+type gatewayRoute struct {
+	// Kind is the object's Gateway API kind: "HTTPRoute" or "GRPCRoute".
+	// The spec fields below are identical across the two kinds, so all
+	// route logic is kind-blind; only ExposurePath attribution differs.
+	Kind       string
 	Namespace  string
 	Name       string
 	ParentRefs []parentRef
 	Hostnames  []string
-	Rules      []httpRouteRule
+	Rules      []gatewayRouteRule
 }
 
-// parentRef names the Gateway (or other parent) an HTTPRoute attaches to.
+// parentRef names the Gateway (or other parent) a route attaches to.
 // Namespace is a pointer because the API defaults an absent namespace to
 // the route's own, per Gateway API's own defaulting rules -- this mirrors
 // that rather than assuming empty-string means "same namespace" implicitly.
@@ -117,15 +132,15 @@ type parentRef struct {
 	Name      string
 }
 
-type httpRouteRule struct {
+type gatewayRouteRule struct {
 	BackendRefs []backendRef
 }
 
-// backendRef names a Service an HTTPRoute rule sends matching traffic to.
-// Namespace defaults to the route's own namespace when nil, same as
-// parentRef -- Gateway API does not support a backendRef reaching into
-// another namespace without a ReferenceGrant, which this package does not
-// model (see AnalyzeExposure's doc comment).
+// backendRef names a Service a route rule sends traffic to. Namespace
+// defaults to the route's own namespace when nil, same as parentRef --
+// Gateway API does not support a backendRef reaching into another
+// namespace without a ReferenceGrant, which this package does not model
+// (see AnalyzeExposure's doc comment).
 type backendRef struct {
 	Namespace *string
 	Name      string
@@ -144,7 +159,7 @@ type listener struct {
 }
 
 // allowedRoutes mirrors Gateway API's AllowedRoutes: which namespaces'
-// HTTPRoutes this listener admits. A nil AllowedRoutes (or a nil Namespaces
+// routes this listener admits. A nil AllowedRoutes (or a nil Namespaces
 // within it) defaults to "Same" -- routes in the Gateway's own namespace
 // only -- per the Gateway API spec's own default.
 type allowedRoutes struct {

--- a/core/pkg/exposure/types.go
+++ b/core/pkg/exposure/types.go
@@ -136,11 +136,15 @@ const gatewayAPIGroup = "gateway.networking.k8s.io"
 // group and an absent kind is Gateway, so a reference to anything else
 // (e.g. a Service parent for mesh use cases) is not a Gateway reference
 // and must not attach a route to a Gateway that merely shares its name.
+// SectionName, when present, pins the attachment to the one listener with
+// that name: per the Gateway API spec the route then attaches to that
+// section only, and no other listener of the Gateway may admit it.
 type parentRef struct {
-	Group     *string
-	Kind      *string
-	Namespace *string
-	Name      string
+	Group       *string
+	Kind        *string
+	Namespace   *string
+	Name        string
+	SectionName *string
 }
 
 // isGatewayParentRef reports whether ref effectively names a Gateway once

--- a/core/pkg/exposure/types.go
+++ b/core/pkg/exposure/types.go
@@ -123,13 +123,31 @@ type gatewayRoute struct {
 	Rules      []gatewayRouteRule
 }
 
+// gatewayAPIGroup is the Gateway API group all route kinds and their
+// parent references belong to. Gateway API's own defaulting rules treat an
+// absent group on a ParentReference as this group.
+const gatewayAPIGroup = "gateway.networking.k8s.io"
+
 // parentRef names the Gateway (or other parent) a route attaches to.
 // Namespace is a pointer because the API defaults an absent namespace to
 // the route's own, per Gateway API's own defaulting rules -- this mirrors
 // that rather than assuming empty-string means "same namespace" implicitly.
+// Group and Kind follow the same rules: an absent group is the Gateway API
+// group and an absent kind is Gateway, so a reference to anything else
+// (e.g. a Service parent for mesh use cases) is not a Gateway reference
+// and must not attach a route to a Gateway that merely shares its name.
 type parentRef struct {
+	Group     *string
+	Kind      *string
 	Namespace *string
 	Name      string
+}
+
+// isGatewayParentRef reports whether ref effectively names a Gateway once
+// Gateway API's own group/kind defaults are applied.
+func isGatewayParentRef(ref parentRef) bool {
+	return (ref.Group == nil || *ref.Group == gatewayAPIGroup) &&
+		(ref.Kind == nil || *ref.Kind == "Gateway")
 }
 
 type gatewayRouteRule struct {
@@ -140,10 +158,22 @@ type gatewayRouteRule struct {
 // defaults to the route's own namespace when nil, same as parentRef --
 // Gateway API does not support a backendRef reaching into another
 // namespace without a ReferenceGrant, which this package does not model
-// (see AnalyzeExposure's doc comment).
+// (see AnalyzeExposure's doc comment). Group and Kind default to a
+// core-group Service when absent; anything else names a non-Service
+// backend (e.g. a multicluster ServiceImport) that this package does not
+// model as a Service exposure path, however closely its name matches one.
 type backendRef struct {
+	Group     *string
+	Kind      *string
 	Namespace *string
 	Name      string
+}
+
+// isServiceBackendRef reports whether ref effectively names a core-group
+// Service once Gateway API's own group/kind defaults are applied.
+func isServiceBackendRef(ref backendRef) bool {
+	return (ref.Group == nil || *ref.Group == "") &&
+		(ref.Kind == nil || *ref.Kind == "Service")
 }
 
 // gateway is a minimal local mirror of gateway.networking.k8s.io/v1 Gateway.
@@ -159,11 +189,36 @@ type listener struct {
 }
 
 // allowedRoutes mirrors Gateway API's AllowedRoutes: which namespaces'
-// routes this listener admits. A nil AllowedRoutes (or a nil Namespaces
-// within it) defaults to "Same" -- routes in the Gateway's own namespace
-// only -- per the Gateway API spec's own default.
+// routes this listener admits, and which route kinds. A nil AllowedRoutes
+// (or a nil Namespaces within it) defaults to "Same" -- routes in the
+// Gateway's own namespace only -- per the Gateway API spec's own default.
+// A nil or empty Kinds list admits every route kind, also per the spec's
+// default.
 type allowedRoutes struct {
 	Namespaces *routeNamespaces
+	Kinds      []routeGroupKind
+}
+
+// routeGroupKind mirrors Gateway API's RouteGroupKind. An absent group is
+// the Gateway API group, per the spec's defaulting rules.
+type routeGroupKind struct {
+	Group *string
+	Kind  string
+}
+
+// admitsRouteKind reports whether the AllowedRoutes kinds list admits a
+// route of the given kind once the group default is applied. An empty list
+// admits every kind.
+func (ar *allowedRoutes) admitsRouteKind(routeKind string) bool {
+	if len(ar.Kinds) == 0 {
+		return true
+	}
+	for _, k := range ar.Kinds {
+		if (k.Group == nil || *k.Group == gatewayAPIGroup) && k.Kind == routeKind {
+			return true
+		}
+	}
+	return false
 }
 
 type fromNamespaces string


### PR DESCRIPTION
## Overview

`analyze_service_exposure` never considered GRPCRoute objects, so a Service whose only ingress path is a Gateway API GRPCRoute came back with `paths: []` and `unclear: false` — which, per the tool's own contract, reads as a **confirmed "not exposed"** verdict that is wrong. GRPCRoute has been a v1 core Gateway API kind since Gateway API v1.1 and carries the same `parentRefs`/`hostnames`/`backendRefs` shape as HTTPRoute; gRPC-first ingress deployments such as Envoy Gateway use it as their primary route kind.

Closes #3727

## What this PR does

- Decodes GRPCRoutes into the same internal route model (renamed `gatewayRoute`, now carrying its `Kind`, since it holds both kinds) so exposure paths are attributed as `kind: "GRPCRoute"`, and the cross-namespace `unclear` signal covers GRPCRoute backendRefs. The Gateway-admission model itself is unchanged — `routeAttachesToAGateway` and `gatewayAdmitsRouteNamespace` work as before.
- Lists `grpcroutes` cluster-wide alongside `httproutes`, with the same missing-API tolerance as before.
- Adds the **version fallback as one shared candidate-version helper** (`listGatewayKind`, v1 → v1beta1) used by all three Gateway API kinds — httproutes, gateways and grpcroutes alike — so clusters whose CRDs predate a kind's v1 graduation stay covered, and everything downstream stays version-blind (the decoded spec shape is identical across versions). Only a missing-API response moves to the next candidate: genuine list failures (RBAC, connectivity) surface as tool errors rather than silently degrading, and when no candidate is served at all, that remains the existing "CRDs not installed" empty case.

## Tests

- `TestAnalyzeServiceExposure_GRPCRouteThroughGatewayExposesService` — red-first: a Service backended only by a GRPCRoute attached to a Gateway reported `paths: []` before this fix; now returns one `GRPCRoute`-attributed path.
- `TestAnalyzeServiceExposure_GRPCRouteV1beta1OnlyClusterStillWorks` — a cluster serving grpcroutes only as v1beta1 (v1 404s) still finds the exposure path via the fallback.
- `TestFromUnstructuredGatewayAPI_DecodesGRPCRoute` — GRPCRoute decodes through the shared route model with correct kind attribution.
- `TestServiceExposure_GRPCRouteBackendReportsGRPCRoutePath` and `TestServiceExposure_CrossNamespaceGRPCRouteBackendRefIsUnclear` — index-level kind attribution and the unclear signal for cross-namespace GRPCRoute backendRefs.
- Full verification: `go test ./core/pkg/exposure/... ./cmd/mcpserver/... -race` → 314 tests pass; `go test ./core/... -count=1` → 5842 tests pass across 49 packages; `gofmt`, `go vet`, `go build ./...` clean.

## Related issue(s)

- #3727 (this fix)
- #3679 — the externalIPs modeling and cross-namespace backendRef `unclear` signal this change extends to GRPCRoute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added service exposure support for Gateway API HTTPRoute and GRPCRoute resources.
  * Exposure results now identify whether access comes through an HTTPRoute or GRPCRoute.
  * Added automatic version fallback for Gateway API resources, including legacy GRPCRoute versions.
* **Bug Fixes**
  * Missing Gateway API resources are now handled gracefully without producing errors.
  * Improved route matching to respect resource kinds, listener policies, and backend references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->