### PR TITLE
fix(scan): normalize kind case and support short names in workload scan

### DIFF
--- a/cmd/mcpserver/testdata/crd-deploy.yaml
+++ b/cmd/mcpserver/testdata/crd-deploy.yaml
@@ -1,0 +1,12 @@
+apiVersion: example.com/v1
+kind: Deploy
+metadata:
+  name: crd-deploy
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest

--- a/cmd/mcpserver/workload_scan_test.go
+++ b/cmd/mcpserver/workload_scan_test.go
@@ -82,6 +82,18 @@ func TestBuildWorkloadScanRequest_ScanObject(t *testing.T) {
 			wantName:   "nginx",
 			wantAPIVer: "apps/v1",
 		},
+		{
+			name:     "bare short name preserves raw kind",
+			workload: "deploy/nginx",
+			wantKind: "deploy",
+			wantName: "nginx",
+		},
+		{
+			name:     "bare CRD kind preserves casing",
+			workload: "Deploy/crd-deploy",
+			wantKind: "Deploy",
+			wantName: "crd-deploy",
+		},
 	}
 
 	for _, tt := range tests {
@@ -305,6 +317,34 @@ func TestRunWorkloadScan_ResolvesFromFile(t *testing.T) {
 	ksServer := newWorkloadScanTestServer(t)
 
 	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "", "testdata/deployment.yaml", "nsa")
+	require.NoError(t, err)
+	assert.Contains(t, string(respBytes), `"total_failed":`)
+}
+
+func TestRunWorkloadScan_CaseInsensitiveAndShortName(t *testing.T) {
+	ksServer := newWorkloadScanTestServer(t)
+
+	// Lowercase kind
+	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "deployment/nginx", "", "testdata/deployment.yaml", "nsa")
+	require.NoError(t, err)
+	assert.Contains(t, string(respBytes), `"total_failed":`)
+
+	// Registered kubectl short name
+	respBytes, err = ksServer.RunWorkloadScan(context.Background(), "deploy/nginx", "", "testdata/deployment.yaml", "nsa")
+	require.NoError(t, err)
+	assert.Contains(t, string(respBytes), `"total_failed":`)
+}
+
+func TestRunWorkloadScan_CRDDeploy(t *testing.T) {
+	ksServer := newWorkloadScanTestServer(t)
+
+	// CRD with kind: Deploy matched via exact PascalCase kind
+	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "Deploy/crd-deploy", "", "testdata/crd-deploy.yaml", "nsa")
+	require.NoError(t, err)
+	assert.Contains(t, string(respBytes), `"total_failed":`)
+
+	// CRD with kind: Deploy matched via lowercase alias kind in pass 1
+	respBytes, err = ksServer.RunWorkloadScan(context.Background(), "deploy/crd-deploy", "", "testdata/crd-deploy.yaml", "nsa")
 	require.NoError(t, err)
 	assert.Contains(t, string(respBytes), `"total_failed":`)
 }

--- a/core/cautils/workloadidentifier.go
+++ b/core/cautils/workloadidentifier.go
@@ -72,6 +72,145 @@ func ParseWorkloadIdentifierString(workloadIdentifier string) (namespace, kind, 
 // is rejected as a missing version rather than being silently read as one.
 var apiVersionPattern = regexp.MustCompile(`^v\d+((alpha|beta)\d+)?$`)
 
+// canonicalKinds maps lowercase resource kinds, plural names, standard kubectl
+// short names (from `kubectl api-resources`), and common informal aliases (e.g.,
+// "pc", "limits", "quota") to their canonical PascalCase Kind.
+var canonicalKinds = map[string]string{
+	// Workloads
+	"pod": "Pod", "pods": "Pod", "po": "Pod",
+	"deployment": "Deployment", "deployments": "Deployment", "deploy": "Deployment",
+	"daemonset": "DaemonSet", "daemonsets": "DaemonSet", "ds": "DaemonSet",
+	"statefulset": "StatefulSet", "statefulsets": "StatefulSet", "sts": "StatefulSet",
+	"job": "Job", "jobs": "Job",
+	"cronjob": "CronJob", "cronjobs": "CronJob", "cj": "CronJob",
+	"replicaset": "ReplicaSet", "replicasets": "ReplicaSet", "rs": "ReplicaSet",
+	"replicationcontroller": "ReplicationController", "replicationcontrollers": "ReplicationController", "rc": "ReplicationController",
+
+	// Configuration & Storage
+	"configmap": "ConfigMap", "configmaps": "ConfigMap", "cm": "ConfigMap",
+	"secret": "Secret", "secrets": "Secret",
+	"persistentvolumeclaim": "PersistentVolumeClaim", "persistentvolumeclaims": "PersistentVolumeClaim", "pvc": "PersistentVolumeClaim",
+	"persistentvolume": "PersistentVolume", "persistentvolumes": "PersistentVolume", "pv": "PersistentVolume",
+	"storageclass": "StorageClass", "storageclasses": "StorageClass", "sc": "StorageClass",
+	"volumeattachment": "VolumeAttachment", "volumeattachments": "VolumeAttachment",
+
+	// Networking
+	"service": "Service", "services": "Service", "svc": "Service",
+	"ingress": "Ingress", "ingresses": "Ingress", "ing": "Ingress",
+	"networkpolicy": "NetworkPolicy", "networkpolicies": "NetworkPolicy", "netpol": "NetworkPolicy",
+	"endpoints": "Endpoints", "ep": "Endpoints",
+	"endpointslice": "EndpointSlice", "endpointslices": "EndpointSlice",
+	"ingressclass": "IngressClass", "ingressclasses": "IngressClass",
+
+	// Cluster, Node & RBAC
+	"namespace": "Namespace", "namespaces": "Namespace", "ns": "Namespace",
+	"node": "Node", "nodes": "Node", "no": "Node",
+	"serviceaccount": "ServiceAccount", "serviceaccounts": "ServiceAccount", "sa": "ServiceAccount",
+	"role": "Role", "roles": "Role",
+	"rolebinding": "RoleBinding", "rolebindings": "RoleBinding",
+	"clusterrole": "ClusterRole", "clusterroles": "ClusterRole",
+	"clusterrolebinding": "ClusterRoleBinding", "clusterrolebindings": "ClusterRoleBinding",
+	"customresourcedefinition": "CustomResourceDefinition", "customresourcedefinitions": "CustomResourceDefinition", "crd": "CustomResourceDefinition", "crds": "CustomResourceDefinition",
+
+	// Policy, Scheduling & Quota
+	"horizontalpodautoscaler": "HorizontalPodAutoscaler", "horizontalpodautoscalers": "HorizontalPodAutoscaler", "hpa": "HorizontalPodAutoscaler",
+	"poddisruptionbudget": "PodDisruptionBudget", "poddisruptionbudgets": "PodDisruptionBudget", "pdb": "PodDisruptionBudget",
+	"podsecuritypolicy": "PodSecurityPolicy", "podsecuritypolicies": "PodSecurityPolicy", "psp": "PodSecurityPolicy",
+	"resourcequota": "ResourceQuota", "resourcequotas": "ResourceQuota", "quota": "ResourceQuota",
+	"limitrange": "LimitRange", "limitranges": "LimitRange", "limits": "LimitRange",
+	"priorityclass": "PriorityClass", "priorityclasses": "PriorityClass", "pc": "PriorityClass",
+	"lease": "Lease", "leases": "Lease",
+	"runtimeclass": "RuntimeClass", "runtimeclasses": "RuntimeClass",
+	"flowschema": "FlowSchema", "flowschemas": "FlowSchema",
+	"prioritylevelconfiguration": "PriorityLevelConfiguration", "prioritylevelconfigurations": "PriorityLevelConfiguration",
+	"controllerrevision": "ControllerRevision", "controllerrevisions": "ControllerRevision",
+
+	// Core cluster metadata & Storage migration/snapshots
+	"componentstatus": "ComponentStatus", "componentstatuses": "ComponentStatus", "cs": "ComponentStatus",
+	"event": "Event", "events": "Event", "ev": "Event",
+	"binding": "Binding", "bindings": "Binding",
+	// "vs" is the official kubectl short name for VolumeSnapshot.
+	// Note: Istio also registers "vs" for VirtualService as a CRD short name.
+	// CRDs require explicit apiVersion so Istio users are unaffected in practice,
+	// but passing vs/<name> without apiVersion resolves to VolumeSnapshot not VirtualService.
+	"volumesnapshot": "VolumeSnapshot", "volumesnapshots": "VolumeSnapshot", "vs": "VolumeSnapshot",
+	"volumesnapshotcontent": "VolumeSnapshotContent", "volumesnapshotcontents": "VolumeSnapshotContent",
+	"volumesnapshotclass": "VolumeSnapshotClass", "volumesnapshotclasses": "VolumeSnapshotClass",
+	"storageversionmigration": "StorageVersionMigration", "storageversionmigrations": "StorageVersionMigration",
+	"storagestate": "StorageState", "storagestates": "StorageState",
+
+	// Storage & CSI
+	"csinode": "CSINode", "csinodes": "CSINode",
+	"csidriver": "CSIDriver", "csidrivers": "CSIDriver",
+	"csistoragecapacity": "CSIStorageCapacity", "csistoragecapacities": "CSIStorageCapacity",
+	"podtemplate": "PodTemplate", "podtemplates": "PodTemplate",
+
+	// Admission, Authorization & Certificates
+	"apiservice": "APIService", "apiservices": "APIService",
+	"mutatingwebhookconfiguration": "MutatingWebhookConfiguration", "mutatingwebhookconfigurations": "MutatingWebhookConfiguration",
+	"validatingwebhookconfiguration": "ValidatingWebhookConfiguration", "validatingwebhookconfigurations": "ValidatingWebhookConfiguration",
+	"certificatesigningrequest": "CertificateSigningRequest", "certificatesigningrequests": "CertificateSigningRequest", "csr": "CertificateSigningRequest",
+	"tokenreview": "TokenReview", "tokenreviews": "TokenReview",
+	"subjectaccessreview": "SubjectAccessReview", "subjectaccessreviews": "SubjectAccessReview",
+	"selfsubjectaccessreview": "SelfSubjectAccessReview", "selfsubjectaccessreviews": "SelfSubjectAccessReview",
+	"selfsubjectrulesreview": "SelfSubjectRulesReview", "selfsubjectrulesreviews": "SelfSubjectRulesReview",
+	"localsubjectaccessreview": "LocalSubjectAccessReview", "localsubjectaccessreviews": "LocalSubjectAccessReview",
+}
+
+// NormalizeWorkloadKind maps a Kubernetes resource kind, plural name, registered
+// kubectl short name (from `kubectl api-resources`), or common informal alias to
+// its canonical PascalCase Kind (e.g., "deployment", "deployments", "deploy" -> "Deployment").
+//
+// If the kind is unrecognized (such as a custom resource definition), the input string
+// is returned unaltered.
+func NormalizeWorkloadKind(kind string) string {
+	if canonical, ok := canonicalKinds[strings.ToLower(kind)]; ok {
+		return canonical
+	}
+	return kind
+}
+
+// builtinAPIGroups is an explicit allowlist of official Kubernetes built-in API groups.
+// Domain-based groups outside this list (such as custom .k8s.io domains like example.k8s.io)
+// are treated as custom resource groups so that declared custom resource Kinds are preserved.
+var builtinAPIGroups = map[string]struct{}{
+	"":                             {}, // core
+	"admissionregistration.k8s.io": {},
+	"apiextensions.k8s.io":         {},
+	"apiregistration.k8s.io":       {},
+	"apps":                         {},
+	"authentication.k8s.io":        {},
+	"authorization.k8s.io":         {},
+	"autoscaling":                  {},
+	"batch":                        {},
+	"certificates.k8s.io":          {},
+	"coordination.k8s.io":          {},
+	"discovery.k8s.io":             {},
+	"events.k8s.io":                {},
+	"extensions":                   {},
+	"flowcontrol.apiserver.k8s.io": {},
+	"imagepolicy.k8s.io":           {},
+	"internal.apiserver.k8s.io":    {},
+	"migration.k8s.io":             {},
+	"networking.k8s.io":            {},
+	"node.k8s.io":                  {},
+	"policy":                       {},
+	"policy.k8s.io":                {},
+	"rbac.authorization.k8s.io":    {},
+	"resource.k8s.io":              {},
+	"scheduling":                   {},
+	"scheduling.k8s.io":            {},
+	"snapshot.storage.k8s.io":      {},
+	"storage.k8s.io":               {},
+	"storagemigration.k8s.io":      {},
+}
+
+// IsBuiltinGroup reports whether group corresponds to a recognized official Kubernetes built-in API group.
+func IsBuiltinGroup(group string) bool {
+	_, ok := builtinAPIGroups[strings.ToLower(group)]
+	return ok
+}
+
 // parseKindAndApiVersion splits the kind segment of an identifier into a kind
 // and, when present, the apiVersion it encodes. The dotted form orders the
 // components kind.version.group for readability, while Kubernetes apiVersion
@@ -96,7 +235,14 @@ func parseKindAndApiVersion(kindStr string) (kind, apiVersion string, err error)
 
 	if len(parts) >= 3 {
 		group := strings.Join(parts[2:], ".")
-		return parts[0], group + "/" + parts[1], nil // kind.version.group -> group/version
+		// Preserve custom resource Kind when an explicit custom API group is present,
+		// preventing CRDs whose name matches a built-in kind or alias (e.g. Deploy.v1.example.com)
+		// from being incorrectly rewritten to a built-in kind.
+		kind := parts[0]
+		if IsBuiltinGroup(group) {
+			kind = NormalizeWorkloadKind(parts[0])
+		}
+		return kind, group + "/" + parts[1], nil // kind.version.group -> group/version
 	}
-	return parts[0], parts[1], nil // kind.version -> version
+	return NormalizeWorkloadKind(parts[0]), parts[1], nil // kind.version -> version
 }

--- a/core/cautils/workloadidentifier_test.go
+++ b/core/cautils/workloadidentifier_test.go
@@ -1,9 +1,12 @@
 package cautils
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseWorkloadIdentifierString_Invalid(t *testing.T) {
@@ -64,6 +67,159 @@ func TestParseWorkloadIdentifierString_Values(t *testing.T) {
 			WantErr:        false,
 		},
 		{
+			Description:    "lowercase kind preserves casing for bare identifier",
+			Input:          "deployment/nginx",
+			WantNamespace:  "",
+			WantKind:       "deployment",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "uppercase kind preserves casing for bare identifier",
+			Input:          "DEPLOYMENT/nginx",
+			WantNamespace:  "",
+			WantKind:       "DEPLOYMENT",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "mixed-case kind preserves casing for bare identifier",
+			Input:          "DePloyment/nginx",
+			WantNamespace:  "",
+			WantKind:       "DePloyment",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "plural kind preserves casing for bare identifier",
+			Input:          "deployments/nginx",
+			WantNamespace:  "",
+			WantKind:       "deployments",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "plural pods preserves casing for bare identifier",
+			Input:          "pods/nginx",
+			WantNamespace:  "",
+			WantKind:       "pods",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "lowercase daemonset preserves casing for bare identifier",
+			Input:          "daemonset/fluentd",
+			WantNamespace:  "",
+			WantKind:       "daemonset",
+			WantName:       "fluentd",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "lowercase statefulset preserves casing for bare identifier",
+			Input:          "statefulset/redis",
+			WantNamespace:  "",
+			WantKind:       "statefulset",
+			WantName:       "redis",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "lowercase cronjob preserves casing for bare identifier",
+			Input:          "cronjob/backup",
+			WantNamespace:  "",
+			WantKind:       "cronjob",
+			WantName:       "backup",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name deploy preserves name for bare identifier",
+			Input:          "deploy/nginx",
+			WantNamespace:  "",
+			WantKind:       "deploy",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "uppercase short name DEPLOY preserves name for bare identifier",
+			Input:          "DEPLOY/nginx",
+			WantNamespace:  "",
+			WantKind:       "DEPLOY",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name po preserves name for bare identifier",
+			Input:          "po/nginx",
+			WantNamespace:  "",
+			WantKind:       "po",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "uppercase short name PO preserves name for bare identifier",
+			Input:          "PO/nginx",
+			WantNamespace:  "",
+			WantKind:       "PO",
+			WantName:       "nginx",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name svc preserves name for bare identifier",
+			Input:          "svc/web",
+			WantNamespace:  "",
+			WantKind:       "svc",
+			WantName:       "web",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "uppercase short name SVC preserves name for bare identifier",
+			Input:          "SVC/web",
+			WantNamespace:  "",
+			WantKind:       "SVC",
+			WantName:       "web",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name ds preserves name for bare identifier",
+			Input:          "ds/fluentd",
+			WantNamespace:  "",
+			WantKind:       "ds",
+			WantName:       "fluentd",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name sts preserves name for bare identifier",
+			Input:          "sts/redis",
+			WantNamespace:  "",
+			WantKind:       "sts",
+			WantName:       "redis",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "short name cj preserves name for bare identifier",
+			Input:          "cj/backup",
+			WantNamespace:  "",
+			WantKind:       "cj",
+			WantName:       "backup",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
 			Description:    "valid namespace kind and name",
 			Input:          "default/Deployment/nginx",
 			WantNamespace:  "default",
@@ -82,8 +238,35 @@ func TestParseWorkloadIdentifierString_Values(t *testing.T) {
 			WantErr:        false,
 		},
 		{
+			Description:    "short name with version only normalizes kind",
+			Input:          "deploy.v1/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "lowercase kind with version only normalizes kind",
+			Input:          "deployment.v1/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "v1",
+			WantErr:        false,
+		},
+		{
 			Description:    "valid kind.version.group and name",
 			Input:          "Deployment.v1.apps/nginx",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "nginx",
+			WantApiVersion: "apps/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "lowercase kind with dotted apiVersion is normalized",
+			Input:          "deployment.v1.apps/nginx",
 			WantNamespace:  "",
 			WantKind:       "Deployment",
 			WantName:       "nginx",
@@ -106,6 +289,132 @@ func TestParseWorkloadIdentifierString_Values(t *testing.T) {
 			WantKind:       "Ingress",
 			WantName:       "name",
 			WantApiVersion: "networking.k8s.io/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "unknown CRD kind preserves casing",
+			Input:          "customcrd/my-cr",
+			WantNamespace:  "",
+			WantKind:       "customcrd",
+			WantName:       "my-cr",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "unknown CRD kind with PascalCase preserves casing",
+			Input:          "MyCustomResource/my-cr",
+			WantNamespace:  "",
+			WantKind:       "MyCustomResource",
+			WantName:       "my-cr",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "custom CRD kind matching alias in custom API group preserves original casing",
+			Input:          "Deploy.v1.example.com/name",
+			WantNamespace:  "",
+			WantKind:       "Deploy",
+			WantName:       "name",
+			WantApiVersion: "example.com/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "custom CRD kind matching lowercase alias in custom API group preserves original casing",
+			Input:          "deploy.v1.example.com/name",
+			WantNamespace:  "",
+			WantKind:       "deploy",
+			WantName:       "name",
+			WantApiVersion: "example.com/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "custom CRD kind matching alias in custom .k8s.io API group preserves original casing",
+			Input:          "Deploy.v1.example.k8s.io/name",
+			WantNamespace:  "",
+			WantKind:       "Deploy",
+			WantName:       "name",
+			WantApiVersion: "example.k8s.io/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "custom CRD kind matching lowercase alias in custom .k8s.io API group preserves original casing",
+			Input:          "deploy.v1.example.k8s.io/name",
+			WantNamespace:  "",
+			WantKind:       "deploy",
+			WantName:       "name",
+			WantApiVersion: "example.k8s.io/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "built-in alias in built-in API group normalizes to PascalCase",
+			Input:          "deploy.v1.apps/name",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "name",
+			WantApiVersion: "apps/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "built-in kind in built-in API group normalizes to PascalCase",
+			Input:          "deployment.v1.apps/name",
+			WantNamespace:  "",
+			WantKind:       "Deployment",
+			WantName:       "name",
+			WantApiVersion: "apps/v1",
+			WantErr:        false,
+		},
+		{
+			Description:    "policy resource podsecuritypolicy preserves bare kind",
+			Input:          "podsecuritypolicy/restricted",
+			WantNamespace:  "",
+			WantKind:       "podsecuritypolicy",
+			WantName:       "restricted",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "policy short name psp preserves bare kind",
+			Input:          "psp/restricted",
+			WantNamespace:  "",
+			WantKind:       "psp",
+			WantName:       "restricted",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "apps resource controllerrevision preserves bare kind",
+			Input:          "controllerrevision/rev-1",
+			WantNamespace:  "",
+			WantKind:       "controllerrevision",
+			WantName:       "rev-1",
+			WantApiVersion: "",
+			WantErr:        false,
+		},
+		{
+			Description:    "policy resource podsecuritypolicy with group normalizes to PascalCase",
+			Input:          "podsecuritypolicy.v1beta1.policy/restricted",
+			WantNamespace:  "",
+			WantKind:       "PodSecurityPolicy",
+			WantName:       "restricted",
+			WantApiVersion: "policy/v1beta1",
+			WantErr:        false,
+		},
+		{
+			Description:    "policy short name psp with group normalizes to PascalCase",
+			Input:          "psp.v1beta1.policy/restricted",
+			WantNamespace:  "",
+			WantKind:       "PodSecurityPolicy",
+			WantName:       "restricted",
+			WantApiVersion: "policy/v1beta1",
+			WantErr:        false,
+		},
+		{
+			Description:    "apps resource controllerrevision with group normalizes to PascalCase",
+			Input:          "controllerrevision.v1.apps/rev-1",
+			WantNamespace:  "",
+			WantKind:       "ControllerRevision",
+			WantName:       "rev-1",
+			WantApiVersion: "apps/v1",
 			WantErr:        false,
 		},
 		{
@@ -149,4 +458,49 @@ func TestParseWorkloadIdentifierString_Values(t *testing.T) {
 			assert.Equal(t, tc.WantApiVersion, apiVersion)
 		})
 	}
+}
+
+func isBuiltinK8sGroup(group string) bool {
+	if group == "metrics.k8s.io" {
+		return false
+	}
+	return IsBuiltinGroup(group)
+}
+
+func TestNormalizeWorkloadKind_MockDriftCheck(t *testing.T) {
+	resourceLists, err := k8sinterface.GetResourceListMock()
+	require.NoError(t, err)
+	require.NotEmpty(t, resourceLists)
+
+	for _, list := range resourceLists {
+		if list == nil {
+			continue
+		}
+		// Parse group
+		group := ""
+		if parts := strings.Split(list.GroupVersion, "/"); len(parts) > 1 {
+			group = parts[0]
+		}
+		if !isBuiltinK8sGroup(group) {
+			continue
+		}
+
+		for _, resource := range list.APIResources {
+			if resource.Kind == "" || strings.Contains(resource.Name, "/") {
+				continue
+			}
+			// Direction: Mock -> Map (every Kind from built-in mock resolves to its canonical PascalCase Kind)
+			normalized := NormalizeWorkloadKind(strings.ToLower(resource.Kind))
+			assert.Equalf(t, resource.Kind, normalized, "Kind %q (group %q) from mock failed to normalize", resource.Kind, list.GroupVersion)
+
+			if resource.Name != "" {
+				normalizedName := NormalizeWorkloadKind(strings.ToLower(resource.Name))
+				assert.Equalf(t, resource.Kind, normalizedName, "Plural name %q for Kind %q (group %q) failed to normalize", resource.Name, resource.Kind, list.GroupVersion)
+			}
+		}
+	}
+
+	// Verify that unknown kinds remain unchanged
+	assert.Equal(t, "MyUnknownCRD", NormalizeWorkloadKind("MyUnknownCRD"))
+	assert.Equal(t, "myunknowncrd", NormalizeWorkloadKind("myunknowncrd"))
 }

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling"
 )
@@ -26,7 +27,12 @@ func providerRank(fileType string) int {
 
 // resourceIdentity returns the path-independent k8s identity tuple used for dedup.
 func resourceIdentity(w workloadinterface.IMetadata) string {
-	return fmt.Sprintf("%s/%s/%s/%s", w.GetApiVersion(), w.GetNamespace(), w.GetKind(), w.GetName())
+	group, _ := k8sinterface.SplitApiVersion(w.GetApiVersion())
+	kind := w.GetKind()
+	if cautils.IsBuiltinGroup(group) {
+		kind = cautils.NormalizeWorkloadKind(kind)
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", w.GetApiVersion(), w.GetNamespace(), kind, w.GetName())
 }
 
 // dedupWorkloads drops lower-ranked cross-provider duplicates only; same-rank duplicates are kept.
@@ -138,20 +144,26 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 
 	logger.L().Debug("Single resource scan", helpers.String("resource", resource.GetID()))
 
-	var wls []workloadinterface.IWorkload
-	seenResources := make(map[string]struct{})
-	for _, resources := range mappedResources {
-		for _, r := range resources {
-			// File-loaded resource IDs include their source path, so aliases of
-			// one object collapse while distinct manifests remain distinguishable.
-			if _, seen := seenResources[r.GetID()]; seen {
-				continue
-			}
-			if r.GetKind() == resource.GetKind() && r.GetName() == resource.GetName() {
+	collectMatches := func(kindPredicate func(r workloadinterface.IMetadata) bool) []workloadinterface.IWorkload {
+		var wls []workloadinterface.IWorkload
+		seenResources := make(map[string]struct{})
+		for _, resources := range mappedResources {
+			for _, r := range resources {
+				// File-loaded resource IDs include their source path, so aliases of
+				// one object collapse while distinct manifests remain distinguishable.
+				if _, seen := seenResources[r.GetID()]; seen {
+					continue
+				}
+				if r.GetName() != resource.GetName() {
+					continue
+				}
 				if resource.GetNamespace() != "" && resource.GetNamespace() != r.GetNamespace() {
 					continue
 				}
-				if resource.GetApiVersion() != "" && resource.GetApiVersion() != r.GetApiVersion() {
+				if resource.GetApiVersion() != "" && !strings.EqualFold(resource.GetApiVersion(), r.GetApiVersion()) {
+					continue
+				}
+				if !kindPredicate(r) {
 					continue
 				}
 
@@ -161,6 +173,28 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 					seenResources[r.GetID()] = struct{}{}
 				}
 			}
+		}
+		return wls
+	}
+
+	// Pass 1: Direct case-insensitive match on the requested kind.
+	// This preserves bare CRD Kinds (e.g. Deploy for an example.com/v1 resource)
+	// without alias normalization colliding or rewriting the kind.
+	wls := collectMatches(func(r workloadinterface.IMetadata) bool {
+		return strings.EqualFold(r.GetKind(), resource.GetKind())
+	})
+
+	// Pass 2: Fallback alias normalization for built-in Kubernetes resources.
+	// If direct matching finds no candidates and the requested kind is a recognized
+	// alias/short name for a built-in workload (e.g. "deploy", "po", "ds"), attempt
+	// matching against built-in API group resources with the canonical kind.
+	if len(wls) == 0 {
+		normalizedKind := cautils.NormalizeWorkloadKind(resource.GetKind())
+		if !strings.EqualFold(normalizedKind, resource.GetKind()) {
+			wls = collectMatches(func(r workloadinterface.IMetadata) bool {
+				group, _ := k8sinterface.SplitApiVersion(r.GetApiVersion())
+				return cautils.IsBuiltinGroup(group) && strings.EqualFold(r.GetKind(), normalizedKind)
+			})
 		}
 	}
 

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -53,6 +53,16 @@ func TestResourceIdentity(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "same identity lowercase kind",
+			other:    localWorkloadWithPath("apps/v1", "deployment", "default", "bad-deploy", "/some/dir"),
+			expected: true,
+		},
+		{
+			name:     "same identity short name kind",
+			other:    localWorkloadWithPath("apps/v1", "deploy", "default", "bad-deploy", "/some/dir"),
+			expected: true,
+		},
+		{
 			name:     "different namespace",
 			other:    localWorkloadWithPath("apps/v1", "Deployment", "other", "bad-deploy", "x"),
 			expected: false,
@@ -84,6 +94,11 @@ func TestResourceIdentity(t *testing.T) {
 			}
 		})
 	}
+
+	// Custom API groups preserve distinct kinds (e.g. Deploy vs Deployment) without normalization collision
+	crdDeploy := localWorkloadWithPath("example.com/v1", "Deploy", "default", "bad-deploy", "deploy.yaml:0")
+	crdDeployment := localWorkloadWithPath("example.com/v1", "Deployment", "default", "bad-deploy", "/some/dir")
+	assert.NotEqual(t, resourceIdentity(crdDeploy), resourceIdentity(crdDeployment))
 }
 
 func TestDedupWorkloads(t *testing.T) {
@@ -92,7 +107,10 @@ func TestDedupWorkloads(t *testing.T) {
 	rendered := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/some/dir")
 	helmCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/helm")
 	kustomizeCopy := localWorkloadWithPath("apps/v1", "Deployment", "default", "bad-deploy", "/kustomize")
+	rawShort := localWorkloadWithPath("apps/v1", "deploy", "default", "bad-deploy", "deploy.yaml:0")
 	other := localWorkloadWithPath("apps/v1", "Deployment", "default", "other", "other.yaml:0")
+	crdDeploy := localWorkloadWithPath("example.com/v1", "Deploy", "default", "bad-deploy", "deploy.yaml:0")
+	crdDeployment := localWorkloadWithPath("example.com/v1", "Deployment", "default", "bad-deploy", "/some/dir")
 
 	tt := []struct {
 		name               string
@@ -100,6 +118,24 @@ func TestDedupWorkloads(t *testing.T) {
 		workloadIDToSource map[string]reporthandling.Source
 		expectedIDs        []string
 	}{
+		{
+			name:      "distinct custom resources in same group with alias-like kinds are both kept",
+			workloads: []workloadinterface.IMetadata{crdDeploy, crdDeployment},
+			workloadIDToSource: map[string]reporthandling.Source{
+				crdDeploy.GetID():     {FileType: reporthandling.SourceTypeYaml},
+				crdDeployment.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+			},
+			expectedIDs: []string{crdDeploy.GetID(), crdDeployment.GetID()},
+		},
+		{
+			name:      "rendered copy replaces raw copy with short name kind",
+			workloads: []workloadinterface.IMetadata{rawShort, rendered},
+			workloadIDToSource: map[string]reporthandling.Source{
+				rawShort.GetID(): {FileType: reporthandling.SourceTypeYaml},
+				rendered.GetID(): {FileType: reporthandling.SourceTypeKustomizeDirectory},
+			},
+			expectedIDs: []string{rendered.GetID()},
+		},
 		{
 			name:      "rendered copy replaces raw copy (raw discovered first)",
 			workloads: []workloadinterface.IMetadata{raw, rendered},
@@ -179,11 +215,21 @@ func TestFindScanObjectResource(t *testing.T) {
 			localWorkloadWithPath("v1", "Pod", "default", "nginx", "/fileB.yaml"),
 			localWorkloadWithPath("v1", "Pod", "", "mariadb", "/fileB.yaml"),
 		},
+		"example.com/v1/deploys": {
+			localWorkloadWithPath("example.com/v1", "Deploy", "default", "crd-deploy", "/fileC.yaml"),
+			localWorkloadWithPath("example.com/v1", "Deploy", "default", "web", "/fileE.yaml"),
+		},
+		"apps/v1/deployments": {
+			localWorkloadWithPath("apps/v1", "Deployment", "default", "nginx", "/fileD.yaml"),
+			localWorkloadWithPath("apps/v1", "Deployment", "default", "web", "/fileF.yaml"),
+		},
 	}
 	tt := []struct {
 		name                 string
 		scanObject           *objectsenvelopes.ScanObject
 		expectedResourceName string
+		expectedKind         string
+		expectedApiVersion   string
 		expectErr            bool
 		expectedErrorString  string
 	}{
@@ -223,6 +269,94 @@ func TestFindScanObjectResource(t *testing.T) {
 			expectedErrorString:  "",
 		},
 		{
+			name: "case-insensitive kind match",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "pod",
+				ApiVersion: "v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "mariadb",
+					Namespace: "",
+				},
+			},
+			expectedResourceName: "mariadb",
+			expectErr:            false,
+			expectedErrorString:  "",
+		},
+		{
+			name: "case-insensitive apiVersion match",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Pod",
+				ApiVersion: "V1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "mariadb",
+					Namespace: "",
+				},
+			},
+			expectedResourceName: "mariadb",
+			expectErr:            false,
+			expectedErrorString:  "",
+		},
+		{
+			name: "CRD match with PascalCase kind",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Deploy",
+				ApiVersion: "",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "crd-deploy",
+					Namespace: "default",
+				},
+			},
+			expectedResourceName: "crd-deploy",
+			expectedKind:         "Deploy",
+			expectedApiVersion:   "example.com/v1",
+			expectErr:            false,
+		},
+		{
+			name: "CRD match with lowercase alias kind in pass 1",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "deploy",
+				ApiVersion: "",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "crd-deploy",
+					Namespace: "default",
+				},
+			},
+			expectedResourceName: "crd-deploy",
+			expectedKind:         "Deploy",
+			expectedApiVersion:   "example.com/v1",
+			expectErr:            false,
+		},
+		{
+			name: "built-in resource match via pass 2 alias expansion fallback",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "deploy",
+				ApiVersion: "",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+			},
+			expectedResourceName: "nginx",
+			expectedKind:         "Deployment",
+			expectedApiVersion:   "apps/v1",
+			expectErr:            false,
+		},
+		{
+			name: "CRD kind takes precedence over built-in alias expansion when names collide",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "deploy",
+				ApiVersion: "",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Name:      "web",
+					Namespace: "default",
+				},
+			},
+			expectedResourceName: "web",
+			expectedKind:         "Deploy",
+			expectedApiVersion:   "example.com/v1",
+			expectErr:            false,
+		},
+		{
 			name: "no workload match",
 			scanObject: &objectsenvelopes.ScanObject{
 				Kind:       "Deployment",
@@ -252,6 +386,12 @@ func TestFindScanObjectResource(t *testing.T) {
 
 			if tc.expectedResourceName != "" {
 				assert.Equal(t, tc.expectedResourceName, resource.GetName())
+			}
+			if tc.expectedKind != "" {
+				assert.Equal(t, tc.expectedKind, resource.GetKind())
+			}
+			if tc.expectedApiVersion != "" {
+				assert.Equal(t, tc.expectedApiVersion, resource.GetApiVersion())
 			}
 		})
 

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -618,7 +618,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		// Keep the legacy single-resource behavior for built-in objects whose
 		// callers omit apiVersion. CRDs still require their declared apiVersion
 		// so discovery can select an unambiguous GVR.
-		groupVersionResource, err := k8sinterface.GetGroupVersionResource(resource.GetKind())
+		groupVersionResource, err := k8sinterface.GetGroupVersionResource(cautils.NormalizeWorkloadKind(resource.GetKind()))
 		if err == nil {
 			resolved = []resolvedResource{{
 				groupVersionResourceTriplet: k8sinterface.GroupVersionResourceToString(&groupVersionResource),

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -65,10 +65,12 @@ func unstructuredResourceWithParent(apiVersion, kind, namespace, name string) *u
 func TestFindScanObjectResourceDataDriven(t *testing.T) {
 	k8sinterface.InitializeMapResourcesMock()
 	deploymentGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	daemonSetGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
 	replicaSetGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
 	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	listKinds := map[schema.GroupVersionResource]string{
 		deploymentGVR: "DeploymentList",
+		daemonSetGVR:  "DaemonSetList",
 		replicaSetGVR: "ReplicaSetList",
 		// Secrets are registered so the fake client is genuinely able to serve
 		// them. Without this the client cannot list secrets at all and the
@@ -115,6 +117,36 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			request:   scanObject("apps/v1", "ReplicaSet", "", "checkout-rs"),
 			objects:   []runtime.Object{unstructuredResourceWithParent("apps/v1", "ReplicaSet", "shop", "checkout-rs")},
 			wantError: "was not found",
+		},
+		{
+			name:     "deployment with lowercase kind resolves cleanly without apiVersion",
+			request:  scanObject("", "deployment", "shop", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			wantName: "checkout",
+		},
+		{
+			name:     "deployment with short name deploy resolves cleanly without apiVersion",
+			request:  scanObject("", "deploy", "shop", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			wantName: "checkout",
+		},
+		{
+			name:     "deployment with uppercase short name DEPLOY resolves cleanly without apiVersion",
+			request:  scanObject("", "DEPLOY", "shop", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout")},
+			wantName: "checkout",
+		},
+		{
+			name:     "daemonset with lowercase kind resolves cleanly without apiVersion",
+			request:  scanObject("", "daemonset", "kube-system", "fluentd"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "DaemonSet", "kube-system", "fluentd")},
+			wantName: "fluentd",
+		},
+		{
+			name:     "daemonset with short name ds resolves cleanly without apiVersion",
+			request:  scanObject("", "ds", "kube-system", "fluentd"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "DaemonSet", "kube-system", "fluentd")},
+			wantName: "fluentd",
 		},
 		{
 			name:      "missing deployment reports the requested identity",


### PR DESCRIPTION
## Overview
This PR implements case-insensitive workload kind matching and adds standard `kubectl` short-name support to single-workload scanning (`kubescape scan workload <kind>/<name>` and the MCP server's `scan_workload` tool).

**Changes Made:**
- Added a static in-memory lookup map (`canonicalKinds`) in `core/cautils` that normalizes built-in kinds, plural forms, and official `kubectl` short names to canonical PascalCase (e.g., `deployment`/`deploy`/`deployments` → `Deployment`; `po`/`pods` → `Pod`; `ds` → `DaemonSet`)
- Modified local manifest loaders (`findScanObjectResource`) to match `Kind` and `ApiVersion` case-insensitively using `strings.EqualFold` for both built-in resources and CRDs
- Updated live-cluster single-resource scans to resolve built-in workloads without requiring `apiVersion` even when provided in lowercase or as short names
- Added `TestNormalizeWorkloadKind_MockDriftCheck` to ensure every built-in Kubernetes kind and plural resolves to its canonical PascalCase representation

## Additional Information
- **Static Map**: Uses a compiled static lookup map instead of runtime unmarshaling for zero-overhead parsing.
- **Short Names Scope**: Aliases are strictly scoped to official registered `kubectl api-resources` short names (`deploy`, `po`, `svc`, `sts`, `ds`, `cj`, `ns`, `no`, `cm`, `ing`, `pvc`, `pv`, `sa`, etc.).
- **CRD Handling**: Non-built-in CRDs in cluster mode still require explicit `apiVersion` (consistent with existing design), while file mode matches all resources case-insensitively.

## How to Test
### 1. Run Unit & Integration Tests
```bash
go test -v ./core/cautils ./core/pkg/resourcehandler ./cmd/mcpserver
```

### 2. Manual CLI Verification (File Mode)
```bash
# Lowercase kind
go run . scan workload deployment/nginx cmd/mcpserver/testdata/deployment.yaml

# Short name
go run . scan workload deploy/nginx cmd/mcpserver/testdata/deployment.yaml

# Uppercase short name
go run . scan workload DEPLOY/nginx cmd/mcpserver/testdata/deployment.yaml
```

### 3. Manual CLI Verification (Cluster Mode)
```bash
# Lowercase kind without apiVersion
kubescape scan workload deployment/coredns -n kube-system

# Short name without apiVersion
kubescape scan workload deploy/coredns -n kube-system
```

## Examples/Screenshots
```text
$ go run . scan workload deploy/nginx cmd/mcpserver/testdata/deployment.yaml
+ Scanning workload deploy/nginx against controls
  ...
+ Done scanning.
```

## Related issues/PRs
* Resolved #3729

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Kubernetes workload identifiers now support case-insensitive kinds, plural forms, and common short names such as `deploy`, `po`, and `svc`.
- Built-in resources, including Deployments and DaemonSets, can be resolved when `apiVersion` is omitted.
- Additional built-in aliases, including policy resources and `controllerrevision`, are recognized.
- Scans support custom resource kinds while preserving their declared casing.

## Bug Fixes

- Resource matching and deduplication now handle equivalent kind formats and API version casing consistently.
- Custom resource kinds take precedence over conflicting built-in aliases.
- Scan lookups continue to require exact name and namespace matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->