### PR TITLE
fix(release): write the cosign signing key owner-only and remove it after the release

### DIFF
--- a/.github/workflows/02-release.yaml
+++ b/.github/workflows/02-release.yaml
@@ -98,8 +98,26 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
+      # goreleaser's docker_signs block reads this file to sign the container
+      # images, so the key has to exist on disk for the length of the release
+      # run. Everything after this step shares the same workspace - the E2E
+      # hook, the system tests, and three third-party actions - so the key is
+      # created owner-only and removed again once the job finishes.
+      #
+      # The secret goes through `env` rather than being interpolated into the
+      # script: `${{ }}` substitution happens before the shell runs, which puts
+      # the key material into the command line itself.
       - name: Create Cosign Key
-        run: echo "${{ secrets.COSIGN_PRIVATE_KEY_V1 }}" > cosign.key
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY_V1 }}
+        run: |
+          set -euo pipefail
+
+          # umask only applies to a file it creates, so remove any leftover
+          # first - otherwise a pre-existing file keeps its old mode.
+          rm -f cosign.key
+          umask 077
+          printf '%s\n' "$COSIGN_PRIVATE_KEY" > cosign.key
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -174,3 +192,10 @@ jobs:
           report_paths: "test-results/system-tests/**/results_xml_format/**.xml"
           annotate_only: true
           job_summary: true
+
+      # Last in the job, and unconditional: goreleaser is the only consumer of
+      # the key, and a failed or cancelled release must not leave signing
+      # material behind in the workspace.
+      - name: Remove Cosign Key
+        if: always()
+        run: rm -f cosign.key

--- a/internal/ghworkflows/cosignkey_test.go
+++ b/internal/ghworkflows/cosignkey_test.go
@@ -1,0 +1,165 @@
+// This test guards how 02-release.yaml materialises the cosign signing key.
+//
+// The release job wrote it with `echo "${{ secrets.COSIGN_PRIVATE_KEY_V1 }}" >
+// cosign.key` and never removed it. Two things follow from that line. The
+// redirection creates the file under the runner's default umask, so private
+// key material landed at mode 0644; and `${{ }}` is substituted before the
+// shell starts, so the key was part of the command the step ran rather than an
+// input to it. With no cleanup step the file then stayed in the workspace for
+// the rest of the job - past the E2E hook, the system tests, and the
+// third-party actions that run after goreleaser.
+//
+// Nothing failed. The key is password-encrypted and goreleaser signed the
+// images exactly as intended, so a release looked identical either way; the
+// only difference was how much of the job the key was readable for.
+//
+// Deliberately test-only: this is a repository-hygiene guard, so it adds no
+// production surface.
+package ghworkflows
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// releaseJobName is the job that builds, signs and publishes a release.
+	releaseJobName = "release"
+
+	// cosignKeyFile is the path goreleaser's docker_signs block reads the
+	// signing key from. It is written by 02-release.yaml and consumed by the
+	// GoReleaser step; nothing else in the repository touches it.
+	cosignKeyFile = "cosign.key"
+
+	// cosignKeySecret is the secret holding the key. An `env:` entry has to
+	// carry it, because the alternative is interpolating it into the script.
+	cosignKeySecret = "COSIGN_PRIVATE_KEY_V1"
+
+	// secretsExpression is the prefix of any `${{ secrets.* }}` reference.
+	// Matching on this rather than on cosignKeySecret keeps the assertion
+	// honest if the environment variable is ever named after the secret.
+	secretsExpression = "secrets."
+)
+
+// cosignKeyStep is the subset of a workflow step these tests assert on.
+// releaseWorkflow decodes the same file for a different question and reads only
+// `name`/`uses`, so the step body is decoded here instead of widening that one.
+type cosignKeyStep struct {
+	Name string            `yaml:"name"`
+	If   string            `yaml:"if"`
+	Run  string            `yaml:"run"`
+	Env  map[string]string `yaml:"env"`
+}
+
+type cosignKeyWorkflow struct {
+	Jobs map[string]struct {
+		Steps []cosignKeyStep `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+// releaseSteps returns the steps of the release job, failing with a message
+// that says what to do if the job is ever renamed.
+func releaseSteps(t *testing.T) []cosignKeyStep {
+	t.Helper()
+
+	var workflow cosignKeyWorkflow
+	loadWorkflow(t, releaseWorkflowName, &workflow)
+
+	job, ok := workflow.Jobs[releaseJobName]
+	require.Truef(t, ok, "%s has no %q job; this guard needs updating to follow it",
+		releaseWorkflowName, releaseJobName)
+	require.NotEmptyf(t, job.Steps, "%s's %q job declares no steps",
+		releaseWorkflowName, releaseJobName)
+
+	return job.Steps
+}
+
+// TestCosignKeyIsWrittenWithRestrictedPermissions is the direct regression
+// test. It asserts on the step that creates the key rather than on a step name,
+// so renaming the step does not silently drop the guard.
+func TestCosignKeyIsWrittenWithRestrictedPermissions(t *testing.T) {
+	var writers []string
+	for _, step := range releaseSteps(t) {
+		// The writer is whichever step redirects into the key file. A step that
+		// only removes it is not one, hence the redirection rather than a bare
+		// mention of the filename.
+		if !strings.Contains(step.Run, "> "+cosignKeyFile) {
+			continue
+		}
+		writers = append(writers, step.Name)
+
+		// `${{ secrets.* }}` is expanded into the script before the shell runs,
+		// which puts the key on the step's command line. An `env:` entry is
+		// passed to the process instead.
+		assert.NotContainsf(t, step.Run, secretsExpression,
+			"%s's %q step interpolates a ${{ %s* }} value into its `run:` script; pass it through `env:` "+
+				"and reference the variable, so the key is never part of the command itself",
+			releaseWorkflowName, step.Name, secretsExpression)
+
+		var fromEnv bool
+		for _, value := range step.Env {
+			if strings.Contains(value, cosignKeySecret) {
+				fromEnv = true
+				break
+			}
+		}
+		assert.Truef(t, fromEnv,
+			"%s's %q step writes %s but no `env:` entry carries secrets.%s; the key has to reach the "+
+				"script as an environment variable",
+			releaseWorkflowName, step.Name, cosignKeyFile, cosignKeySecret)
+
+		// A redirection creates the file under the runner's default umask -
+		// 0644 on GitHub-hosted runners. Either tightening the umask before
+		// creating it or fixing the mode explicitly closes that; both forms are
+		// accepted so a later rewrite is not forced into one of them.
+		restricted := strings.Contains(step.Run, "umask 077") ||
+			strings.Contains(step.Run, "chmod 600 "+cosignKeyFile) ||
+			strings.Contains(step.Run, "install -m 600")
+		assert.Truef(t, restricted,
+			"%s's %q step writes %s without restricting its permissions; a plain redirection uses the "+
+				"runner's default umask, so the signing key lands world-readable in a workspace shared "+
+				"with every later step in the job",
+			releaseWorkflowName, step.Name, cosignKeyFile)
+	}
+
+	require.Lenf(t, writers, 1,
+		"expected exactly one step in %s to write %s, found %v; this guard asserts on the step that "+
+			"creates the key and cannot tell which one to check",
+		releaseWorkflowName, cosignKeyFile, writers)
+}
+
+// TestCosignKeyIsRemovedAfterTheRelease covers the other half. The key only has
+// to exist while goreleaser runs, and `if: always()` is what makes that true of
+// a failed release too - which is the run most likely to leave the workspace
+// behind for inspection.
+func TestCosignKeyIsRemovedAfterTheRelease(t *testing.T) {
+	steps := releaseSteps(t)
+
+	var removed, unconditional bool
+	for _, step := range steps {
+		if !strings.Contains(step.Run, "rm -f "+cosignKeyFile) {
+			continue
+		}
+		// The step that creates the key also clears a stale copy first; that
+		// one is not the cleanup.
+		if strings.Contains(step.Run, "> "+cosignKeyFile) {
+			continue
+		}
+		removed = true
+		if strings.Contains(step.If, "always()") {
+			unconditional = true
+		}
+	}
+
+	require.Truef(t, removed,
+		"no step in %s removes %s; the signing key stays in the workspace for the rest of the job, "+
+			"which continues past goreleaser into the system tests and the third-party actions after them",
+		releaseWorkflowName, cosignKeyFile)
+	assert.Truef(t, unconditional,
+		"%s removes %s only on success; a release that fails after the key is written leaves it behind, "+
+			"so the cleanup needs `if: always()`",
+		releaseWorkflowName, cosignKeyFile)
+}

--- a/internal/ghworkflows/releasesigning_test.go
+++ b/internal/ghworkflows/releasesigning_test.go
@@ -90,6 +90,9 @@ var guardedFiles = append([]string{
 	// the same "**.yaml" blind spot as everything else in this list.
 	filepath.Join(".github", "workflows", commentsWorkflowName),
 	filepath.Join("internal", "ghworkflows", "comments_test.go"),
+	// cosignkey_test.go guards how the release job writes and removes the
+	// signing key. It reads the release workflow already listed above.
+	filepath.Join("internal", "ghworkflows", "cosignkey_test.go"),
 }, installScripts...)
 
 // goreleaserSign is the subset of a `signs` / `docker_signs` entry these tests


### PR DESCRIPTION
## Overview

The release job creates the container-image signing key with

```yaml
run: echo "${{ secrets.COSIGN_PRIVATE_KEY_V1 }}" > cosign.key
```

and never deletes it. Two things follow from that one line:

* the redirection creates the file under the runner's default umask, so the key lands at **mode 0644**;
* `${{ }}` is substituted before the shell starts, so the key is part of the command the step runs rather than an input to it.

With no cleanup step the file then stays in `$GITHUB_WORKSPACE` for the rest of the job, which continues past GoReleaser into the E2E hook, the system tests, and the third-party actions after them (`krew-release-bot`, `sbom-action`, `action-junit-report`).

Nothing fails today. The key is password-encrypted and GoReleaser signs the images exactly as intended, so a release looks identical either way — the only difference is how much of the job the key is readable for. This is least-privilege hardening on signing material, not a report of an active compromise.

## Changes

* Pass the secret through `env:` and reference the variable from the script.
* Clear any stale copy first, then create the file under `umask 077` (umask only applies to a file it creates, so a pre-existing file would otherwise keep its old mode).
* Remove the key in a final `if: always()` step, so a failed or cancelled release leaves no signing material behind.

The bytes written are unchanged — `printf '%s\n' "$X"` is byte-identical to `echo "$X"` — so `docker_signs` reads exactly the same key.

## How to Test

Added `internal/ghworkflows/cosignkey_test.go`, following the pattern the package already uses for `comments.yaml` and `.goreleaser.yaml`. It asserts that the step writing `cosign.key` takes the secret from `env:` rather than interpolating `${{ secrets.* }}`, that it restricts the file's permissions, and that a cleanup step exists with `if: always()`.

Both tests fail against the previous workflow and pass against this one, and each half was mutation-tested separately (dropping the cleanup, dropping `if: always()`, and dropping the `umask` are each caught).

Beyond the unit tests, the two `run:` scripts were extracted from the workflow YAML and executed directly: the key lands at `0600`, its contents are byte-identical to what the old step produced, and the cleanup step removes it. Also checked an empty secret (a fork without it configured), a stale world-writable file, and values containing quotes, backslashes and `$`.

```
go build ./...                          # ok
go vet ./...                            # ok
go test -race ./internal/ghworkflows/   # ok
```

`cosignkey_test.go` is registered in `guardedFiles`, since `repo-hygiene.yaml`'s allow-list is the only reason these tests run on a workflow-only PR — `00-pr-scanner.yaml` ignores `**.yaml`.

## Related issues/PRs

No tracking issue; found while reviewing how the release pipeline handles signing material. Related to #3344, which moved blob signing to keyless but deliberately left `docker_signs` keyed — so `cosign.key` is still produced and consumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Release signing keys are now handled with stricter file permissions during builds.
  - Signing keys are automatically removed after release jobs finish, including unsuccessful or cancelled runs.
  - Existing signing-key files are cleared before use to reduce the risk of stale credentials being retained.

- **Reliability**
  - Added automated safeguards to verify secure signing-key handling throughout the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->