### PR TITLE
fix(rbacgraph): order escalation results instead of reading map order

### DIFF
--- a/core/pkg/rbacgraph/adapter.go
+++ b/core/pkg/rbacgraph/adapter.go
@@ -3,6 +3,8 @@ package rbacgraph
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +17,15 @@ import (
 // ignored. An object of one of those five kinds that fails to decode is
 // skipped, with its error appended to errs, rather than aborting the whole
 // conversion over one bad object.
+//
+// Resources are visited in resource-ID order rather than map order: every
+// slice returned here becomes part of an Index, and the order of that data
+// reaches the reported escalation paths. Map iteration order is randomized,
+// so reading it directly would make the same cluster snapshot produce a
+// differently-ordered report on every run.
 func FromResources(resources map[string]workloadinterface.IMetadata) (roles []rbacv1.Role, clusterRoles []rbacv1.ClusterRole, roleBindings []rbacv1.RoleBinding, clusterRoleBindings []rbacv1.ClusterRoleBinding, serviceAccounts []corev1.ServiceAccount, errs []error) {
-	for _, resource := range resources {
+	for _, id := range slices.Sorted(maps.Keys(resources)) {
+		resource := resources[id]
 		if resource == nil {
 			continue
 		}

--- a/core/pkg/rbacgraph/closure_test.go
+++ b/core/pkg/rbacgraph/closure_test.go
@@ -1,8 +1,12 @@
 package rbacgraph
 
 import (
+	"slices"
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -640,5 +644,127 @@ func TestAnalyzeEscalation_EscalateTargetNotInIndexFallsBackToScopeUnbounded(t *
 	}
 	if len(result.Unbounded) == 0 {
 		t.Error("Unbounded = empty, want the fallback finding recorded")
+	}
+}
+
+// --- deterministic ordering ---
+
+// escalationFingerprint renders everything a caller can observe about a
+// result's ordering: the reached identities in order, the edges of each path,
+// and the unbounded findings.
+func escalationFingerprint(r EscalationResult) string {
+	var b strings.Builder
+	for _, p := range r.Reached {
+		for _, e := range p.Edges {
+			b.WriteString(string(e.Primitive) + "|" + e.Detail + "\n")
+		}
+		b.WriteString("--\n")
+	}
+	for _, f := range r.Unbounded {
+		b.WriteString(f.Subject.String() + "|" + f.Edge.Detail + "\n")
+	}
+	return b.String()
+}
+
+func TestAnalyzeEscalation_ClusterWideGrantEnumeratesNamespacesInStableOrder(t *testing.T) {
+	// A cluster-wide "create pods" grant enumerates every namespace the
+	// Index has ServiceAccounts for. That list came straight out of a map,
+	// so the reported escalation paths arrived in a different order on
+	// every run and two scans of one unchanged cluster never matched.
+	cr := clusterRole("pod-creator", rule([]string{""}, []string{"pods"}, []string{"create"}, nil))
+	crb := clusterRoleBinding("crb", "pod-creator", saSubject("home", "attacker"))
+	accounts := []corev1.ServiceAccount{
+		saObj("home", "attacker"),
+		saObj("delta", "d1"),
+		saObj("alpha", "a1"),
+		saObj("charlie", "c1"),
+		saObj("bravo", "b1"),
+		saObj("echo", "e1"),
+	}
+	idx := NewIndex(nil, []rbacv1.ClusterRole{cr}, nil, []rbacv1.ClusterRoleBinding{crb}, accounts)
+
+	want := escalationFingerprint(idx.AnalyzeEscalation(sa("home", "attacker")))
+	for i := 1; i < 25; i++ {
+		if got := escalationFingerprint(idx.AnalyzeEscalation(sa("home", "attacker"))); got != want {
+			t.Fatalf("run %d differs from run 0:\nfirst:\n%s\ngot:\n%s", i, want, got)
+		}
+	}
+
+	namespaces := idx.targetNamespaces("")
+	if !sort.StringsAreSorted(namespaces) {
+		t.Errorf("targetNamespaces(\"\") = %v, want sorted", namespaces)
+	}
+}
+
+func TestAnalyzeEscalation_BindableRolesAndClusterRolesAreEnumeratedInStableOrder(t *testing.T) {
+	// bind-verb walks the collected Roles and ClusterRoles, both stored in
+	// maps, so the edges it emits carried map order into the report too.
+	binder := clusterRole("binder",
+		rule([]string{"rbac.authorization.k8s.io"}, []string{"clusterroles", "roles"}, []string{"bind"}, nil),
+		rule([]string{"rbac.authorization.k8s.io"}, []string{"rolebindings", "clusterrolebindings"}, []string{"create"}, nil),
+	)
+	get := rule([]string{""}, []string{"pods"}, []string{"get"}, nil)
+	idx := NewIndex(
+		[]rbacv1.Role{role("dev", "zeta", get), role("dev", "alpha", get), role("prod", "mu", get), role("prod", "beta", get)},
+		[]rbacv1.ClusterRole{binder, clusterRole("zulu", get), clusterRole("kilo", get), clusterRole("alfa", get)},
+		nil,
+		[]rbacv1.ClusterRoleBinding{clusterRoleBinding("crb", "binder", saSubject("dev", "attacker"))},
+		[]corev1.ServiceAccount{saObj("dev", "attacker")},
+	)
+
+	want := escalationFingerprint(idx.AnalyzeEscalation(sa("dev", "attacker")))
+	for i := 1; i < 25; i++ {
+		if got := escalationFingerprint(idx.AnalyzeEscalation(sa("dev", "attacker"))); got != want {
+			t.Fatalf("run %d differs from run 0:\nfirst:\n%s\ngot:\n%s", i, want, got)
+		}
+	}
+
+	var clusterRoleNames []string
+	for _, cr := range idx.matchingClusterRoles(nil, false) {
+		clusterRoleNames = append(clusterRoleNames, cr.Name)
+	}
+	if !sort.StringsAreSorted(clusterRoleNames) {
+		t.Errorf("matchingClusterRoles = %v, want sorted by name", clusterRoleNames)
+	}
+
+	var roleKeys []string
+	for _, r := range idx.matchingRolesAnyNamespace(nil, false) {
+		roleKeys = append(roleKeys, roleKey(r.Namespace, r.Name))
+	}
+	if !sort.StringsAreSorted(roleKeys) {
+		t.Errorf("matchingRolesAnyNamespace = %v, want sorted by namespace/name", roleKeys)
+	}
+}
+
+func TestFromResources_ConvertsInResourceIDOrder(t *testing.T) {
+	// FromResources reads a map, and everything it returns becomes Index
+	// state that the report's ordering depends on.
+	resources := map[string]workloadinterface.IMetadata{}
+	for _, name := range []string{"zeta", "alpha", "mu", "beta", "kilo"} {
+		obj := workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata":   map[string]any{"name": name, "namespace": "dev"},
+		})
+		resources[obj.GetID()] = obj
+	}
+
+	var want []string
+	for i := 0; i < 25; i++ {
+		_, _, _, _, serviceAccounts, errs := FromResources(resources)
+		if len(errs) != 0 {
+			t.Fatalf("errs = %v, want none", errs)
+		}
+		got := make([]string, 0, len(serviceAccounts))
+		for _, sa := range serviceAccounts {
+			got = append(got, sa.Name)
+		}
+		if i == 0 {
+			want = got
+			continue
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("run %d = %v, want %v (same order every run)", i, got, want)
+		}
 	}
 }

--- a/core/pkg/rbacgraph/escalation.go
+++ b/core/pkg/rbacgraph/escalation.go
@@ -2,6 +2,8 @@ package rbacgraph
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -175,7 +177,8 @@ func (idx *Index) escalateVerbEdges(rules []ScopedRule) []EscalationEdge {
 			}
 		}
 
-		for scope, esc := range escalateByScope {
+		for _, scope := range slices.Sorted(maps.Keys(escalateByScope)) {
+			esc := escalateByScope[scope]
 			if resource == "clusterroles" && scope != "" {
 				continue
 			}
@@ -396,22 +399,21 @@ func (idx *Index) mintServiceAccountTokenEdges(rules []ScopedRule) []EscalationE
 // targetNamespaces expands a ScopedRule's own scope into the namespaces an
 // edge should enumerate targets against: just that one namespace for a
 // namespace-scoped rule, or every namespace this Index has ServiceAccount
-// data for when the rule is cluster-wide.
+// data for when the rule is cluster-wide. Sorted, like every other
+// map-derived list in this package -- see matchingClusterRoles.
 func (idx *Index) targetNamespaces(scopeNamespace string) []string {
 	if scopeNamespace != "" {
 		return []string{scopeNamespace}
 	}
-	out := make([]string, 0, len(idx.serviceAccountsByNS))
-	for ns := range idx.serviceAccountsByNS {
-		out = append(out, ns)
-	}
-	return out
+	return slices.Sorted(maps.Keys(idx.serviceAccountsByNS))
 }
 
 // knownNamespaces returns every namespace this Index has any evidence of,
 // drawn from collected ServiceAccounts, Roles, and RoleBindings -- used to
 // expand a cluster-wide grant (e.g. create rolebindings with no namespace
 // restriction) into the concrete namespaces this package can reason about.
+// Sorted, like every other map-derived list in this package -- see
+// matchingClusterRoles.
 func (idx *Index) knownNamespaces() []string {
 	seen := map[string]bool{}
 	var out []string
@@ -431,12 +433,20 @@ func (idx *Index) knownNamespaces() []string {
 	for _, rb := range idx.roleBindings {
 		add(rb.Namespace)
 	}
+	sort.Strings(out)
 	return out
 }
 
+// matchingClusterRoles returns the collected ClusterRoles a grant covers, in
+// name order. idx.clusterRoles is a map, and every list this package derives
+// from a map feeds an EscalationEdge and so reaches the reported result, both
+// as the order edges are emitted in and as the order the BFS discovers
+// subjects in. Reading map order directly would make the same cluster
+// snapshot report differently-ordered escalation paths on every run.
 func (idx *Index) matchingClusterRoles(names []string, restricted bool) []*rbacv1.ClusterRole {
 	var out []*rbacv1.ClusterRole
-	for _, cr := range idx.clusterRoles {
+	for _, name := range slices.Sorted(maps.Keys(idx.clusterRoles)) {
+		cr := idx.clusterRoles[name]
 		if restricted && !containsOrWildcard(names, cr.Name) {
 			continue
 		}
@@ -447,7 +457,8 @@ func (idx *Index) matchingClusterRoles(names []string, restricted bool) []*rbacv
 
 func (idx *Index) matchingRoles(namespace string, names []string, restricted bool) []*rbacv1.Role {
 	var out []*rbacv1.Role
-	for _, r := range idx.roles {
+	for _, key := range slices.Sorted(maps.Keys(idx.roles)) {
+		r := idx.roles[key]
 		if r.Namespace != namespace {
 			continue
 		}
@@ -464,7 +475,8 @@ func (idx *Index) matchingRoles(namespace string, names []string, restricted boo
 // which applies to Role objects in every namespace, not just one.
 func (idx *Index) matchingRolesAnyNamespace(names []string, restricted bool) []*rbacv1.Role {
 	var out []*rbacv1.Role
-	for _, r := range idx.roles {
+	for _, key := range slices.Sorted(maps.Keys(idx.roles)) {
+		r := idx.roles[key]
 		if restricted && !containsOrWildcard(names, r.Name) {
 			continue
 		}

--- a/core/pkg/rbacgraph/index.go
+++ b/core/pkg/rbacgraph/index.go
@@ -1,6 +1,8 @@
 package rbacgraph
 
 import (
+	"sort"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -45,6 +47,12 @@ func NewIndex(roles []rbacv1.Role, clusterRoles []rbacv1.ClusterRole, roleBindin
 	}
 	for _, sa := range serviceAccounts {
 		idx.serviceAccountsByNS[sa.Namespace] = append(idx.serviceAccountsByNS[sa.Namespace], sa.Name)
+	}
+	// Sorted so the Index is canonical whatever order its inputs arrived in:
+	// these names are enumerated straight into escalation edges, and an
+	// escalation report should not depend on collection order.
+	for ns := range idx.serviceAccountsByNS {
+		sort.Strings(idx.serviceAccountsByNS[ns])
 	}
 	return idx
 }


### PR DESCRIPTION
## Overview

`analyze_rbac_escalation_paths` returns a differently-ordered result on every run against one unchanged cluster snapshot, so two scans of the same cluster never match and a report can't be diffed against a baseline.

Six places in `core/pkg/rbacgraph` read a Go map directly, and everything they yield reaches the report. `targetNamespaces` and `knownNamespaces` in `escalation.go` range over `idx.serviceAccountsByNS` to expand a cluster-wide grant into namespaces. `matchingClusterRoles`, `matchingRoles` and `matchingRolesAnyNamespace` range over `idx.clusterRoles` and `idx.roles` to find the roles a bind or escalate grant covers. `escalateVerbEdges` ranges over its `escalateByScope` map. `FromResources` in `adapter.go` ranges over the collected resource map, so even the slices that build the `Index` arrive shuffled. Map iteration order is randomized, so the edges come out in a different order each time, the BFS in `closure.go` discovers subjects in a different order, and `Reached`, `EffectiveRules` and `Unbounded` all end up ordered by chance.

Order also decides which findings survive. The search stops early once `ClusterAdmin` is confirmed, and again at `maxEscalationHops`, so on a large cluster a truncated result keeps a random subset of the paths rather than a stable one.

The fix sorts each of them: namespaces and scopes by name, roles by namespace/name, cluster roles by name, resources by resource ID. `NewIndex` also sorts the ServiceAccount names it collects per namespace, so an `Index` built directly is canonical whatever order its inputs arrived in. Which edges are found does not change, only the order they come out in.

This is what the rest of the repo already does where map iteration feeds output: `dedupeServedVersionAliases` in `core/pkg/resourcehandler/k8sresources.go` walks `slices.Sorted(maps.Keys(allResources))`, the related-location loop in `core/pkg/resultshandling/printer/v2/sarifprinter.go` sorts with the comment "map iteration order is randomized and this feeds directly into the written SARIF file", and `groupByManifest` in `core/pkg/resultshandling/printer/v2/fixcache.go` notes that sorting "makes the report order deterministic, which map iteration was not". `rbacgraph` is the newest of these packages and was missed.

## How to Test

Three tests in `core/pkg/rbacgraph/closure_test.go`. Two run the analysis 25 times over one `Index` and compare the full ordering of every reached path and unbounded finding, and check the accessors return sorted lists; one does the same for `FromResources`. All three fail on master and pass with the change.

On master, with the tests applied and the source reverted:

```
$ git checkout master -- core/pkg/rbacgraph/adapter.go core/pkg/rbacgraph/escalation.go core/pkg/rbacgraph/index.go
$ go test -count=1 -run 'StableOrder|TestFromResources_ConvertsInResourceIDOrder' ./core/pkg/rbacgraph/...
--- FAIL: TestAnalyzeEscalation_ClusterWideGrantEnumeratesNamespacesInStableOrder
    closure_test.go:689: run 1 differs from run 0
--- FAIL: TestAnalyzeEscalation_BindableRolesAndClusterRolesAreEnumeratedInStableOrder
    closure_test.go:730: matchingClusterRoles = [kilo alfa binder zulu], want sorted by name
    closure_test.go:738: matchingRolesAnyNamespace = [prod/beta dev/zeta dev/alpha prod/mu], want sorted by namespace/name
--- FAIL: TestFromResources_ConvertsInResourceIDOrder
    closure_test.go:770: run 1 = [beta kilo zeta alpha mu], want [zeta alpha mu beta kilo] (same order every run)
FAIL
```

With the change:

```
$ go test -count=5 -race ./core/pkg/rbacgraph/...
ok  	github.com/kubescape/kubescape/v4/core/pkg/rbacgraph	2.227s

$ go test -count=1 -run 'RBAC|Escalation' ./cmd/mcpserver/
ok  	github.com/kubescape/kubescape/v4/cmd/mcpserver	8.314s

$ golangci-lint run --timeout 10m ./core/pkg/rbacgraph/...     # v2.12.2, the version CI pins
0 issues.

$ gofmt -l core/pkg/rbacgraph/     # no output
$ go vet ./core/pkg/rbacgraph/... ./cmd/mcpserver/...     # no output
```

`TestRunWorkloadScan_AmbiguousInFile` in `cmd/mcpserver` fails here with `framework 'nsa' not found` because this machine can't reach the policy service. It fails identically on unmodified master, so it is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of RBAC escalation results by applying stable ordering to resources, namespaces, service accounts, roles, and escalation paths.
  * Ensured repeated analyses produce the same output regardless of input collection order.

* **Tests**
  * Added coverage verifying deterministic ordering across escalation analysis and resource conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->