### PR TITLE
fix(mcpserver): return explicit error for unsupported resource_kind in scan_resource_slice

### DIFF
--- a/cmd/mcpserver/advanced_tools.go
+++ b/cmd/mcpserver/advanced_tools.go
@@ -49,12 +49,9 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		}
 		continueToken, _ := args["continue"].(string)
 
-		k8sClient, err := ksServer.getK8sClient()
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
-		}
-
-		// Simplified mapping for common kinds, to support granular resource fetching
+		// Simplified mapping for common kinds, to support granular resource fetching.
+		// Validated before client acquisition so an unsupported kind is rejected
+		// regardless of whether a Kubernetes configuration is available.
 		var gvr schema.GroupVersionResource
 		switch strings.ToLower(kind) {
 		case "pods", "pod":
@@ -67,6 +64,11 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 			gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unsupported resource kind %q; supported kinds are: pods, deployments, daemonsets, statefulsets", kind)), nil
+		}
+
+		k8sClient, err := ksServer.getK8sClient()
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
 		}
 
 		listOpts := metav1.ListOptions{

--- a/cmd/mcpserver/advanced_tools.go
+++ b/cmd/mcpserver/advanced_tools.go
@@ -66,8 +66,7 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		case "statefulsets", "statefulset":
 			gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
 		default:
-			// Defaulting to try core v1
-			gvr = schema.GroupVersionResource{Group: "", Version: "v1", Resource: strings.ToLower(kind)}
+			return mcp.NewToolResultError(fmt.Sprintf("unsupported resource kind %q; supported kinds are: pods, deployments, daemonsets, statefulsets", kind)), nil
 		}
 
 		listOpts := metav1.ListOptions{

--- a/cmd/mcpserver/advanced_tools_test.go
+++ b/cmd/mcpserver/advanced_tools_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -58,6 +59,38 @@ func TestScanResourceSlice_UnsupportedKindReturnsError(t *testing.T) {
 			server.WithRecovery(),
 		),
 		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createAdvancedTools(ksServer)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "scan_resource_slice", map[string]any{
+		"resource_kind": "jobs",
+	}))
+	require.True(t, result.IsError)
+	text := toolResultText(t, result)
+	require.Contains(t, text, `unsupported resource kind "jobs"`)
+	require.Contains(t, text, "pods")
+	require.Contains(t, text, "deployments")
+	require.Contains(t, text, "daemonsets")
+	require.Contains(t, text, "statefulsets")
+}
+
+// TestScanResourceSlice_UnsupportedKindReturnsErrorWithoutClusterConfig
+// guards against the unsupported-kind check being reordered behind
+// getK8sClient(): with no pre-populated k8sClient and no reachable cluster
+// config, the tool must still report the unsupported kind rather than
+// masking it behind "failed to get k8s client".
+func TestScanResourceSlice_UnsupportedKindReturnsErrorWithoutClusterConfig(t *testing.T) {
+	origLoadK8sConfig := loadK8sConfig
+	t.Cleanup(func() { loadK8sConfig = origLoadK8sConfig })
+	loadK8sConfig = func() error { return errors.New("no kubeconfig") }
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
 	}
 	createAdvancedTools(ksServer)
 

--- a/cmd/mcpserver/advanced_tools_test.go
+++ b/cmd/mcpserver/advanced_tools_test.go
@@ -41,3 +41,29 @@ func TestScanResourceSlice_EmptyResultMarshalsAsEmptyArray(t *testing.T) {
 	raw := toolResultText(t, result)
 	require.JSONEq(t, `{"resources":[],"continue":"","count":0}`, raw)
 }
+
+// TestScanResourceSlice_UnsupportedKindReturnsError guards against a silent
+// fallback to core/v1 for resource kinds the tool does not explicitly map
+// (e.g. "jobs"). Falling back would send a request to the wrong API group and
+// surface the cluster's "resource not found" rejection as an opaque list
+// failure, indistinguishable from a connectivity problem.
+func TestScanResourceSlice_UnsupportedKindReturnsError(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+
+	ksServer := &KubescapeMcpserver{
+		s: server.NewMCPServer(
+			"kubescape-test",
+			"test",
+			server.WithToolCapabilities(false),
+			server.WithRecovery(),
+		),
+		k8sClient: &k8sinterface.KubernetesApi{DynamicClient: dyn},
+	}
+	createAdvancedTools(ksServer)
+
+	result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "scan_resource_slice", map[string]any{
+		"resource_kind": "jobs",
+	}))
+	require.True(t, result.IsError)
+	require.Contains(t, toolResultText(t, result), `unsupported resource kind "jobs"`)
+}


### PR DESCRIPTION
## Overview
The `scan_resource_slice` MCP tool resolves `resource_kind` to a Group/Version/Resource via a static switch that only handles pods, deployments, daemonsets, and statefulsets. Previously, the `default` branch silently built `Group: "", Version: "v1", Resource: <kind>` for any other kind (e.g. "jobs", "ingresses"), sending the request to the wrong API group. The cluster's resulting "resource not found" error was indistinguishable from a connectivity failure to the caller.

This PR replaces the silent fallback with an explicit error naming the unsupported kind and listing the kinds that are supported, returned before any API call is made.

## Additional Information
The `dry_run_remediation` tool's own kind-to-GVR switch in the same file is not affected: it is already gated by an `allowedKinds` allowlist that restricts `resource_kind` to exactly the four kinds the switch handles, so it cannot reach an unmapped default. Scope was kept to `scan_resource_slice`, matching the issue.

## How to Test
Run the mcpserver package tests:
```
go test ./cmd/mcpserver/... -run TestScanResourceSlice -v
```
`TestScanResourceSlice_UnsupportedKindReturnsError` calls the tool with `resource_kind: "jobs"` and asserts the tool returns an error containing `unsupported resource kind "jobs"` instead of attempting a list call.

## Validation
- `go build ./cmd/mcpserver/...` passes.
- `go test ./cmd/mcpserver/... -run TestScanResourceSlice -v` passes (both the existing empty-result test and the new unsupported-kind test).
- `go test -race ./cmd/mcpserver/...` passes (full package, race detector).
- Confirmed the new test is a genuine regression guard: with the fix reverted, it fails with a recovered panic from the fake dynamic client (`... /v1, Resource=jobs out of map[]`), proving the old code path really did construct and use a bogus core/v1 GVR for "jobs". With the fix restored, it passes.
- `golangci-lint run ./cmd/mcpserver/...` (v2.12.2, matching this repo's CI-pinned version) reports only one pre-existing, unrelated staticcheck hint at `cmd/mcpserver/mcpserver.go:1404`, a line not touched by this change.
- Did not run the full-repo `go test -race ./...` that this repo's CI executes, due to local disk space constraints in this environment; validation was scoped to the affected package (build, targeted tests, race detector, and lint all green there) plus lint on the changed files.

## Related issues/PRs:
Report: https://github.com/kubescape/kubescape/issues/3732

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Fixes #3732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unsupported resource kinds now return a clear error instead of being treated as core resources.
  - Error messages identify the supported resource kinds: pods, deployments, daemonsets, and statefulsets.
  - Unsupported-kind errors are reported even when cluster configuration is unavailable.

- **Tests**
  - Added coverage to verify unsupported kinds are rejected correctly in different configuration conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->