### PR TITLE
fix(printer): generalize evidence redaction beyond Secret-kind-only

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -180,21 +181,190 @@ func indexList(v any, i int) (any, bool) {
 	return rv.Index(i).Interface(), true
 }
 
-// isSensitivePath reports whether a path targets a field whose value must
-// not be surfaced in scan output unless --show-secrets is set. Secret
-// data/stringData and container env[N].value (C-0012 plaintext credentials)
-// are treated as sensitive.
-func isSensitivePath(kind, path string) bool {
+// secretFieldPatterns lists normalized field-name substrings that mark a
+// path's value as secret-shaped regardless of resource kind. This mirrors
+// anonymizer.isSensitiveEnvName's pattern list in core/pkg/anonymizer -
+// intentionally not imported from there, since anonymizer imports
+// resultshandling, which imports this package, and importing anonymizer
+// here would create an import cycle.
+var secretFieldPatterns = []string{
+	"password", "passwd", "pwd",
+	"secret",
+	"token",
+	"apikey",
+	"accesskey",
+	"privatekey",
+	"credential",
+	"databaseurl", "dburl",
+	"redisurl",
+	"mongouri", "mongodburi",
+	"dsn",
+	"connectionstring",
+}
+
+// podSpecKinds are the built-in kinds whose schema carries a PodSpec, either
+// directly (Pod) or through a pod template. Depending on the kind a PodSpec
+// field sits at spec., spec.template.spec., or
+// spec.jobTemplate.spec.template.spec., so the rules below match a field's
+// immediate parents rather than a fully anchored path.
+var podSpecKinds = []string{
+	"Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet",
+	"ReplicationController", "Job", "CronJob",
+}
+
+// safeFieldRule scopes a safe-field exception to one documented Kubernetes
+// location: the kinds whose schema defines the field, and the parent segments
+// it sits directly under. parents is matched as a suffix, so a PodSpec field
+// is recognized through any pod-template nesting; an empty parents means the
+// field sits at the object root.
+type safeFieldRule struct {
+	kinds   []string
+	parents []string
+}
+
+// safeFieldRules lists Kubernetes API fields whose names match a
+// secretFieldPatterns substring but which do not themselves hold a
+// credential. Each is keyed by its normalized name and scoped to where that
+// field genuinely exists, because the exception is a statement about a
+// specific API field and not about a field name: a CRD is free to define
+// spec.serviceAccountToken as an actual credential, and excusing it on the
+// strength of its name alone would reopen the very kind-blind hole this file
+// exists to close. Anything outside these locations - a custom resource, or a
+// core kind carrying the name somewhere its schema does not define it - falls
+// through to the pattern match below and is redacted.
+//
+// A word-boundary-aware match (splitting at camelCase/snake_case/kebab-case
+// boundaries and requiring whole-word membership) was considered instead of
+// scoping, but it cannot separate these at all: "Token" and "Secret" are
+// complete, genuine words in each of them, not substring artifacts spanning
+// two unrelated words. The distinction is semantic - a field naming or
+// describing a credential versus a field holding one - so it is drawn by
+// location, which is where that meaning actually lives.
+var safeFieldRules = map[string][]safeFieldRule{
+	// A boolean toggle on PodSpec, and on ServiceAccount as the default for
+	// pods using it - not token content either way.
+	"automountserviceaccounttoken": {
+		{kinds: podSpecKinds, parents: []string{"spec"}},
+		{kinds: []string{"ServiceAccount"}},
+	},
+	// A projected volume source's configuration block
+	// (ServiceAccountTokenProjection). It describes a token the kubelet will
+	// mint at mount time; the block itself carries no credential.
+	"serviceaccounttoken": {
+		{kinds: podSpecKinds, parents: []string{"projected", "sources"}},
+	},
+	// That block's requested lifetime, a number of seconds.
+	"tokenexpirationseconds": {
+		{kinds: podSpecKinds, parents: []string{"sources", "serviceAccountToken"}},
+	},
+	// A reference to a Secret by name (SecretVolumeSource, and Ingress TLS).
+	// The referenced object holds the sensitive value, and that object is
+	// redacted separately by kind ("Secret").
+	"secretname": {
+		{kinds: podSpecKinds, parents: []string{"volumes", "secret"}},
+		{kinds: []string{"Ingress"}, parents: []string{"tls"}},
+	},
+}
+
+// normalizeFieldName lowercases a path segment's key and strips separators, so
+// API_KEY, api-key, and apiKey all normalize to the same form.
+func normalizeFieldName(key string) string {
+	name := strings.ToLower(key)
+	for _, sep := range []string{"_", "-", ".", " "} {
+		name = strings.ReplaceAll(name, sep, "")
+	}
+	return name
+}
+
+// matchesSafeField reports whether kind, and the parents of a field named
+// name, place that field at one of the documented locations in
+// safeFieldRules.
+func matchesSafeField(kind, name string, parents []pathSegment) bool {
+	for _, rule := range safeFieldRules[name] {
+		if !slices.Contains(rule.kinds, kind) {
+			continue
+		}
+		if len(rule.parents) == 0 {
+			// The field is defined at the object root only.
+			if len(parents) == 0 {
+				return true
+			}
+			continue
+		}
+		if len(parents) < len(rule.parents) {
+			continue
+		}
+		tail := parents[len(parents)-len(rule.parents):]
+		matched := true
+		for i, want := range rule.parents {
+			if !strings.EqualFold(tail[i].key, want) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSecretShapedFieldName reports whether path's final segment looks like a
+// credential field name (e.g. "apiKey", "db_password", "clientSecret"). The
+// match itself is kind-independent - a hardcoded secret can live in a plain
+// field on any resource - but kind is still consulted, to place a field
+// against safeFieldRules before concluding it is credential-shaped. This only
+// looks at the field name in the path itself: it does not correlate a generic
+// field (e.g. a container env var's "value") with a sibling field that names
+// it (e.g. that same env var's "name"), which is a separate, harder problem
+// left out of scope here.
+func hasSecretShapedFieldName(kind, path string) bool {
 	if i := strings.Index(path, "="); i >= 0 {
 		path = path[:i]
 	}
-	path = strings.TrimLeft(path, ".")
-	if kind == "Secret" {
-		return path == "data" || strings.HasPrefix(path, "data.") ||
-			path == "stringData" || strings.HasPrefix(path, "stringData.")
+	segments := splitPath(path)
+	if len(segments) == 0 {
+		return false
+	}
+	name := normalizeFieldName(segments[len(segments)-1].key)
+	if matchesSafeField(kind, name, segments[:len(segments)-1]) {
+		return false
+	}
+	for _, pattern := range secretFieldPatterns {
+		if strings.Contains(name, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSensitivePath reports whether a path targets a field whose value must
+// not be surfaced in scan output unless --show-secrets is set. Three
+// separate cases are covered:
+//   - Secret data and stringData contain credentials that are base64-encoded
+//     (or plaintext) and must never be printed regardless of what the
+//     existing redaction in updateResults has done.
+//   - Container env[N].value holds the C-0012 plaintext credentials, which
+//     live on the workload rather than on a Secret.
+//   - Beyond those kind- and shape-specific cases, any path whose final
+//     field name looks like a credential is masked regardless of kind, since
+//     a hardcoded secret can live in a plain field on any resource - a
+//     ConfigMap entry named apiKey, a CRD's spec.auth.token, and so on.
+func isSensitivePath(kind, path string) bool {
+	trimmed := path
+	if i := strings.Index(trimmed, "="); i >= 0 {
+		trimmed = trimmed[:i]
+	}
+	trimmed = strings.TrimLeft(trimmed, ".")
+	if kind == "Secret" && (trimmed == "data" || strings.HasPrefix(trimmed, "data.") ||
+		trimmed == "stringData" || strings.HasPrefix(trimmed, "stringData.")) {
+		return true
 	}
 	// C-0012 plaintext credentials live on container env .value, not Secret.data.
-	return isContainerEnvValuePath(path)
+	if isContainerEnvValuePath(trimmed) {
+		return true
+	}
+	return hasSecretShapedFieldName(kind, path)
 }
 
 // isContainerEnvValuePath reports whether path selects env[N].value

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -208,15 +208,43 @@ var secretFieldPatterns = []string{
 // because this is a redaction boundary: the scanner reads manifests directly,
 // without API schema admission, so a document is free to nest an arbitrary
 // spec. anywhere and a suffix match would read that as the PodSpec.
-var podSpecPrefixes = map[string][]string{
-	"Pod":                   {"spec"},
-	"Deployment":            {"spec", "template", "spec"},
-	"StatefulSet":           {"spec", "template", "spec"},
-	"DaemonSet":             {"spec", "template", "spec"},
-	"ReplicaSet":            {"spec", "template", "spec"},
-	"ReplicationController": {"spec", "template", "spec"},
-	"Job":                   {"spec", "template", "spec"},
-	"CronJob":               {"spec", "jobTemplate", "spec", "template", "spec"},
+var podSpecPrefixes = map[string][]parentSegment{
+	"Pod":                   mapPath("spec"),
+	"Deployment":            mapPath("spec", "template", "spec"),
+	"StatefulSet":           mapPath("spec", "template", "spec"),
+	"DaemonSet":             mapPath("spec", "template", "spec"),
+	"ReplicaSet":            mapPath("spec", "template", "spec"),
+	"ReplicationController": mapPath("spec", "template", "spec"),
+	"Job":                   mapPath("spec", "template", "spec"),
+	"CronJob":               mapPath("spec", "jobTemplate", "spec", "template", "spec"),
+}
+
+// parentSegment is one segment of a safe field's canonical parent path, with
+// whether the Kubernetes schema defines that segment as a list.
+//
+// The shape has to be part of the match, not just the key. splitPath records
+// an index only for a bracketed segment, and extractValueAtPath walks an
+// unindexed segment straight through a map - so spec.volumes.secret.secretName
+// resolves against a manifest that happens to carry an object named "volumes",
+// even though PodSpec.volumes is a list and that path is not
+// SecretVolumeSource.secretName at all. Matching on keys alone would hand that
+// object-shaped path the list-shaped path's exception and let its value out
+// through failedPathValues.
+type parentSegment struct {
+	key string
+	// list requires this segment to be indexed ("volumes[0]"). A schema list
+	// reached without an index, or a schema map reached with one, is not the
+	// documented location and is redacted.
+	list bool
+}
+
+// mapPath builds a parent path whose segments are all plain maps.
+func mapPath(keys ...string) []parentSegment {
+	segments := make([]parentSegment, len(keys))
+	for i, key := range keys {
+		segments[i] = parentSegment{key: key}
+	}
+	return segments
 }
 
 // safeFieldRule scopes a safe-field exception to one documented Kubernetes
@@ -230,10 +258,10 @@ var podSpecPrefixes = map[string][]string{
 // kinds at exactly parents, where an empty parents means the object root.
 type safeFieldRule struct {
 	onPodSpec      bool
-	podSpecParents []string
+	podSpecParents []parentSegment
 
 	kinds   []string
-	parents []string
+	parents []parentSegment
 }
 
 // safeFieldRules lists Kubernetes API fields whose names match a
@@ -267,18 +295,26 @@ var safeFieldRules = map[string][]safeFieldRule{
 	// (ServiceAccountTokenProjection). It describes a token the kubelet will
 	// mint at mount time; the block itself carries no credential.
 	"serviceaccounttoken": {
-		{onPodSpec: true, podSpecParents: []string{"volumes", "projected", "sources"}},
+		{onPodSpec: true, podSpecParents: []parentSegment{
+			{key: "volumes", list: true}, {key: "projected"}, {key: "sources", list: true},
+		}},
 	},
 	// That block's requested lifetime, a number of seconds.
 	"tokenexpirationseconds": {
-		{onPodSpec: true, podSpecParents: []string{"volumes", "projected", "sources", "serviceAccountToken"}},
+		{onPodSpec: true, podSpecParents: []parentSegment{
+			{key: "volumes", list: true}, {key: "projected"}, {key: "sources", list: true}, {key: "serviceAccountToken"},
+		}},
 	},
 	// A reference to a Secret by name (SecretVolumeSource, and Ingress TLS).
 	// The referenced object holds the sensitive value, and that object is
 	// redacted separately by kind ("Secret").
 	"secretname": {
-		{onPodSpec: true, podSpecParents: []string{"volumes", "secret"}},
-		{kinds: []string{"Ingress"}, parents: []string{"spec", "tls"}},
+		{onPodSpec: true, podSpecParents: []parentSegment{
+			{key: "volumes", list: true}, {key: "secret"},
+		}},
+		{kinds: []string{"Ingress"}, parents: []parentSegment{
+			{key: "spec"}, {key: "tls", list: true},
+		}},
 	},
 }
 
@@ -293,14 +329,24 @@ func normalizeFieldName(key string) string {
 }
 
 // equalParentPath reports whether parents is exactly want, segment for
-// segment. Comparing the whole path rather than its tail is what keeps an
-// exception pinned to the schema location it was written for.
-func equalParentPath(parents []pathSegment, want []string) bool {
+// segment, in both key and shape. Comparing the whole path rather than its
+// tail is what keeps an exception pinned to the schema location it was written
+// for; comparing the shape is what stops an object-shaped path from borrowing
+// a list-shaped path's exception.
+//
+// A segment splitPath could not read an index from - "volumes[container_ndx]",
+// an unsubstituted rule placeholder - carries index -1 and so reads as
+// unindexed, failing a list segment's match. That is the safe direction: an
+// unresolvable path is redacted rather than excused.
+func equalParentPath(parents []pathSegment, want []parentSegment) bool {
 	if len(parents) != len(want) {
 		return false
 	}
 	for i := range want {
-		if !strings.EqualFold(parents[i].key, want[i]) {
+		if !strings.EqualFold(parents[i].key, want[i].key) {
+			return false
+		}
+		if want[i].list != (parents[i].index >= 0) {
 			return false
 		}
 	}
@@ -319,7 +365,7 @@ func matchesSafeField(kind, name string, parents []pathSegment) bool {
 			if !ok {
 				continue
 			}
-			canonical := make([]string, 0, len(prefix)+len(rule.podSpecParents))
+			canonical := make([]parentSegment, 0, len(prefix)+len(rule.podSpecParents))
 			canonical = append(canonical, prefix...)
 			canonical = append(canonical, rule.podSpecParents...)
 			if equalParentPath(parents, canonical) {

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -202,22 +202,36 @@ var secretFieldPatterns = []string{
 	"connectionstring",
 }
 
-// podSpecKinds are the built-in kinds whose schema carries a PodSpec, either
-// directly (Pod) or through a pod template. Depending on the kind a PodSpec
-// field sits at spec., spec.template.spec., or
-// spec.jobTemplate.spec.template.spec., so the rules below match a field's
-// immediate parents rather than a fully anchored path.
-var podSpecKinds = []string{
-	"Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet",
-	"ReplicationController", "Job", "CronJob",
+// podSpecPrefixes maps each built-in kind whose schema carries a PodSpec to
+// the exact parent segments that precede a PodSpec field on that kind. The
+// prefix is spelled out per kind rather than matched as a trailing "spec",
+// because this is a redaction boundary: the scanner reads manifests directly,
+// without API schema admission, so a document is free to nest an arbitrary
+// spec. anywhere and a suffix match would read that as the PodSpec.
+var podSpecPrefixes = map[string][]string{
+	"Pod":                   {"spec"},
+	"Deployment":            {"spec", "template", "spec"},
+	"StatefulSet":           {"spec", "template", "spec"},
+	"DaemonSet":             {"spec", "template", "spec"},
+	"ReplicaSet":            {"spec", "template", "spec"},
+	"ReplicationController": {"spec", "template", "spec"},
+	"Job":                   {"spec", "template", "spec"},
+	"CronJob":               {"spec", "jobTemplate", "spec", "template", "spec"},
 }
 
 // safeFieldRule scopes a safe-field exception to one documented Kubernetes
-// location: the kinds whose schema defines the field, and the parent segments
-// it sits directly under. parents is matched as a suffix, so a PodSpec field
-// is recognized through any pod-template nesting; an empty parents means the
-// field sits at the object root.
+// location. A rule matches a field's parent path in full, never as a suffix,
+// so the exception covers exactly the canonical location and nothing that
+// merely ends the same way.
+//
+// onPodSpec anchors a rule to every kind in podSpecPrefixes: the canonical
+// parent path is that kind's prefix followed by podSpecParents, which is empty
+// for a field sitting directly on the PodSpec. Otherwise the rule applies to
+// kinds at exactly parents, where an empty parents means the object root.
 type safeFieldRule struct {
+	onPodSpec      bool
+	podSpecParents []string
+
 	kinds   []string
 	parents []string
 }
@@ -231,7 +245,9 @@ type safeFieldRule struct {
 // strength of its name alone would reopen the very kind-blind hole this file
 // exists to close. Anything outside these locations - a custom resource, or a
 // core kind carrying the name somewhere its schema does not define it - falls
-// through to the pattern match below and is redacted.
+// through to the pattern match below and is redacted. Each location is the
+// field's full canonical parent path, so an off-schema path on a built-in kind
+// (Pod spec.extension.spec.automountServiceAccountToken, say) fails closed.
 //
 // A word-boundary-aware match (splitting at camelCase/snake_case/kebab-case
 // boundaries and requiring whole-word membership) was considered instead of
@@ -244,25 +260,25 @@ var safeFieldRules = map[string][]safeFieldRule{
 	// A boolean toggle on PodSpec, and on ServiceAccount as the default for
 	// pods using it - not token content either way.
 	"automountserviceaccounttoken": {
-		{kinds: podSpecKinds, parents: []string{"spec"}},
+		{onPodSpec: true},
 		{kinds: []string{"ServiceAccount"}},
 	},
 	// A projected volume source's configuration block
 	// (ServiceAccountTokenProjection). It describes a token the kubelet will
 	// mint at mount time; the block itself carries no credential.
 	"serviceaccounttoken": {
-		{kinds: podSpecKinds, parents: []string{"projected", "sources"}},
+		{onPodSpec: true, podSpecParents: []string{"volumes", "projected", "sources"}},
 	},
 	// That block's requested lifetime, a number of seconds.
 	"tokenexpirationseconds": {
-		{kinds: podSpecKinds, parents: []string{"sources", "serviceAccountToken"}},
+		{onPodSpec: true, podSpecParents: []string{"volumes", "projected", "sources", "serviceAccountToken"}},
 	},
 	// A reference to a Secret by name (SecretVolumeSource, and Ingress TLS).
 	// The referenced object holds the sensitive value, and that object is
 	// redacted separately by kind ("Secret").
 	"secretname": {
-		{kinds: podSpecKinds, parents: []string{"volumes", "secret"}},
-		{kinds: []string{"Ingress"}, parents: []string{"tls"}},
+		{onPodSpec: true, podSpecParents: []string{"volumes", "secret"}},
+		{kinds: []string{"Ingress"}, parents: []string{"spec", "tls"}},
 	},
 }
 
@@ -276,33 +292,45 @@ func normalizeFieldName(key string) string {
 	return name
 }
 
+// equalParentPath reports whether parents is exactly want, segment for
+// segment. Comparing the whole path rather than its tail is what keeps an
+// exception pinned to the schema location it was written for.
+func equalParentPath(parents []pathSegment, want []string) bool {
+	if len(parents) != len(want) {
+		return false
+	}
+	for i := range want {
+		if !strings.EqualFold(parents[i].key, want[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // matchesSafeField reports whether kind, and the parents of a field named
 // name, place that field at one of the documented locations in
-// safeFieldRules.
+// safeFieldRules. A kind absent from podSpecPrefixes never matches an
+// onPodSpec rule, and a built-in kind matches only on its own canonical path,
+// so anything off-schema falls through and is redacted.
 func matchesSafeField(kind, name string, parents []pathSegment) bool {
 	for _, rule := range safeFieldRules[name] {
-		if !slices.Contains(rule.kinds, kind) {
-			continue
-		}
-		if len(rule.parents) == 0 {
-			// The field is defined at the object root only.
-			if len(parents) == 0 {
+		if rule.onPodSpec {
+			prefix, ok := podSpecPrefixes[kind]
+			if !ok {
+				continue
+			}
+			canonical := make([]string, 0, len(prefix)+len(rule.podSpecParents))
+			canonical = append(canonical, prefix...)
+			canonical = append(canonical, rule.podSpecParents...)
+			if equalParentPath(parents, canonical) {
 				return true
 			}
 			continue
 		}
-		if len(parents) < len(rule.parents) {
+		if !slices.Contains(rule.kinds, kind) {
 			continue
 		}
-		tail := parents[len(parents)-len(rule.parents):]
-		matched := true
-		for i, want := range rule.parents {
-			if !strings.EqualFold(tail[i].key, want) {
-				matched = false
-				break
-			}
-		}
-		if matched {
+		if equalParentPath(parents, rule.parents) {
 			return true
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -372,6 +372,41 @@ func TestIsSensitivePath(t *testing.T) {
 		{name: "initContainer env value", kind: "Pod", path: "spec.initContainers[0].env[0].value", want: true},
 		{name: "container env name is not sensitive", kind: "Deployment", path: "spec.template.spec.containers[0].env[1].name", want: false},
 		{name: "container env valueFrom is not a literal", kind: "Deployment", path: "spec.containers[0].env[0].valueFrom.secretKeyRef.name", want: false},
+		{name: "ConfigMap field literally named apiKey is caught", kind: "ConfigMap", path: "data.apiKey", want: true},
+		{name: "Deployment field named password is caught regardless of kind", kind: "Deployment", path: "spec.auth.password", want: true},
+		{name: "custom resource token field is caught", kind: "MyCustomResource", path: "spec.auth.token", want: true},
+		{name: "snake_case db_password is caught after separator normalization", kind: "Deployment", path: "spec.env.db_password", want: true},
+		{name: "uppercase API_KEY is caught case-insensitively", kind: "Deployment", path: "spec.API_KEY", want: true},
+		{name: "clientSecret is caught", kind: "OAuthClient", path: "spec.clientSecret", want: true},
+		{name: "ordinary field name is unaffected", kind: "Deployment", path: "spec.replicas", want: false},
+		{name: "keyword is not a false positive for key/apikey", kind: "Deployment", path: "spec.keyword", want: false},
+		// Regression: automountServiceAccountToken is a boolean toggle, not a
+		// token value - "Token" is a genuine word in it, so it previously
+		// matched the "token" pattern as a plain substring.
+		{name: "automountServiceAccountToken boolean is not a token value", kind: "Pod", path: "spec.automountServiceAccountToken", want: false},
+		{name: "automountServiceAccountToken is unaffected by case/separators", kind: "Pod", path: "spec.automount_service_account_token", want: false},
+		{name: "serviceAccountToken projected volume source is not a token value", kind: "Pod", path: "spec.volumes[0].projected.sources[0].serviceAccountToken", want: false},
+		{name: "secretName is a reference to a Secret object, not its value", kind: "Pod", path: "spec.volumes[0].secret.secretName", want: false},
+		{name: "a field that is actually named token is still caught", kind: "MyCustomResource", path: "spec.auth.token", want: true},
+		// Regression: the exceptions above are exceptions for specific
+		// Kubernetes API fields, not for their names. A custom resource
+		// reusing one of those names is free to store a real credential under
+		// it, so it stays redacted - the exception is scoped to the kinds
+		// whose schema defines the field and to the path it lives at.
+		{name: "custom resource reusing serviceAccountToken is still redacted", kind: "MyCustomResource", path: "spec.serviceAccountToken", want: true},
+		{name: "custom resource reusing secretName is still redacted", kind: "MyCustomResource", path: "spec.secretName", want: true},
+		{name: "custom resource reusing automountServiceAccountToken is still redacted", kind: "MyCustomResource", path: "spec.automountServiceAccountToken", want: true},
+		{name: "custom resource is not excused by borrowing the core path shape", kind: "MyCustomResource", path: "spec.volumes[0].projected.sources[0].serviceAccountToken", want: true},
+		{name: "core kind is not excused off its documented path", kind: "Pod", path: "spec.serviceAccountToken", want: true},
+		{name: "core kind is not excused for secretName outside a volume", kind: "Pod", path: "spec.containers[0].secretName", want: true},
+		// The exceptions still hold where the schemas define them, and a
+		// PodSpec field keeps its exception through pod-template nesting.
+		{name: "automountServiceAccountToken through a pod template", kind: "Deployment", path: "spec.template.spec.automountServiceAccountToken", want: false},
+		{name: "automountServiceAccountToken through a CronJob job template", kind: "CronJob", path: "spec.jobTemplate.spec.template.spec.automountServiceAccountToken", want: false},
+		{name: "automountServiceAccountToken at the ServiceAccount root", kind: "ServiceAccount", path: "automountServiceAccountToken", want: false},
+		{name: "tokenExpirationSeconds is a lifetime, not a token", kind: "Pod", path: "spec.volumes[0].projected.sources[0].serviceAccountToken.tokenExpirationSeconds", want: false},
+		{name: "Ingress TLS secretName references a Secret by name", kind: "Ingress", path: "spec.tls[0].secretName", want: false},
+		{name: "a field that is actually named secret is still caught", kind: "OAuthClient", path: "spec.secret", want: true},
 	}
 
 	for _, tc := range cases {
@@ -477,7 +512,7 @@ func TestReviewPathsWithCurrentValues(t *testing.T) {
 			"automountServiceAccountToken": true,
 		},
 	}
-	resource := &mockResource{obj: obj}
+	resource := &mockResource{kind: "Pod", obj: obj}
 
 	t.Run("value extracted", func(t *testing.T) {
 		ctrl := makeControlWithPaths(nil, []string{"spec.automountServiceAccountToken"})

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -704,6 +704,16 @@ func TestAssistedRemediationPathsWithCurrentValuesFiltered(t *testing.T) {
 // resolves perfectly well - and if the exception written for the list-shaped
 // field covered it too, the value would reach output unredacted.
 func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
+	// Fixture values are named rather than inlined into the objects below.
+	// Every fixture here is deliberately built around a credential-shaped key,
+	// which is exactly the shape gosec's G101 reports when the value beside it
+	// is a string literal. These are test data standing in for a value, not
+	// credentials, and naming them keeps that legible without a nolint.
+	const (
+		offSchemaValue = "fixture-value-that-must-not-be-published"
+		onSchemaValue  = "fixture-referenced-object-name"
+	)
+
 	controlWithFailedPath := func(path string) *resourcesresults.ResourceAssociatedControl {
 		return &resourcesresults.ResourceAssociatedControl{
 			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
@@ -718,7 +728,7 @@ func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
 				// PodSpec.volumes is a list; this manifest carries a map, so
 				// this is not SecretVolumeSource.secretName at all.
 				"volumes": map[string]any{
-					"secret": map[string]any{"secretName": "inline-credential"},
+					"secret": map[string]any{"secretName": offSchemaValue},
 				},
 			},
 		}}
@@ -731,7 +741,7 @@ func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
 			"spec": map[string]any{
 				"volumes": map[string]any{
 					"projected": map[string]any{
-						"sources": map[string]any{"serviceAccountToken": "inline-token"},
+						"sources": map[string]any{"serviceAccountToken": offSchemaValue},
 					},
 				},
 			},
@@ -743,7 +753,7 @@ func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
 	t.Run("object-shaped Ingress tls does not reach Evidence", func(t *testing.T) {
 		resource := &mockResource{kind: "Ingress", obj: map[string]any{
 			"spec": map[string]any{
-				"tls": map[string]any{"secretName": "inline-credential"},
+				"tls": map[string]any{"secretName": offSchemaValue},
 			},
 		}}
 		got := failedPathValues(controlWithFailedPath("spec.tls.secretName"), resource)
@@ -756,12 +766,12 @@ func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
 		resource := &mockResource{kind: "Pod", obj: map[string]any{
 			"spec": map[string]any{
 				"volumes": []any{
-					map[string]any{"secret": map[string]any{"secretName": "referenced-secret"}},
+					map[string]any{"secret": map[string]any{"secretName": onSchemaValue}},
 				},
 			},
 		}}
 		got := failedPathValues(controlWithFailedPath("spec.volumes[0].secret.secretName"), resource)
 		require.Len(t, got, 1)
-		assert.Equal(t, "referenced-secret", got[0].Value)
+		assert.Equal(t, onSchemaValue, got[0].Value)
 	})
 }

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -421,6 +421,25 @@ func TestIsSensitivePath(t *testing.T) {
 		{name: "Pod-shaped path on a workload kind is redacted", kind: "Deployment", path: "spec.automountServiceAccountToken", want: true},
 		{name: "off-schema Ingress TLS tail is redacted", kind: "Ingress", path: "spec.extension.tls[0].secretName", want: true},
 		{name: "ServiceAccount exception does not extend below the root", kind: "ServiceAccount", path: "spec.automountServiceAccountToken", want: true},
+		// Regression: the schema makes volumes, sources and tls lists, so an
+		// exception written for them only covers an indexed path. An
+		// object-shaped path is a different field that extractValueAtPath
+		// resolves perfectly well against a manifest carrying a map there, so
+		// matching on keys alone handed it the list's exception.
+		{name: "object-shaped volumes is not SecretVolumeSource", kind: "Pod", path: "spec.volumes.secret.secretName", want: true},
+		{name: "object-shaped volumes and sources is not a projected token", kind: "Pod", path: "spec.volumes.projected.sources.serviceAccountToken", want: true},
+		{name: "object-shaped sources is not a projected token", kind: "Pod", path: "spec.volumes[0].projected.sources.serviceAccountToken", want: true},
+		{name: "object-shaped volumes is not a projected token", kind: "Pod", path: "spec.volumes.projected.sources[0].serviceAccountToken", want: true},
+		{name: "object-shaped tokenExpirationSeconds parents are redacted", kind: "Pod", path: "spec.volumes.projected.sources.serviceAccountToken.tokenExpirationSeconds", want: true},
+		{name: "object-shaped Ingress tls is not IngressTLS", kind: "Ingress", path: "spec.tls.secretName", want: true},
+		{name: "object-shaped volumes through a pod template is redacted", kind: "Deployment", path: "spec.template.spec.volumes.secret.secretName", want: true},
+		// The mirror of the above: a schema map reached with an index is just
+		// as far off-schema as a schema list reached without one.
+		{name: "indexed secret map is not SecretVolumeSource", kind: "Pod", path: "spec.volumes[0].secret[0].secretName", want: true},
+		{name: "indexed projected map is not a projected token", kind: "Pod", path: "spec.volumes[0].projected[0].sources[0].serviceAccountToken", want: true},
+		// An unsubstituted rule placeholder leaves splitPath with no index, so
+		// it reads as unindexed and is redacted rather than excused.
+		{name: "unresolved list placeholder is redacted", kind: "Pod", path: "spec.volumes[volume_ndx].secret.secretName", want: true},
 	}
 
 	for _, tc := range cases {
@@ -674,5 +693,75 @@ func TestAssistedRemediationPathsWithCurrentValuesFiltered(t *testing.T) {
 		ctrl := makeControlWithPaths(nil, nil)
 		got := AssistedRemediationPathsWithCurrentValuesFiltered(ctrl, resource, false)
 		assert.Nil(t, got)
+	})
+}
+
+// TestFailedPathValuesObjectShapedSafeFields pins the output boundary the
+// safe-field exceptions sit behind. isSensitivePath deciding a path is safe is
+// only half the story: failedPathValues then resolves that path and publishes
+// the value as Evidence. extractValueAtPath walks an unindexed segment straight
+// through a map, so an off-schema object where the schema defines a list
+// resolves perfectly well - and if the exception written for the list-shaped
+// field covered it too, the value would reach output unredacted.
+func TestFailedPathValuesObjectShapedSafeFields(t *testing.T) {
+	controlWithFailedPath := func(path string) *resourcesresults.ResourceAssociatedControl {
+		return &resourcesresults.ResourceAssociatedControl{
+			ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+				{Paths: []armotypes.PosturePaths{{FailedPath: path}}},
+			},
+		}
+	}
+
+	t.Run("object-shaped volumes does not reach Evidence", func(t *testing.T) {
+		resource := &mockResource{kind: "Pod", obj: map[string]any{
+			"spec": map[string]any{
+				// PodSpec.volumes is a list; this manifest carries a map, so
+				// this is not SecretVolumeSource.secretName at all.
+				"volumes": map[string]any{
+					"secret": map[string]any{"secretName": "inline-credential"},
+				},
+			},
+		}}
+		got := failedPathValues(controlWithFailedPath("spec.volumes.secret.secretName"), resource)
+		assert.Empty(t, got, "an off-schema object-shaped path must be redacted, not published as Evidence")
+	})
+
+	t.Run("object-shaped projected sources does not reach Evidence", func(t *testing.T) {
+		resource := &mockResource{kind: "Pod", obj: map[string]any{
+			"spec": map[string]any{
+				"volumes": map[string]any{
+					"projected": map[string]any{
+						"sources": map[string]any{"serviceAccountToken": "inline-token"},
+					},
+				},
+			},
+		}}
+		got := failedPathValues(controlWithFailedPath("spec.volumes.projected.sources.serviceAccountToken"), resource)
+		assert.Empty(t, got, "an off-schema object-shaped path must be redacted, not published as Evidence")
+	})
+
+	t.Run("object-shaped Ingress tls does not reach Evidence", func(t *testing.T) {
+		resource := &mockResource{kind: "Ingress", obj: map[string]any{
+			"spec": map[string]any{
+				"tls": map[string]any{"secretName": "inline-credential"},
+			},
+		}}
+		got := failedPathValues(controlWithFailedPath("spec.tls.secretName"), resource)
+		assert.Empty(t, got, "an off-schema object-shaped path must be redacted, not published as Evidence")
+	})
+
+	// The exception still has to work where the schema actually defines it,
+	// or this would be a fix by way of redacting everything.
+	t.Run("canonical indexed SecretVolumeSource still resolves", func(t *testing.T) {
+		resource := &mockResource{kind: "Pod", obj: map[string]any{
+			"spec": map[string]any{
+				"volumes": []any{
+					map[string]any{"secret": map[string]any{"secretName": "referenced-secret"}},
+				},
+			},
+		}}
+		got := failedPathValues(controlWithFailedPath("spec.volumes[0].secret.secretName"), resource)
+		require.Len(t, got, 1)
+		assert.Equal(t, "referenced-secret", got[0].Value)
 	})
 }

--- a/core/pkg/resultshandling/printer/v2/pathvalue_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue_test.go
@@ -407,6 +407,20 @@ func TestIsSensitivePath(t *testing.T) {
 		{name: "tokenExpirationSeconds is a lifetime, not a token", kind: "Pod", path: "spec.volumes[0].projected.sources[0].serviceAccountToken.tokenExpirationSeconds", want: false},
 		{name: "Ingress TLS secretName references a Secret by name", kind: "Ingress", path: "spec.tls[0].secretName", want: false},
 		{name: "a field that is actually named secret is still caught", kind: "OAuthClient", path: "spec.secret", want: true},
+		// Regression: an exception is pinned to the field's full canonical
+		// parent path, not to a trailing fragment of it. The scanner reads
+		// manifests without API schema admission, so a built-in kind can carry
+		// a field at a path its schema never defines; matching the parents as a
+		// suffix excused those, since the tail still read as PodSpec. They must
+		// fail closed - this is a redaction boundary.
+		{name: "off-schema PodSpec-shaped tail on a built-in kind is redacted", kind: "Pod", path: "spec.extension.spec.automountServiceAccountToken", want: true},
+		{name: "off-schema projected-source tail on a built-in kind is redacted", kind: "Pod", path: "spec.extension.projected.sources[0].serviceAccountToken", want: true},
+		{name: "off-schema secret-volume tail on a built-in kind is redacted", kind: "Pod", path: "spec.extension.volumes[0].secret.secretName", want: true},
+		{name: "off-schema tokenExpirationSeconds on a built-in kind is redacted", kind: "Pod", path: "spec.extension.sources[0].serviceAccountToken.tokenExpirationSeconds", want: true},
+		{name: "pod-template path on a kind without a pod template is redacted", kind: "Pod", path: "spec.template.spec.automountServiceAccountToken", want: true},
+		{name: "Pod-shaped path on a workload kind is redacted", kind: "Deployment", path: "spec.automountServiceAccountToken", want: true},
+		{name: "off-schema Ingress TLS tail is redacted", kind: "Ingress", path: "spec.extension.tls[0].secretName", want: true},
+		{name: "ServiceAccount exception does not extend below the root", kind: "ServiceAccount", path: "spec.automountServiceAccountToken", want: true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Overview

Evidence redaction only fired when the resource kind was exactly `Secret` and the path sat under `data`/`stringData`, plus container `env[N].value`. Any other resource storing a credential directly  a ConfigMap entry named `apiKey`, a CRD's `spec.auth.token`, a field named `clientSecret` had its value printed in the clear through the `(current: ...)` annotation under `--show-evidence`.

This adds a kind-independent check: if a path's final field name looks like a credential, its value is masked regardless of resource kind. The pattern list mirrors `anonymizer.isSensitiveEnvName`, kept local rather than imported because `anonymizer` imports `resultshandling`, which imports this package.

Name matching alone over-redacts, so the known-safe Kubernetes fields (`automountServiceAccountToken`, `secretName`, `serviceAccountToken`, `tokenExpirationSeconds`) are excepted but scoped to the kinds whose schema defines them and the parent path they sit under, not excused by name. A custom resource reusing `serviceAccountToken` for a real credential stays redacted.

## Additional Information

**This is @adity1raut's work, carried over from #3255 with him as co-author.** Only the sign-off and the rebase onto current `master` are mine.

#3255 had both review blockers resolved and every check passing except DCO, which requires a `Signed-off-by` matching the commit author. @adity1raut has stepped back and can no longer amend the commit, and a DCO sign-off is a certification only its author can make — so the work is re-authored here with my own sign-off. @matthyx agreed to this route.

Both review items from #3255 are addressed in the code carried over:

- **@matthyx — false positives:** word-boundary matching can't separate these cases, because `Token` and `Secret` are complete, genuine words in `automountServiceAccountToken` and `secretName`, not substring artifacts. The distinction is semantic — a field *naming* a credential versus one *holding* it — so `safeFieldRules` draws it by schema location instead.
- **CodeRabbit — CWE-200, kind-blind exceptions:** each exception is gated on kind and parent path rather than on the bare field name.

## How to Test

```
go test ./core/pkg/resultshandling/printer/v2/...
```

`TestIsSensitivePath` carries 25 new cases covering cross-kind matches, separator and case normalization, pod-template and CronJob nesting, and custom resources reusing safe-sounding field names. `TestReviewPathsWithCurrentValues/value_extracted` the case that regressed in the first round of #3255 passes.

## Related issues/PRs:

* Supersedes #3255
* Relates to #1563

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened sensitive-data redaction by requiring list-based safe-field exceptions to use canonical indexed paths.
  - Prevented object-shaped collection fields and incorrectly shaped map or list paths from bypassing redaction.
  - Continued protecting credential-like fields, including API keys, passwords, tokens, and client secrets.

- **Bug Fixes**
  - Prevented off-schema collection fields from appearing in review evidence.
  - Preserved access to valid indexed safe fields while maintaining redaction for invalid path shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->