### PR TITLE
fix(diff): do not print command usage when --fail-on-new fails (#3755)

### DIFF
--- a/cmd/diff/diff.go
+++ b/cmd/diff/diff.go
@@ -70,6 +70,10 @@ func GetDiffCmd(ks meta.IKubescape) *cobra.Command {
 				return err
 			}
 
+			// The invocation is valid from this point on. Runtime and result-gate
+			// failures should not print command usage.
+			cmd.SilenceUsage = true
+
 			newFailures, err := ks.Diff(&diffInfo)
 			if err != nil {
 				return err

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -184,7 +184,6 @@ func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diffCmd := GetDiffCmd(&stubKubescape{newFailures: tt.newFailures})
-			diffCmd.SilenceUsage = true
 			diffCmd.SilenceErrors = true
 			diffCmd.SetArgs(tt.args)
 
@@ -194,6 +193,65 @@ func TestGetDiffCmd_FailOnNewAndSeverity(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestGetDiffCmd_FailOnNewDoesNotPrintUsage(t *testing.T) {
+	stub := &stubKubescape{newFailures: 1}
+	diffCmd := GetDiffCmd(stub)
+	var buf strings.Builder
+	diffCmd.SetOut(&buf)
+	diffCmd.SetErr(&buf)
+	diffCmd.SetArgs([]string{"base.json", "head.json", "--fail-on-new"})
+
+	err := diffCmd.Execute()
+
+	assert.ErrorContains(t, err, "found 1 new or incomparable failure(s)")
+	assert.NotContains(t, buf.String(), "Usage:", "threshold failure must not dump command usage")
+}
+
+func TestGetDiffCmd_ValidationErrorStillPrintsUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		errMatch string
+	}{
+		{
+			name:     "missing arguments",
+			args:     []string{"base.json"},
+			errMatch: "accepts 2 arg(s), received 1",
+		},
+		{
+			name:     "invalid format",
+			args:     []string{"base.json", "head.json", "--format", "invalid"},
+			errMatch: "invalid format",
+		},
+		{
+			name:     "invalid severity",
+			args:     []string{"base.json", "head.json", "--severity-threshold", "invalid"},
+			errMatch: "unknown severity",
+		},
+		{
+			name:     "invalid granularity",
+			args:     []string{"base.json", "head.json", "--granularity", "invalid"},
+			errMatch: "invalid diff granularity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubKubescape{}
+			diffCmd := GetDiffCmd(stub)
+			var buf strings.Builder
+			diffCmd.SetOut(&buf)
+			diffCmd.SetErr(&buf)
+			diffCmd.SetArgs(tt.args)
+
+			err := diffCmd.Execute()
+
+			assert.ErrorContains(t, err, tt.errMatch)
+			assert.Contains(t, buf.String(), "Usage:", "input validation errors must print command usage")
 		})
 	}
 }


### PR DESCRIPTION
## Overview
When running `kubescape diff base.json head.json --fail-on-new` as a CI gate and new posture regressions are detected, Kubescape exits with an error code as expected, but Cobra also prints the entire CLI usage manual, examples, and flag descriptions (~40 lines) to stderr alongside the failure error.

This pull request sets `cmd.SilenceUsage = true` in `cmd/diff/diff.go` after argument count, format, severity, and granularity validations succeed. This ensures:
- **Syntax / input errors** (missing files, unsupported `--format`, invalid `--severity-threshold`, invalid `--granularity`) continue to display the `Usage:` manual to help users fix invalid inputs.
- **Valid invocations** that encounter runtime errors or fail the `--fail-on-new` regression gate exit cleanly with only the failure error message, preventing CI log pollution.

This brings `diff` into direct parity with the behavior merged for `scan` subcommands in #3716 / #3717.

## Additional Information

### Proof of Fix (Before vs. After)

#### Before (v4.0.13)
When posture regressions trigger `--fail-on-new`, the full `Usage:` manual is dumped to stderr:
```text
New failures (1)
----------------------
+ [High] Require a security context (C-1000)
    Resource: apps/v1/default/Deployment/api
    Rule: require-security-context
    Evidence: rule

Summary: 1 new, 0 resolved, 0 unchanged, 0 incomparable
Error: found 1 new or incomparable failure(s) at or above severity threshold "high"
Usage:
  kubescape diff <base-report.json> <head-report.json> [flags]

Examples:
  # Compare two Kubescape scan results and display human-readable differences
  kubescape diff base.json head.json
  ... [~40 lines of flags and examples dumped to stderr]
```

#### After (with this PR)
The diff summary and the gate failure are clearly displayed without dumping the manual:
```text
New failures (1)
----------------------
+ [High] Require a security context (C-1000)
    Resource: apps/v1/default/Deployment/api
    Rule: require-security-context
    Evidence: rule

Summary: 1 new, 0 resolved, 0 unchanged, 0 incomparable
Error: found 1 new or incomparable failure(s) at or above severity threshold "high"
```

### Changes in `cmd/diff/diff_test.go`
- Removed the manual `diffCmd.SilenceUsage = true` preset workaround from `TestGetDiffCmd_FailOnNewAndSeverity` since `GetDiffCmd` now handles usage silencing internally.
- Added `TestGetDiffCmd_FailOnNewDoesNotPrintUsage`: verifies that a `--fail-on-new` gate failure returns an error without `"Usage:"` in stderr.
- Added `TestGetDiffCmd_ValidationErrorStillPrintsUsage`: verifies that input/flag validation errors (missing files, invalid format, invalid severity, invalid granularity) continue to print command usage.

## How to Test

Run the unit tests in `cmd/diff`:
```bash
go test -v ./cmd/diff
```

**Test Output:**
```text
=== RUN   TestGetDiffCmd_FormatValidation
--- PASS: TestGetDiffCmd_FormatValidation (0.45s)
=== RUN   TestGetDiffCmd_Granularity
--- PASS: TestGetDiffCmd_Granularity (0.19s)
=== RUN   TestGetDiffCmd_HelpExplainsEvidenceComparison
--- PASS: TestGetDiffCmd_HelpExplainsEvidenceComparison (0.03s)
=== RUN   TestGetDiffCmd_FailOnNewAndSeverity
--- PASS: TestGetDiffCmd_FailOnNewAndSeverity (0.19s)
=== RUN   TestGetDiffCmd_FailOnNewDoesNotPrintUsage
--- PASS: TestGetDiffCmd_FailOnNewDoesNotPrintUsage (0.03s)
=== RUN   TestGetDiffCmd_ValidationErrorStillPrintsUsage
=== RUN   TestGetDiffCmd_ValidationErrorStillPrintsUsage/missing_arguments
=== RUN   TestGetDiffCmd_ValidationErrorStillPrintsUsage/invalid_format
=== RUN   TestGetDiffCmd_ValidationErrorStillPrintsUsage/invalid_severity
=== RUN   TestGetDiffCmd_ValidationErrorStillPrintsUsage/invalid_granularity
--- PASS: TestGetDiffCmd_ValidationErrorStillPrintsUsage (0.10s)
PASS
ok      github.com/kubescape/kubescape/v4/cmd/diff      1.485s
```

## Related issues/PRs:
* Resolved #3755

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The diff command no longer displays command usage for runtime or result-threshold errors after valid arguments and options are provided.
  * Usage information continues to appear for invalid arguments and options.

* **Tests**
  * Added coverage to verify usage suppression for threshold failures and usage display for validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->