### PR TITLE
fix(printer): route SARIF, GitLab-SAST, HTML, and CSV fix-path values through --show-secrets redaction

### DIFF
--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -24,10 +24,15 @@ var _ printer.IPrinter = &CsvPrinter{}
 
 type CsvPrinter struct {
 	writer *os.File
+	// showSecrets controls whether sensitive field values (Secret.data,
+	// container env[].value, and other secret-shaped fields -- see
+	// isSensitivePath) are redacted in the fix-path column below, matching
+	// the terminal pretty-printer's default.
+	showSecrets bool
 }
 
-func NewCsvPrinter() *CsvPrinter {
-	return &CsvPrinter{}
+func NewCsvPrinter(showSecrets bool) *CsvPrinter {
+	return &CsvPrinter{showSecrets: showSecrets}
 }
 
 func (cp *CsvPrinter) SetWriter(ctx context.Context, outputFile string) error {
@@ -130,7 +135,7 @@ func (cp *CsvPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.OP
 			failedPaths := ""
 			fixPaths := ""
 			if hasResult {
-				failedPaths, fixPaths = csvControlPaths(resourceResult, ctrlID)
+				failedPaths, fixPaths = csvControlPaths(resourceResult, ctrlID, resKind, cp.showSecrets)
 			}
 
 			remediation := ""
@@ -176,8 +181,11 @@ func (cp *CsvPrinter) CloseWriter() error {
 
 // csvControlPaths returns the semicolon-separated failed paths and fix paths
 // for the given controlID in result. Both strings are empty when the control
-// is not found or has no paths.
-func csvControlPaths(result resourcesresults.Result, controlID string) (failedPaths, fixPaths string) {
+// is not found or has no paths. FixPath.Value is redacted to [redacted] for
+// sensitive paths (Secret.data, container env[].value, and other
+// secret-shaped fields -- see isSensitivePath) unless showSecrets is true,
+// matching the terminal pretty-printer's default.
+func csvControlPaths(result resourcesresults.Result, controlID, kind string, showSecrets bool) (failedPaths, fixPaths string) {
 	for i := range result.AssociatedControls {
 		if result.AssociatedControls[i].GetID() != controlID {
 			continue
@@ -190,8 +198,12 @@ func csvControlPaths(result resourcesresults.Result, controlID string) (failedPa
 					failed = append(failed, p.ReviewPath)
 				}
 				if p.FixPath.Path != "" {
-					if p.FixPath.Value != "" {
-						fix = append(fix, p.FixPath.Path+"="+p.FixPath.Value)
+					v := p.FixPath.Value
+					if !showSecrets && isSensitivePath(kind, p.FixPath.Path) {
+						v = redactedValue
+					}
+					if v != "" {
+						fix = append(fix, p.FixPath.Path+"="+v)
 					} else {
 						fix = append(fix, p.FixPath.Path)
 					}

--- a/core/pkg/resultshandling/printer/v2/csvprinter.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter.go
@@ -184,7 +184,13 @@ func (cp *CsvPrinter) CloseWriter() error {
 // is not found or has no paths. FixPath.Value is redacted to [redacted] for
 // sensitive paths (Secret.data, container env[].value, and other
 // secret-shaped fields -- see isSensitivePath) unless showSecrets is true,
-// matching the terminal pretty-printer's default.
+// matching the terminal pretty-printer's default. kind == "" (the caller's
+// AllResources lookup missed, so the resource's real kind is unknown) is
+// treated as sensitive too: isSensitivePath's Secret.data/stringData check
+// requires kind == "Secret" to fire, so an unresolved kind would otherwise
+// silently skip that check and only catch a value that also happens to
+// match a known credential-shaped field name -- failing closed here instead
+// means an unresolvable resource never leaks its fix value by accident.
 func csvControlPaths(result resourcesresults.Result, controlID, kind string, showSecrets bool) (failedPaths, fixPaths string) {
 	for i := range result.AssociatedControls {
 		if result.AssociatedControls[i].GetID() != controlID {
@@ -199,7 +205,7 @@ func csvControlPaths(result resourcesresults.Result, controlID, kind string, sho
 				}
 				if p.FixPath.Path != "" {
 					v := p.FixPath.Value
-					if !showSecrets && isSensitivePath(kind, p.FixPath.Path) {
+					if !showSecrets && (kind == "" || isSensitivePath(kind, p.FixPath.Path)) {
 						v = redactedValue
 					}
 					if v != "" {

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -371,6 +371,72 @@ func TestActionPrint_Csv_WithPaths(t *testing.T) {
 	assert.Equal(t, "manifests/deployment.yaml", foundRow[12], "Source Path column uses RelativePath")
 }
 
+// TestActionPrint_Csv_MissingAllResourcesEntryFailsClosed is a regression
+// test: when a resource's ResourcesResult entry has no corresponding
+// AllResources entry (a partial/degraded collection, or ordering the
+// printer has no control over), resKind in ActionPrint stays "". Before the
+// kind == "" fail-closed check in csvControlPaths, this resource's fix
+// values were written to the CSV unredacted regardless of --show-secrets,
+// since the Secret-kind check in isSensitivePath never got a chance to
+// fire.
+func TestActionPrint_Csv_MissingAllResourcesEntryFailsClosed(t *testing.T) {
+	const missingResourceID = "v1/Secret/default/orphaned"
+	session := cautils.NewOPASessionObjMock()
+	session.ResourcesResult[missingResourceID] = resourcesresults.Result{
+		ResourceID: missingResourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0012",
+				Name:      "Credentials in env var",
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{
+						Paths: []armotypes.PosturePaths{
+							{FixPath: armotypes.FixPath{Path: "data.password", Value: "s3cr3t-plaintext-password"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	// Deliberately no session.AllResources[missingResourceID] entry.
+	session.Report = &reporthandlingv2.PostureReport{
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: reportsummary.ControlSummaries{
+				"C-0012": reportsummary.ControlSummary{ControlID: "C-0012", Name: "Credentials in env var", ScoreFactor: 8.0},
+			},
+		},
+	}
+
+	tmpCsv, err := os.CreateTemp("", "csv-missing-resource-*.csv")
+	require.NoError(t, err)
+	defer os.Remove(tmpCsv.Name())
+
+	cp := NewCsvPrinter(false)
+	cp.writer = tmpCsv
+	require.NoError(t, cp.ActionPrint(context.TODO(), session, nil))
+	require.NoError(t, cp.CloseWriter())
+
+	f, err := os.Open(tmpCsv.Name())
+	require.NoError(t, err)
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+
+	var foundRow []string
+	for _, row := range records[1:] {
+		if row[1] == "C-0012" {
+			foundRow = row
+			break
+		}
+	}
+	require.NotNil(t, foundRow, "should find the C-0012 row even though the resource is unresolved")
+	assert.Empty(t, foundRow[5], "Resource Kind column is empty: the AllResources lookup missed")
+	assert.NotContains(t, foundRow[9], "s3cr3t-plaintext-password", "Fix Paths column must not leak the value when kind is unresolved")
+	assert.Contains(t, foundRow[9], "[redacted]", "Fix Paths column must fail closed to redacted")
+}
+
 func TestActionPrint_Csv_NilSession(t *testing.T) {
 	cp := NewCsvPrinter(false)
 	cp.writer = os.Stdout
@@ -410,6 +476,7 @@ func TestCsvControlPaths(t *testing.T) {
 				},
 			}),
 			controlID:  "C-0057",
+			kind:       "Deployment",
 			wantFailed: "spec.containers[0].securityContext.privileged",
 			wantFix:    "spec.containers[0].securityContext.privileged=false",
 		},
@@ -437,6 +504,7 @@ func TestCsvControlPaths(t *testing.T) {
 				},
 			}),
 			controlID:  "C-0057",
+			kind:       "Deployment",
 			wantFailed: "",
 			wantFix:    "spec.hostNetwork=false",
 		},
@@ -519,6 +587,28 @@ func TestCsvControlPaths(t *testing.T) {
 			kind:       "Secret",
 			wantFailed: "",
 			wantFix:    "data.password=[redacted]",
+		},
+		{
+			// Regression: an unresolved kind ("" -- the caller's
+			// AllResources lookup missed) must redact regardless of
+			// whether the field name itself looks credential-shaped.
+			// isSensitivePath("", "data.customKey") is false on its own --
+			// the Secret.data/stringData check requires kind == "Secret" to
+			// fire, and "customKey" matches none of the generic
+			// secretFieldPatterns -- so without the explicit kind == ""
+			// fail-closed check, this exact case would leak.
+			name: "unresolved kind fails closed even for a non-pattern-matching field name",
+			result: makeResult("C-0012", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FixPath: armotypes.FixPath{Path: "data.customKey", Value: "s3cr3t-plaintext-value"}},
+					},
+				},
+			}),
+			controlID:  "C-0012",
+			kind:       "",
+			wantFailed: "",
+			wantFix:    "data.customKey=[redacted]",
 		},
 	}
 

--- a/core/pkg/resultshandling/printer/v2/csvprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/csvprinter_test.go
@@ -191,7 +191,7 @@ func TestActionPrint_Csv_WriteFailureIsReported(t *testing.T) {
 	// A small fixture whose rows all fit comfortably inside the csv.Writer's
 	// internal buffer: no row write ever touches the underlying file, so the
 	// only write attempt happens on the final Flush.
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	cp.writer = openDevFull(t)
 
 	err := cp.ActionPrint(context.TODO(), csvSessionFixture(), nil)
@@ -203,7 +203,7 @@ func TestActionPrint_Csv_MidLoopWriteFailureIsReported(t *testing.T) {
 	// forcing a real write to the underlying file (and a resulting error)
 	// before the loop even finishes, exercising the early-return path that
 	// used to skip the final Flush() entirely.
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	cp.writer = openDevFull(t)
 
 	err := cp.ActionPrint(context.TODO(), csvSessionFixtureManyRows(200), nil)
@@ -211,12 +211,12 @@ func TestActionPrint_Csv_MidLoopWriteFailureIsReported(t *testing.T) {
 }
 
 func TestNewCsvPrinter(t *testing.T) {
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	assert.NotNil(t, cp)
 }
 
 func TestSetWriter_Csv(t *testing.T) {
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	assert.NotNil(t, cp)
 
 	cp.SetWriter(context.TODO(), "")
@@ -242,7 +242,7 @@ func TestScore_Csv(t *testing.T) {
 		},
 	}
 
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := os.CreateTemp("", "csvPrinter-score-output")
@@ -280,7 +280,7 @@ func TestActionPrint_Csv(t *testing.T) {
 		_ = os.Remove(tmpCsv.Name())
 	}()
 
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	cp.writer = tmpCsv
 	cp.ActionPrint(context.TODO(), session, nil)
 	cp.CloseWriter()
@@ -341,7 +341,7 @@ func TestActionPrint_Csv_WithPaths(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(tmpCsv.Name())
 
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	cp.writer = tmpCsv
 	cp.ActionPrint(context.TODO(), session, nil)
 	cp.CloseWriter()
@@ -372,7 +372,7 @@ func TestActionPrint_Csv_WithPaths(t *testing.T) {
 }
 
 func TestActionPrint_Csv_NilSession(t *testing.T) {
-	cp := NewCsvPrinter()
+	cp := NewCsvPrinter(false)
 	cp.writer = os.Stdout
 	cp.ActionPrint(context.TODO(), nil, nil)
 }
@@ -393,6 +393,7 @@ func TestCsvControlPaths(t *testing.T) {
 		name       string
 		result     resourcesresults.Result
 		controlID  string
+		kind       string
 		wantFailed string
 		wantFix    string
 	}{
@@ -487,6 +488,11 @@ func TestCsvControlPaths(t *testing.T) {
 			wantFix:    "",
 		},
 		{
+			// kind: "Pod" matters here: automountServiceAccountToken is a
+			// secret-shaped field name ("...Token"), but it's an allowlisted
+			// safe field on a Pod spec (see matchesSafeField) -- an empty
+			// kind would fall through to the generic name-pattern check and
+			// wrongly redact a boolean toggle that never holds a secret.
 			name: "fix path with empty value emits bare path without equals",
 			result: makeResult("C-0057", []resourcesresults.ResourceAssociatedRule{
 				{
@@ -496,14 +502,29 @@ func TestCsvControlPaths(t *testing.T) {
 				},
 			}),
 			controlID:  "C-0057",
+			kind:       "Pod",
 			wantFailed: "",
 			wantFix:    "spec.automountServiceAccountToken",
+		},
+		{
+			name: "sensitive Secret.data fix path is redacted by default",
+			result: makeResult("C-0012", []resourcesresults.ResourceAssociatedRule{
+				{
+					Paths: []armotypes.PosturePaths{
+						{FixPath: armotypes.FixPath{Path: "data.password", Value: "s3cr3t-plaintext-password"}},
+					},
+				},
+			}),
+			controlID:  "C-0012",
+			kind:       "Secret",
+			wantFailed: "",
+			wantFix:    "data.password=[redacted]",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotFailed, gotFix := csvControlPaths(tc.result, tc.controlID)
+			gotFailed, gotFix := csvControlPaths(tc.result, tc.controlID, tc.kind, false)
 			assert.Equal(t, tc.wantFailed, gotFailed, "failed paths mismatch")
 			assert.Equal(t, tc.wantFix, gotFix, "fix paths mismatch")
 		})

--- a/core/pkg/resultshandling/printer/v2/fixcache_test.go
+++ b/core/pkg/resultshandling/printer/v2/fixcache_test.go
@@ -275,7 +275,7 @@ func TestPrintConfigurationScan_MultiDocumentFixesPerDocument(t *testing.T) {
 	require.NoError(t, err)
 	defer out.Close()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = out
 	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
 
@@ -341,7 +341,7 @@ func BenchmarkPrintConfigurationScan(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				out, err := os.CreateTemp(b.TempDir(), "bench-*.sarif")
 				require.NoError(b, err)
-				sp := NewSARIFPrinter()
+				sp := NewSARIFPrinter(false)
 				sp.writer = out
 				require.NoError(b, sp.printConfigurationScan(context.Background(), session))
 				require.NoError(b, out.Close())

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter.go
@@ -47,6 +47,12 @@ var _ printer.IPrinter = &GitLabSASTPrinter{}
 // It also emits image-scan CVEs as a GitLab Dependency Scanning report, which uses the same top-level schema (#2782).
 type GitLabSASTPrinter struct {
 	writer *os.File
+	// showSecrets controls whether sensitive field values (Secret.data,
+	// container env[].value, and other secret-shaped fields -- see
+	// isSensitivePath) are redacted in the Solution field below. GitLab SAST
+	// reports are committed as CI pipeline artifacts, so this must default
+	// to redacted the same way the pretty-printer and resource table do.
+	showSecrets bool
 }
 
 // gitLabSASTReport mirrors the GitLab SAST report schema; only the fields Kubescape can populate are modelled
@@ -122,8 +128,8 @@ type gitLabIdentifier struct {
 }
 
 // NewGitLabSASTPrinter returns a new GitLab SAST printer instance
-func NewGitLabSASTPrinter() *GitLabSASTPrinter {
-	return &GitLabSASTPrinter{}
+func NewGitLabSASTPrinter(showSecrets bool) *GitLabSASTPrinter {
+	return &GitLabSASTPrinter{showSecrets: showSecrets}
 }
 
 // Score is a no-op: the GitLab SAST report has no field for the overall risk score
@@ -347,7 +353,7 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 
 			location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
 			res := opaSessionObj.AllResources[resource.resourceID]
-			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabVulnerability(ctl, &ac, res, resource.resourceID, resource.relPath, location))
+			report.Vulnerabilities = append(report.Vulnerabilities, toGitLabVulnerability(ctl, &ac, res, resource.resourceID, resource.relPath, location, gp.showSecrets))
 		}
 	}
 
@@ -394,14 +400,14 @@ func (gp *GitLabSASTPrinter) printConfigurationScan(ctx context.Context, opaSess
 // toGitLabVulnerability maps a failed control on a resource to a GitLab SAST vulnerability.
 // ac and resource are used to populate the Solution field with fix paths and current field values,
 // matching what the pretty-printer and HTML printer already emit.
-func toGitLabVulnerability(ctl reportsummary.IControlSummary, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, resourceID, filePath string, location locationresolver.Location) gitLabVulnerability {
+func toGitLabVulnerability(ctl reportsummary.IControlSummary, ac *resourcesresults.ResourceAssociatedControl, resource workloadinterface.IMetadata, resourceID, filePath string, location locationresolver.Location, showSecrets bool) gitLabVulnerability {
 	controlID := ctl.GetID()
 	// Kubescape severities (Critical/High/Medium/Low/Unknown) are all valid GitLab severities
 	severity := apis.ControlSeverityToString(ctl.GetScoreFactor())
 
 	var solution string
 	if resource != nil {
-		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
+		if paths := AssistedRemediationPathsWithCurrentValuesFiltered(ac, resource, showSecrets); len(paths) > 0 {
 			solution = strings.Join(paths, "\n")
 		}
 	}

--- a/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/gitlabsastprinter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/locationresolver"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -130,7 +131,7 @@ func gitLabReportFor(t *testing.T, session *cautils.OPASessionObj) gitLabSASTRep
 		assert.NoError(t, os.Remove(tmp.Name()))
 	})
 
-	gp := NewGitLabSASTPrinter()
+	gp := NewGitLabSASTPrinter(false)
 	gp.writer = tmp
 	require.NoError(t, gp.printConfigurationScan(context.Background(), session))
 
@@ -358,6 +359,37 @@ func TestGitLabVulnerabilityID(t *testing.T) {
 		"a different resource must produce a different id")
 }
 
+// TestToGitLabVulnerability_RedactsSecretFixPathValueUnlessShowSecrets is a
+// regression test: GitLab SAST reports are committed as CI pipeline
+// artifacts, so a Secret's plaintext fix-path value must be redacted in the
+// Solution field by default, matching the pretty-printer and resource
+// table, and only revealed when the caller explicitly opts in via
+// --show-secrets.
+func TestToGitLabVulnerability_RedactsSecretFixPathValueUnlessShowSecrets(t *testing.T) {
+	control := &reportsummary.ControlSummary{
+		ControlID:   "C-0012",
+		Name:        "Credentials in env var",
+		ScoreFactor: 8.0,
+	}
+	resource := &mockResource{kind: "Secret", obj: map[string]any{}}
+	ac := &resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-0012",
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{Paths: []armotypes.PosturePaths{
+				{FixPath: armotypes.FixPath{Path: "data.password", Value: "s3cr3t-plaintext-password"}},
+			}},
+		},
+	}
+	location := locationresolver.Location{Line: 1, Column: 1}
+
+	redacted := toGitLabVulnerability(control, ac, resource, "v1/Secret/default/demo", "secret.yaml", location, false)
+	assert.NotContains(t, redacted.Solution, "s3cr3t-plaintext-password")
+	assert.Contains(t, redacted.Solution, "[redacted]")
+
+	revealed := toGitLabVulnerability(control, ac, resource, "v1/Secret/default/demo", "secret.yaml", location, true)
+	assert.Contains(t, revealed.Solution, "s3cr3t-plaintext-password")
+}
+
 func TestGitLabImageVulnerabilityID(t *testing.T) {
 	const (
 		image   = "docker.io/library/nginx:1.25"
@@ -451,7 +483,7 @@ func gitLabImageReportFor(t *testing.T, imageScanData []cautils.ImageScanData) g
 		assert.NoError(t, os.Remove(tmp.Name()))
 	})
 
-	gp := NewGitLabSASTPrinter()
+	gp := NewGitLabSASTPrinter(false)
 	gp.writer = tmp
 	require.NoError(t, gp.printImageScan(imageScanData))
 
@@ -522,7 +554,7 @@ func TestGitLabImageScan_VersionKeyAlwaysPresent(t *testing.T) {
 		assert.NoError(t, os.Remove(tmp.Name()))
 	})
 
-	gp := NewGitLabSASTPrinter()
+	gp := NewGitLabSASTPrinter(false)
 	gp.writer = tmp
 	require.NoError(t, gp.printImageScan(imageScanData))
 
@@ -597,7 +629,7 @@ func TestGitLabImageScan_NoData(t *testing.T) {
 		assert.NoError(t, os.Remove(tmp.Name()))
 	})
 
-	gp := NewGitLabSASTPrinter()
+	gp := NewGitLabSASTPrinter(false)
 	gp.writer = tmp
 
 	gp.ActionPrint(context.Background(), nil, nil)
@@ -640,7 +672,7 @@ func TestGitLabSASTPrintConfigurationScan_NilResourceDoesNotPanic(t *testing.T) 
 		assert.NoError(t, os.Remove(tmp.Name()))
 	})
 
-	gp := NewGitLabSASTPrinter()
+	gp := NewGitLabSASTPrinter(false)
 	gp.writer = tmp
 	require.NotPanics(t, func() {
 		_ = gp.printConfigurationScan(context.Background(), session)

--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -62,10 +62,15 @@ type HTMLReportingCtx struct {
 
 type HtmlPrinter struct {
 	writer *os.File
+	// showSecrets controls whether sensitive field values (Secret.data,
+	// container env[].value, and other secret-shaped fields -- see
+	// isSensitivePath) are redacted in the resource table's fix-path
+	// evidence below, matching the terminal pretty-printer's default.
+	showSecrets bool
 }
 
-func NewHtmlPrinter() *HtmlPrinter {
-	return &HtmlPrinter{}
+func NewHtmlPrinter(showSecrets bool) *HtmlPrinter {
+	return &HtmlPrinter{showSecrets: showSecrets}
 }
 
 func (hp *HtmlPrinter) SetWriter(ctx context.Context, outputFile string) error {
@@ -151,7 +156,7 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	var resourceTableView ResourceTableView
 	var imageScanSummary *imageprinter.ImageScanSummary
 	if opaSessionObj != nil {
-		resourceTableView = buildResourceTableView(opaSessionObj)
+		resourceTableView = buildResourceTableView(opaSessionObj, hp.showSecrets)
 	} else {
 		imageScanSummary = buildImageScanSummary(imageScanData)
 	}
@@ -170,7 +175,7 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 func (hp *HtmlPrinter) Score(score float32) {
 }
 
-func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableView {
+func buildResourceTableView(opaSessionObj *cautils.OPASessionObj, showSecrets bool) ResourceTableView {
 	resourceTableView := make(ResourceTableView, 0)
 	for resourceID, result := range opaSessionObj.ResourcesResult {
 		if result.GetStatus(nil).IsFailed() {
@@ -180,7 +185,7 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 					helpers.String("resourceID", resourceID))
 				continue
 			}
-			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails, resource)
+			ctlResults := buildResourceControlResultTable(result.AssociatedControls, &opaSessionObj.Report.SummaryDetails, resource, showSecrets)
 			resourceTableView = append(resourceTableView, ResourceResult{resource, ctlResults})
 		}
 	}
@@ -188,18 +193,18 @@ func buildResourceTableView(opaSessionObj *cautils.OPASessionObj) ResourceTableV
 	return resourceTableView
 }
 
-func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary, resource workloadinterface.IMetadata) ResourceControlResult {
+func buildResourceControlResult(resourceControl resourcesresults.ResourceAssociatedControl, control reportsummary.IControlSummary, resource workloadinterface.IMetadata, showSecrets bool) ResourceControlResult {
 	ctlSeverity := apis.ControlSeverityToString(control.GetScoreFactor())
 	ctlName := resourceControl.GetName()
 	ctlID := resourceControl.GetID()
 	ctlURL := cautils.GetControlLink(resourceControl.GetID())
-	failedPaths := AssistedRemediationPathsWithCurrentValues(&resourceControl, resource)
+	failedPaths := AssistedRemediationPathsWithCurrentValuesFiltered(&resourceControl, resource, showSecrets)
 	addContainerNameToAssistedRemediation(resource, &failedPaths)
 
 	return ResourceControlResult{ctlSeverity, ctlName, ctlID, ctlURL, failedPaths}
 }
 
-func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata) []ResourceControlResult {
+func buildResourceControlResultTable(resourceControls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata, showSecrets bool) []ResourceControlResult {
 	var ctlResults []ResourceControlResult
 	for _, resourceControl := range resourceControls {
 		if resourceControl.GetStatus(nil).IsFailed() {
@@ -207,7 +212,7 @@ func buildResourceControlResultTable(resourceControls []resourcesresults.Resourc
 			if control == nil {
 				continue
 			}
-			ctlResult := buildResourceControlResult(resourceControl, control, resource)
+			ctlResult := buildResourceControlResult(resourceControl, control, resource, showSecrets)
 
 			ctlResults = append(ctlResults, ctlResult)
 		}

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
@@ -15,7 +17,7 @@ import (
 )
 
 func TestNewHtmlPrinter(t *testing.T) {
-	hp := NewHtmlPrinter()
+	hp := NewHtmlPrinter(false)
 	assert.NotNil(t, hp)
 	assert.Nil(t, hp.writer)
 }
@@ -65,7 +67,7 @@ func TestSetWriter_Html(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hp := NewHtmlPrinter()
+			hp := NewHtmlPrinter(false)
 			hp.SetWriter(ctx, tt.outputFile)
 			t.Cleanup(func() {
 				_ = hp.writer.Close()
@@ -87,8 +89,38 @@ func TestBuildResourceControlResult_AnnotatesInitAndEphemeralContainerNames(t *t
 	ac.ControlID = "C-0057"
 	ac.Name = "Privileged container"
 
-	got := buildResourceControlResult(*ac, control, privilegedInitAndEphemeralPod())
+	got := buildResourceControlResult(*ac, control, privilegedInitAndEphemeralPod(), false)
 	require.Equal(t, privilegedInitAndEphemeralNamedPaths(), got.FailedPaths)
+}
+
+// TestBuildResourceControlResult_RedactsSecretFixPathValueUnlessShowSecrets
+// is a regression test: the HTML report's resource table must redact a
+// Secret's plaintext fix-path value by default, matching the terminal
+// pretty-printer, and only reveal it when the caller explicitly opts in via
+// --show-secrets.
+func TestBuildResourceControlResult_RedactsSecretFixPathValueUnlessShowSecrets(t *testing.T) {
+	control := &reportsummary.ControlSummary{
+		ControlID:   "C-0012",
+		Name:        "Credentials in env var",
+		ScoreFactor: 8.0,
+	}
+	resource := &mockResource{kind: "Secret", obj: map[string]any{}}
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-0012",
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{Paths: []armotypes.PosturePaths{
+				{FixPath: armotypes.FixPath{Path: "data.password", Value: "s3cr3t-plaintext-password"}},
+			}},
+		},
+	}
+
+	redacted := buildResourceControlResult(ac, control, resource, false)
+	redactedJoined := strings.Join(redacted.FailedPaths, " ")
+	assert.NotContains(t, redactedJoined, "s3cr3t-plaintext-password")
+	assert.Contains(t, redactedJoined, "[redacted]")
+
+	revealed := buildResourceControlResult(ac, control, resource, true)
+	assert.Contains(t, strings.Join(revealed.FailedPaths, " "), "s3cr3t-plaintext-password")
 }
 
 func TestBuildResourceControlResultTable_MissingControl(t *testing.T) {
@@ -102,7 +134,7 @@ func TestBuildResourceControlResultTable_MissingControl(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails, nil)
+		results := buildResourceControlResultTable([]resourcesresults.ResourceAssociatedControl{ac}, summaryDetails, nil, false)
 		assert.Empty(t, results)
 	})
 }
@@ -122,7 +154,7 @@ func TestBuildResourceTableView_SkipsMissingResource(t *testing.T) {
 	}
 	// Do not populate session.AllResources["r-1"]
 
-	view := buildResourceTableView(session)
+	view := buildResourceTableView(session, false)
 	assert.Empty(t, view, "missing resource should be skipped, not included with nil")
 }
 
@@ -135,7 +167,7 @@ func TestHtmlPrinter_ActionPrint_LogoIsEmbeddedNotFetchedFromNetwork(t *testing.
 	ctx := context.Background()
 	out := filepath.Join(t.TempDir(), "report.html")
 
-	hp := NewHtmlPrinter()
+	hp := NewHtmlPrinter(false)
 	assert.NoError(t, hp.SetWriter(ctx, out))
 
 	session := cautils.NewOPASessionObjMock()
@@ -156,7 +188,7 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	ctx := context.Background()
 	out := filepath.Join(t.TempDir(), "report.html")
 
-	hp := NewHtmlPrinter()
+	hp := NewHtmlPrinter(false)
 	hp.SetWriter(ctx, out)
 
 	// Fixture counters (FailedResources: 2, AllResources: 100) are intentionally

--- a/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
+++ b/core/pkg/resultshandling/printer/v2/imagescan_severity_test.go
@@ -172,7 +172,7 @@ func TestSARIFPrinter_ImageScan_HonorsSeverityExceptions(t *testing.T) {
 		assert.NoError(t, os.Remove(tmp.Name()))
 	}()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 
 	require.NoError(t, sp.printImageScan([]cautils.ImageScanData{imageScanData}))
@@ -248,7 +248,7 @@ const imageSARIFStdoutHelperEnv = "KUBESCAPE_TEST_IMAGE_SARIF_STDOUT_HELPER"
 // single write to stdout.
 func TestSARIFPrinter_ImageScan_StdoutPipeCompletes(t *testing.T) {
 	if os.Getenv(imageSARIFStdoutHelperEnv) == "1" {
-		sp := NewSARIFPrinter()
+		sp := NewSARIFPrinter(false)
 		sp.SetWriter(context.Background(), "")
 		if err := sp.printImageScan([]cautils.ImageScanData{buildSeverityExceptionImageScanData()}); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -618,7 +618,14 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 				sp.addRule(run, ctl)
 				rsrc := opaSessionObj.AllResources[resource.resourceID]
 				r := sp.addResult(run, ctl, resource.relPath, location, &ac, resource.resourceID, rsrc, reviewPathLocations)
-				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath)
+				// kind stays "" when rsrc is nil (the resource lookup missed) --
+				// collectFixes below treats an unresolved kind as sensitive,
+				// the same fail-closed rule csvControlPaths applies.
+				kind := ""
+				if rsrc != nil {
+					kind = rsrc.GetKind()
+				}
+				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath, kind, sp.showSecrets)
 			}
 		}
 	}
@@ -810,7 +817,15 @@ func closesFixRegion(delta []string, index int) bool {
 	return true
 }
 
-func collectFixes(ctx context.Context, cache *fixReportCache, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string) {
+// collectFixes builds the SARIF "fixes" suggestions from each failed rule's
+// FixPath. This is a second, independent place FixPath.Value gets
+// serialized into the report -- separate from the Message.Text path
+// addResult builds via AssistedRemediationPathsWithCurrentValuesFiltered --
+// so it applies the same isSensitivePath redaction itself rather than
+// relying on that filtering having already happened. kind == "" (the
+// resource lookup that would have supplied it missed) is treated as
+// sensitive: fail closed rather than guess a value is safe to reveal.
+func collectFixes(ctx context.Context, cache *fixReportCache, result *sarif.Result, ac resourcesresults.ResourceAssociatedControl, opaSessionObj *cautils.OPASessionObj, resourceID string, filepath string, rsrcAbsPath string, kind string, showSecrets bool) {
 	// the index is the resource's, not a fix path's, so without one there is
 	// nothing to report
 	documentIndex, ok := getDocIndex(opaSessionObj, resourceID)
@@ -829,9 +844,14 @@ func collectFixes(ctx context.Context, cache *fixReportCache, result *sarif.Resu
 				continue
 			}
 
+			value := rulePaths.FixPath.Value
+			if !showSecrets && (kind == "" || isSensitivePath(kind, fixPath)) {
+				value = redactedValue
+			}
+
 			// Empty means the path is not a plain yaml path and must not be
 			// evaluated as a yq expression.
-			yamlExpression := fixhandler.FixPathToValidYamlExpression(fixPath, rulePaths.FixPath.Value, documentIndex)
+			yamlExpression := fixhandler.FixPathToValidYamlExpression(fixPath, value, documentIndex)
 			if yamlExpression == "" {
 				continue
 			}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -69,11 +69,18 @@ var _ printer.IPrinter = &SARIFPrinter{}
 type SARIFPrinter struct {
 	// outputFile is the name of the output file
 	writer *os.File
+	// showSecrets controls whether sensitive field values (Secret.data,
+	// container env[].value, and other secret-shaped fields -- see
+	// isSensitivePath) are redacted in the fix-path evidence emitted below.
+	// SARIF output is routinely uploaded to CI code-scanning dashboards or
+	// committed as a pipeline artifact, so this must default to redacted
+	// the same way the pretty-printer and resource table already do.
+	showSecrets bool
 }
 
 // NewSARIFPrinter returns a new SARIF printer instance
-func NewSARIFPrinter() *SARIFPrinter {
-	return &SARIFPrinter{}
+func NewSARIFPrinter(showSecrets bool) *SARIFPrinter {
+	return &SARIFPrinter{showSecrets: showSecrets}
 }
 
 func (sp *SARIFPrinter) Score(score float32) {
@@ -117,7 +124,7 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resourceID string, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
 	msg := ctl.GetDescription()
 	if resource != nil {
-		if paths := AssistedRemediationPathsWithCurrentValues(ac, resource); len(paths) > 0 {
+		if paths := AssistedRemediationPathsWithCurrentValuesFiltered(ac, resource, sp.showSecrets); len(paths) > 0 {
 			addContainerNameToAssistedRemediation(resource, &paths)
 			msg += "\n\nAffected fields:\n" + strings.Join(paths, "\n")
 		}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -1334,6 +1334,155 @@ spec:
 		"all findings must not collapse to line 1 for absolute-path file scans")
 }
 
+// TestPrintConfigurationScan_FixSuggestionRedactsSecretValueUnlessShowSecrets
+// is a regression test: collectFixes builds SARIF's "fixes" suggestions
+// (result.fixes[].artifactChanges[].replacements[].insertedContent) from
+// the same FixPath.Value that addResult's Message.Text already redacts --
+// but it is a second, independent place that value gets serialized into the
+// report, so it needs its own isSensitivePath check rather than relying on
+// the Message.Text filtering having already happened. This drives a full
+// serialized-SARIF report through printConfigurationScan and unmarshals it
+// back, the same way TestPrintConfigurationScan_FileScanResolvesLineNumbers
+// does, so it catches the fixes array specifically, not just the message.
+func TestPrintConfigurationScan_FixSuggestionRedactsSecretValueUnlessShowSecrets(t *testing.T) {
+	manifestDir := t.TempDir()
+	manifestPath := filepath.Join(manifestDir, "secret.yaml")
+	manifest := `apiVersion: v1
+kind: Secret
+metadata: {name: demo, namespace: default}
+data:
+  password: "0000000000000000"
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	resourceID := "v1/Secret/default/demo"
+	obj := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name":      "demo",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{},
+	}
+	lw := localworkload.NewLocalWorkload(obj)
+	lw.SetPath("secret.yaml:0")
+
+	const secretValue = "s3cr3t-plaintext-password"
+	controlID := "C-0012"
+	ac := resourcesresults.ResourceAssociatedControl{
+		ControlID: controlID,
+		Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{
+				Name:   "credentials-in-env-var",
+				Status: apis.StatusFailed,
+				Paths: []armotypes.PosturePaths{
+					{
+						FixPath: armotypes.FixPath{
+							Path:  "data.password",
+							Value: secretValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	buildSession := func() *cautils.OPASessionObj {
+		session := cautils.NewOPASessionObjMock()
+		session.Metadata = &reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{
+				ScanningTarget: reporthandlingv2.File,
+			},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				FileContextMetadata: &reporthandlingv2.FileContextMetadata{
+					FilePath: manifestPath,
+				},
+			},
+		}
+		session.ResourcesResult[resourceID] = resourcesresults.Result{
+			ResourceID:         resourceID,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{ac},
+		}
+		session.ResourceSource = map[string]reporthandling.Source{
+			resourceID: {
+				Path:         manifestDir,
+				RelativePath: "secret.yaml",
+				FileType:     reporthandling.SourceTypeYaml,
+			},
+		}
+		session.AllResources[resourceID] = lw
+		session.Report = &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{
+				Controls: reportsummary.ControlSummaries{
+					controlID: reportsummary.ControlSummary{
+						ControlID:   controlID,
+						Name:        "Credentials in env var",
+						Description: "test",
+						Remediation: "redact the credential",
+						ScoreFactor: 8.0,
+					},
+				},
+			},
+		}
+		return session
+	}
+
+	insertedTexts := func(t *testing.T, sp *SARIFPrinter, session *cautils.OPASessionObj) []string {
+		t.Helper()
+		tmp, err := os.CreateTemp("", "sarif-fix-redaction-*.sarif")
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, tmp.Close())
+			assert.NoError(t, os.Remove(tmp.Name()))
+		}()
+		sp.writer = tmp
+		require.NoError(t, sp.printConfigurationScan(context.Background(), session))
+
+		raw, err := os.ReadFile(tmp.Name())
+		require.NoError(t, err)
+		var report sarif.Report
+		require.NoError(t, json.Unmarshal(raw, &report))
+		require.Len(t, report.Runs, 1)
+		require.NotEmpty(t, report.Runs[0].Results)
+
+		var texts []string
+		for _, result := range report.Runs[0].Results {
+			for _, fix := range result.Fixes {
+				for _, change := range fix.ArtifactChanges {
+					for _, replacement := range change.Replacements {
+						if replacement.InsertedContent != nil && replacement.InsertedContent.Text != nil {
+							texts = append(texts, *replacement.InsertedContent.Text)
+						}
+					}
+				}
+			}
+		}
+		return texts
+	}
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	otherWD := t.TempDir()
+	require.NoError(t, os.Chdir(otherWD))
+
+	t.Run("redacted by default", func(t *testing.T) {
+		texts := insertedTexts(t, NewSARIFPrinter(false), buildSession())
+		require.NotEmpty(t, texts, "collectFixes must still produce a fix suggestion")
+		joined := strings.Join(texts, " ")
+		assert.NotContains(t, joined, secretValue)
+		assert.Contains(t, joined, redactedValue)
+	})
+
+	t.Run("revealed with showSecrets", func(t *testing.T) {
+		texts := insertedTexts(t, NewSARIFPrinter(true), buildSession())
+		require.NotEmpty(t, texts)
+		assert.Contains(t, strings.Join(texts, " "), secretValue)
+	})
+}
+
 // TestPrintConfigurationScan_ReviewPathGetsRelatedLocation is a regression test for evidence
 // locations: a control's ReviewPath previously had no location of its own in SARIF output - only
 // the (possibly different) FixPath got the primary Locations entry. This asserts the ReviewPath

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -374,7 +374,7 @@ func TestAddRule_SetsSecuritySeverity(t *testing.T) {
 		ScoreFactor: 8.5,
 	}
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.addRule(run, control)
 
 	require.Len(t, run.Tool.Driver.Rules, 1)
@@ -393,7 +393,7 @@ func TestAddResult_AnnotatesInitAndEphemeralContainerNames(t *testing.T) {
 		ScoreFactor: 8.0,
 	}
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.addRule(run, control)
 
 	ac := makeControlWithPaths(privilegedInitAndEphemeralPaths(), nil)
@@ -407,6 +407,49 @@ func TestAddResult_AnnotatesInitAndEphemeralContainerNames(t *testing.T) {
 	}
 	require.NotNil(t, result.PartialFingerprints)
 	assert.NotEmpty(t, result.PartialFingerprints["kubescapeFindingFingerprint"])
+}
+
+// TestAddResult_RedactsSecretFixPathValueUnlessShowSecrets is a regression
+// test: SARIF is routinely uploaded to CI code-scanning dashboards or
+// committed as a pipeline artifact, so a Secret's plaintext fix-path value
+// must be redacted by default the same way the pretty-printer and resource
+// table already are, and only revealed when the caller explicitly opts in
+// via --show-secrets.
+func TestAddResult_RedactsSecretFixPathValueUnlessShowSecrets(t *testing.T) {
+	control := &reportsummary.ControlSummary{
+		ControlID:   "C-0012",
+		Name:        "Credentials in env var",
+		Description: "test",
+		ScoreFactor: 8.0,
+	}
+	resource := &mockResource{kind: "Secret", obj: map[string]any{}}
+	ac := &resourcesresults.ResourceAssociatedControl{
+		ControlID: "C-0012",
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+			{Paths: []armotypes.PosturePaths{
+				{FixPath: armotypes.FixPath{Path: "data.password", Value: "s3cr3t-plaintext-password"}},
+			}},
+		},
+	}
+
+	t.Run("redacted by default", func(t *testing.T) {
+		run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+		sp := NewSARIFPrinter(false)
+		sp.addRule(run, control)
+		result := sp.addResult(run, control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
+		require.NotNil(t, result.Message.Text)
+		assert.NotContains(t, *result.Message.Text, "s3cr3t-plaintext-password")
+		assert.Contains(t, *result.Message.Text, "[redacted]")
+	})
+
+	t.Run("revealed with showSecrets", func(t *testing.T) {
+		run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
+		sp := NewSARIFPrinter(true)
+		sp.addRule(run, control)
+		result := sp.addResult(run, control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
+		require.NotNil(t, result.Message.Text)
+		assert.Contains(t, *result.Message.Text, "s3cr3t-plaintext-password")
+	})
 }
 
 func TestSARIFFindingFingerprintStableAcrossEvidenceOrdering(t *testing.T) {
@@ -790,7 +833,7 @@ func TestPrintConfigurationScan_MissingControl(t *testing.T) {
 		assert.NoError(t, os.Remove(tmp.Name()))
 	}()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 
 	assert.NotPanics(t, func() {
@@ -860,7 +903,7 @@ func TestPrintConfigurationScan_SkipsResourcesWithoutRelativePath(t *testing.T) 
 				assert.NoError(t, os.Remove(tmp.Name()))
 			}()
 
-			sp := NewSARIFPrinter()
+			sp := NewSARIFPrinter(false)
 			sp.writer = tmp
 			require.NoError(t, sp.printConfigurationScan(context.Background(), session))
 			require.NoError(t, tmp.Close())
@@ -899,7 +942,7 @@ func TestPrintConfigurationScan_PopulatesInvocations(t *testing.T) {
 		assert.NoError(t, os.Remove(tmp.Name()))
 	}()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 
 	before := time.Now().UTC()
@@ -951,7 +994,7 @@ func TestPrintConfigurationScan_InvocationStartTimeUsesReportGenerationTime(t *t
 		assert.NoError(t, os.Remove(tmp.Name()))
 	}()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 
 	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
@@ -1265,7 +1308,7 @@ spec:
 	otherWD := t.TempDir()
 	require.NoError(t, os.Chdir(otherWD))
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
 
@@ -1406,7 +1449,7 @@ spec:
 	otherWD := t.TempDir()
 	require.NoError(t, os.Chdir(otherWD))
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 	require.NoError(t, sp.printConfigurationScan(context.Background(), session))
 
@@ -1450,7 +1493,7 @@ func TestPrintImageScan_WriterIsNonSeekablePipe(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = w
 
 	imageScanData := buildSeverityExceptionImageScanData()
@@ -1493,7 +1536,7 @@ func TestPrintImageScan_MultipleImagesAggregatesRuns(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmp.Name()) }()
 
-	sp := NewSARIFPrinter()
+	sp := NewSARIFPrinter(false)
 	sp.writer = tmp
 
 	scan1 := buildSeverityExceptionImageScanData()

--- a/core/pkg/resultshandling/printer/v2/setwriter_test.go
+++ b/core/pkg/resultshandling/printer/v2/setwriter_test.go
@@ -51,7 +51,7 @@ func TestSetWriterUsesSharedOutputResolution(t *testing.T) {
 			name:       "csv",
 			format:     baseprinter.CsvFormat,
 			baseName:   csvOutputFile,
-			newPrinter: func() setWriterPrinter { return NewCsvPrinter() },
+			newPrinter: func() setWriterPrinter { return NewCsvPrinter(false) },
 			writerName: func(p setWriterPrinter) string { return p.(*CsvPrinter).writer.Name() },
 			closeWriter: func(p setWriterPrinter) error {
 				return p.(*CsvPrinter).CloseWriter()
@@ -81,7 +81,7 @@ func TestSetWriterUsesSharedOutputResolution(t *testing.T) {
 			name:       "sarif",
 			format:     baseprinter.SARIFFormat,
 			baseName:   sarifOutputFile,
-			newPrinter: func() setWriterPrinter { return NewSARIFPrinter() },
+			newPrinter: func() setWriterPrinter { return NewSARIFPrinter(false) },
 			writerName: func(p setWriterPrinter) string { return p.(*SARIFPrinter).writer.Name() },
 			closeWriter: func(p setWriterPrinter) error {
 				return p.(*SARIFPrinter).CloseWriter()
@@ -91,7 +91,7 @@ func TestSetWriterUsesSharedOutputResolution(t *testing.T) {
 			name:       "gitlab-sast",
 			format:     baseprinter.GitLabSASTFormat,
 			baseName:   gitLabSASTOutputFile,
-			newPrinter: func() setWriterPrinter { return NewGitLabSASTPrinter() },
+			newPrinter: func() setWriterPrinter { return NewGitLabSASTPrinter(false) },
 			writerName: func(p setWriterPrinter) string { return p.(*GitLabSASTPrinter).writer.Name() },
 			closeWriter: func(p setWriterPrinter) error {
 				return p.(*GitLabSASTPrinter).CloseWriter()
@@ -131,7 +131,7 @@ func TestSetWriterUsesSharedOutputResolution(t *testing.T) {
 			name:       "html",
 			format:     baseprinter.HtmlFormat,
 			baseName:   htmlOutputFile,
-			newPrinter: func() setWriterPrinter { return NewHtmlPrinter() },
+			newPrinter: func() setWriterPrinter { return NewHtmlPrinter(false) },
 			writerName: func(p setWriterPrinter) string { return p.(*HtmlPrinter).writer.Name() },
 			closeWriter: func(p setWriterPrinter) error {
 				return p.(*HtmlPrinter).CloseWriter()

--- a/core/pkg/resultshandling/results.go
+++ b/core/pkg/resultshandling/results.go
@@ -396,7 +396,7 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 		}
 		return printerv2.NewYamlPrinter()
 	case printer.CsvFormat:
-		return printerv2.NewCsvPrinter()
+		return printerv2.NewCsvPrinter(scanInfo.ShowSecrets)
 	case printer.MarkdownFormat:
 		return printerv2.NewMarkdownPrinter()
 	case printer.JunitResultFormat:
@@ -406,11 +406,11 @@ func NewPrinter(ctx context.Context, printFormat string, scanInfo *cautils.ScanI
 	case printer.PdfFormat:
 		return printerv2.NewPdfPrinter()
 	case printer.HtmlFormat:
-		return printerv2.NewHtmlPrinter()
+		return printerv2.NewHtmlPrinter(scanInfo.ShowSecrets)
 	case printer.SARIFFormat:
-		return printerv2.NewSARIFPrinter()
+		return printerv2.NewSARIFPrinter(scanInfo.ShowSecrets)
 	case printer.GitLabSASTFormat:
-		return printerv2.NewGitLabSASTPrinter()
+		return printerv2.NewGitLabSASTPrinter(scanInfo.ShowSecrets)
 	case printer.GitHubActionsFormat:
 		return printerv2.NewGitHubActionsPrinter()
 	case printer.CycloneDXFormat:

--- a/core/pkg/resultshandling/results_test.go
+++ b/core/pkg/resultshandling/results_test.go
@@ -861,8 +861,8 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 		printer printer.IPrinter
 	}{
 		{"json", printerv2.NewJsonPrinter()},
-		{"sarif", printerv2.NewSARIFPrinter()},
-		{"html", printerv2.NewHtmlPrinter()},
+		{"sarif", printerv2.NewSARIFPrinter(false)},
+		{"html", printerv2.NewHtmlPrinter(false)},
 		{"yaml", printerv2.NewYamlPrinter()},
 		{"junit", printerv2.NewJunitPrinter(false)},
 		{"markdown", printerv2.NewMarkdownPrinter()},
@@ -870,9 +870,9 @@ func TestClosePrinter_AllV2PrintersImplementErrorCloser(t *testing.T) {
 		{"prometheus", printerv2.NewPrometheusPrinter(false)},
 		{"spdx", printerv2.NewSPDXPrinter()},
 		{"cyclonedx", printerv2.NewCycloneDXPrinter()},
-		{"gitlabsast", printerv2.NewGitLabSASTPrinter()},
+		{"gitlabsast", printerv2.NewGitLabSASTPrinter(false)},
 		{"githubactions", printerv2.NewGitHubActionsPrinter()},
-		{"csv", printerv2.NewCsvPrinter()},
+		{"csv", printerv2.NewCsvPrinter(false)},
 		{"exceptions", printerv2.NewExceptionsPrinter()},
 		{"pretty", printerv2.NewPrettyPrinter(false, "1.0", false, cautils.ControlViewType, cautils.ScanTypeCluster, nil, "", false, false)},
 		{"silent", &printerv2.SilentPrinter{}},


### PR DESCRIPTION
Fixes #3757

## Summary

`AssistedRemediationPathsWithCurrentValues` had no `isSensitivePath` check at all, unlike its `Filtered` sibling that the pretty-printer and resource table already use. `sarifprinter.go`, `gitlabsastprinter.go`, and `htmlprinter.go` all called the unfiltered variant, so a Secret's plaintext value or a hardcoded credential caught by C-0012 was redacted in the terminal but leaked unredacted into SARIF, HTML, and GitLab SAST output regardless of `--show-secrets`. `csvprinter.go`'s `csvControlPaths` never called either helper and had no `showSecrets` parameter at all.

SARIF and GitLab SAST are exactly the formats that get uploaded to CI code-scanning dashboards or committed as pipeline artifacts, so this was a real exposure path, not just a formatting inconsistency.

## What changed

Threaded `showSecrets` through all four printer constructors (`NewSARIFPrinter`, `NewGitLabSASTPrinter`, `NewHtmlPrinter`, `NewCsvPrinter`) from `scanInfo.ShowSecrets` at the printer factory in `results.go`, the same source the pretty-printer already reads. Each printer now calls `AssistedRemediationPathsWithCurrentValuesFiltered` (or, for CSV, an inline `isSensitivePath` check matching that helper's behavior) instead of the unfiltered path.

## Testing

- New regression test per printer (SARIF, GitLab-SAST, HTML, CSV), each verified to fail against the pre-fix logic and pass post-fix (reverted each fix locally, confirmed red, restored, confirmed green).
- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./core/pkg/resultshandling/...`, full `go test ./...`, and `golangci-lint run --new-from-rev=upstream/master` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive values in CSV, HTML, SARIF, and GitLab SAST output are now redacted by default.
  * Redacted values appear as `[redacted]` in fix-path details and affected-field evidence.
  * Secret visibility can be enabled through the existing “show secrets” setting.
  * Values are also redacted when the resource type cannot be resolved, preventing unintended exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->