### PR TITLE
fix(fix): warn when --output-dir is ignored for file-based reports

### DIFF
--- a/core/core/fix.go
+++ b/core/core/fix.go
@@ -26,6 +26,8 @@ const (
 
 	nonInteractiveWarning = "stdin is not interactive; treating the fix confirmation as declined and applying no changes (pass --no-confirm to apply without a prompt)"
 	stdinClosedWarning    = "stdin was closed before a confirmation was given; treating the fix confirmation as declined and applying no changes (pass --no-confirm to apply without a prompt)"
+
+	outputDirIgnoredWarning = "--output-dir has no effect when fixing manifest files; it applies to cluster scan reports. The files recorded in the report are fixed in place"
 )
 
 // isTerminal and isCygwinTerminal are vars (not direct isatty calls) so tests
@@ -43,6 +45,19 @@ func (ks *Kubescape) Fix(fixInfo *metav1.FixInfo) error {
 	handler, err := fixhandler.NewFixHandler(fixInfo)
 	if err != nil {
 		return err
+	}
+
+	// --output-dir only means something for a cluster report, whose fixes are
+	// rendered and emitted rather than applied. A file-based report is fixed in
+	// place, so passing it used to be accepted in silence: an empty directory,
+	// rewritten manifests, and nothing saying the flag did nothing (#3733).
+	// Which kind of report this is only becomes knowable once the report is
+	// parsed, which is why the check cannot live in the flag-parsing layer.
+	if fixInfo.OutputDir != "" && !handler.IsClusterReport() {
+		logger.L().Ctx(ks.Context()).Warning(outputDirIgnoredWarning)
+		// Cleared so nothing downstream can act on a value the user has just
+		// been told is inert.
+		fixInfo.OutputDir = ""
 	}
 
 	resourcesToFix := handler.PrepareResourcesToFix(ks.Context())

--- a/core/core/fix_test.go
+++ b/core/core/fix_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/go-logger"
 	metav1 "github.com/kubescape/kubescape/v4/core/meta/datastructures/v1"
 	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -334,4 +335,105 @@ func TestFix_ReturnsErrorWhenApplyFails(t *testing.T) {
 	err := ks.Fix(&metav1.FixInfo{ReportFile: reportPath, NoConfirm: true})
 
 	assert.Error(t, err)
+}
+
+// captureLoggerOutput redirects the package logger to a file for the duration
+// of the test and returns a reader for whatever was written to it.
+func captureLoggerOutput(t *testing.T) func() string {
+	t.Helper()
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "log"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	prev := logger.L().GetWriter()
+	logger.L().SetWriter(f)
+	t.Cleanup(func() { logger.L().SetWriter(prev) })
+
+	return func() string {
+		require.NoError(t, f.Sync())
+		b, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+		return string(b)
+	}
+}
+
+// TestFix_OutputDirIsIgnoredWithAWarningForFileReports covers #3733.
+// --output-dir applies only to cluster reports, whose fixes are emitted rather
+// than applied. Passing it to a file-based fix used to be accepted in silence:
+// the directory stayed empty, the manifests were rewritten in place, and
+// nothing told the user the flag had done nothing — so an empty ./patches read
+// as "the fix failed" rather than "that flag doesn't apply here".
+func TestFix_OutputDirIsIgnoredWithAWarningForFileReports(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := buildFixableReport(t, dir)
+	outputDir := filepath.Join(dir, "patches")
+	require.NoError(t, os.MkdirAll(outputDir, 0o750))
+
+	readLog := captureLoggerOutput(t)
+
+	fixInfo := &metav1.FixInfo{ReportFile: reportPath, NoConfirm: true, OutputDir: outputDir}
+	ks := &Kubescape{Ctx: context.Background()}
+	require.NoError(t, ks.Fix(fixInfo))
+
+	assert.Contains(t, readLog(), "--output-dir has no effect when fixing manifest files",
+		"the user must be told the flag was ignored rather than left to guess from an empty directory")
+
+	entries, err := os.ReadDir(outputDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a file-based fix writes no manifests into --output-dir")
+
+	assert.Contains(t, manifestContent(t, dir), "privileged: false",
+		"the warning must not stop the in-place fix from being applied")
+
+	assert.Empty(t, fixInfo.OutputDir,
+		"the ignored --output-dir must be cleared, so no later code can act on a value the user was told is inert")
+}
+
+// TestFix_OutputDirWarnsBeforeDryRunReturns pins the placement of the warning:
+// it is about whether the flag applies at all, so it has to fire on every path
+// through Fix — including --dry-run, which returns long before any fix is
+// applied.
+func TestFix_OutputDirWarnsBeforeDryRunReturns(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := buildFixableReport(t, dir)
+
+	readLog := captureLoggerOutput(t)
+
+	ks := &Kubescape{Ctx: context.Background()}
+	require.NoError(t, ks.Fix(&metav1.FixInfo{
+		ReportFile: reportPath,
+		DryRun:     true,
+		OutputDir:  filepath.Join(dir, "patches"),
+	}))
+
+	assert.Contains(t, readLog(), "--output-dir has no effect when fixing manifest files")
+}
+
+// TestFix_OutputDirIsKeptForClusterReports is the other half of #3733: the
+// warning must be scoped to file-based reports. A cluster report is exactly
+// what --output-dir exists for, so warning there — or clearing the field, which
+// would silently redirect the manifests to stdout — would be a regression.
+func TestFix_OutputDirIsKeptForClusterReports(t *testing.T) {
+	dir := t.TempDir()
+	report := &reporthandlingv2.PostureReport{
+		Metadata: reporthandlingv2.Metadata{
+			ScanMetadata: reporthandlingv2.ScanMetadata{ScanningTarget: reporthandlingv2.Cluster},
+			ContextMetadata: reporthandlingv2.ContextMetadata{
+				ClusterContextMetadata: &reporthandlingv2.ClusterMetadata{ContextName: "dev"},
+			},
+		},
+	}
+	reportPath := writeReportFile(t, dir, report)
+	outputDir := filepath.Join(dir, "fixes")
+
+	readLog := captureLoggerOutput(t)
+
+	fixInfo := &metav1.FixInfo{ReportFile: reportPath, NoConfirm: true, OutputDir: outputDir}
+	ks := &Kubescape{Ctx: context.Background()}
+	require.NoError(t, ks.Fix(fixInfo))
+
+	assert.NotContains(t, readLog(), "--output-dir has no effect",
+		"--output-dir is meaningful for a cluster report and must not be warned about")
+	assert.Equal(t, outputDir, fixInfo.OutputDir, "a cluster report must keep its --output-dir")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -826,6 +826,9 @@ kubectl apply -f ./fixes
 > The prompt does not apply to cluster scans: that path edits nothing in place,
 > so there is nothing to confirm. With `--output-dir`, a non-empty directory is
 > refused unless you pass `--no-confirm`.
+>
+> `--output-dir` belongs to that cluster path alone. Passing it when fixing
+> manifest files warns and is ignored — those files are always fixed in place.
 
 ---
 


### PR DESCRIPTION
## Overview

`--output-dir` applies only to cluster scan reports, whose fixes are rendered from the scanned objects and emitted rather than written back to manifests. A file-based report is fixed in place, so the flag has nothing to act on there.

**Current behavior:** passing it to a file-based fix is accepted in silence. The directory stays empty, the manifests are rewritten in place, and nothing indicates the flag was ignored — so an empty `./patches` reads as "the fix failed" rather than "that flag does not apply here", while the user's files have in fact already been modified.

**New behavior:** a warning is logged and the field is cleared, then the in-place fix proceeds exactly as before.

```
[warning] --output-dir has no effect when fixing manifest files; it applies to
cluster scan reports. The files recorded in the report are fixed in place
```

No behavioral change beyond the warning: file-based reports are still fixed in place, and cluster reports still honour `--output-dir`.

## Additional Information

**On placement.** The issue suggests doing this in `cmd/fix/fix.go` after argument parsing. That layer only has `args[0]` — a filename — and whether the report is cluster-based or file-based is a property of its contents, decided by `isClusterReport` against an unmarshalled `PostureReport`. That parse happens inside `fixhandler.NewFixHandler`, so the check sits immediately after that constructor returns in `core.Fix` — the earliest point where the question is answerable.

It is deliberately above every early return in `Fix` (`noResourcesToFix`, `--dry-run`, declined confirmation), since flag applicability is independent of whether anything ends up being fixed.

**On clearing the field.** Strictly belt-and-braces today: `OutputDir` is read only in `clusterfix.go`, which is unreachable from the file-based path. Clearing makes "has no effect" structurally true rather than true-by-inspection, so the invariant survives any future code that threads the field further down.

**On the stream.** The warning goes to stderr via `logger.L()`, which matters because `kubescape fix cluster.json | kubectl apply -f -` consumes stdout as a YAML document stream. Verified: with stderr discarded the message is absent from stdout; with stdout discarded it is present.

## How to Test

```bash
# 1. Produce a file-based report
kubescape scan . --format json --output results.json

# 2. Fix it, passing the cluster-only flag
kubescape fix results.json --output-dir ./patches --no-confirm
```

Before this change: `./patches` is empty, the manifests are modified in place, and nothing mentions `--output-dir`.

After: the warning above is printed to stderr; `./patches` is still empty and the manifests are still fixed in place, as documented.

Automated coverage in `core/core/fix_test.go`:

- `TestFix_OutputDirIsIgnoredWithAWarningForFileReports` — warning emitted, output dir untouched, fix still applied, field cleared
- `TestFix_OutputDirWarnsBeforeDryRunReturns` — the warning survives the `--dry-run` early exit
- `TestFix_OutputDirIsKeptForClusterReports` — the inverse: no warning and `OutputDir` preserved, so cluster manifests cannot be silently rerouted to stdout

The first two were confirmed to fail against `master` before the fix. `go test ./cmd/... ./core/...` and `golangci-lint v2.12.2` both pass.

## Related issues/PRs

* Resolved #3733

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `kubescape fix` now warns when `--output-dir` is used with manifest reports, since these files are always fixed in place.
  - The option is ignored for manifest fixes, including dry runs.
  - Cluster report fixes continue to honor `--output-dir`.

- **Documentation**
  - Clarified the supported behavior of `--output-dir` in the CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->