### PR TITLE
fix(policyhandler): route mixed Framework/Control scan identifiers by their own kind

### DIFF
--- a/core/pkg/policyhandler/handlepullpolicies.go
+++ b/core/pkg/policyhandler/handlepullpolicies.go
@@ -239,9 +239,16 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 		persistPolicyArtifacts = persistence.ShouldPersistPolicyArtifacts()
 	}
 
-	switch getScanKind(policyIdentifier) {
-	case apisv1.KindFramework: // Download frameworks
-		for _, rule := range policyIdentifier {
+	// Requests can mix Framework and Control identifiers in the same slice (e.g. a
+	// ScanAll request appends both, see core/core/scan.go). Switch on each rule's own
+	// Kind rather than assuming the whole batch shares policyIdentifier[0]'s kind -
+	// otherwise control identifiers get downloaded via GetFramework and fail with a
+	// misleading "framework '<control-id>' not found" error.
+	controlsFramework := reporthandling.Framework{}
+	var hasControls bool
+	for _, rule := range policyIdentifier {
+		switch rule.Kind {
+		case apisv1.KindFramework: // Download framework
 			logger.L().Debug("Downloading framework", helpers.String("framework", rule.Identifier))
 			receivedFramework, err := getters.PolicyGetter.GetFramework(rule.Identifier)
 			if err != nil {
@@ -264,35 +271,33 @@ func (policyHandler *PolicyHandler) downloadScanPolicies(ctx context.Context, po
 					logger.L().Ctx(ctx).Warning("failed to cache framework", helpers.String("file", cache), helpers.Error(err))
 				}
 			}
-		}
-	case apisv1.KindControl: // Download controls
-		f := reporthandling.Framework{}
-		var receivedControl *reporthandling.Control
-		var err error
-		for _, policy := range policyIdentifier {
-			logger.L().Debug("Downloading control", helpers.String("control", policy.Identifier))
-			receivedControl, err = getters.PolicyGetter.GetControl(policy.Identifier)
+		case apisv1.KindControl: // Download control
+			logger.L().Debug("Downloading control", helpers.String("control", rule.Identifier))
+			receivedControl, err := getters.PolicyGetter.GetControl(rule.Identifier)
 			if err != nil {
-				return frameworks, controlDownloadError(err, policy.Identifier)
+				return frameworks, controlDownloadError(err, rule.Identifier)
 			}
 			if receivedControl != nil {
-				f.Controls = append(f.Controls, *receivedControl)
+				hasControls = true
+				controlsFramework.Controls = append(controlsFramework.Controls, *receivedControl)
 				if !persistPolicyArtifacts {
 					continue
 				}
-				cache, err := getter.PolicyCachePath(policy.Identifier)
+				cache, err := getter.PolicyCachePath(rule.Identifier)
 				if err != nil {
-					logger.L().Ctx(ctx).Warning("skipping control cache write", helpers.String("identifier", policy.Identifier), helpers.Error(err))
+					logger.L().Ctx(ctx).Warning("skipping control cache write", helpers.String("identifier", rule.Identifier), helpers.Error(err))
 					continue
 				}
 				if err := getter.SaveInFile(receivedControl, cache); err != nil {
 					logger.L().Ctx(ctx).Warning("failed to cache control", helpers.String("file", cache), helpers.Error(err))
 				}
 			}
+		default:
+			return frameworks, fmt.Errorf("unknown policy kind")
 		}
-		frameworks = append(frameworks, f)
-	default:
-		return frameworks, fmt.Errorf("unknown policy kind")
+	}
+	if hasControls {
+		frameworks = append(frameworks, controlsFramework)
 	}
 	return frameworks, nil
 }

--- a/core/pkg/policyhandler/handlepullpolicies_test.go
+++ b/core/pkg/policyhandler/handlepullpolicies_test.go
@@ -221,6 +221,31 @@ func TestDownloadScanPolicies(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test: a ScanAll request appends all frameworks followed by all
+			// controls into the same []PolicyIdentifier (see core/core/scan.go). Before the
+			// fix, downloadScanPolicies used the *first* identifier's Kind for the whole
+			// batch, so with Framework first it tried to download every control identifier
+			// via GetFramework and failed with "framework '<control-id>' not found".
+			name:          "Mixed Framework and Control identifiers",
+			policyHandler: NewPolicyHandler("test-cluster"),
+			policyIdent: []cautils.PolicyIdentifier{
+				{Identifier: "framework-0006-0013", Kind: "Framework"},
+				{Identifier: "control1", Kind: "Control"},
+			},
+			scanInfo:      &cautils.ScanInfo{},
+			expectedError: nil,
+			expectedResult: []reporthandling.Framework{
+				*mocks.MockFramework_0006_0013(),
+				{
+					Controls: []reporthandling.Control{
+						{
+							ControlID: "",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/core/pkg/policyhandler/handlepullpoliciesutils.go
+++ b/core/pkg/policyhandler/handlepullpoliciesutils.go
@@ -6,16 +6,9 @@ import (
 	"time"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
-	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/reporthandling"
 )
 
-func getScanKind(policyIdentifier []cautils.PolicyIdentifier) apisv1.NotificationPolicyKind {
-	if len(policyIdentifier) > 0 {
-		return policyIdentifier[0].Kind
-	}
-	return "unknown"
-}
 func frameworkDownloadError(err error, fwName string) error {
 	if strings.Contains(err.Error(), "unsupported protocol scheme") {
 		err = fmt.Errorf("failed to download from GitHub release, try running with `--use-default` flag")

--- a/core/pkg/policyhandler/handlepullpoliciesutils_test.go
+++ b/core/pkg/policyhandler/handlepullpoliciesutils_test.go
@@ -59,31 +59,6 @@ func Test_validateFramework(t *testing.T) {
 	}
 }
 
-func TestGetScanKind(t *testing.T) {
-	tests := []struct {
-		policyIdentifier []cautils.PolicyIdentifier
-		want             string
-	}{
-		{
-			policyIdentifier: []cautils.PolicyIdentifier{
-				{Kind: "ClusterAdmissionRule", Identifier: "policy1"},
-				{Kind: "K8sPSP", Identifier: "policy2"},
-			},
-			want: "ClusterAdmissionRule",
-		},
-		{
-			policyIdentifier: []cautils.PolicyIdentifier{},
-			want:             "unknown",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			assert.Equal(t, tt.want, string(getScanKind(tt.policyIdentifier)))
-		})
-	}
-}
-
 func TestPolicyDownloadError(t *testing.T) {
 	tests := []struct {
 		err  error


### PR DESCRIPTION
## Overview

Configuration scans triggered via a ScanAll request (e.g. by the kubescape-operator, or `kubescape scan framework --scan-all`) fail in a loop with `framework 'C-0240' not found, run \`kubescape list frameworks\` for available frameworks`, even though `C-0240` is a valid control ID, not a framework name.

This is caused by `downloadScanPolicies` in `core/pkg/policyhandler/handlepullpolicies.go` using only the *first* policy identifier's `Kind` to decide how to download the *entire* requested batch. A ScanAll request builds a single `[]PolicyIdentifier` slice containing all framework names followed by all control IDs (see `core/core/scan.go`), so once the first entry is a Framework, every subsequent Control identifier in the same slice is incorrectly downloaded via `GetFramework` instead of `GetControl`, and the scan aborts on the first control ID that doesn't exist as a framework.

The fix switches on each identifier's own `Kind` inside a single loop, so Framework and Control identifiers are routed to `GetFramework`/`GetControl` respectively regardless of ordering or mixing within the request.

## Additional Information

Regression bisected to commit fbe8eef8 ("feat(scan): implement missing controls listing in ScanAll functionality", #3300), which made the `ScanAll` branch in `core/core/scan.go` append both all framework names and all control IDs into the same `policyIdentifiers` slice. Before that commit, ScanAll only ever added Framework-kind identifiers, so the single-kind assumption in `downloadScanPolicies` never mattered.

The now-unused `getScanKind` helper (and its test) were removed since nothing else in the repository calls it after this change.

## How to Test

```
go test -race ./core/pkg/policyhandler/...
golangci-lint run ./core/pkg/policyhandler/...
go build ./...
```

The new `TestDownloadScanPolicies/Mixed_Framework_and_Control_identifiers` case reproduces the exact Framework-then-Control ordering that triggers the bug. It fails against the pre-fix code and passes against the fix.

Note: this is validated with a targeted mock-based unit test, not a live cluster / kubescape-operator reproduction (not available in this environment). The defect is deterministic routing logic over a mixed-kind slice, fully provable with a failing-then-passing unit test.

## Related issues/PRs:

* Resolved #3753

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy downloads now correctly handle requests containing a mix of Framework and Control identifiers.
  * Frameworks are retrieved individually, while Control identifiers are combined into a single framework.
  * Unknown policy kinds now return an error instead of being processed using another identifier’s kind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->