### PR TITLE
fix(httphandler): gracefully shut down HTTP server and scan worker

### DIFF
--- a/httphandler/README.md
+++ b/httphandler/README.md
@@ -5,6 +5,7 @@ The HTTP Handler provides a REST API for running Kubescape scans programmaticall
 ## Table of Contents
 
 - [Overview](#overview)
+- [Graceful shutdown](#graceful-shutdown)
 - [API Reference](#api-reference)
   - [Trigger Scan](#trigger-scan)
   - [Get Results](#get-results)
@@ -28,6 +29,23 @@ When running Kubescape as a service, it starts a web server on port `8080` that 
 - Managing cached results
 
 ---
+
+## Graceful shutdown
+
+On SIGTERM or SIGINT, the server stops accepting connections and new scans.
+Scan requests already being parsed, including metrics scans, receive `503` if
+shutdown closes admission before they enqueue. Accepted scans drain for up to
+20 seconds, including result handling and persistence. Remaining scans are then
+cancelled using the same cancellation mechanism as `DELETE /v1/scan`.
+
+Successful shutdown waits for the scan worker to exit. If HTTP draining or the
+worker has not finished within 25 seconds, shutdown reports an error, closes
+remaining connections and exits unsuccessfully after attempting an OpenTelemetry
+flush (up to five additional seconds). This failure path may interrupt work;
+it does not guarantee persistence. Size the pod termination grace period for
+your workload; Kubernetes can forcibly terminate the process before cleanup
+finishes. Completion callbacks retain their existing best-effort behavior and
+are not included in the worker-join guarantee.
 
 ## API Reference
 

--- a/httphandler/examples/microservice/ks-deployment.yaml
+++ b/httphandler/examples/microservice/ks-deployment.yaml
@@ -74,6 +74,8 @@ spec:
       labels:
         app: kubescape
     spec:
+      # Allow 25s for shutdown, 5s for telemetry, and a scheduling margin.
+      terminationGracePeriodSeconds: 35
       serviceAccountName: kubescape-discovery
       containers:
       - name: kubescape

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -76,6 +76,12 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	select {
 	case results = <-scanParams.resp:
 	case <-r.Context().Done():
+		// Wait for the worker to finish writing before removing abandoned results.
+		go func() {
+			<-scanParams.resp
+			removeResultsFile(scanID)
+			os.Remove(resultsFile)
+		}()
 		return
 	}
 	defer removeResultsFile(scanID) // remove json format results file

--- a/httphandler/handlerequests/v1/prometheus.go
+++ b/httphandler/handlerequests/v1/prometheus.go
@@ -42,12 +42,6 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scanCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
-	defer cancel()
-
-	handler.state.setBusy(scanID, cancel)
-	defer handler.state.setNotBusy(scanID)
-
 	metricsQueryParams := &MetricsQueryParams{}
 	if err := schema.NewDecoder().Decode(metricsQueryParams, r.URL.Query()); err != nil {
 		handler.writeError(w, fmt.Errorf("failed to parse query params, reason: %w", err), scanID)
@@ -56,6 +50,7 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 	resultsFile := filepath.Join(OutputDir, scanID)
 	scanInfo, policyIdentifiers := getPrometheusDefaultScanCommand(scanID, resultsFile, metricsQueryParams.Frameworks)
 
+	scanCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
 	scanParams := &scanRequestParams{
 		scanQueryParams: &ScanQueryParams{
 			ReturnResults:   true,
@@ -71,18 +66,18 @@ func (handler *HTTPHandler) Metrics(w http.ResponseWriter, r *http.Request) {
 
 	// send to scan queue
 	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/metrics"))
-	select {
-	case handler.scanRequestChan <- scanParams:
-	default:
-		w.Header().Set("Retry-After", "1")
-		handler.writeErrorWithStatus(w,
-			fmt.Errorf("scan queue is full; retry the request later"),
-			"", http.StatusTooManyRequests)
+	if err := handler.enqueueScan(scanParams, cancel); err != nil {
+		handler.writeAdmissionError(w, err)
 		return
 	}
 
-	// wait for scan to complete
-	results := <-scanParams.resp
+	// The worker owns accepted work even if the HTTP caller disconnects.
+	var results *utilsmetav1.Response
+	select {
+	case results = <-scanParams.resp:
+	case <-r.Context().Done():
+		return
+	}
 	defer removeResultsFile(scanID) // remove json format results file
 	defer os.Remove(resultsFile)    // remove prometheus format results file
 

--- a/httphandler/handlerequests/v1/prometheus_test.go
+++ b/httphandler/handlerequests/v1/prometheus_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
@@ -76,38 +77,43 @@ func TestGetPrometheusDefaultScanCommand(t *testing.T) {
 // aborted when the scrape request context is cancelled (e.g. a Prometheus
 // scrape timeout): the scan must keep running to completion.
 func TestMetrics_ScanContextDecoupledFromRequest(t *testing.T) {
-	defer func(o scanner) { scanImpl = o }(scanImpl)
-	scanCtxErr := make(chan error, 1)
+	synctest.Test(t, func(t *testing.T) {
+		defer func(o scanner) { scanImpl = o }(scanImpl)
+		scanCtxErr := make(chan error, 1)
 
-	reqCtx, cancel := context.WithCancel(context.Background())
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
-		cancel() // simulate the scrape connection going away mid-scan
-		scanCtxErr <- ctx.Err()
-		return nil, nil
-	}
+		reqCtx, cancel := context.WithCancel(context.Background())
+		scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			cancel() // simulate the scrape connection going away mid-scan
+			scanCtxErr <- ctx.Err()
+			return nil, nil
+		}
 
-	h := NewHTTPHandler(false)
-	rq := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil).WithContext(reqCtx)
-	w := httptest.NewRecorder()
+		h := NewHTTPHandler(false)
+		rq := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil).WithContext(reqCtx)
+		w := httptest.NewRecorder()
 
-	handlerDone := make(chan struct{})
-	go func() {
-		h.Metrics(w, rq)
-		close(handlerDone)
-	}()
+		handlerDone := make(chan struct{})
+		go func() {
+			h.Metrics(w, rq)
+			close(handlerDone)
+		}()
 
-	select {
-	case err := <-scanCtxErr:
-		assert.NoError(t, err, "scan context must not be cancelled when the request context is")
-	case <-time.After(5 * time.Second):
-		t.Fatal("scan was not invoked")
-	}
+		select {
+		case err := <-scanCtxErr:
+			assert.NoError(t, err, "scan context must not be cancelled when the request context is")
+		case <-time.After(5 * time.Second):
+			t.Fatal("scan was not invoked")
+		}
 
-	select {
-	case <-handlerDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("handler did not complete")
-	}
+		select {
+		case <-handlerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handler did not complete")
+		}
+		assert.NoError(t, h.Shutdown(context.Background(), time.Second))
+		// Join response cleanup before the next test changes the output directories.
+		synctest.Wait()
+	})
 }
 
 func TestMetrics_UsesDecodedSkipPersistenceQueryParam(t *testing.T) {

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/schema"
@@ -43,7 +44,7 @@ type HTTPHandler struct {
 	offline             bool
 	state               *serverState
 	scanRequestChan     chan *scanRequestParams
-	cancelWatch         context.CancelFunc
+	workerDone          chan struct{}
 	maxRequestBodyBytes int64
 }
 
@@ -53,24 +54,77 @@ func NewHTTPHandler(offline bool) *HTTPHandler {
 	return newHTTPHandler(offline, queueCapacity, maxRequestBody)
 }
 
-// Shutdown stops the background scan watcher goroutine. It should be called
-// when the HTTP handler is no longer needed (e.g. on server shutdown).
-func (handler *HTTPHandler) Shutdown() {
-	if handler.cancelWatch != nil {
-		handler.cancelWatch()
+// BeginShutdown rejects new scans and closes the queue. Accepted scans continue
+// to drain. It is safe to call more than once, concurrently with admission.
+func (handler *HTTPHandler) BeginShutdown() {
+	handler.state.beginShutdown(func() { close(handler.scanRequestChan) })
+}
+
+// Shutdown drains accepted scans for drainPeriod, then cancels outstanding work.
+// A nil result guarantees the worker exited, including executeScan's persistence
+// path. If ctx expires first, an error is returned: work may still be running.
+func (handler *HTTPHandler) Shutdown(ctx context.Context, drainPeriod time.Duration) error {
+	handler.BeginShutdown()
+	timer := time.NewTimer(drainPeriod)
+	defer timer.Stop()
+	select {
+	case <-handler.workerDone:
+		return nil
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+	handler.state.cancelAll()
+	select {
+	case <-handler.workerDone:
+		return nil
+	case <-ctx.Done():
+		// Prefer an already completed join when completion races with the deadline.
+		select {
+		case <-handler.workerDone:
+			return nil
+		default:
+			return fmt.Errorf("scan worker shutdown: %w", ctx.Err())
+		}
 	}
 }
 
+// enqueueScan is the only production path into the queue, for Scan and Metrics.
+func (handler *HTTPHandler) enqueueScan(req *scanRequestParams, cancel context.CancelFunc) error {
+	err := handler.state.admitScan(req.scanID, cancel, req.isUserScan, func() bool {
+		select {
+		case handler.scanRequestChan <- req:
+			return true
+		default:
+			return false
+		}
+	})
+	if err != nil {
+		cancel()
+	}
+	return err
+}
+
+func (handler *HTTPHandler) writeAdmissionError(w http.ResponseWriter, err error) {
+	status := http.StatusTooManyRequests
+	if errors.Is(err, errShuttingDown) {
+		status = http.StatusServiceUnavailable
+	}
+	w.Header().Set("Retry-After", "1")
+	handler.writeErrorWithStatus(w, err, "", status)
+}
+
 func newHTTPHandler(offline bool, queueCapacity int, maxRequestBodyBytes int64) *HTTPHandler {
-	ctx, cancel := context.WithCancel(context.Background())
 	handler := &HTTPHandler{
 		offline:             offline,
 		state:               newServerState(),
 		scanRequestChan:     make(chan *scanRequestParams, queueCapacity),
-		cancelWatch:         cancel,
+		workerDone:          make(chan struct{}),
 		maxRequestBodyBytes: maxRequestBodyBytes,
 	}
-	go handler.watchForScan(ctx)
+	go func() {
+		defer close(handler.workerDone)
+		handler.watchForScan()
+	}()
 	return handler
 }
 
@@ -171,24 +225,8 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		scanRequestParams.scanInfo.UseArtifactsFrom = getter.DefaultLocalStore
 	}
 
-	// Mark busy, enqueue, and record the accepted user scan as one atomic
-	// admission step. Status and the offline Results fallback resolve "latest"
-	// through latestUserScanID, so it has to be written in the same critical
-	// section that decides acceptance -- otherwise two concurrent requests can
-	// be accepted in one order and recorded in the other.
-	admitted := handler.state.admitUserScan(scanID, cancel, func() bool {
-		select {
-		case handler.scanRequestChan <- scanRequestParams:
-			return true
-		default:
-			return false
-		}
-	})
-	if !admitted {
-		w.Header().Set("Retry-After", "1")
-		handler.writeErrorWithStatus(w,
-			fmt.Errorf("scan queue is full; retry the request later"),
-			"", http.StatusTooManyRequests)
+	if err := handler.enqueueScan(scanRequestParams, cancel); err != nil {
+		handler.writeAdmissionError(w, err)
 		return
 	}
 	logger.L().Info("requesting scan", helpers.String("scanID", scanID), helpers.String("api", "v1/scan"))
@@ -200,7 +238,11 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 	if scanRequestParams.resp != nil {
 		// wait for scan to complete
-		response = <-scanRequestParams.resp
+		select {
+		case response = <-scanRequestParams.resp:
+		case <-r.Context().Done():
+			return
+		}
 
 		if response.Type == utilsapisv1.ResultsV1ScanResponseType {
 			// populate the response with the report before it is deleted below

--- a/httphandler/handlerequests/v1/requestshandler.go
+++ b/httphandler/handlerequests/v1/requestshandler.go
@@ -241,6 +241,13 @@ func (handler *HTTPHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		select {
 		case response = <-scanRequestParams.resp:
 		case <-r.Context().Done():
+			if !scanRequestParams.scanQueryParams.KeepResults {
+				// The worker may still be writing results after the caller leaves.
+				go func() {
+					<-scanRequestParams.resp
+					removeResultsFile(scanID)
+				}()
+			}
 			return
 		}
 

--- a/httphandler/handlerequests/v1/requestshandlerutil_test.go
+++ b/httphandler/handlerequests/v1/requestshandlerutil_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/httphandler/config"
 	apisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
-	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -193,64 +191,12 @@ func TestRemoveResultsFile(t *testing.T) {
 
 func TestWatchForScan_GracefulShutdown(t *testing.T) {
 	h := NewHTTPHandler(false)
-
-	// Shutdown should cause the watchForScan goroutine to exit cleanly.
-	h.Shutdown()
-
-	// Verify the handler is still usable for non-scan operations
-	// (the scan channel is still there, just no one listening).
-	assert.NotNil(t, h.scanRequestChan)
-}
-
-func TestWatchForScan_ProcessesRequestThenExits(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-
-	h := &HTTPHandler{
-		state:           newServerState(),
-		scanRequestChan: make(chan *scanRequestParams, 2),
-		cancelWatch:     cancel,
-	}
-
-	// Override scanImpl so executeScan returns immediately.
-	oldScanImpl := scanImpl
-	defer func() { scanImpl = oldScanImpl }()
-	scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
-		return nil, nil
-	}
-
-	// done signals that watchForScan has exited.
-	done := make(chan struct{})
-
-	go func() {
-		h.watchForScan(ctx)
-		close(done)
-	}()
-
-	// Send a scan request — it should be processed.
-	h.scanRequestChan <- &scanRequestParams{
-		scanID:          "test-shutdown",
-		scanInfo:        &cautils.ScanInfo{},
-		scanQueryParams: &ScanQueryParams{},
-		resp:            make(chan *utilsmetav1.Response, 1),
-	}
-
-	// Cancel the context — watchForScan should exit.
-	cancel()
-
-	// Wait for the goroutine to exit (with timeout).
+	assert.NoError(t, h.Shutdown(ctx, 0))
 	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("watchForScan did not exit after context cancellation")
-	}
-
-	// After shutdown, sending to the buffered channel should not block
-	// because no one is reading from it and the buffer has capacity.
-	h.scanRequestChan <- &scanRequestParams{
-		scanID:          "after-shutdown",
-		scanInfo:        &cautils.ScanInfo{},
-		scanQueryParams: &ScanQueryParams{},
-		resp:            make(chan *utilsmetav1.Response, 1),
+	case <-h.workerDone:
+	default:
+		t.Fatal("Shutdown returned without joining the worker")
 	}
 }

--- a/httphandler/handlerequests/v1/requestshandlerutils.go
+++ b/httphandler/handlerequests/v1/requestshandlerutils.go
@@ -137,48 +137,43 @@ func (handler *HTTPHandler) executeScan(scanReq *scanRequestParams) {
 
 // watchForScan dequeues scan requests and executes them, honoring
 // cancellation that happened while a request was still queued.
-func (handler *HTTPHandler) watchForScan(ctx context.Context) {
-	for {
-		select {
-		case scanReq := <-handler.scanRequestChan:
-			logger.L().Info("triggering scan", helpers.String("scanID", scanReq.scanID))
-			if scanReq.isUserScan {
-				handler.state.setRunningUserScanID(scanReq.scanID)
-			}
-			if handler.state.isCancelled(scanReq.scanID) {
-				logger.L().Info("skipping cancelled scan", helpers.String("scanID", scanReq.scanID))
-				if scanReq.resp != nil {
-					select {
-					case scanReq.resp <- &utilsmetav1.Response{
-						ID:       scanReq.scanID,
-						Type:     utilsapisv1.ErrorScanResponseType,
-						Response: fmt.Sprintf("scan '%s' was cancelled", scanReq.scanID),
-					}:
-					default:
-					}
+func (handler *HTTPHandler) watchForScan() {
+	for scanReq := range handler.scanRequestChan {
+		logger.L().Info("triggering scan", helpers.String("scanID", scanReq.scanID))
+		if scanReq.isUserScan {
+			handler.state.setRunningUserScanID(scanReq.scanID)
+		}
+		if handler.state.isCancelled(scanReq.scanID) {
+			logger.L().Info("skipping cancelled scan", helpers.String("scanID", scanReq.scanID))
+			if scanReq.resp != nil {
+				select {
+				case scanReq.resp <- &utilsmetav1.Response{
+					ID:       scanReq.scanID,
+					Type:     utilsapisv1.ErrorScanResponseType,
+					Response: fmt.Sprintf("scan '%s' was cancelled", scanReq.scanID),
+				}:
+				default:
 				}
-				if scanReq.callbackURL != "" {
-					payload := scanCallbackPayload{ID: scanReq.scanID, Status: callbackStatusFailed, Error: "scan cancelled"}
-					cbCtx := context.WithoutCancel(scanReq.ctx)
-					go func() {
-						defer func() {
-							if r := recover(); r != nil {
-								logger.L().Ctx(cbCtx).Error("scan completion callback panicked", helpers.String("ID", scanReq.scanID), helpers.Error(fmt.Errorf("%v", r)))
-							}
-						}()
-						if cbErr := postScanCallback(cbCtx, scanReq.callbackURL, payload); cbErr != nil {
-							logger.L().Ctx(cbCtx).Error("failed to deliver scan completion callback", helpers.String("ID", scanReq.scanID), helpers.Error(cbErr))
+			}
+			if scanReq.callbackURL != "" {
+				payload := scanCallbackPayload{ID: scanReq.scanID, Status: callbackStatusFailed, Error: "scan cancelled"}
+				cbCtx := context.WithoutCancel(scanReq.ctx)
+				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							logger.L().Ctx(cbCtx).Error("scan completion callback panicked", helpers.String("ID", scanReq.scanID), helpers.Error(fmt.Errorf("%v", r)))
 						}
 					}()
-				}
-				handler.state.releaseCancel(scanReq.scanID)
-				handler.state.setNotBusy(scanReq.scanID)
-				continue
+					if cbErr := postScanCallback(cbCtx, scanReq.callbackURL, payload); cbErr != nil {
+						logger.L().Ctx(cbCtx).Error("failed to deliver scan completion callback", helpers.String("ID", scanReq.scanID), helpers.Error(cbErr))
+					}
+				}()
 			}
-			handler.executeScan(scanReq)
-		case <-ctx.Done():
-			return
+			handler.state.releaseCancel(scanReq.scanID)
+			handler.state.setNotBusy(scanReq.scanID)
+			continue
 		}
+		handler.executeScan(scanReq)
 	}
 }
 func scan(ctx context.Context, scanInfo *cautils.ScanInfo, policyIdentifiers []cautils.PolicyIdentifier, scanID string, skipPersistence bool) (*reporthandlingv2.PostureReport, error) {

--- a/httphandler/handlerequests/v1/serverstate.go
+++ b/httphandler/handlerequests/v1/serverstate.go
@@ -2,8 +2,14 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+)
+
+var (
+	errShuttingDown  = errors.New("server is shutting down")
+	errScanQueueFull = errors.New("scan queue is full; retry the request later")
 )
 
 type scanEntry struct {
@@ -12,6 +18,7 @@ type scanEntry struct {
 }
 
 type serverState struct {
+	shuttingDown      bool
 	statusID          map[string]*scanEntry
 	latestID          string
 	latestUserScanID  string
@@ -37,35 +44,47 @@ func (s *serverState) setBusy(id string, cancel context.CancelFunc) {
 	s.mtx.Unlock()
 }
 
-// admitUserScan runs the whole admission step for a user scan under a single
-// hold of the state mutex: it marks id busy, attempts the enqueue, and -- only
-// if that succeeded -- records id as the latest accepted user scan. It returns
-// false when enqueue failed, having rolled the busy entry back.
-//
-// enqueue must not block; Scan passes the non-blocking channel send. Holding
-// the mutex across it is what keeps acceptance order and latestUserScanID order
-// identical. With the enqueue and the bookkeeping in separate critical
-// sections, two concurrent Scan handlers can enqueue as A-then-B but run their
-// bookkeeping as B-then-A, leaving latestUserScanID on the older scan -- so
-// Status and the offline Results fallback resolve "latest" to a stale scan.
-//
-// The rollback deliberately leaves latestID pointing at the rejected scan,
-// matching what setBusy followed by setNotBusy did before. runningUserScanID
-// needs no rollback: only watchForScan sets it, and it never saw this id.
-func (s *serverState) admitUserScan(id string, cancel context.CancelFunc, enqueue func() bool) bool {
+// admitScan serializes registration, enqueueing and latest-user bookkeeping
+// with shutdown. enqueue must not block and is never called after shutdown.
+// Keeping enqueue and latestUserScanID under one lock preserves acceptance
+// order. A full queue rolls back busy state but retains the historical latestID
+// behavior; only an accepted user scan advances latestUserScanID.
+func (s *serverState) admitScan(id string, cancel context.CancelFunc, userScan bool, enqueue func() bool) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-
+	if s.shuttingDown {
+		return errShuttingDown
+	}
 	s.statusID[id] = &scanEntry{cancel: cancel}
 	s.latestID = id
-
 	if !enqueue() {
 		delete(s.statusID, id)
-		return false
+		return errScanQueueFull
 	}
+	if userScan {
+		s.latestUserScanID = id
+	}
+	return nil
+}
 
-	s.latestUserScanID = id
-	return true
+// beginShutdown closes admission and the queue under the same lock as all
+// producers. No sender can race with closeQueue.
+func (s *serverState) beginShutdown(closeQueue func()) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if !s.shuttingDown {
+		s.shuttingDown = true
+		closeQueue()
+	}
+}
+
+// cancelAll retains busy entries until the worker actually finishes them.
+func (s *serverState) cancelAll() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for id := range s.statusID {
+		s.releaseLocked(id)
+	}
 }
 
 func (s *serverState) setNotBusy(id string) {
@@ -90,7 +109,7 @@ func (s *serverState) getLatestID() string {
 // still resolve "latest" after the scan finishes, and Metrics never writes it,
 // which is what keeps a /v1/metrics scrape from hijacking those two endpoints.
 //
-// Request handling must not call this directly -- admitUserScan writes the
+// Request handling must not call this directly -- admitScan writes the
 // field as part of the admission critical section, and updating it separately
 // is exactly the race that serialization exists to prevent. It remains for
 // tests that need to seed an already-accepted user scan.

--- a/httphandler/handlerequests/v1/serverstate_test.go
+++ b/httphandler/handlerequests/v1/serverstate_test.go
@@ -272,7 +272,7 @@ func TestServerState_UserScanIDLifecycle(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// admitUserScan concurrency tests
+// admitScan concurrency tests
 //
 // Scan() runs one goroutine per HTTP request, so nothing orders two handlers
 // against each other. If the enqueue and the latestUserScanID write are not in
@@ -294,7 +294,7 @@ func TestServerState_AdmitUserScan_BookkeepingFollowsAcceptanceOrder(t *testing.
 		// stall is the window the race needs: with the steps unserialized,
 		// scan-B runs to completion during it and scan-A's write still lands
 		// last, so "latest" ends up on scan-A.
-		s.admitUserScan("scan-A", func() {}, func() bool {
+		s.admitScan("scan-A", func() {}, true, func() bool {
 			close(inFirstEnqueue)
 			time.Sleep(100 * time.Millisecond)
 			return true
@@ -304,7 +304,7 @@ func TestServerState_AdmitUserScan_BookkeepingFollowsAcceptanceOrder(t *testing.
 	<-inFirstEnqueue
 	go func() {
 		defer close(secondDone)
-		s.admitUserScan("scan-B", func() {}, func() bool { return true })
+		s.admitScan("scan-B", func() {}, true, func() bool { return true })
 	}()
 
 	<-firstDone
@@ -321,11 +321,11 @@ func TestServerState_AdmitUserScan_BookkeepingFollowsAcceptanceOrder(t *testing.
 func TestServerState_AdmitUserScan_RejectedScanNeverBecomesLatest(t *testing.T) {
 	s := newServerState()
 
-	if !s.admitUserScan("accepted", func() {}, func() bool { return true }) {
-		t.Fatal("admitUserScan returned false for a successful enqueue")
+	if err := s.admitScan("accepted", func() {}, true, func() bool { return true }); err != nil {
+		t.Fatal("admitScan rejected a successful enqueue")
 	}
-	if s.admitUserScan("rejected", func() {}, func() bool { return false }) {
-		t.Fatal("admitUserScan returned true for a failed enqueue")
+	if err := s.admitScan("rejected", func() {}, true, func() bool { return false }); err == nil {
+		t.Fatal("admitScan accepted a failed enqueue")
 	}
 
 	if id := s.getLatestUserScanID(); id != "accepted" {
@@ -353,8 +353,8 @@ func TestServerState_AdmitUserScan_ConcurrentAdmissions(t *testing.T) {
 		wg.Add(1)
 		go func(id string) {
 			defer wg.Done()
-			if !s.admitUserScan(id, func() {}, func() bool { return true }) {
-				t.Errorf("admitUserScan(%q) = false; want true", id)
+			if err := s.admitScan(id, func() {}, true, func() bool { return true }); err != nil {
+				t.Errorf("admitScan(%q) failed", id)
 			}
 		}(ids[i])
 	}

--- a/httphandler/handlerequests/v1/shutdown_test.go
+++ b/httphandler/handlerequests/v1/shutdown_test.go
@@ -1,0 +1,305 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
+	"github.com/kubescape/kubescape/v4/httphandler/config"
+	"github.com/kubescape/kubescape/v4/httphandler/storage"
+	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// Run inside synctest so the negative join assertions wait until all runnable
+// goroutines have settled, rather than depending on scheduler timing.
+func TestShutdown_CancellationMustJoinAsyncScan(t *testing.T) {
+	withTempOutputDirs(t)
+	synctest.Test(t, func(t *testing.T) {
+		started, cancelled, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+		original := scanImpl
+		defer func() { scanImpl = original }()
+		scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			close(started)
+			<-ctx.Done()
+			close(cancelled)
+			<-release
+			return nil, ctx.Err()
+		}
+		h := NewHTTPHandler(false)
+		response := performAsyncScanRequest(t, h, `{}`)
+		require.Equal(t, http.StatusOK, response.Code)
+		id := decodeScanResponse(t, response).ID
+		<-started
+		done := make(chan error, 1)
+		go func() { done <- h.Shutdown(context.Background(), time.Second) }()
+		time.Sleep(time.Second) // virtual drain deadline
+		<-cancelled
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("shutdown returned before executeScan: %v", err)
+		default:
+		}
+		require.True(t, h.state.isBusy(id))
+		close(release)
+		require.NoError(t, <-done)
+		require.Zero(t, h.state.len())
+		<-h.workerDone
+	})
+}
+
+func TestShutdown_HardDeadlineReportsUnjoinedWorker(t *testing.T) {
+	withTempOutputDirs(t)
+	synctest.Test(t, func(t *testing.T) {
+		started, release := make(chan struct{}), make(chan struct{})
+		original := scanImpl
+		defer func() { scanImpl = original }()
+		scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			close(started)
+			<-release
+			return nil, ctx.Err()
+		}
+		h := NewHTTPHandler(false)
+		performAsyncScanRequest(t, h, `{}`)
+		<-started
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.ErrorIs(t, h.Shutdown(ctx, time.Second), context.DeadlineExceeded)
+		require.Equal(t, 1, h.state.len(), "timing out must not claim work completed")
+		select {
+		case <-h.workerDone:
+			t.Fatal("worker exited before the scan returned")
+		default:
+		}
+		close(release)
+		require.NoError(t, h.Shutdown(context.Background(), 0))
+		require.Zero(t, h.state.len())
+	})
+}
+
+func TestShutdown_DrainsAcceptedScansAndRejectsAdmission(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started, release := make(chan struct{}), make(chan struct{})
+		var executed []string
+		original := scanImpl
+		defer func() { scanImpl = original }()
+		scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, id string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			if len(executed) == 0 {
+				close(started)
+				<-release // includes time spent persisting inside scanImpl
+			}
+			require.NoError(t, ctx.Err())
+			executed = append(executed, id)
+			return nil, nil
+		}
+		h := NewHTTPHandler(false)
+		first := decodeScanResponse(t, performAsyncScanRequest(t, h, `{}`)).ID
+		<-started
+		second := decodeScanResponse(t, performAsyncScanRequest(t, h, `{}`)).ID
+		h.BeginShutdown()
+		require.Equal(t, http.StatusServiceUnavailable, performAsyncScanRequest(t, h, `{}`).Code)
+		metrics := httptest.NewRecorder()
+		h.Metrics(metrics, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
+		require.Equal(t, http.StatusServiceUnavailable, metrics.Code)
+		done := make(chan error, 2)
+		for range 2 {
+			go func() { done <- h.Shutdown(context.Background(), time.Minute) }()
+		}
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("shutdown did not wait for persistence")
+		default:
+		}
+		close(release)
+		require.NoError(t, <-done)
+		require.NoError(t, <-done)
+		require.Equal(t, []string{first, second}, executed)
+		require.Zero(t, h.state.len())
+		require.Zero(t, len(h.scanRequestChan))
+	})
+}
+
+func TestShutdown_CancelsQueueAndReleasesWaiters(t *testing.T) {
+	withTempOutputDirs(t)
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		calls := 0
+		original := scanImpl
+		defer func() { scanImpl = original }()
+		scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+			calls++
+			if calls == 1 {
+				close(started)
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		h := NewHTTPHandler(false)
+		performAsyncScanRequest(t, h, `{}`)
+		<-started
+		responses := make(chan *httptest.ResponseRecorder, 2)
+		go func() {
+			w := httptest.NewRecorder()
+			h.Scan(w, httptest.NewRequest(http.MethodPost, "/v1/scan?wait=true", strings.NewReader(`{}`)))
+			responses <- w
+		}()
+		go func() {
+			w := httptest.NewRecorder()
+			h.Metrics(w, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
+			responses <- w
+		}()
+		synctest.Wait()
+		require.Equal(t, 3, h.state.len())
+		require.NoError(t, h.Shutdown(context.Background(), 0))
+		for range 2 {
+			w := <-responses
+			require.Equal(t, http.StatusInternalServerError, w.Code)
+			require.Equal(t, utilsapisv1.ErrorScanResponseType, decodeScanResponse(t, w).Type)
+		}
+		require.Equal(t, 1, calls)
+		require.Zero(t, h.state.len())
+	})
+}
+
+func TestShutdown_AdmissionRace(t *testing.T) {
+	// Exercise both producer kinds without starting a worker: every accepted
+	// request must be present exactly once in the closed queue.
+	h := &HTTPHandler{state: newServerState(), scanRequestChan: make(chan *scanRequestParams, 100)}
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range 100 {
+		wg.Go(func() {
+			<-start
+			ctx, cancel := context.WithCancel(context.Background())
+			req := &scanRequestParams{scanID: fmt.Sprint(i), ctx: ctx, isUserScan: i%2 == 0}
+			err := h.enqueueScan(req, cancel)
+			if err != nil {
+				require.ErrorIs(t, err, errShuttingDown)
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+			}
+		})
+	}
+	wg.Go(func() { <-start; h.BeginShutdown() })
+	close(start)
+	wg.Wait()
+	accepted := h.state.len()
+	count := 0
+	for req := range h.scanRequestChan {
+		count++
+		h.state.releaseCancel(req.scanID)
+		h.state.setNotBusy(req.scanID)
+	}
+	require.Equal(t, accepted, count)
+	require.Zero(t, h.state.len())
+}
+
+func TestShutdown_DisconnectedWaiterDoesNotReleaseScan(t *testing.T) {
+	for _, metrics := range []bool{false, true} {
+		t.Run(fmt.Sprint("metrics=", metrics), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				started, release := make(chan struct{}), make(chan struct{})
+				original := scanImpl
+				defer func() { scanImpl = original }()
+				scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+					close(started)
+					<-release
+					require.NoError(t, ctx.Err())
+					return nil, nil
+				}
+				h := NewHTTPHandler(false)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					w := httptest.NewRecorder()
+					if metrics {
+						h.Metrics(w, httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/metrics", nil))
+					} else {
+						h.Scan(w, httptest.NewRequestWithContext(ctx, http.MethodPost, "/v1/scan?wait=true", strings.NewReader(`{}`)))
+					}
+				}()
+				<-started
+				cancel()
+				<-done
+				require.Equal(t, 1, h.state.len())
+				close(release)
+				require.NoError(t, h.Shutdown(context.Background(), time.Minute))
+			})
+		})
+	}
+}
+
+func TestShutdown_JoinsActualStoragePersistence(t *testing.T) {
+	withTempOutputDirs(t)
+	originalScan, originalRun := scanImpl, runKubescapeScan
+	originalStorage, originalAccount := storage.GetStorage(), config.GetAccount()
+	t.Cleanup(func() {
+		scanImpl, runKubescapeScan = originalScan, originalRun
+		storage.SetStorage(originalStorage)
+		config.SetAccount(originalAccount)
+	})
+	synctest.Test(t, func(t *testing.T) {
+		started, release := make(chan struct{}), make(chan struct{})
+		//nolint:staticcheck // The pinned storage client lacks the summary apply schema required by NewClientset.
+		client := fake.NewSimpleClientset()
+		client.PrependReactor("create", "workloadconfigurationscansummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+			close(started)
+			<-release
+			return false, nil, nil // continue through the real fake-client store
+		})
+		store, err := storage.NewAPIServerStorage("test-cluster", "default", client.SpdxV1beta1(), false)
+		require.NoError(t, err)
+		storage.SetStorage(store)
+		config.SetAccount("")
+		scanImpl = scan
+		runKubescapeScan = func(_ context.Context, info *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
+			results := newFormatLifecycleResultsHandler(info.Output, "", []byte(`{}`))
+			data := cautils.NewOPASessionObjMock()
+			data.Report.ClusterName = "test-cluster"
+			obj := workloadinterface.NewWorkloadObj(map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "shutdown-test", "namespace": "default"},
+			})
+			id := obj.GetID()
+			data.AllResources[id] = obj
+			data.ResourcesResult[id] = resourcesresults.Result{ResourceID: id}
+			results.SetData(data)
+			return results, nil
+		}
+		h := NewHTTPHandler(false)
+		performAsyncScanRequest(t, h, `{}`)
+		<-started
+		done := make(chan error, 1)
+		go func() { done <- h.Shutdown(context.Background(), time.Minute) }()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("shutdown returned while storage Create was blocked: %v", err)
+		default:
+		}
+		close(release)
+		require.NoError(t, <-done)
+		stored, err := client.SpdxV1beta1().WorkloadConfigurationScanSummaries("default").List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, stored.Items, 1)
+		require.Zero(t, h.state.len())
+	})
+}

--- a/httphandler/handlerequests/v1/shutdown_test.go
+++ b/httphandler/handlerequests/v1/shutdown_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -20,6 +22,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,7 +107,7 @@ func TestShutdown_DrainsAcceptedScansAndRejectsAdmission(t *testing.T) {
 				close(started)
 				<-release // includes time spent persisting inside scanImpl
 			}
-			require.NoError(t, ctx.Err())
+			assert.NoError(t, ctx.Err())
 			executed = append(executed, id)
 			return nil, nil
 		}
@@ -191,8 +194,8 @@ func TestShutdown_AdmissionRace(t *testing.T) {
 			req := &scanRequestParams{scanID: fmt.Sprint(i), ctx: ctx, isUserScan: i%2 == 0}
 			err := h.enqueueScan(req, cancel)
 			if err != nil {
-				require.ErrorIs(t, err, errShuttingDown)
-				require.ErrorIs(t, ctx.Err(), context.Canceled)
+				assert.ErrorIs(t, err, errShuttingDown)
+				assert.ErrorIs(t, ctx.Err(), context.Canceled)
 			}
 		})
 	}
@@ -211,16 +214,26 @@ func TestShutdown_AdmissionRace(t *testing.T) {
 }
 
 func TestShutdown_DisconnectedWaiterDoesNotReleaseScan(t *testing.T) {
-	for _, metrics := range []bool{false, true} {
-		t.Run(fmt.Sprint("metrics=", metrics), func(t *testing.T) {
+	for _, mode := range []string{"scan", "metrics", "keep"} {
+		t.Run(mode, func(t *testing.T) {
+			withTempOutputDirs(t)
+			metrics := mode == "metrics"
 			synctest.Test(t, func(t *testing.T) {
 				started, release := make(chan struct{}), make(chan struct{})
+				var artifacts []string
 				original := scanImpl
 				defer func() { scanImpl = original }()
-				scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, _ string, _ bool) (*reporthandlingv2.PostureReport, error) {
+				scanImpl = func(ctx context.Context, _ *cautils.ScanInfo, _ []cautils.PolicyIdentifier, id string, _ bool) (*reporthandlingv2.PostureReport, error) {
+					artifacts = []string{filepath.Join(OutputDir, id), filepath.Join(OutputDir, id+".json")}
+					for _, path := range artifacts {
+						assert.NoError(t, os.WriteFile(path, []byte("partial"), 0600))
+					}
 					close(started)
 					<-release
-					require.NoError(t, ctx.Err())
+					assert.NoError(t, ctx.Err())
+					for _, path := range artifacts {
+						assert.NoError(t, os.WriteFile(path, []byte("complete"), 0600))
+					}
 					return nil, nil
 				}
 				h := NewHTTPHandler(false)
@@ -233,15 +246,27 @@ func TestShutdown_DisconnectedWaiterDoesNotReleaseScan(t *testing.T) {
 					if metrics {
 						h.Metrics(w, httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/metrics", nil))
 					} else {
-						h.Scan(w, httptest.NewRequestWithContext(ctx, http.MethodPost, "/v1/scan?wait=true", strings.NewReader(`{}`)))
+						h.Scan(w, httptest.NewRequestWithContext(ctx, http.MethodPost, "/v1/scan?wait=true&keep="+fmt.Sprint(mode == "keep"), strings.NewReader(`{}`)))
 					}
 				}()
 				<-started
 				cancel()
 				<-done
 				require.Equal(t, 1, h.state.len())
+				synctest.Wait()
+				for _, path := range artifacts {
+					require.FileExists(t, path, "cleanup must wait for the writer")
+				}
 				close(release)
 				require.NoError(t, h.Shutdown(context.Background(), time.Minute))
+				synctest.Wait()
+				for _, path := range artifacts {
+					if mode == "keep" {
+						require.FileExists(t, path)
+					} else {
+						require.NoFileExists(t, path)
+					}
+				}
 			})
 		})
 	}

--- a/httphandler/listener/setup.go
+++ b/httphandler/listener/setup.go
@@ -1,8 +1,10 @@
 package listener
 
 import (
+	"context"
 	"crypto/subtle"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,6 +23,9 @@ import (
 )
 
 const (
+	scanDrainPeriod            = 20 * time.Second
+	applicationShutdownTimeout = 25 * time.Second
+
 	// v1 paths
 	v1PathPrefix            = "/v1"
 	v1ScanPath              = "/scan"
@@ -38,8 +43,9 @@ const (
 	authTokenEnv = "KS_API_TOKEN"
 )
 
-// SetupHTTPListener set up listening http servers
-func SetupHTTPListener() error {
+// SetupHTTPListener serves requests until ctx is cancelled or serving fails.
+// Successful shutdown drains HTTP requests and joins the scan worker.
+func SetupHTTPListener(ctx context.Context) error {
 	keyPair, err := loadTLSKey(getCertFile(), getKeyFile())
 	if err != nil {
 		return err
@@ -125,12 +131,54 @@ func SetupHTTPListener() error {
 
 	servePprof()
 
-	defer httpHandler.Shutdown()
+	return serveUntilShutdown(ctx, server, ln, httpHandler, scanDrainPeriod, applicationShutdownTimeout)
+}
 
-	if keyPair != nil {
-		return server.ServeTLS(ln, "", "")
+// serveUntilShutdown joins both HTTP draining and the application-owned worker.
+// Durations are internal policy, passed explicitly for deterministic tests.
+func serveUntilShutdown(ctx context.Context, server *http.Server, ln net.Listener, handler *handlerequestsv1.HTTPHandler, drainPeriod, shutdownTimeout time.Duration) error {
+	served := make(chan error, 1)
+	go func() {
+		if server.TLSConfig != nil {
+			served <- server.ServeTLS(ln, "", "")
+		} else {
+			served <- server.Serve(ln)
+		}
+	}()
+	var serveErr error
+	expectedClose := false
+	select {
+	case serveErr = <-served:
+		// A serve failure must also cancel and join application-owned work.
+		drainPeriod = 0
+	case <-ctx.Done():
+		expectedClose = true
+		logger.L().Info("Shutting down Kubescape server")
 	}
-	return server.Serve(ln)
+	shutdownStarted := time.Now()
+	handler.BeginShutdown()
+	shutdownCtx, cancel := context.WithDeadline(context.Background(), shutdownStarted.Add(shutdownTimeout))
+	defer cancel()
+	workerResult := make(chan error, 1)
+	go func() {
+		workerResult <- handler.Shutdown(shutdownCtx, time.Until(shutdownStarted.Add(drainPeriod)))
+	}()
+	httpErr := server.Shutdown(shutdownCtx)
+	if httpErr != nil {
+		httpErr = errors.Join(httpErr, server.Close())
+	}
+	workerErr := <-workerResult
+	if serveErr == nil {
+		serveErr = <-served
+	}
+	if expectedClose && errors.Is(serveErr, http.ErrServerClosed) {
+		serveErr = nil
+	}
+	err := errors.Join(serveErr, httpErr, workerErr)
+	if err == nil {
+		logger.L().Info("Kubescape server shutdown complete")
+	}
+	return err
 }
 
 func loadTLSKey(certFile, keyFile string) (*tls.Certificate, error) {

--- a/httphandler/listener/setup_test.go
+++ b/httphandler/listener/setup_test.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -103,7 +104,7 @@ func TestSetupHTTPListener(t *testing.T) {
 		t.Setenv("KS_CERT_FILE", "cert.pem")
 		t.Setenv("KS_KEY_FILE", "")
 
-		err := SetupHTTPListener()
+		err := SetupHTTPListener(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "KS_CERT_FILE and KS_KEY_FILE")
 	})
@@ -116,7 +117,7 @@ func TestSetupHTTPListener(t *testing.T) {
 		t.Setenv("KS_KEY_FILE", "")
 		t.Setenv("KS_PORT", port)
 
-		err := SetupHTTPListener()
+		err := SetupHTTPListener(context.Background())
 		// The specific errno isn't portable (syscall.EADDRINUSE doesn't map
 		// to Windows' WSAEADDRINUSE); the point of this test is that
 		// SetupHTTPListener propagates the ListenAndServe(TLS) error instead
@@ -133,7 +134,7 @@ func TestSetupHTTPListener(t *testing.T) {
 		t.Setenv("KS_KEY_FILE", keyFile)
 		t.Setenv("KS_PORT", port)
 
-		err := SetupHTTPListener()
+		err := SetupHTTPListener(context.Background())
 		// The specific errno isn't portable (syscall.EADDRINUSE doesn't map
 		// to Windows' WSAEADDRINUSE); the point of this test is that
 		// SetupHTTPListener propagates the ListenAndServe(TLS) error instead

--- a/httphandler/listener/shutdown_test.go
+++ b/httphandler/listener/shutdown_test.go
@@ -1,0 +1,159 @@
+package listener
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	v1 "github.com/kubescape/kubescape/v4/httphandler/handlerequests/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdown_HTTPAndTLS(t *testing.T) {
+	for _, encrypted := range []bool{false, true} {
+		name := "HTTP"
+		if encrypted {
+			name = "TLS"
+		}
+		t.Run(name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer ln.Close()
+			h := v1.NewHTTPHandler(false)
+			started, release := make(chan struct{}), make(chan struct{})
+			server := &http.Server{ReadHeaderTimeout: time.Second, Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				close(started)
+				<-release
+				w.WriteHeader(http.StatusNoContent)
+			})}
+			transport := &http.Transport{}
+			defer transport.CloseIdleConnections()
+			scheme := "http"
+			if encrypted {
+				cert, key := writeTestTLSFiles(t)
+				pair, err := loadTLSKey(cert, key)
+				require.NoError(t, err)
+				server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*pair}}
+				certificate, err := x509.ParseCertificate(pair.Certificate[0])
+				require.NoError(t, err)
+				roots := x509.NewCertPool()
+				roots.AddCert(certificate)
+				transport.TLSClientConfig = &tls.Config{RootCAs: roots, ServerName: "localhost", MinVersion: tls.VersionTLS12}
+				scheme = "https"
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- serveUntilShutdown(ctx, server, ln, h, time.Second, 3*time.Second) }()
+			response := make(chan error, 1)
+			go func() {
+				client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+				resp, err := client.Get(scheme + "://" + ln.Addr().String())
+				if err == nil {
+					resp.Body.Close()
+					if resp.StatusCode != http.StatusNoContent {
+						err = errors.New("request did not finish normally")
+					}
+				}
+				response <- err
+			}()
+			<-started
+			cancel()
+			close(release)
+			require.NoError(t, <-response)
+			require.NoError(t, <-done)
+			conn, err := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+			if conn != nil {
+				conn.Close()
+			}
+			require.Error(t, err, "listener must be closed before shutdown returns")
+		})
+	}
+}
+
+func TestShutdown_IdleAndAlreadyCancelled(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	server := &http.Server{ReadHeaderTimeout: time.Second}
+	require.NoError(t, serveUntilShutdown(ctx, server, ln, v1.NewHTTPHandler(false), time.Second, time.Second))
+}
+
+type failingListener struct {
+	net.Listener
+	err error
+}
+
+func (l failingListener) Accept() (net.Conn, error) { return nil, l.err }
+
+func TestShutdown_PreservesServeFailure(t *testing.T) {
+	for _, cancelled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "serve failure", true: "racing cancellation"}[cancelled], func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer ln.Close()
+			want := errors.New("accept failed")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			// Cancel in Serve's deferred listener close, after Serve has selected
+			// its error. Both cancellation and the genuine serve error can then
+			// reach the coordinator together.
+			listener := &cancelOnCloseListener{Listener: failingListener{ln, want}}
+			if cancelled {
+				listener.cancel = cancel
+			}
+			server := &http.Server{ReadHeaderTimeout: time.Second}
+			require.ErrorIs(t, serveUntilShutdown(ctx, server, listener, v1.NewHTTPHandler(false), time.Second, time.Second), want)
+		})
+	}
+}
+
+type cancelOnCloseListener struct {
+	net.Listener
+	cancel context.CancelFunc
+}
+
+func (l *cancelOnCloseListener) Close() error {
+	err := l.Listener.Close()
+	if l.cancel != nil {
+		l.cancel()
+	}
+	return err
+}
+
+func TestShutdown_HTTPDeadlineClosesActiveRequest(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	started, finished := make(chan struct{}), make(chan struct{})
+	server := &http.Server{ReadHeaderTimeout: time.Second, Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(finished)
+	})}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- serveUntilShutdown(ctx, server, ln, v1.NewHTTPHandler(false), 0, 10*time.Millisecond) }()
+	requestDone := make(chan error, 1)
+	go func() {
+		client := &http.Client{Timeout: 3 * time.Second}
+		resp, err := client.Get("http://" + ln.Addr().String())
+		if resp != nil {
+			resp.Body.Close()
+		}
+		requestDone <- err
+	}()
+	<-started
+	cancel()
+	require.ErrorIs(t, <-done, context.DeadlineExceeded)
+	<-finished
+	require.Error(t, <-requestDone)
+}

--- a/httphandler/main.go
+++ b/httphandler/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	v1 "github.com/kubescape/backend/pkg/client/v1"
@@ -39,7 +41,21 @@ const (
 var serviceDiscoveryTimeout = 10 * time.Second
 
 func main() {
-	ctx := context.Background()
+	if err := runWithSignals(run); err != nil {
+		logger.L().Error("Kubescape server stopped", helpers.Error(err))
+		os.Exit(1)
+	}
+}
+
+// Keep signal registration and deferred application cleanup inside the runner,
+// so even an error exit from main happens after cleanup has completed.
+func runWithSignals(serve func(context.Context) error) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return serve(ctx)
+}
+
+func run(ctx context.Context) error {
 	versioncheck.BuildNumber = version
 
 	logger.L().Info("Starting Kubescape server",
@@ -58,12 +74,12 @@ func main() {
 
 	// to enable otel, set OTEL_COLLECTOR_SVC=otel-collector:4317
 	if otelHost, present := os.LookupEnv("OTEL_COLLECTOR_SVC"); present {
-		ctx = logger.InitOtel("kubescape",
+		logger.InitOtel("kubescape",
 			version,
 			config.GetAccount(),
 			clusterName,
 			url.URL{Host: otelHost})
-		defer logger.ShutdownOtel(ctx)
+		defer flushOtel(ctx, logger.ShutdownOtel)
 	}
 
 	logger.L().Debug("setting cluster context name", helpers.String("context", os.Getenv("KS_CONTEXT")))
@@ -75,7 +91,13 @@ func main() {
 	initializeStorage(clusterName, cfg)
 	// traces will be created by otelmux.Middleware in SetupHTTPListener()
 
-	logger.L().Ctx(ctx).Fatal(listener.SetupHTTPListener().Error())
+	return listener.SetupHTTPListener(ctx)
+}
+
+func flushOtel(ctx context.Context, shutdown func(context.Context)) {
+	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	shutdown(flushCtx)
 }
 
 func initializeStorage(clusterName string, cfg config.Config) {

--- a/httphandler/shutdown_test.go
+++ b/httphandler/shutdown_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdown_Signals(t *testing.T) {
+	if os.Getenv("KS_SHUTDOWN_TEST_CHILD") == "1" {
+		err := runWithSignals(func(ctx context.Context) error {
+			defer flushOtel(ctx, func(flushCtx context.Context) {
+				if flushCtx.Err() != nil {
+					panic("cancelled flush context")
+				}
+				fmt.Println("cleanup complete")
+			})
+			fmt.Println("ready")
+			<-ctx.Done()
+			return nil
+		})
+		if err != nil {
+			panic(err)
+		}
+		return
+	}
+	for _, signal := range []os.Signal{syscall.SIGTERM, os.Interrupt} {
+		t.Run(signal.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			executable, err := os.Executable()
+			require.NoError(t, err)
+			cmd := exec.CommandContext(ctx, executable, "-test.run=^TestShutdown_Signals$")
+			cmd.Env = append(os.Environ(), "KS_SHUTDOWN_TEST_CHILD=1")
+			stdout, err := cmd.StdoutPipe()
+			require.NoError(t, err)
+			require.NoError(t, cmd.Start())
+			lines := bufio.NewScanner(stdout)
+			require.True(t, lines.Scan())
+			require.Equal(t, "ready", lines.Text())
+			require.NoError(t, cmd.Process.Signal(signal))
+			require.True(t, lines.Scan())
+			require.Equal(t, "cleanup complete", lines.Text())
+			for lines.Scan() {
+			}
+			require.NoError(t, cmd.Wait())
+		})
+	}
+}
+
+func TestShutdown_ErrorRunsCleanup(t *testing.T) {
+	want := errors.New("server failed")
+	flushed := false
+	err := runWithSignals(func(ctx context.Context) error {
+		defer flushOtel(ctx, func(flushCtx context.Context) {
+			require.NoError(t, flushCtx.Err())
+			deadline, ok := flushCtx.Deadline()
+			require.True(t, ok)
+			require.WithinDuration(t, time.Now().Add(5*time.Second), deadline, time.Second)
+			flushed = true
+		})
+		return want
+	})
+	require.ErrorIs(t, err, want)
+	require.True(t, flushed)
+}


### PR DESCRIPTION

  ## Overview

  Handle SIGTERM/SIGINT by stopping HTTP traffic and scan admission, draining accepted work, and waiting for the asynchronous scan worker before completing shutdown.

  Previously, stopping the HTTP server did not wait for asynchronous scans or their persistence operations. The fatal exit path also  bypassed deferred OpenTelemetry cleanup.

  This change:
  - Coordinates admission for `/v1/scan` and `/v1/metrics` so requests cannot enqueue scans after shutdown begins.
  - Allows accepted scans to drain for 20 seconds, then cancels outstanding work using the existing scan cancellation mechanism.
  - Joins the scan worker before reporting successful shutdown, including synchronous result handling and persistence.
  - Uses `http.Server.Shutdown()` for HTTP/TLS and preserves genuine server errors.
  - Runs deferred OpenTelemetry cleanup with a fresh, bounded context.

  ## Additional Information

  Application shutdown has a 25-second deadline, followed by an OpenTelemetry flush of up to five seconds. If work does not stop within the
  application deadline, shutdown returns an error and the process exits unsuccessfully; persistence is not guaranteed on that failure path.

  Completion callbacks retain their existing best-effort behavior.

  This addresses the blocker identified in #2238: waiting for HTTP handlers alone does not wait for asynchronous scan work.

  ## How to Test

  The following focused checks passed locally:

  ```bash
  GOMAXPROCS=2 GOMEMLIMIT=2GiB go test -p 1 -mod=readonly -timeout 60s ./httphandler/...

  GOMAXPROCS=2 GOMEMLIMIT=2GiB CGO_ENABLED=1 go test -p 1 -mod=readonly -race -timeout 120s ./httphandler/...

  GOMAXPROCS=2 GOMEMLIMIT=2GiB CGO_ENABLED=1 go test -p 1 -mod=readonly -race -count=20 -timeout 120s \
    ./httphandler/handlerequests/v1 ./httphandler/listener \
    -run 'Shutdown|Admission|Cancel'

  GOMAXPROCS=2 GOMEMLIMIT=2GiB CGO_ENABLED=0 go build -p 1 -mod=readonly \
    -o /tmp/ksserver-2220 ./httphandler
    
  ```

  Regression tests cover signal handling, HTTP/TLS shutdown, scan admission races, queue draining and cancellation, waiting callers, worker  joining, and persistence through a fake Kubernetes storage client.

  The regression for #2238 deliberately delays a scan after it observes cancellation and verifies that successful shutdown remains blocked until execution returns.

  Scoped lint and formatting checks also passed. The full repository suite was not completed due to local resource constraints. Live  Kubernetes termination and delivery to a real OpenTelemetry collector remain unverified.

  ## Related issues/PRs

  Fixes #2220.

  Addresses the asynchronous-worker shutdown gap identified in #2238.

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests.
  - [x] New and existing unit tests pass locally with my changes (affected httphandler packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown for HTTP and HTTPS services.
  * Servers now stop accepting new scans, drain active work, cancel remaining scans, and wait for workers to finish.
  * Added interrupt and termination signal handling with a final telemetry flush.
  * Requests affected by shutdown or queue capacity now receive appropriate responses.
  * Disconnected clients no longer interrupt accepted scans or leave temporary results behind.

* **Documentation**
  * Documented shutdown behavior, time limits, and deployment grace-period recommendations.

* **Tests**
  * Expanded coverage for shutdown, draining, cancellation, signals, TLS, and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->