### PR TITLE
feat(fleet): add cross-cluster control matrix and fleet report types [LFX 2026]

### DIFF
--- a/core/pkg/fleet/clusterstate_test.go
+++ b/core/pkg/fleet/clusterstate_test.go
@@ -1,0 +1,116 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+)
+
+// stubDiscovery answers ServerPreferredResources with a canned list. Every
+// other method is left to the embedded nil interface, which is safe here
+// because InitializeMapResources calls nothing else.
+type stubDiscovery struct {
+	discovery.DiscoveryInterface
+	resources []*metav1.APIResourceList
+}
+
+// ServerPreferredResources returns the canned list. InitializeMapResources
+// reads the API groups through this one call, so nothing else needs answering.
+func (s stubDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return s.resources, nil
+}
+
+// clusterResources builds a discovery client advertising a single custom
+// resource, so a test can tell two clusters' API-group snapshots apart by
+// looking up a name that only one of them serves.
+func clusterResources(name, kind string) stubDiscovery {
+	return stubDiscovery{resources: []*metav1.APIResourceList{{
+		GroupVersion: "fleet.example.com/v1",
+		APIResources: []metav1.APIResource{{
+			Name:       name,
+			Kind:       kind,
+			Namespaced: true,
+			Verbs:      metav1.Verbs{"list", "get"},
+		}},
+	}}}
+}
+
+// TestDiscoveryRefreshFollowsTheScannedCluster pins the half of per-cluster
+// isolation that the aggregation layer reads.
+//
+// Switching context is owned by cautils.EnterClusterContext and has its own
+// unit and two-cluster integration tests, so this does not re-test it. What it
+// guards is the API-group snapshot: control evaluation resolves resources
+// through it, so a run that scans several contexts in one process needs it to
+// follow the cluster currently being scanned.
+//
+// It used to work the other way round. InitializeMapResources returned early
+// once the map had been populated ("load discovery data only if the map is
+// empty"), so a second cluster kept resolving through the first cluster's
+// snapshot; the fix was to treat an explicitly supplied discovery client as
+// authoritative. If a future k8s-interface bump reintroduces the early return,
+// this fails here rather than surfacing later as a fleet report that quietly
+// describes the wrong cluster.
+func TestDiscoveryRefreshFollowsTheScannedCluster(t *testing.T) {
+	// The resource map and the context name are process-global, so this test
+	// must not run in parallel with anything else that touches them.
+	//
+	// Both are restored afterwards. Leaving the map holding this test's
+	// invented CRDs would let a later test resolve a resource that exists in no
+	// cluster, or fail depending on the order the package's tests happen to run
+	// in. InitializeMapResourcesMock is the supported reset: it swaps in the
+	// standard mock snapshot, which is the state the map holds for any test
+	// that never populated it explicitly.
+	previousContext := k8sinterface.GetContextName()
+	t.Cleanup(func() {
+		k8sinterface.SetClusterContextName(previousContext)
+		k8sinterface.InitializeMapResourcesMock()
+	})
+
+	first := clusterResources("firstclusterwidgets", "FirstClusterWidget")
+	second := clusterResources("secondclusterwidgets", "SecondClusterWidget")
+
+	leaveFirst := cautils.EnterClusterContext("first-cluster")
+	k8sinterface.InitializeMapResources(first)
+	_, hasFirst := k8sinterface.GetResourceFromGroupMapping("firstclusterwidgets")
+	require.True(t, hasFirst,
+		"a cluster's own resources should resolve while it is the active context")
+	leaveFirst()
+
+	leaveSecond := cautils.EnterClusterContext("second-cluster")
+	defer leaveSecond()
+	k8sinterface.InitializeMapResources(second)
+
+	_, hasSecond := k8sinterface.GetResourceFromGroupMapping("secondclusterwidgets")
+	assert.True(t, hasSecond,
+		"the second cluster's resources are missing: InitializeMapResources is no longer treating an "+
+			"explicit discovery client as authoritative, so a scan would resolve resources through the "+
+			"previous cluster's snapshot")
+
+	_, stillHasFirst := k8sinterface.GetResourceFromGroupMapping("firstclusterwidgets")
+	assert.False(t, stillHasFirst,
+		"the first cluster's resources still resolve after switching: the snapshot is being merged "+
+			"rather than replaced, which lets one cluster's API groups leak into another cluster's scan")
+}
+
+// TestEnterClusterContextRestoresPrevious covers the property the orchestrator
+// relies on when it defers leave() around each cluster: whatever context was
+// active before a run is active again after it, so a fleet command does not
+// leave the process pointed at the last cluster it happened to scan.
+func TestEnterClusterContextRestoresPrevious(t *testing.T) {
+	previousContext := k8sinterface.GetContextName()
+	t.Cleanup(func() { k8sinterface.SetClusterContextName(previousContext) })
+
+	k8sinterface.SetClusterContextName("before-the-run")
+
+	leave := cautils.EnterClusterContext("prod")
+	require.Equal(t, "prod", k8sinterface.GetContextName())
+
+	leave()
+	assert.Equal(t, "before-the-run", k8sinterface.GetContextName())
+}

--- a/core/pkg/fleet/doc.go
+++ b/core/pkg/fleet/doc.go
@@ -1,0 +1,107 @@
+// Package fleet turns the per-cluster results of a multi-context scan into a
+// single cross-cluster view.
+//
+// # The problem
+//
+// Kubescape scans one cluster per invocation, and nothing in the codebase sits
+// above a single reporthandlingv2.PostureReport. Every printer, the compliance
+// score and ScanCoverage are all shaped around one cluster.
+//
+// Scanning several contexts is already possible: --kube-contexts loops them
+// sequentially and writes one report per context to a context-suffixed output
+// path. What it does not do, deliberately, is combine them. Ten contexts
+// produce ten independent report files.
+//
+// That leaves the questions an operator actually asks unanswered. "Which of my
+// clusters fail C-0016" and "staging passes this control and prod fails it, so
+// where did we drift" both require reading every report and correlating them by
+// hand. This package is that correlation, written and tested once, rather than
+// re-implemented per organisation in a shell script.
+//
+// # Where this sits
+//
+// The input is []ClusterResult: results that have already been collected. This
+// package does not scan, does not talk to a cluster, and does not touch the
+// scan path. core.Scan, PostureReport and every existing printer are unchanged
+// by it, and deleting this directory leaves the single-cluster CLI byte for
+// byte identical.
+//
+// Taking already-collected results rather than driving the scan is what makes
+// the whole aggregation testable with no cluster involved. Every function here
+// runs against fixtures.
+//
+// # Design decisions
+//
+// Four choices are not obvious from the types alone, and each exists because
+// the obvious alternative produces a report that quietly misleads.
+//
+// Skipped and not-evaluated are kept apart. Upstream, a control that could not
+// be evaluated and a control that was skipped on purpose are both recorded as
+// apis.StatusSkipped, and only the sub-status separates them.
+// OPAProcessor.markControlsSkipped is where that pairing is written. Inside one
+// cluster the collapse is harmless. Across clusters it is not: two skipped
+// controls genuinely agree with each other, whereas a control that one cluster
+// evaluated and another did not is a gap in what was measured rather than a
+// difference in posture. CellStatus splits the two at the bottom of the stack,
+// because a distinction lost on the first hop cannot be recovered later by
+// anything reading the matrix.
+//
+// A cluster that was not scanned keeps its row. It appears in Clusters with its
+// status and its error preserved verbatim, and contributes no cells to the
+// matrix. Dropping it would produce a report that looks complete and is not,
+// which is worse than one that is visibly missing a cluster.
+//
+// Measurements that were never taken are absent, not zero. ComplianceScore and
+// Coverage are pointers so an unscanned cluster serialises without them. Plain
+// value types would emit "complianceScore": 0 beside a zeroed coverage block,
+// which reads as "fully non-compliant and fully unmeasured" rather than "never
+// measured", and would drag down anything averaging the column. The same
+// instinct runs through the rest of the aggregation: an absence of evidence is
+// never reported as evidence of a problem.
+//
+// Cluster outcomes are four values, not two. A pipeline responds differently to
+// each. Unreachable is an infrastructure condition and may be worth retrying,
+// error means the scan ran and something inside it failed, and cancelled means
+// the run was interrupted so nothing was learned about that cluster at all. A
+// single "failed" value would force every consumer to parse error strings to
+// tell those apart, which is the ambiguity a machine-readable report exists to
+// remove.
+//
+// # Determinism
+//
+// Control summaries live in a map, so BuildControlMatrix sorts its rows by
+// control ID. Without that, row order would follow Go's randomised map
+// iteration and two reports of an unchanged fleet would not compare equal. A
+// fleet report that cannot be diffed against its own previous run is of little
+// use in CI, so the sort has a test that runs twenty iterations rather than
+// relying on one lucky ordering.
+//
+// # Per-cluster isolation
+//
+// Scanning several clusters in one process is only correct because
+// cautils.EnterClusterContext re-points the process-global Kubernetes client at
+// each context and restores the previous one on the way out. That work landed
+// separately and ships its own tests, so this package does not duplicate them.
+//
+// What it does guard is the half the aggregation reads directly. Control
+// evaluation resolves resources through the API-group snapshot, so
+// TestDiscoveryRefreshFollowsTheScannedCluster pins the property that the
+// snapshot follows the cluster currently being scanned. If a future
+// k8s-interface bump reintroduces the early return that once made the snapshot
+// sticky, that test fails here rather than surfacing later as a fleet report
+// quietly describing the wrong cluster.
+//
+// # Not here yet
+//
+//   - Drift detection, which compares each control's cell against a baseline
+//     cluster and reports posture divergence separately from coverage gaps. It
+//     reads the matrix built here, so the matrix settles first.
+//   - The compliance rollup across clusters.
+//   - Printers for the aggregate, and the wiring that produces a FleetReport
+//     from a multi-context run.
+//   - Concurrency. Contexts are scanned one at a time because k8sinterface's
+//     process-global connection state has no locking around it, so two scans
+//     running concurrently would race on that state regardless of
+//     EnterClusterContext, which only makes sequential context switches safe.
+//     Tracked in https://github.com/kubescape/kubescape/issues/2004.
+package fleet

--- a/core/pkg/fleet/fixtures_test.go
+++ b/core/pkg/fleet/fixtures_test.go
@@ -1,0 +1,148 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// controlSpec is a compact description of one control's outcome, so a test can
+// say what it means ("C-0016 failed on two resources") instead of assembling a
+// reportsummary.ControlSummary literal every time.
+type controlSpec struct {
+	id          string
+	name        string
+	status      apis.ScanningStatus
+	subStatus   apis.ScanningSubStatus
+	failed      int
+	scoreFactor float32
+	// complianceScore is a pointer because ControlSummary treats an absent
+	// score as -1 rather than 0, and some tests need to cover that.
+	complianceScore *float32
+	// legacyStatusOnly leaves StatusInfo empty and records the verdict only in
+	// the deprecated top-level Status field, which is the shape a report
+	// written by an older Kubescape arrives in.
+	legacyStatusOnly bool
+}
+
+// passed, failed, skipped and notEvaluated cover the four outcomes the matrix
+// distinguishes. scoreFactor 8 maps to "High" via apis.ControlSeverityToString.
+//
+// passed is a control the cluster evaluated and satisfied.
+func passed(id, name string) controlSpec {
+	return controlSpec{id: id, name: name, status: apis.StatusPassed, scoreFactor: 8, complianceScore: score(100)}
+}
+
+// failed is a control the cluster evaluated and did not satisfy, on
+// failedResources resources.
+func failed(id, name string, failedResources int) controlSpec {
+	return controlSpec{
+		id: id, name: name, status: apis.StatusFailed,
+		failed: failedResources, scoreFactor: 8, complianceScore: score(0),
+	}
+}
+
+// skipped is a control deliberately not applied, which upstream records as
+// skipped with an irrelevant sub-status.
+func skipped(id, name string) controlSpec {
+	return controlSpec{
+		id: id, name: name, status: apis.StatusSkipped,
+		subStatus: apis.SubStatusIrrelevant, scoreFactor: 8, complianceScore: score(100),
+	}
+}
+
+// notEvaluated mirrors what OPAProcessor.markControlsSkipped writes when a
+// control could not be evaluated: skipped, with a notEvaluated sub-status.
+func notEvaluated(id, name string) controlSpec {
+	return controlSpec{
+		id: id, name: name, status: apis.StatusSkipped,
+		subStatus: apis.SubStatusNotEvaluated, scoreFactor: 8,
+	}
+}
+
+// legacyStatus mirrors a report written before StatusInfo existed: the verdict
+// lives only in the deprecated top-level Status field, and ControlSummary's
+// GetStatus backfills StatusInfo from it on the first read.
+func legacyStatus(id, name string, status apis.ScanningStatus) controlSpec {
+	return controlSpec{
+		id: id, name: name, status: status,
+		scoreFactor: 8, complianceScore: score(0), legacyStatusOnly: true,
+	}
+}
+
+// score returns a pointer to v, for the fields that distinguish an absent
+// measurement from a zero one.
+func score(v float32) *float32 {
+	return &v
+}
+
+// newPostureReport builds the minimum report the fleet aggregation reads: the
+// summary details and their control summaries. Nothing here fills in resources
+// or results, because the matrix never looks at them.
+func newPostureReport(clusterName string, specs ...controlSpec) *reporthandlingv2.PostureReport {
+	controls := make(reportsummary.ControlSummaries, len(specs))
+	for _, spec := range specs {
+		summary := reportsummary.ControlSummary{
+			ControlID: spec.id,
+			Name:      spec.name,
+			StatusInfo: apis.StatusInfo{
+				InnerStatus: spec.status,
+				SubStatus:   spec.subStatus,
+			},
+			Status:          spec.status,
+			ScoreFactor:     spec.scoreFactor,
+			ComplianceScore: spec.complianceScore,
+			StatusCounters:  reportsummary.StatusCounters{FailedResources: spec.failed},
+		}
+		if spec.legacyStatusOnly {
+			summary.StatusInfo = apis.StatusInfo{}
+		}
+		controls[spec.id] = summary
+	}
+
+	return &reporthandlingv2.PostureReport{
+		ClusterName: clusterName,
+		SummaryDetails: reportsummary.SummaryDetails{
+			Controls: controls,
+		},
+	}
+}
+
+// scannedCluster is a cluster whose scan completed.
+func scannedCluster(name string, specs ...controlSpec) ClusterResult {
+	return ClusterResult{
+		ClusterID:       name,
+		Context:         name,
+		Status:          ClusterScanned,
+		ComplianceScore: score(100),
+		Coverage:        &cautils.ScanCoverage{CoverageScore: 100},
+		Duration:        "1m0s",
+		Report:          newPostureReport(name, specs...),
+	}
+}
+
+// unreachableCluster is a cluster the scan could not reach. Report stays nil,
+// which is what every consumer has to cope with.
+func unreachableCluster(name, reason string) ClusterResult {
+	return ClusterResult{
+		ClusterID: name,
+		Context:   name,
+		Status:    ClusterUnreachable,
+		Error:     reason,
+	}
+}
+
+// requireCell fails the test unless the row has a cell for cluster with the
+// expected status.
+func requireCell(t *testing.T, row FleetControlRow, cluster string, want CellStatus) {
+	t.Helper()
+
+	cell, ok := row.ByCluster[cluster]
+	require.True(t, ok, "control %s: expected a cell for cluster %q", row.ControlID, cluster)
+	assert.Equal(t, want, cell.Status, "control %s on cluster %s", row.ControlID, cluster)
+}

--- a/core/pkg/fleet/matrix.go
+++ b/core/pkg/fleet/matrix.go
@@ -1,0 +1,121 @@
+package fleet
+
+import (
+	"sort"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+)
+
+// BuildControlMatrix builds the control x cluster grid from per-cluster results.
+//
+// Only clusters with ClusterScanned status and a non-nil Report contribute
+// cells. Everything else is skipped rather than represented as a zero value:
+// an unreachable cluster has no opinion about whether a control passes, and
+// recording one as "passed" or as an empty status would let a cluster nobody
+// could reach silently improve the fleet's apparent posture.
+//
+// Rows are sorted by control ID. Control summaries come out of a map, so
+// without sorting the same fleet would render its rows in a different order on
+// every run and two JSON reports of an unchanged fleet would not compare equal.
+//
+// A row's Name and Severity are taken from the first scanned cluster that
+// reports the control, which is deterministic because results is a slice. Two
+// clusters could in principle disagree on either, for instance when they were
+// scanned against different control versions, and the first one wins. That is
+// deliberate: the matrix reports what each cluster found rather than trying to
+// reconcile the definitions behind it.
+func BuildControlMatrix(results []ClusterResult) FleetControlMatrix {
+	rows := make(map[string]*FleetControlRow)
+
+	for i := range results {
+		cluster := &results[i]
+		if !cluster.Scanned() {
+			continue
+		}
+
+		controls := cluster.Report.SummaryDetails.Controls
+		for controlID := range controls {
+			// The summary is copied out of the map on purpose. Reading a
+			// control's status mutates it: GetStatus fills StatusInfo in from
+			// the legacy Status field when StatusInfo is empty. Working on a
+			// copy keeps that write off the caller's report, so building a
+			// matrix leaves the reports it was built from untouched.
+			summary := controls[controlID]
+
+			row, ok := rows[controlID]
+			if !ok {
+				row = &FleetControlRow{
+					ControlID: controlID,
+					Name:      summary.GetName(),
+					Severity:  apis.ControlSeverityToString(summary.GetScoreFactor()),
+					ByCluster: make(map[string]ControlStatusCell),
+				}
+				rows[controlID] = row
+			}
+			row.ByCluster[cluster.ClusterID] = newControlStatusCell(&summary)
+		}
+	}
+
+	controls := make([]FleetControlRow, 0, len(rows))
+	for _, row := range rows {
+		controls = append(controls, *row)
+	}
+	sort.Slice(controls, func(i, j int) bool {
+		return controls[i].ControlID < controls[j].ControlID
+	})
+
+	return FleetControlMatrix{Controls: controls}
+}
+
+// newControlStatusCell reads one control summary into a cell.
+//
+// It takes a pointer because every getter on ControlSummary has a pointer
+// receiver, and GetStatus in particular writes back: when StatusInfo carries no
+// status it fills it in from the legacy Status field. The pointer therefore has
+// to address a copy rather than anything the caller keeps. BuildControlMatrix
+// passes the loop variable, which Go gives a fresh address on each iteration
+// and which is already a copy of the map value, so the write-back stays inside
+// this function and the caller's report is never modified.
+func newControlStatusCell(summary *reportsummary.ControlSummary) ControlStatusCell {
+	return ControlStatusCell{
+		Status:          cellStatus(summary),
+		FailedResources: summary.NumberOfResources().Failed(),
+		ComplianceScore: summary.GetComplianceScore(),
+	}
+}
+
+// cellStatus normalises a control summary into a CellStatus, separating a
+// control that was skipped on purpose from one that never reached a verdict.
+//
+// Only a genuine skip can be deliberate, and even then the sub-status decides:
+// OPAProcessor.markControlsSkipped writes skipped with a notEvaluated
+// sub-status for a control that could not run, which is a coverage gap rather
+// than a decision.
+//
+// Everything that reached no verdict at all maps to CellNotEvaluated, not to
+// CellSkipped. That covers a control whose status was never set, and the
+// deprecated "error" status. Calling either of those skipped would assert a
+// deliberate exclusion nobody chose, and would hide the gap behind a value that
+// compares equal to a real skip on another cluster, which is the exact
+// confusion CellStatus exists to prevent. The deprecated "excluded" and
+// "irrelevant" spellings are genuine non-application and stay skipped.
+func cellStatus(summary *reportsummary.ControlSummary) CellStatus {
+	status := summary.GetStatus()
+
+	switch {
+	case status.IsPassed():
+		return CellPassed
+	case status.IsFailed():
+		return CellFailed
+	case status.IsSkipped():
+		if status.GetSubStatus() == apis.SubStatusNotEvaluated {
+			return CellNotEvaluated
+		}
+		return CellSkipped
+	case status.Status() == apis.StatusExcluded, status.Status() == apis.StatusIrrelevant:
+		return CellSkipped
+	default:
+		return CellNotEvaluated
+	}
+}

--- a/core/pkg/fleet/matrix_test.go
+++ b/core/pkg/fleet/matrix_test.go
@@ -1,0 +1,285 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildControlMatrix covers what a row is made of and, more importantly,
+// which clusters are allowed to put a cell in one. A cluster that produced no
+// usable report contributes nothing, so a cluster nobody could reach cannot
+// improve or worsen the fleet's apparent posture.
+func TestBuildControlMatrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []ClusterResult
+		wantRows []string
+		assert   func(t *testing.T, matrix FleetControlMatrix)
+	}{
+		{
+			name: "control present in every cluster gets a cell per cluster",
+			results: []ClusterResult{
+				scannedCluster("prod", failed("C-0016", "Allow privilege escalation", 4)),
+				scannedCluster("staging", passed("C-0016", "Allow privilege escalation")),
+			},
+			wantRows: []string{"C-0016"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				row := matrix.Controls[0]
+				require.Len(t, row.ByCluster, 2)
+				requireCell(t, row, "prod", CellFailed)
+				requireCell(t, row, "staging", CellPassed)
+
+				assert.Equal(t, 4, row.ByCluster["prod"].FailedResources)
+				assert.Equal(t, "Allow privilege escalation", row.Name)
+				assert.Equal(t, apis.SeverityHighString, row.Severity)
+			},
+		},
+		{
+			name: "control missing from one cluster leaves that cluster out of the row",
+			results: []ClusterResult{
+				scannedCluster("prod",
+					failed("C-0016", "Allow privilege escalation", 1),
+					passed("C-0038", "Host PID/IPC privileges"),
+				),
+				scannedCluster("staging", passed("C-0016", "Allow privilege escalation")),
+			},
+			wantRows: []string{"C-0016", "C-0038"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				hostPID := matrix.Controls[1]
+				assert.NotContains(t, hostPID.ByCluster, "staging",
+					"staging did not run C-0038, so it should have no cell in that row")
+				requireCell(t, hostPID, "prod", CellPassed)
+			},
+		},
+		{
+			name: "a control that could not be evaluated is not reported as skipped",
+			results: []ClusterResult{
+				scannedCluster("prod", notEvaluated("C-0260", "Missing network policy")),
+				scannedCluster("staging", skipped("C-0260", "Missing network policy")),
+			},
+			wantRows: []string{"C-0260"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				// Both clusters record the control as apis.StatusSkipped and only
+				// the sub-status tells them apart. Collapsing them here would hide
+				// a coverage gap behind an apparent agreement.
+				requireCell(t, matrix.Controls[0], "prod", CellNotEvaluated)
+				requireCell(t, matrix.Controls[0], "staging", CellSkipped)
+			},
+		},
+		{
+			name: "unreachable clusters contribute no cells",
+			results: []ClusterResult{
+				scannedCluster("prod", failed("C-0016", "Allow privilege escalation", 2)),
+				unreachableCluster("dr", "context deadline exceeded"),
+			},
+			wantRows: []string{"C-0016"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				row := matrix.Controls[0]
+				assert.NotContains(t, row.ByCluster, "dr",
+					"dr was never scanned, so it must not appear as a cell")
+				assert.Len(t, row.ByCluster, 1)
+			},
+		},
+		{
+			name: "a scanned status with a nil report is skipped rather than dereferenced",
+			results: []ClusterResult{
+				{ClusterID: "prod", Context: "prod", Status: ClusterScanned},
+				scannedCluster("staging", passed("C-0016", "Allow privilege escalation")),
+			},
+			wantRows: []string{"C-0016"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				assert.NotContains(t, matrix.Controls[0].ByCluster, "prod",
+					"a cluster with no report must not produce a cell")
+			},
+		},
+		{
+			name: "every cluster failing yields an empty matrix, not a panic",
+			results: []ClusterResult{
+				unreachableCluster("prod", "no route to host"),
+				{ClusterID: "dr", Context: "dr", Status: ClusterError, Error: "policy download failed"},
+				{ClusterID: "eu", Context: "eu", Status: ClusterCancelled, Error: "context canceled"},
+			},
+			wantRows: []string{},
+		},
+		{
+			name: "a cancelled cluster contributes no cells",
+			results: []ClusterResult{
+				scannedCluster("prod", failed("C-0016", "Allow privilege escalation", 2)),
+				{ClusterID: "dr", Context: "dr", Status: ClusterCancelled, Error: "context canceled"},
+			},
+			wantRows: []string{"C-0016"},
+			assert: func(t *testing.T, matrix FleetControlMatrix) {
+				t.Helper()
+
+				// An interrupted run learned nothing about dr. Giving it a cell
+				// would put a verdict in the matrix that was never measured.
+				assert.NotContains(t, matrix.Controls[0].ByCluster, "dr")
+				assert.Len(t, matrix.Controls[0].ByCluster, 1)
+			},
+		},
+		{
+			name:     "no clusters at all yields an empty matrix",
+			results:  nil,
+			wantRows: []string{},
+		},
+		{
+			name: "a single cluster still produces a full matrix",
+			results: []ClusterResult{
+				scannedCluster("prod",
+					passed("C-0038", "Host PID/IPC privileges"),
+					failed("C-0016", "Allow privilege escalation", 3),
+				),
+			},
+			wantRows: []string{"C-0016", "C-0038"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matrix := BuildControlMatrix(tt.results)
+
+			got := make([]string, 0, len(matrix.Controls))
+			for _, row := range matrix.Controls {
+				got = append(got, row.ControlID)
+			}
+			require.Equal(t, tt.wantRows, got)
+
+			if tt.assert != nil {
+				tt.assert(t, matrix)
+			}
+		})
+	}
+}
+
+// TestCellStatusCoversEveryScanningStatus pins how each upstream status maps
+// into a cell, including the ones no fixture produces today.
+//
+// The cases that matter are the last two. A control whose status was never set,
+// and the deprecated "error" status, both reach no verdict, so reporting either
+// as skipped would claim a deliberate exclusion nobody made and would compare
+// equal to a real skip on another cluster. They map to notEvaluated so the gap
+// stays visible. The deprecated "excluded" and "irrelevant" spellings are
+// genuine non-application and stay skipped.
+func TestCellStatusCoversEveryScanningStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status apis.ScanningStatus
+		sub    apis.ScanningSubStatus
+		want   CellStatus
+	}{
+		{"passed", apis.StatusPassed, "", CellPassed},
+		{"failed", apis.StatusFailed, "", CellFailed},
+		{"skipped as irrelevant", apis.StatusSkipped, apis.SubStatusIrrelevant, CellSkipped},
+		{"skipped with no sub-status", apis.StatusSkipped, "", CellSkipped},
+		{"skipped because it could not be evaluated", apis.StatusSkipped, apis.SubStatusNotEvaluated, CellNotEvaluated},
+		{"status never set", apis.StatusUnknown, "", CellNotEvaluated},
+		{"deprecated error status", apis.StatusError, "", CellNotEvaluated},
+		{"deprecated excluded status", apis.StatusExcluded, "", CellSkipped},
+		{"deprecated irrelevant status", apis.StatusIrrelevant, "", CellSkipped},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := controlSpec{
+				id: "C-0016", name: "Allow privilege escalation",
+				status: tt.status, subStatus: tt.sub, scoreFactor: 8,
+			}
+			matrix := BuildControlMatrix([]ClusterResult{scannedCluster("prod", spec)})
+
+			require.Len(t, matrix.Controls, 1)
+			assert.Equal(t, tt.want, matrix.Controls[0].ByCluster["prod"].Status)
+		})
+	}
+}
+
+// TestBuildControlMatrixReadsLegacyStatusWithoutMutatingTheReport covers a
+// report written before StatusInfo existed, where the verdict lives only in the
+// deprecated top-level Status field.
+//
+// Two things have to hold at once. The legacy field still has to produce a
+// verdict, because ControlSummary.GetStatus backfills StatusInfo from it. And
+// that backfill is a write: it modifies the summary it is called on. Building a
+// matrix is a read of the fleet's results, so it must not leave the reports it
+// read from in a different state than it found them, or a caller that prints a
+// report after aggregating it would be printing something the aggregation
+// edited. newControlStatusCell takes the loop's copy for exactly this reason,
+// and this pins it.
+func TestBuildControlMatrixReadsLegacyStatusWithoutMutatingTheReport(t *testing.T) {
+	cluster := scannedCluster("prod", legacyStatus("C-0016", "Allow privilege escalation", apis.StatusFailed))
+
+	before := cluster.Report.SummaryDetails.Controls["C-0016"]
+	require.Equal(t, apis.StatusUnknown, before.StatusInfo.Status(),
+		"fixture must start with an empty StatusInfo for this test to mean anything")
+
+	matrix := BuildControlMatrix([]ClusterResult{cluster})
+
+	require.Len(t, matrix.Controls, 1)
+	assert.Equal(t, CellFailed, matrix.Controls[0].ByCluster["prod"].Status,
+		"a control whose verdict is only in the legacy Status field must still reach a cell")
+
+	after := cluster.Report.SummaryDetails.Controls["C-0016"]
+	assert.Equal(t, apis.StatusUnknown, after.StatusInfo.Status(),
+		"BuildControlMatrix backfilled StatusInfo on the source report: reading the matrix must leave "+
+			"the reports it was built from byte for byte as they arrived")
+}
+
+// TestBuildControlMatrixOrderIsIndependentOfInput guards the sort in
+// BuildControlMatrix. Control summaries live in a map, so without it the rows
+// would follow Go's randomised map iteration and two reports of an unchanged
+// fleet would not compare equal.
+func TestBuildControlMatrixOrderIsIndependentOfInput(t *testing.T) {
+	specs := []controlSpec{
+		passed("C-0038", "Host PID/IPC privileges"),
+		failed("C-0016", "Allow privilege escalation", 1),
+		skipped("C-0260", "Missing network policy"),
+		passed("C-0017", "Immutable container filesystem"),
+	}
+	want := []string{"C-0016", "C-0017", "C-0038", "C-0260"}
+
+	// Repeat so a run that happened to hash in the right order cannot pass by
+	// luck.
+	for i := 0; i < 20; i++ {
+		matrix := BuildControlMatrix([]ClusterResult{scannedCluster("prod", specs...)})
+
+		got := make([]string, 0, len(matrix.Controls))
+		for _, row := range matrix.Controls {
+			got = append(got, row.ControlID)
+		}
+		require.Equal(t, want, got, "row order changed on iteration %d", i)
+	}
+}
+
+// TestBuildControlMatrixReadsComplianceScore covers the distinction between a
+// control that scored zero and one that was never scored: ControlSummary
+// reports an absent compliance score as -1, and the cell has to carry that
+// through rather than flattening it to 0.
+func TestBuildControlMatrixReadsComplianceScore(t *testing.T) {
+	matrix := BuildControlMatrix([]ClusterResult{
+		scannedCluster("prod", failed("C-0016", "Allow privilege escalation", 2)),
+		scannedCluster("staging", notEvaluated("C-0016", "Allow privilege escalation")),
+	})
+
+	require.Len(t, matrix.Controls, 1)
+	row := matrix.Controls[0]
+
+	// A delta of zero is exact equality. Both values are sentinels copied
+	// through verbatim rather than computed, so anything looser would stop the
+	// test from telling -1 and 0 apart, which is the whole point of it.
+	assert.InDelta(t, 0, row.ByCluster["prod"].ComplianceScore, 0,
+		"a control that scored zero must be reported as zero")
+	assert.InDelta(t, -1, row.ByCluster["staging"].ComplianceScore, 0,
+		"an unscored control must not be reported as scoring zero")
+}

--- a/core/pkg/fleet/testdata/fleetreport_golden.json
+++ b/core/pkg/fleet/testdata/fleetreport_golden.json
@@ -1,0 +1,214 @@
+{
+  "metadata": {
+    "generatedAt": "2026-08-14T09:30:00Z",
+    "kubescapeVersion": "v4.0.0",
+    "contexts": [
+      "prod",
+      "staging",
+      "dr"
+    ]
+  },
+  "clusters": [
+    {
+      "clusterID": "prod",
+      "context": "prod",
+      "status": "scanned",
+      "complianceScore": 72,
+      "coverage": {
+        "coverageScore": 88,
+        "evaluatedControls": 44,
+        "totalControls": 50,
+        "degraded": true
+      },
+      "duration": "4m12s",
+      "report": {
+        "generationTime": "0001-01-01T00:00:00Z",
+        "clusterAPIServerInfo": null,
+        "clusterCloudProvider": "",
+        "customerGUID": "",
+        "clusterName": "prod",
+        "reportGUID": "",
+        "jobID": "",
+        "summaryDetails": {
+          "controls": {
+            "C-0016": {
+              "statusInfo": {
+                "status": "failed"
+              },
+              "controlID": "C-0016",
+              "name": "Allow privilege escalation",
+              "status": "failed",
+              "resourceIDs": {},
+              "ResourceCounters": {
+                "passedResources": 0,
+                "failedResources": 18,
+                "skippedResources": 0,
+                "excludedResources": 0
+              },
+              "subStatusCounters": {
+                "ignoredResources": 0,
+                "acknowledgedResources": 0
+              },
+              "score": 0,
+              "complianceScore": 0,
+              "scoreFactor": 8
+            }
+          },
+          "status": "",
+          "frameworks": null,
+          "resourcesSeverityCounters": {
+            "criticalSeverity": 0,
+            "highSeverity": 0,
+            "mediumSeverity": 0,
+            "lowSeverity": 0
+          },
+          "controlsSeverityCounters": {
+            "criticalSeverity": 0,
+            "highSeverity": 0,
+            "mediumSeverity": 0,
+            "lowSeverity": 0
+          },
+          "ResourceCounters": {
+            "passedResources": 0,
+            "failedResources": 0,
+            "skippedResources": 0,
+            "excludedResources": 0
+          },
+          "vulnerabilities": {
+            "mapsSeverityToSummary": null,
+            "CVEs": null,
+            "packageScores": null,
+            "images": null
+          },
+          "score": 0,
+          "complianceScore": 0
+        },
+        "attributes": null,
+        "metadata": {
+          "targetMetadata": {},
+          "clusterMetadata": {},
+          "scanMetadata": {}
+        },
+        "paginationInfo": {
+          "chunkNumber": 0,
+          "isLastChunk": false
+        },
+        "customerGUIDGenerated": false
+      }
+    },
+    {
+      "clusterID": "staging",
+      "context": "staging",
+      "status": "scanned",
+      "complianceScore": 100,
+      "coverage": {
+        "coverageScore": 100,
+        "evaluatedControls": 0,
+        "totalControls": 0,
+        "degraded": false
+      },
+      "duration": "2m05s",
+      "report": {
+        "generationTime": "0001-01-01T00:00:00Z",
+        "clusterAPIServerInfo": null,
+        "clusterCloudProvider": "",
+        "customerGUID": "",
+        "clusterName": "staging",
+        "reportGUID": "",
+        "jobID": "",
+        "summaryDetails": {
+          "controls": {
+            "C-0016": {
+              "statusInfo": {
+                "status": "passed"
+              },
+              "controlID": "C-0016",
+              "name": "Allow privilege escalation",
+              "status": "passed",
+              "resourceIDs": {},
+              "ResourceCounters": {
+                "passedResources": 0,
+                "failedResources": 0,
+                "skippedResources": 0,
+                "excludedResources": 0
+              },
+              "subStatusCounters": {
+                "ignoredResources": 0,
+                "acknowledgedResources": 0
+              },
+              "score": 0,
+              "complianceScore": 100,
+              "scoreFactor": 8
+            }
+          },
+          "status": "",
+          "frameworks": null,
+          "resourcesSeverityCounters": {
+            "criticalSeverity": 0,
+            "highSeverity": 0,
+            "mediumSeverity": 0,
+            "lowSeverity": 0
+          },
+          "controlsSeverityCounters": {
+            "criticalSeverity": 0,
+            "highSeverity": 0,
+            "mediumSeverity": 0,
+            "lowSeverity": 0
+          },
+          "ResourceCounters": {
+            "passedResources": 0,
+            "failedResources": 0,
+            "skippedResources": 0,
+            "excludedResources": 0
+          },
+          "vulnerabilities": {
+            "mapsSeverityToSummary": null,
+            "CVEs": null,
+            "packageScores": null,
+            "images": null
+          },
+          "score": 0,
+          "complianceScore": 0
+        },
+        "attributes": null,
+        "metadata": {
+          "targetMetadata": {},
+          "clusterMetadata": {},
+          "scanMetadata": {}
+        },
+        "paginationInfo": {
+          "chunkNumber": 0,
+          "isLastChunk": false
+        },
+        "customerGUIDGenerated": false
+      }
+    },
+    {
+      "clusterID": "dr",
+      "context": "dr",
+      "status": "unreachable",
+      "error": "context deadline exceeded"
+    }
+  ],
+  "controlMatrix": {
+    "controls": [
+      {
+        "controlID": "C-0016",
+        "name": "Allow privilege escalation",
+        "severity": "High",
+        "byCluster": {
+          "prod": {
+            "status": "failed",
+            "failedResources": 18,
+            "complianceScore": 0
+          },
+          "staging": {
+            "status": "passed",
+            "failedResources": 0,
+            "complianceScore": 100
+          }
+        }
+      }
+    ]
+  }
+}

--- a/core/pkg/fleet/types.go
+++ b/core/pkg/fleet/types.go
@@ -1,0 +1,187 @@
+package fleet
+
+import (
+	"time"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
+)
+
+// FleetReport is the top-level aggregate: one entry per scanned context plus
+// the cross-cluster views derived from them.
+type FleetReport struct {
+	Metadata      FleetMetadata      `json:"metadata"`
+	Clusters      []ClusterResult    `json:"clusters"`
+	ControlMatrix FleetControlMatrix `json:"controlMatrix"`
+}
+
+// FleetMetadata describes the run that produced the report.
+type FleetMetadata struct {
+	GeneratedAt      time.Time `json:"generatedAt"`
+	KubescapeVersion string    `json:"kubescapeVersion,omitempty"`
+	// Contexts is the scan set that was requested, in the order it was given.
+	// Keeping it separate from Clusters is what lets a consumer tell a context
+	// that was asked for but produced no entry from one that was never asked
+	// for at all.
+	Contexts []string `json:"contexts"`
+}
+
+// ClusterScanStatus is the outcome of one cluster's scan.
+//
+// The non-scanned outcomes are kept apart because they need different
+// responses. A pipeline can retry an unreachable cluster or treat it as an
+// infrastructure problem; an error means the scan ran and something in it
+// failed; a cancellation means nobody has learned anything about the cluster
+// yet. A single "failed" value would force every consumer to parse the error
+// string to tell those apart.
+type ClusterScanStatus string
+
+// The four outcomes a cluster can have. Every ClusterResult carries exactly one
+// of them, and only ClusterScanned implies a populated Report.
+const (
+	// ClusterScanned means the scan completed and Report is populated.
+	ClusterScanned ClusterScanStatus = "scanned"
+	// ClusterUnreachable means the cluster's API server could not be reached.
+	ClusterUnreachable ClusterScanStatus = "unreachable"
+	// ClusterError means the scan started and failed for some other reason.
+	ClusterError ClusterScanStatus = "error"
+	// ClusterCancelled means the run was interrupted before this cluster
+	// finished, typically by a signal.
+	//
+	// It is deliberately not folded into ClusterUnreachable. An operator who
+	// presses Ctrl-C has learned nothing about whether the cluster was
+	// reachable, and reporting it as unreachable would put a claim about the
+	// infrastructure into the report that the run never actually tested.
+	ClusterCancelled ClusterScanStatus = "cancelled"
+)
+
+// ClusterResult wraps one cluster's PostureReport with fleet-level status.
+//
+// A cluster that could not be scanned still gets an entry, with Status set and
+// Report nil, so it stays visible in the output instead of being dropped. An
+// operator reading a fleet report needs to see that a cluster is missing;
+// silently omitting it produces a report that looks complete and is not.
+type ClusterResult struct {
+	// ClusterID identifies the cluster across the report. It is the context
+	// name for now, which is a kubeconfig label rather than a cluster identity
+	// and is therefore not stable across machines. It is a separate field from
+	// Context so it can carry a portable identifier later without changing the
+	// shape of the report.
+	ClusterID string `json:"clusterID"`
+	// Context is the kubeconfig context the scan was run against.
+	Context string            `json:"context"`
+	Status  ClusterScanStatus `json:"status"`
+	// Error is the failure that produced a non-scanned Status, kept verbatim.
+	// Flattening it loses the difference between an expired credential and an
+	// unroutable API server, which is exactly what the reader needs.
+	Error string `json:"error,omitempty"`
+	// ComplianceScore is the cluster's own score, copied out so a consumer can
+	// read the summary rows without walking into Report.
+	//
+	// It is a pointer so that a cluster which was never scanned serialises
+	// without a score at all. A plain float32 would emit 0 for an unreachable
+	// cluster, which reads as "fully non-compliant" rather than "not measured"
+	// and would drag down any consumer that averages the column.
+	ComplianceScore *float32 `json:"complianceScore,omitempty"`
+	// Coverage records how complete the scan was. A control that diverges
+	// between two clusters means something different when one of them was only
+	// partially scanned, so coverage travels with the result rather than being
+	// looked up separately. Nil for the same reason as ComplianceScore.
+	Coverage *cautils.ScanCoverage `json:"coverage,omitempty"`
+	// Duration is how long this cluster's scan took, formatted by
+	// time.Duration.String. It is a string rather than a duration so the JSON
+	// stays readable to a human skimming a report; a consumer that needs to
+	// compute with it can parse it back with time.ParseDuration.
+	Duration string `json:"duration,omitempty"`
+	// Report is the unmodified single-cluster report. It is nil for any
+	// non-scanned cluster, so every consumer has to check Status first.
+	Report *reporthandlingv2.PostureReport `json:"report,omitempty"`
+}
+
+// Scanned reports whether the cluster produced a usable report. Aggregation
+// starts from this rather than from Status alone, so a result that claims to
+// have been scanned but carries no report is treated as missing data instead of
+// being dereferenced.
+//
+// It guards Report only. ComplianceScore and Coverage are separate pointers and
+// can still be nil on a result this returns true for, so anything reading them
+// needs its own check; Scored covers the common case.
+func (c *ClusterResult) Scanned() bool {
+	return c.Status == ClusterScanned && c.Report != nil
+}
+
+// Scored reports whether the cluster carries the measurements a fleet-wide
+// score is computed from. A scanned cluster whose score or coverage is missing
+// is not a zero, it is an absence, and callers that average across clusters
+// have to exclude it rather than fold a nil into the arithmetic.
+func (c *ClusterResult) Scored() bool {
+	return c.Scanned() && c.ComplianceScore != nil && c.Coverage != nil
+}
+
+// FleetControlMatrix is the control x cluster grid: for each control, its
+// status in every cluster that was scanned.
+type FleetControlMatrix struct {
+	// Controls is sorted by control ID so the same inputs always render the
+	// same way, in a table or in a diff of two JSON reports.
+	Controls []FleetControlRow `json:"controls"`
+}
+
+// FleetControlRow is one control across the fleet.
+type FleetControlRow struct {
+	ControlID string `json:"controlID"`
+	Name      string `json:"name"`
+	Severity  string `json:"severity"`
+	// ByCluster is keyed by ClusterResult.ClusterID. A cluster missing from
+	// this map contributed no data for this control, either because it was not
+	// scanned or because the control was not in its scan set.
+	ByCluster map[string]ControlStatusCell `json:"byCluster"`
+}
+
+// ControlStatusCell is one control's outcome in one cluster.
+type ControlStatusCell struct {
+	Status          CellStatus `json:"status"`
+	FailedResources int        `json:"failedResources"`
+	// ComplianceScore is the control's score in this cluster, and is -1 when
+	// the control carries no score at all.
+	//
+	// That sentinel is inherited rather than invented: ControlSummary stores
+	// the score as a pointer and GetComplianceScore returns -1 when it is nil,
+	// so -1 already means "not scored" everywhere else a control score is read.
+	// Reporting it as 0 here would be a fabricated measurement, the same
+	// mistake the pointer fields on ClusterResult exist to avoid, and inventing
+	// a second convention for absence would leave two ways to say the same
+	// thing. Consumers that average this column must exclude negative values.
+	ComplianceScore float32 `json:"complianceScore"`
+}
+
+// CellStatus is a control's outcome in a single cluster, normalised for
+// cross-cluster comparison.
+//
+// This is deliberately not apis.ScanningStatus. A control that could not be
+// evaluated is recorded upstream as status "skipped" with sub-status
+// "notEvaluated" (see OPAProcessor.markControlsSkipped), which puts it in the
+// same bucket as a control skipped by an exception or as irrelevant. Those two
+// mean opposite things across clusters: a skipped control agrees with a skipped
+// control, whereas a control that one cluster evaluated and another did not is
+// a gap in what was measured. Collapsing the pair into one value here keeps
+// that distinction available to everything downstream.
+type CellStatus string
+
+// The four cell outcomes. Passed and failed are verdicts the control reached;
+// skipped and notEvaluated are both absences of a verdict, kept apart because
+// one was chosen and the other was not.
+const (
+	// CellPassed is a control the cluster evaluated and satisfied.
+	CellPassed CellStatus = "passed"
+	// CellFailed is a control the cluster evaluated and did not satisfy.
+	CellFailed CellStatus = "failed"
+	// CellSkipped is a control that was deliberately not applied, for example
+	// because an exception matched or it was irrelevant to the cluster.
+	CellSkipped CellStatus = "skipped"
+	// CellNotEvaluated is a control that reached no verdict: Kubescape could
+	// not evaluate it, for example because a required resource type failed to
+	// collect or the control timed out, or the report carries no status for it
+	// at all. It is distinct from CellSkipped, which records a deliberate
+	// decision not to apply the control.
+	CellNotEvaluated CellStatus = "notEvaluated"
+)

--- a/core/pkg/fleet/types_test.go
+++ b/core/pkg/fleet/types_test.go
@@ -1,0 +1,261 @@
+package fleet
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenPath is the fixture TestFleetReportGoldenFile compares against.
+const goldenPath = "testdata/fleetreport_golden.json"
+
+// updateGolden regenerates testdata/fleetreport_golden.json instead of
+// comparing against it. Deliberate changes to the JSON envelope are made by
+// running the test with it and reviewing the resulting diff.
+var updateGolden = flag.Bool("update-golden", false, "regenerate the fleet report golden fixture under testdata/")
+
+// newFleetReport builds the report the wire-format tests work from.
+//
+// Clusters and ControlMatrix are derived from one slice of results rather than
+// assembled independently. That is the point of the helper: a matrix cell for a
+// cluster missing from Clusters, or a cluster marked scanned with no report
+// behind it, is not a report a consumer should ever have to accept, so the
+// fixtures must not be able to describe one. Building both views from the same
+// input makes that impossible by construction rather than by review.
+func newFleetReport() FleetReport {
+	results := []ClusterResult{
+		scannedCluster("prod", failed("C-0016", "Allow privilege escalation", 18)),
+		scannedCluster("staging", passed("C-0016", "Allow privilege escalation")),
+		unreachableCluster("dr", "context deadline exceeded"),
+	}
+
+	// Vary the measurements so the fixture pins a degraded scan and a healthy
+	// one side by side, rather than two identical rows.
+	results[0].ComplianceScore = score(72)
+	results[0].Coverage = &cautils.ScanCoverage{
+		CoverageScore:     88,
+		EvaluatedControls: 44,
+		TotalControls:     50,
+		Degraded:          true,
+	}
+	results[0].Duration = "4m12s"
+	results[1].Duration = "2m05s"
+
+	return FleetReport{
+		Metadata: FleetMetadata{
+			GeneratedAt:      time.Date(2026, 8, 14, 9, 30, 0, 0, time.UTC),
+			KubescapeVersion: "v4.0.0",
+			Contexts:         []string{"prod", "staging", "dr"},
+		},
+		Clusters:      results,
+		ControlMatrix: BuildControlMatrix(results),
+	}
+}
+
+// requireFleetReportIsSelfConsistent fails unless the report obeys the
+// invariants the types declare, so a fixture cannot bless output that a
+// consumer would have to treat as incomplete.
+//
+// Three things have to hold. A cluster marked scanned carries a report, because
+// Scanned() promises exactly that and everything downstream dereferences on the
+// strength of it. Every matrix cell names a cluster that appears in Clusters and
+// was actually scanned, because a verdict attributed to a cluster the report
+// does not otherwise mention cannot be traced back to anything. And every
+// cluster's context appears in Metadata.Contexts, which is what lets a consumer
+// tell a context that produced no entry from one that was never requested.
+func requireFleetReportIsSelfConsistent(t *testing.T, report *FleetReport) {
+	t.Helper()
+
+	byID := make(map[string]*ClusterResult, len(report.Clusters))
+	for i := range report.Clusters {
+		cluster := &report.Clusters[i]
+		byID[cluster.ClusterID] = cluster
+
+		if cluster.Status == ClusterScanned {
+			assert.NotNil(t, cluster.Report,
+				"cluster %q is marked scanned but carries no report", cluster.ClusterID)
+		}
+		assert.Contains(t, report.Metadata.Contexts, cluster.Context,
+			"cluster %q was reported but its context is not in metadata.contexts", cluster.ClusterID)
+	}
+
+	for _, row := range report.ControlMatrix.Controls {
+		for clusterID := range row.ByCluster {
+			cluster, ok := byID[clusterID]
+			if !assert.True(t, ok,
+				"control %s has a cell for %q, which is absent from clusters", row.ControlID, clusterID) {
+				continue
+			}
+			assert.True(t, cluster.Scanned(),
+				"control %s has a cell for %q, which produced no usable report", row.ControlID, clusterID)
+		}
+	}
+}
+
+// TestFleetReportGoldenFile pins the serialised shape of the report.
+//
+// The JSON is what a CI job or a dashboard consumes, so a field renamed or
+// dropped by accident breaks consumers rather than the compiler. Comparing
+// against a golden fixture makes any change to the envelope show up as a diff
+// at review time. A fixed GeneratedAt keeps the output deterministic; run with
+// `go test -update-golden` to regenerate the fixture.
+func TestFleetReportGoldenFile(t *testing.T) {
+	report := newFleetReport()
+	requireFleetReportIsSelfConsistent(t, &report)
+
+	got, err := json.MarshalIndent(report, "", "  ")
+	require.NoError(t, err)
+	got = append(got, '\n')
+
+	if *updateGolden {
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o600))
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "golden fixture missing, run `go test -update-golden`")
+	assert.Equal(t, string(want), string(got), "fleet report JSON diverged from testdata/fleetreport_golden.json")
+}
+
+// TestClusterResultOmitsUnmeasuredFields checks that a cluster which was never
+// scanned serialises without the fields it has no value for, rather than with
+// zeroes. A fabricated "0% compliant, 0% covered" row sitting next to real
+// measurements is worse than an absent one, because it reads as a finding.
+func TestClusterResultOmitsUnmeasuredFields(t *testing.T) {
+	raw, err := json.Marshal(unreachableCluster("dr", "no route to host"))
+	require.NoError(t, err)
+
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	for _, key := range []string{"report", "complianceScore", "coverage"} {
+		assert.NotContains(t, decoded, key, "an unscanned cluster must not carry a %q key", key)
+	}
+	assert.Contains(t, decoded, "status", "every cluster must carry a status")
+	assert.Contains(t, decoded, "error", "an unscanned cluster must carry the error that produced its status")
+}
+
+// TestFleetReportRoundTrips checks that the report survives a marshal and
+// unmarshal unchanged. The struct tags are the wire contract, so a tag that
+// does not match its field would let a report serialise and come back with the
+// value silently missing.
+func TestFleetReportRoundTrips(t *testing.T) {
+	want := newFleetReport()
+	requireFleetReportIsSelfConsistent(t, &want)
+
+	raw, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	var got FleetReport
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	// The decoded report has to satisfy the same invariants as the encoded one.
+	// A tag mismatch that dropped Clusters or ByCluster would otherwise show up
+	// only as a nil map somewhere downstream.
+	requireFleetReportIsSelfConsistent(t, &got)
+
+	assert.True(t, got.Metadata.GeneratedAt.Equal(want.Metadata.GeneratedAt))
+	assert.Equal(t, want.Metadata.Contexts, got.Metadata.Contexts)
+
+	require.Len(t, got.Clusters, len(want.Clusters))
+	assert.Equal(t, ClusterScanned, got.Clusters[0].Status)
+	require.NotNil(t, got.Clusters[0].ComplianceScore)
+	assert.InDelta(t, 72, *got.Clusters[0].ComplianceScore, 0)
+	require.NotNil(t, got.Clusters[0].Coverage)
+	assert.True(t, got.Clusters[0].Coverage.Degraded)
+	assert.Equal(t, ClusterUnreachable, got.Clusters[2].Status)
+	assert.Equal(t, "context deadline exceeded", got.Clusters[2].Error)
+	assert.Nil(t, got.Clusters[2].ComplianceScore, "an unscanned cluster must not decode a score")
+
+	require.Len(t, got.ControlMatrix.Controls, 1)
+	row := got.ControlMatrix.Controls[0]
+	assert.Equal(t, "C-0016", row.ControlID)
+	assert.Equal(t, CellFailed, row.ByCluster["prod"].Status)
+	assert.Equal(t, CellPassed, row.ByCluster["staging"].Status)
+	assert.NotContains(t, row.ByCluster, "dr", "an unreachable cluster must not decode a cell")
+}
+
+// TestClusterResultScanned pins the guard the aggregation dereferences behind.
+// The case that matters is the second one: a result claiming ClusterScanned
+// with no report is missing data, not usable data, and treating the status
+// alone as sufficient would panic on the next field access.
+func TestClusterResultScanned(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ClusterResult
+		want   bool
+	}{
+		{
+			name:   "scanned with a report",
+			result: scannedCluster("prod", passed("C-0016", "Allow privilege escalation")),
+			want:   true,
+		},
+		{
+			name:   "scanned status but no report is not usable data",
+			result: ClusterResult{ClusterID: "prod", Status: ClusterScanned},
+			want:   false,
+		},
+		{
+			name:   "unreachable",
+			result: unreachableCluster("dr", "no route to host"),
+			want:   false,
+		},
+		{
+			name:   "errored",
+			result: ClusterResult{ClusterID: "dr", Status: ClusterError, Error: "policy download failed"},
+			want:   false,
+		},
+		{
+			name:   "cancelled before it ran",
+			result: ClusterResult{ClusterID: "dr", Status: ClusterCancelled, Error: "context canceled"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.result.Scanned())
+		})
+	}
+}
+
+// TestClusterResultScored covers the stricter guard used by anything that
+// averages across clusters. A scanned cluster can still be missing its score or
+// its coverage, and folding either absence in as a zero would report a fleet as
+// less compliant than it was measured to be.
+func TestClusterResultScored(t *testing.T) {
+	scanned := scannedCluster("prod", passed("C-0016", "Allow privilege escalation"))
+
+	noScore := scannedCluster("staging", passed("C-0016", "Allow privilege escalation"))
+	noScore.ComplianceScore = nil
+
+	noCoverage := scannedCluster("dr", passed("C-0016", "Allow privilege escalation"))
+	noCoverage.Coverage = nil
+
+	tests := []struct {
+		name   string
+		result ClusterResult
+		want   bool
+	}{
+		{name: "scanned with both measurements", result: scanned, want: true},
+		{name: "scanned but never scored", result: noScore, want: false},
+		{name: "scanned but no coverage recorded", result: noCoverage, want: false},
+		{name: "unreachable", result: unreachableCluster("dr", "no route to host"), want: false},
+		{
+			name:   "cancelled before it ran",
+			result: ClusterResult{ClusterID: "dr", Status: ClusterCancelled},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.result.Scored())
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`--kube-contexts` scans several contexts in one run and writes one report per context. It deliberately stops there: ten contexts produce ten independent report files and nothing combines them.

That leaves the questions which motivate scanning a fleet unanswered. "Which of my clusters fail C-0016" and "staging passes this control and prod fails it, so where did we drift" both require reading every report and correlating them by hand, which is how each organisation ends up maintaining its own untested jq script.

This adds the aggregate types and the first view derived from them, the control x cluster matrix.

Nothing is wired into the CLI here. The package takes `[]ClusterResult` as input rather than driving a scan, so `core.Scan`, `PostureReport` and every existing printer are untouched, and deleting `core/pkg/fleet` leaves the single-cluster CLI byte for byte identical. It also means the whole aggregation is exercised against fixtures with no cluster involved.

## Additional Information

Three decisions are worth calling out, because in each case the obvious alternative produces a report that quietly misleads.

**Skipped and not-evaluated are kept apart.** Upstream, a control that could not be evaluated and a control that was skipped on purpose are both recorded as `apis.StatusSkipped`, separated only by the sub-status that `OPAProcessor.markControlsSkipped` writes. Within one cluster that collapse is harmless. Across clusters it is not: two skipped controls genuinely agree, whereas a control one cluster evaluated and another did not is a gap in what was measured rather than a difference in posture. `CellStatus` splits them at the bottom of the stack, because a distinction lost on the first hop cannot be recovered by anything reading the matrix later.

**A cluster that was not scanned keeps its row**, carrying its status and error verbatim, and contributes no cells. Dropping it would produce a report that looks complete and is not. Its `ComplianceScore` and `Coverage` are pointers so they serialise as absent rather than as zero: plain value types would emit `"complianceScore": 0` beside a zeroed coverage block, which reads as a finding rather than as missing data and drags down anything averaging the column.

**Cluster outcomes are four values rather than a single "failed"**, because a pipeline responds differently to each. Unreachable is an infrastructure condition worth retrying, error means the scan ran and something in it failed, and cancelled means the run was interrupted so nothing was learned about that cluster at all. Collapsing them would force every consumer to parse error strings to recover the difference.

`BuildControlMatrix` sorts rows by control ID. Control summaries live in a map, so without the sort two reports of an unchanged fleet would not compare equal, and a fleet report that cannot be diffed against its own previous run is of little use in CI. The sort has a test that runs twenty iterations rather than relying on one lucky ordering. This is the same class of issue as #3739.

One note for reviewers: `ClusterResult.Scored()` is exported but has no caller in this PR. It guards the case where a cluster scanned successfully but is missing its score or coverage, and it is used by the compliance rollup that follows. It is included here so the guard lives beside `Scanned()`, which it builds on, rather than arriving separately later.

Per-cluster isolation is already handled by `cautils.EnterClusterContext`, which ships its own tests, so they are not duplicated. The tests here pin the two properties the aggregation depends on directly: that the API-group snapshot follows the cluster being scanned, and that leaving a context restores the one active before it.

## How to Test

```
go test -race -count=1 ./core/pkg/fleet/...
```

39 cases covering the matrix, the four cluster outcomes, the JSON envelope against a golden fixture, row ordering across repeated runs, and a table pinning how every `apis.ScanningStatus` maps into a cell.

To regenerate the golden fixture after an intentional change to the report shape:

```
go test ./core/pkg/fleet/ -run TestFleetReportGoldenFile -update-golden
```

## Related issues/PRs

Follows #3438 and #3440, which added sequential multi-context scanning. This is the aggregation those runs currently lack.

Drift detection, the compliance rollup, the printers, and the wiring that produces a `FleetReport` from a multi-context run all build on these types and follow separately.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fleet-level reporting for multi-cluster scans, including metadata, coverage, scores, durations, and cluster outcomes.
  - Added a control-by-cluster matrix with passed, failed, skipped, and not-evaluated results.
  - Added support for unreachable, errored, cancelled, and incomplete scan states.
  - Reports use deterministic control ordering and preserve unavailable versus zero-valued measurements.
  - Added JSON serialization for fleet reports and scan results.

- **Documentation**
  - Added package documentation describing fleet reporting behavior and supported outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->