### PR TITLE
fix(printer): honor --show-evidence in control and resource views

### DIFF
--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -98,7 +98,12 @@ func (pp *PrettyPrinter) ActionPrint(_ context.Context, opaSessionObj *cautils.O
 		case cautils.ControlViewType:
 			pp.printResults(&opaSessionObj.Report.SummaryDetails.Controls, opaSessionObj.AllResources, opaSessionObj.ResourcesResult, sortedControlIDs)
 		case cautils.ResourceViewType:
-			if pp.verboseMode {
+			// The resource table is the one place that already reads
+			// showEvidence (see generateResourceRows), so gating it on
+			// --verbose alone meant `-E --view resource` printed no table at
+			// all and the evidence column it builds was unreachable without
+			// also passing --verbose.
+			if pp.verboseMode || pp.showEvidence {
 				pp.resourceTable(opaSessionObj)
 			}
 		case cautils.NamespaceViewType:
@@ -243,13 +248,23 @@ func (prettyPrinter *PrettyPrinter) printTitle(controlSummary reportsummary.ICon
 func (pp *PrettyPrinter) printResources(controlSummary reportsummary.IControlSummary, allResources map[string]workloadinterface.IMetadata, resourcesResult map[string]resourcesresults.Result) {
 
 	workloadsSummary := listResultSummary(controlSummary, allResources)
-	if pp.verboseMode {
+	// --show-evidence asks for the evidence, so it enables the evidence on its
+	// own here. Gating this on --verbose alone left the flag unread on the
+	// control view: showEvidence was threaded all the way to the printer and
+	// then never consulted on this path, so `kubescape scan -E --view control`
+	// printed exactly what a bare scan printed.
+	if pp.verboseMode || pp.showEvidence {
 		attachAssistedRemediation(workloadsSummary, controlSummary.GetID(), resourcesResult, pp.showSecrets)
 	}
 
 	failedWorkloads := groupByNamespaceOrKind(workloadsSummary, workloadSummaryFailed)
 	skippedWorkloads := groupByNamespaceOrKind(workloadsSummary, workloadSummarySkipped)
 
+	// Passed resources stay behind --verbose. They are a different request:
+	// --verbose widens *which resources* are listed, --show-evidence deepens
+	// *what is shown* about a failed one. Widening on -E would change the
+	// output of every control that has passing resources, which is not what
+	// the flag asks for.
 	var passedWorkloads map[string][]WorkloadSummary
 	if pp.verboseMode {
 		passedWorkloads = groupByNamespaceOrKind(workloadsSummary, workloadSummaryPassed)

--- a/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter_test.go
@@ -464,3 +464,85 @@ func TestActionPrint_ControlViewVerboseOmitsRemediationOnPassedAndSkipped(t *tes
 	assert.NotContains(t, out, "spec.hostPID")
 	assert.NotContains(t, out, "spec.hostNetwork")
 }
+
+// --show-evidence was threaded to the printer by #3220 and then never read on
+// the control view: printResources gated the evidence on verboseMode alone, so
+// `kubescape scan -E --view control` produced byte-identical output to a bare
+// scan. The tests below pin the flag's own behaviour, independent of -v.
+
+// TestActionPrint_ControlViewShowEvidenceIncludesPathsWithoutVerbose is the
+// RED->GREEN case: it fails on the old verboseMode-only condition.
+func TestActionPrint_ControlViewShowEvidenceIncludesPathsWithoutVerbose(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.showEvidence = true
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewAssistedRemediationSession(), nil))
+
+	out := read()
+	assert.Contains(t, out, "checkout-api")
+	assert.Contains(t, out, controlViewEnvVarPath+" (current: DB_PASSWORD)")
+}
+
+// TestActionPrint_ControlViewShowEvidenceKeepsPassedResourcesHidden separates
+// the two flags. --verbose widens *which* resources are listed; --show-evidence
+// deepens what is shown about a failed one. -E must not start listing passing
+// resources, which would change the output of every control that has any.
+func TestActionPrint_ControlViewShowEvidenceKeepsPassedResourcesHidden(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.showEvidence = true
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewMixedStatusSession(), nil))
+
+	out := read()
+	assert.Contains(t, out, "failed-deploy")
+	assert.Contains(t, out, controlViewEnvVarPath)
+	assert.NotContains(t, out, "passed-deploy")
+}
+
+// TestActionPrint_ControlViewShowEvidenceDoesNotLeakEnvValue guards the new
+// route into evidence output. -E reaches attachAssistedRemediation without -v
+// now, so the C-0012 plaintext credential must still be redacted on that route.
+func TestActionPrint_ControlViewShowEvidenceDoesNotLeakEnvValue(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.showEvidence = true
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewEnvValueSession(), nil))
+
+	out := read()
+	assert.NotContains(t, out, controlViewEnvSecret)
+	assert.Contains(t, out, controlViewEnvValuePath+" (current: "+redactedValue+")")
+}
+
+// TestActionPrint_ControlViewShowSecretsWithoutVerbose confirms --show-secrets
+// still opts back in on the -E route, matching its behaviour under -v.
+func TestActionPrint_ControlViewShowSecretsWithoutVerbose(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.showEvidence = true
+	pp.showSecrets = true
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewEnvValueSession(), nil))
+
+	out := read()
+	assert.Contains(t, out, controlViewEnvValuePath+" (current: "+controlViewEnvSecret+")")
+}
+
+// TestActionPrint_ResourceViewShowEvidenceRendersTableWithoutVerbose covers the
+// second unread site. resourceTable is the one place that already consulted
+// showEvidence, but it sat behind --verbose, so the evidence column it builds
+// was unreachable unless -v was passed too.
+func TestActionPrint_ResourceViewShowEvidenceRendersTableWithoutVerbose(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.viewType = cautils.ResourceViewType
+	pp.showEvidence = true
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewAssistedRemediationSession(), nil))
+
+	out := read()
+	assert.Contains(t, out, "checkout-api")
+	assert.Contains(t, out, controlViewEnvVarPath)
+}
+
+// TestActionPrint_ResourceViewDefaultStillPrintsNoTable keeps the default
+// unchanged: neither -v nor -E means no resource table, exactly as before.
+func TestActionPrint_ResourceViewDefaultStillPrintsNoTable(t *testing.T) {
+	pp, read := newControlViewPrettyPrinter(t, false)
+	pp.viewType = cautils.ResourceViewType
+	require.NoError(t, pp.ActionPrint(context.Background(), controlViewAssistedRemediationSession(), nil))
+
+	assert.NotContains(t, read(), "checkout-api")
+}


### PR DESCRIPTION
## Overview

`--show-evidence` was threaded through to the pretty-printer by #3220 but never read on the control view, and the resource table that does read it sat behind `--verbose`. So `-E` on its own produced byte-identical output to a bare scan, on every view.

Two conditions now honour the flag:

- `printResources` attaches assisted-remediation paths on `verboseMode || showEvidence`
- the resource table renders on `verboseMode || showEvidence`

Passed resources deliberately stay behind `--verbose`. `--verbose` widens *which* resources are listed; `--show-evidence` deepens what is shown about a failed one.

## Additional Information

The `-E` no-op was reported by @manumathon on #1563 and root-caused by @saladin0x1 to a single unread flag — credit to both.

The default `security` view still prints no evidence, since it has no per-resource section to attach it to. Giving it one is an output change rather than a flag fix, so I've left it out happy to follow up if you'd prefer `-E` to imply a view that prints.

## How to Test

```
kubescape scan . --view control -E
```

Evidence paths now appear without `-v`. Redaction is unchanged: values stay `[redacted]` unless `--show-secrets` is passed.

```
go test ./core/pkg/resultshandling/printer/v2/
```

## Related issues/PRs:

* Relates to #1563

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The `--show-evidence` (`-E`) option now correctly displays resource details and assisted-remediation information without requiring `--verbose`.
  - Passed resources remain hidden unless `--verbose` is enabled.
  - Sensitive environment values remain redacted by default, with `--show-secrets` available to reveal them when requested.
  - Default resource views continue to omit the resource table unless an appropriate display option is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->