### PR TITLE
feat(mcpserver): introduce structured machine-readable error responses

### DIFF
--- a/.github/scripts/check_mcp_errors.sh
+++ b/.github/scripts/check_mcp_errors.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail if any non-test source file in cmd/mcpserver (recursively) uses
+# bare mcp.NewToolResultError, bypassing mcpToolError.
+#
+# Uses find + grep instead of a shell glob so this works if the package
+# is later reorganized into subdirectories.
+
+VIOLATIONS=$(find cmd/mcpserver -name '*.go' \
+    ! -name '*_test.go' \
+    ! -name 'mcperror.go' \
+    -exec grep -Hn 'mcp\.NewToolResultError(' {} + 2>/dev/null \
+    | grep -v 'mcpToolError' || true)
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "ERROR: Found bare mcp.NewToolResultError() outside mcpToolError helper:"
+    echo "$VIOLATIONS"
+    echo ""
+    echo "Use mcpToolError(code, message, details) instead."
+    exit 1
+fi
+
+echo "OK: all MCP error call sites use mcpToolError"

--- a/.github/workflows/a-pr-scanner.yaml
+++ b/.github/workflows/a-pr-scanner.yaml
@@ -53,6 +53,9 @@ jobs:
           CGO_ENABLED: 1
         run: ${{ env.DOCKER_CMD }} go test -v -race ./core/cautils/...
 
+      - name: Check MCP structured errors
+        run: bash .github/scripts/check_mcp_errors.sh
+
       - uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         name: Setup Syft
 

--- a/cmd/mcpserver/advanced_tools.go
+++ b/cmd/mcpserver/advanced_tools.go
@@ -33,14 +33,14 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 
 		kind, ok := args["resource_kind"].(string)
 		if !ok || kind == "" {
-			return mcp.NewToolResultError("resource_kind is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "resource_kind is required", map[string]any{"argument": "resource_kind"}), nil
 		}
 		namespace, _ := args["namespace"].(string)
 
 		limit := int64(10)
 		if l, ok := args["limit"].(float64); ok {
 			if l <= 0 || l != float64(int64(l)) {
-				return mcp.NewToolResultError("limit must be a positive integer"), nil
+				return mcpToolError(ErrCodeInvalidArgument, "limit must be a positive integer", map[string]any{"argument": "limit"}), nil
 			}
 			limit = int64(l)
 			if limit > 500 {
@@ -63,12 +63,12 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		case "statefulsets", "statefulset":
 			gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
 		default:
-			return mcp.NewToolResultError(fmt.Sprintf("unsupported resource kind %q; supported kinds are: pods, deployments, daemonsets, statefulsets", kind)), nil
+			return mcpToolError(ErrCodeUnsupportedResource, fmt.Sprintf("unsupported resource kind %q; supported kinds are: pods, deployments, daemonsets, statefulsets", kind), map[string]any{"kind": kind, "supported_kinds": []string{"pods", "deployments", "daemonsets", "statefulsets"}}), nil
 		}
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 
 		listOpts := metav1.ListOptions{
@@ -85,7 +85,7 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		}
 
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list resources: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to list resources: %v", err), map[string]any{"resource_type": kind}), nil
 		}
 
 		nextContinueToken := list.GetContinue()
@@ -133,44 +133,44 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 
 		celExpr, ok := args["cel_expression"].(string)
 		if !ok || celExpr == "" {
-			return mcp.NewToolResultError("cel_expression is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "cel_expression is required", map[string]any{"argument": "cel_expression"}), nil
 		}
 		resourceJSON, ok := args["resource_json"].(string)
 		if !ok || resourceJSON == "" {
-			return mcp.NewToolResultError("resource_json is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "resource_json is required", map[string]any{"argument": "resource_json"}), nil
 		}
 
 		if len(resourceJSON) > 1000000 || len(celExpr) > 10000 {
-			return mcp.NewToolResultError("input exceeds size limits"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "input exceeds size limits", nil), nil
 		}
 
 		var resourceObj map[string]any
 		if err := json.Unmarshal([]byte(resourceJSON), &resourceObj); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to parse resource_json: %v", err)), nil
+			return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("failed to parse resource_json: %v", err), nil), nil
 		}
 
 		env, err := cel.NewEnv(
 			cel.Variable("object", cel.DynType),
 		)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to create CEL env: %v", err)), nil
+			return mcpToolError(ErrCodeScanFailed, fmt.Sprintf("failed to create CEL env: %v", err), nil), nil
 		}
 
 		ast, issues := env.Compile(celExpr)
 		if issues != nil && issues.Err() != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to compile CEL expression: %v", issues.Err())), nil
+			return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("failed to compile CEL expression: %v", issues.Err()), nil), nil
 		}
 
 		prg, err := env.Program(ast, cel.CostLimit(100000))
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to create CEL program: %v", err)), nil
+			return mcpToolError(ErrCodeScanFailed, fmt.Sprintf("failed to create CEL program: %v", err), nil), nil
 		}
 
 		out, _, err := prg.Eval(map[string]any{
 			"object": resourceObj,
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to evaluate CEL rule: %v", err)), nil
+			return mcpToolError(ErrCodeScanFailed, fmt.Sprintf("failed to evaluate CEL rule: %v", err), nil), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("%v", out.Value())), nil
@@ -198,7 +198,7 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		patchJSON, _ := args["patch_json"].(string)
 
 		if kind == "" || name == "" || patchJSON == "" {
-			return mcp.NewToolResultError("resource_kind, resource_name, and patch_json are required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "resource_kind, resource_name, and patch_json are required", nil), nil
 		}
 
 		// Security/Privilege Drop checks: explicitly allow only certain workload kinds.
@@ -209,12 +209,12 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 			"statefulset": true, "statefulsets": true,
 		}
 		if !allowedKinds[strings.ToLower(kind)] {
-			return mcp.NewToolResultError(fmt.Sprintf("security barrier: patching kind '%s' is not permitted", kind)), nil
+			return mcpToolError(ErrCodeUnsupportedResource, fmt.Sprintf("security barrier: patching kind '%s' is not permitted", kind), map[string]any{"kind": kind}), nil
 		}
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 
 		var gvr schema.GroupVersionResource
@@ -245,7 +245,7 @@ func createAdvancedTools(ksServer *KubescapeMcpserver) {
 		}
 
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("dry-run patch failed: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("dry-run patch failed: %v", err), nil), nil
 		}
 
 		resBytes, _ := json.Marshal(patchedObj.Object)

--- a/cmd/mcpserver/advanced_tools_test.go
+++ b/cmd/mcpserver/advanced_tools_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -66,12 +67,14 @@ func TestScanResourceSlice_UnsupportedKindReturnsError(t *testing.T) {
 		"resource_kind": "jobs",
 	}))
 	require.True(t, result.IsError)
-	text := toolResultText(t, result)
-	require.Contains(t, text, `unsupported resource kind "jobs"`)
-	require.Contains(t, text, "pods")
-	require.Contains(t, text, "deployments")
-	require.Contains(t, text, "daemonsets")
-	require.Contains(t, text, "statefulsets")
+	var toolErr ToolError
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
+	require.Equal(t, ErrCodeUnsupportedResource, toolErr.Code)
+	require.Contains(t, toolErr.Message, `unsupported resource kind "jobs"`)
+	require.Contains(t, toolErr.Message, "pods")
+	require.Contains(t, toolErr.Message, "deployments")
+	require.Contains(t, toolErr.Message, "daemonsets")
+	require.Contains(t, toolErr.Message, "statefulsets")
 }
 
 // TestScanResourceSlice_UnsupportedKindReturnsErrorWithoutClusterConfig
@@ -98,5 +101,8 @@ func TestScanResourceSlice_UnsupportedKindReturnsErrorWithoutClusterConfig(t *te
 		"resource_kind": "jobs",
 	}))
 	require.True(t, result.IsError)
-	require.Contains(t, toolResultText(t, result), `unsupported resource kind "jobs"`)
+	var toolErr ToolError
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
+	require.Equal(t, ErrCodeUnsupportedResource, toolErr.Code)
+	require.Contains(t, toolErr.Message, `unsupported resource kind "jobs"`)
 }

--- a/cmd/mcpserver/mcperror.go
+++ b/cmd/mcpserver/mcperror.go
@@ -1,0 +1,76 @@
+package mcpserver
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// ErrorCode is a machine-readable string identifying the failure class.
+type ErrorCode string
+
+const (
+	ErrCodeMalformedIdentifier ErrorCode = "MALFORMED_IDENTIFIER"
+	// ErrCodeResourceNotFound indicates the requested target resource could not be found
+	// in the cluster. This applies both during single-resource scan resolution
+	// (via classifyScanError) and admission policy impact lookup (when the target object
+	// does not exist in the cluster). From an LLM agent's perspective, the recovery
+	// action for both cases is identical: verify and correct the resource kind, name,
+	// or namespace.
+	ErrCodeResourceNotFound    ErrorCode = "RESOURCE_NOT_FOUND"
+	ErrCodeAmbiguousResource   ErrorCode = "AMBIGUOUS_RESOURCE"
+	ErrCodeRBACDenied          ErrorCode = "RBAC_DENIED"
+	ErrCodeInvalidArgument     ErrorCode = "INVALID_ARGUMENT"
+	ErrCodeScanFailed          ErrorCode = "SCAN_EXECUTION_FAILED"
+	ErrCodeK8sClientError      ErrorCode = "K8S_CLIENT_ERROR"
+	ErrCodeMarshalError        ErrorCode = "MARSHAL_ERROR"
+	ErrCodeTimeout             ErrorCode = "TIMEOUT"
+	ErrCodeResourceHasParent   ErrorCode = "RESOURCE_HAS_PARENT"
+	ErrCodeNotWorkload         ErrorCode = "NOT_A_WORKLOAD"
+	ErrCodeSecretScanDenied    ErrorCode = "SECRET_SCAN_DENIED"
+	ErrCodeUnsupportedResource ErrorCode = "UNSUPPORTED_RESOURCE_KIND"
+)
+
+// ToolError is the structured JSON payload returned inside
+// mcp.NewToolResultError's text content.
+type ToolError struct {
+	Code    ErrorCode      `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// mcpToolError builds a *mcp.CallToolResult with IsError=true whose text
+// content is the JSON-encoded ToolError.
+func mcpToolError(code ErrorCode, message string, details map[string]any) *mcp.CallToolResult {
+	te := ToolError{Code: code, Message: message, Details: sanitizeDetails(details)}
+	b, err := json.Marshal(te)
+	if err != nil {
+		return mcp.NewToolResultError(message)
+	}
+	return mcp.NewToolResultError(string(b))
+}
+
+// sanitizeDetails returns a copy of details with only scalar values
+// (string, int, int32, int64, float32, float64, bool) and string slices. This prevents
+// leaking raw k8s objects, internal file paths, tokens, or deeply
+// nested structures into the tool result. Nil input returns nil.
+//
+// Rule of thumb for contributors: details should contain only identifiers
+// (argument, kind, name, namespace, resource_type, framework) and
+// enumerations (supported_kinds, supported_values). Never: raw error
+// stacks, file paths, auth tokens, k8s object dumps.
+func sanitizeDetails(details map[string]any) map[string]any {
+	if details == nil {
+		return nil
+	}
+	clean := make(map[string]any, len(details))
+	for k, v := range details {
+		switch val := v.(type) {
+		case string, int, int32, int64, float32, float64, bool:
+			clean[k] = val
+		case []string:
+			clean[k] = val
+		}
+	}
+	return clean
+}

--- a/cmd/mcpserver/mcperror_classify.go
+++ b/cmd/mcpserver/mcperror_classify.go
@@ -1,0 +1,87 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// classifyScanError maps a raw error from the scan pipeline to a
+// machine-readable ErrorCode. Uses only errors.Is and typed error
+// checks — no string matching.
+//
+// Ordering safety: sentinels are errors.New values (never
+// *apierrors.StatusError), so they cannot match apierrors.IsForbidden
+// or apierrors.IsNotFound. Conversely, apierrors checks only match
+// *apierrors.StatusError, which no sentinel wraps. The two groups are
+// type-disjoint, so no cross-matching is possible.
+func classifyScanError(err error) ErrorCode {
+	if err == nil {
+		return ""
+	}
+
+	switch {
+	case errors.Is(err, cautils.ErrInvalidWorkloadIdentifier):
+		return ErrCodeMalformedIdentifier
+
+	case errors.Is(err, resourcehandler.ErrResourceNotFound),
+		errors.Is(err, resourcehandler.ErrResourceNotInDiscovery):
+		return ErrCodeResourceNotFound
+	case errors.Is(err, resourcehandler.ErrAmbiguousResource):
+		return ErrCodeAmbiguousResource
+	case errors.Is(err, resourcehandler.ErrResourceHasParent):
+		return ErrCodeResourceHasParent
+	case errors.Is(err, resourcehandler.ErrNotWorkload):
+		return ErrCodeNotWorkload
+	case errors.Is(err, resourcehandler.ErrSecretScanDenied):
+		return ErrCodeSecretScanDenied
+
+	case apierrors.IsForbidden(err):
+		return ErrCodeRBACDenied
+	case apierrors.IsNotFound(err):
+		return ErrCodeResourceNotFound
+
+	case errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled):
+		return ErrCodeTimeout
+
+	default:
+		var statusErr *apierrors.StatusError
+		if errors.As(err, &statusErr) {
+			return ErrCodeK8sClientError
+		}
+		return ErrCodeScanFailed
+	}
+}
+
+// classifyScanErrorMessage returns a cause-specific human-readable
+// message prefix for a classified scan error. The caller appends
+// the original err.Error() for full context.
+func classifyScanErrorMessage(code ErrorCode, label string, err error) string {
+	switch code {
+	case ErrCodeMalformedIdentifier:
+		return fmt.Sprintf("invalid workload identifier: %v", err)
+	case ErrCodeResourceNotFound:
+		return fmt.Sprintf("resource not found: %v", err)
+	case ErrCodeAmbiguousResource:
+		return fmt.Sprintf("ambiguous resource match: %v", err)
+	case ErrCodeResourceHasParent:
+		return fmt.Sprintf("resource has a parent controller and cannot be scanned directly: %v", err)
+	case ErrCodeNotWorkload:
+		return fmt.Sprintf("resource is not a scannable workload: %v", err)
+	case ErrCodeSecretScanDenied:
+		return fmt.Sprintf("scanning Secret resources is not supported: %v", err)
+	case ErrCodeRBACDenied:
+		return fmt.Sprintf("insufficient permissions: %v", err)
+	case ErrCodeK8sClientError:
+		return fmt.Sprintf("kubernetes client error during %s scan: %v", label, err)
+	case ErrCodeTimeout:
+		return fmt.Sprintf("%s scan timed out: %v", label, err)
+	default:
+		return fmt.Sprintf("failed to run %s scan: %v", label, err)
+	}
+}

--- a/cmd/mcpserver/mcperror_test.go
+++ b/cmd/mcpserver/mcperror_test.go
@@ -1,0 +1,302 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestClassifyScanError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ErrorCode
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: "",
+		},
+		{
+			name:     "invalid workload identifier",
+			err:      fmt.Errorf("wrap: %w", cautils.ErrInvalidWorkloadIdentifier),
+			expected: ErrCodeMalformedIdentifier,
+		},
+		{
+			name:     "resource not found sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrResourceNotFound),
+			expected: ErrCodeResourceNotFound,
+		},
+		{
+			name:     "resource not in discovery sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrResourceNotInDiscovery),
+			expected: ErrCodeResourceNotFound,
+		},
+		{
+			name:     "ambiguous resource sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrAmbiguousResource),
+			expected: ErrCodeAmbiguousResource,
+		},
+		{
+			name:     "resource has parent sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrResourceHasParent),
+			expected: ErrCodeResourceHasParent,
+		},
+		{
+			name:     "not workload sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrNotWorkload),
+			expected: ErrCodeNotWorkload,
+		},
+		{
+			name:     "secret scan denied sentinel",
+			err:      fmt.Errorf("wrap: %w", resourcehandler.ErrSecretScanDenied),
+			expected: ErrCodeSecretScanDenied,
+		},
+		{
+			name:     "apierrors forbidden",
+			err:      apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "nginx", errors.New("forbidden")),
+			expected: ErrCodeRBACDenied,
+		},
+		{
+			name:     "apierrors not found",
+			err:      apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "nginx"),
+			expected: ErrCodeResourceNotFound,
+		},
+		{
+			name:     "apierrors unauthorized maps to k8s client error",
+			err:      apierrors.NewUnauthorized("unauthorized"),
+			expected: ErrCodeK8sClientError,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: ErrCodeTimeout,
+		},
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: ErrCodeTimeout,
+		},
+		{
+			name:     "generic unknown error",
+			err:      errors.New("something totally unknown"),
+			expected: ErrCodeScanFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := classifyScanError(tt.err)
+			assert.Equal(t, tt.expected, code)
+		})
+	}
+}
+
+func TestClassifyScanError_IntegrationWithResourceHandler(t *testing.T) {
+	sentinelMappings := []struct {
+		sentinel error
+		expected ErrorCode
+	}{
+		{resourcehandler.ErrResourceNotFound, ErrCodeResourceNotFound},
+		{resourcehandler.ErrResourceNotInDiscovery, ErrCodeResourceNotFound},
+		{resourcehandler.ErrAmbiguousResource, ErrCodeAmbiguousResource},
+		{resourcehandler.ErrResourceHasParent, ErrCodeResourceHasParent},
+		{resourcehandler.ErrNotWorkload, ErrCodeNotWorkload},
+		{resourcehandler.ErrSecretScanDenied, ErrCodeSecretScanDenied},
+	}
+
+	for _, sm := range sentinelMappings {
+		t.Run(string(sm.expected), func(t *testing.T) {
+			wrapped := fmt.Errorf("failed to pull resource: %w", sm.sentinel)
+			code := classifyScanError(wrapped)
+			assert.Equal(t, sm.expected, code)
+		})
+	}
+}
+
+func TestClassifyScanErrorMessage(t *testing.T) {
+	err := errors.New("detailed root cause")
+	tests := []struct {
+		code     ErrorCode
+		label    string
+		contains []string
+	}{
+		{ErrCodeMalformedIdentifier, "workload", []string{"invalid workload identifier", "detailed root cause"}},
+		{ErrCodeResourceNotFound, "workload", []string{"resource not found", "detailed root cause"}},
+		{ErrCodeAmbiguousResource, "workload", []string{"ambiguous resource match", "detailed root cause"}},
+		{ErrCodeResourceHasParent, "workload", []string{"parent controller", "detailed root cause"}},
+		{ErrCodeNotWorkload, "workload", []string{"not a scannable workload", "detailed root cause"}},
+		{ErrCodeSecretScanDenied, "workload", []string{"Secret resources is not supported", "detailed root cause"}},
+		{ErrCodeRBACDenied, "workload", []string{"insufficient permissions", "detailed root cause"}},
+		{ErrCodeK8sClientError, "workload", []string{"kubernetes client error during workload scan", "detailed root cause"}},
+		{ErrCodeTimeout, "workload", []string{"workload scan timed out", "detailed root cause"}},
+		{ErrCodeScanFailed, "workload", []string{"failed to run workload scan", "detailed root cause"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			msg := classifyScanErrorMessage(tt.code, tt.label, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, msg, substr)
+			}
+		})
+	}
+}
+
+func TestMcpToolError(t *testing.T) {
+	result := mcpToolError(ErrCodeInvalidArgument, "invalid input", map[string]any{
+		"argument": "path",
+	})
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	require.Len(t, result.Content, 1)
+
+	var payload ToolError
+	text := result.Content[0].(mcp.TextContent).Text
+	err := json.Unmarshal([]byte(text), &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, ErrCodeInvalidArgument, payload.Code)
+	assert.Equal(t, "invalid input", payload.Message)
+	assert.Equal(t, "path", payload.Details["argument"])
+}
+
+func TestSanitizeDetails(t *testing.T) {
+	assert.Nil(t, sanitizeDetails(nil))
+
+	input := map[string]any{
+		"str":       "valid",
+		"integer":   42,
+		"int64":     int64(100),
+		"float":     3.14,
+		"boolean":   true,
+		"str_slice": []string{"a", "b"},
+		// The following unsafe types should be dropped:
+		"byte_slice": []byte("secrets"),
+		"map":        map[string]string{"foo": "bar"},
+		"struct":     struct{ X string }{X: "leak"},
+	}
+
+	sanitized := sanitizeDetails(input)
+	assert.Equal(t, "valid", sanitized["str"])
+	assert.Equal(t, 42, sanitized["integer"])
+	assert.Equal(t, int64(100), sanitized["int64"])
+	assert.Equal(t, 3.14, sanitized["float"])
+	assert.Equal(t, true, sanitized["boolean"])
+	assert.Equal(t, []string{"a", "b"}, sanitized["str_slice"])
+
+	assert.NotContains(t, sanitized, "byte_slice")
+	assert.NotContains(t, sanitized, "map")
+	assert.NotContains(t, sanitized, "struct")
+}
+
+func TestMcpRequiredStringArg(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		param     string
+		wantVal   string
+		wantErr   bool
+	}{
+		{
+			name:      "valid string",
+			arguments: map[string]any{"target": "  nginx  "},
+			param:     "target",
+			wantVal:   "nginx",
+			wantErr:   false,
+		},
+		{
+			name:      "missing parameter",
+			arguments: map[string]any{},
+			param:     "target",
+			wantVal:   "",
+			wantErr:   true,
+		},
+		{
+			name:      "null parameter",
+			arguments: map[string]any{"target": nil},
+			param:     "target",
+			wantVal:   "",
+			wantErr:   true,
+		},
+		{
+			name:      "empty string",
+			arguments: map[string]any{"target": "   "},
+			param:     "target",
+			wantVal:   "",
+			wantErr:   true,
+		},
+		{
+			name:      "non-string value",
+			arguments: map[string]any{"target": 12345},
+			param:     "target",
+			wantVal:   "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, toolErr := mcpRequiredStringArg(tt.arguments, tt.param)
+			if tt.wantErr {
+				assert.NotNil(t, toolErr)
+				assert.True(t, toolErr.IsError)
+				assert.Empty(t, val)
+			} else {
+				assert.Nil(t, toolErr)
+				assert.Equal(t, tt.wantVal, val)
+			}
+		})
+	}
+}
+
+func TestErrorCodes_AllReferenced(t *testing.T) {
+	allCodes := []string{
+		"ErrCodeMalformedIdentifier",
+		"ErrCodeResourceNotFound",
+		"ErrCodeAmbiguousResource",
+		"ErrCodeRBACDenied",
+		"ErrCodeInvalidArgument",
+		"ErrCodeScanFailed",
+		"ErrCodeK8sClientError",
+		"ErrCodeMarshalError",
+		"ErrCodeTimeout",
+		"ErrCodeResourceHasParent",
+		"ErrCodeNotWorkload",
+		"ErrCodeSecretScanDenied",
+		"ErrCodeUnsupportedResource",
+	}
+
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	var combinedSource strings.Builder
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") || file == "mcperror.go" {
+			continue
+		}
+		content, err := os.ReadFile(file)
+		require.NoError(t, err)
+		combinedSource.Write(content)
+		combinedSource.WriteString("\n")
+	}
+
+	sourceText := combinedSource.String()
+	for _, code := range allCodes {
+		assert.True(t, strings.Contains(sourceText, code),
+			"ErrorCode constant %s must be referenced in at least one non-test source file outside mcperror.go", code)
+	}
+}

--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -80,6 +80,10 @@ func mcpScanNamespace(arguments map[string]any) (string, error) {
 // null for an optional parameter they are not setting, and refusing the whole
 // call because an unset argument was spelled null rather than omitted would be
 // hostile to exactly the callers these optional arguments exist for.
+//
+// Note: for required arguments, use mcpRequiredStringArg instead. mcpStringArg
+// returns ("", nil) when an argument is missing or null, which requires manual
+// empty-string validation and is prone to omission bugs.
 func mcpStringArg(arguments map[string]any, name string) (string, *mcp.CallToolResult) {
 	raw, ok := arguments[name]
 	if !ok || raw == nil {
@@ -87,9 +91,27 @@ func mcpStringArg(arguments map[string]any, name string) (string, *mcp.CallToolR
 	}
 	s, ok := raw.(string)
 	if !ok {
-		return "", mcp.NewToolResultError(fmt.Sprintf("%s argument must be a string", name))
+		return "", mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("%s argument must be a string", name), map[string]any{"argument": name})
 	}
 	return strings.TrimSpace(s), nil
+}
+
+// mcpRequiredStringArg reads a required string tool argument. Returns a
+// structured INVALID_ARGUMENT error if the argument is absent, null,
+// non-string, or empty after trimming. This eliminates the footgun where
+// a caller of mcpStringArg forgets to check for empty string after a nil
+// toolErr return.
+func mcpRequiredStringArg(arguments map[string]any, name string) (string, *mcp.CallToolResult) {
+	s, toolErr := mcpStringArg(arguments, name)
+	if toolErr != nil {
+		return "", toolErr
+	}
+	if s == "" {
+		return "", mcpToolError(ErrCodeInvalidArgument,
+			fmt.Sprintf("%s argument is required and cannot be empty", name),
+			map[string]any{"argument": name})
+	}
+	return s, nil
 }
 
 // jsonMarshal is a package-level var so tests can inject marshal failures.
@@ -259,14 +281,16 @@ func (ksServer *KubescapeMcpserver) toolHandler(name string) server.ToolHandlerF
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args, ok := request.Params.Arguments.(map[string]any)
 		if !ok && request.Params.Arguments != nil {
-			return mcp.NewToolResultError("arguments must be a JSON object"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "arguments must be a JSON object", nil), nil
 		}
 		if args == nil {
 			args = map[string]any{}
 		}
 		res, err := ksServer.CallTool(ctx, name, args)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, name, err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		return res, nil
 	}
@@ -492,7 +516,7 @@ func parseVulnManifestURI(uri string) (*vulnManifestURI, error) {
 // wrong type, or yields no valid IDs after trimming.
 func parseControlIDs(raw any, present bool) ([]string, *mcp.CallToolResult) {
 	if !present {
-		return nil, mcp.NewToolResultError("control_ids argument is required")
+		return nil, mcpToolError(ErrCodeInvalidArgument, "control_ids argument is required", map[string]any{"argument": "control_ids"})
 	}
 	var ids []string
 	switch v := raw.(type) {
@@ -506,17 +530,17 @@ func parseControlIDs(raw any, present bool) ([]string, *mcp.CallToolResult) {
 		for _, item := range v {
 			s, ok := item.(string)
 			if !ok {
-				return nil, mcp.NewToolResultError("control_ids array elements must be strings")
+				return nil, mcpToolError(ErrCodeInvalidArgument, "control_ids array elements must be strings", map[string]any{"argument": "control_ids"})
 			}
 			if s = strings.TrimSpace(s); s != "" {
 				ids = append(ids, s)
 			}
 		}
 	default:
-		return nil, mcp.NewToolResultError("control_ids must be a comma-separated string or array")
+		return nil, mcpToolError(ErrCodeInvalidArgument, "control_ids must be a comma-separated string or array", map[string]any{"argument": "control_ids"})
 	}
 	if len(ids) == 0 {
-		return nil, mcp.NewToolResultError("control_ids must contain at least one control ID")
+		return nil, mcpToolError(ErrCodeInvalidArgument, "control_ids must contain at least one control ID", map[string]any{"argument": "control_ids"})
 	}
 	return ids, nil
 }
@@ -655,36 +679,27 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 	case "run_rbac_security_scan":
 		namespace, err := mcpScanNamespace(arguments)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return mcpToolError(ErrCodeInvalidArgument, err.Error(), map[string]any{"argument": "namespace"}), nil
 		}
 		key := fmt.Sprintf("rbac_scan:%s", namespace)
 		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
 			return rbacScanFn(ksServer, scanCtx, namespace)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run RBAC scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "RBAC", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
 	case "scan_local_iac":
-		path := ""
-		if p, ok := arguments["path"]; ok {
-			pStr, ok := p.(string)
-			if !ok {
-				return mcp.NewToolResultError("path argument must be a string"), nil
-			}
-			path = strings.TrimSpace(pStr)
+		path, toolErr := mcpRequiredStringArg(arguments, "path")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		if path == "" {
-			return mcp.NewToolResultError("path argument is required and cannot be empty"), nil
-		}
-		framework := ""
-		if fw, ok := arguments["framework"]; ok {
-			fwStr, ok := fw.(string)
-			if !ok {
-				return mcp.NewToolResultError("framework argument must be a string"), nil
-			}
-			framework = strings.TrimSpace(fwStr)
+		framework, toolErr := mcpStringArg(arguments, "framework")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 
 		key := fmt.Sprintf("scan_local_iac:%s:%s", url.QueryEscape(path), url.QueryEscape(framework))
@@ -692,21 +707,16 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return ksServer.runIaCScan(scanCtx, path, framework)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run IaC scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "IaC", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
 	case "scan_local_iac_controls":
-		path := ""
-		if p, ok := arguments["path"]; ok {
-			pStr, ok := p.(string)
-			if !ok {
-				return mcp.NewToolResultError("path argument must be a string"), nil
-			}
-			path = strings.TrimSpace(pStr)
-		}
-		if path == "" {
-			return mcp.NewToolResultError("path argument is required and cannot be empty"), nil
+		path, toolErr := mcpRequiredStringArg(arguments, "path")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 		rawControlIDs, hasControlIDs := arguments["control_ids"]
 		controlIDs, toolErr := parseControlIDs(rawControlIDs, hasControlIDs)
@@ -718,20 +728,15 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return ksServer.runIaCScanControls(scanCtx, path, controlIDs)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run IaC control scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "IaC control", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "apply_remediation":
-		path := ""
-		if p, ok := arguments["path"]; ok {
-			pStr, ok := p.(string)
-			if !ok {
-				return mcp.NewToolResultError("path argument must be a string"), nil
-			}
-			path = strings.TrimSpace(pStr)
-		}
-		if path == "" {
-			return mcp.NewToolResultError("path argument is required and cannot be empty"), nil
+		path, toolErr := mcpRequiredStringArg(arguments, "path")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 		rawControlIDs, hasControlIDs := arguments["control_ids"]
 		controlIDs, toolErr := parseControlIDs(rawControlIDs, hasControlIDs)
@@ -743,20 +748,24 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return ksServer.runApplyRemediation(scanCtx, path, controlIDs)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to compute remediation: %v", err)), nil
+			code := classifyScanError(err)
+			msg := fmt.Sprintf("failed to compute remediation: %v", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "run_network_security_scan":
 		namespace, err := mcpScanNamespace(arguments)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return mcpToolError(ErrCodeInvalidArgument, err.Error(), map[string]any{"argument": "namespace"}), nil
 		}
 		key := fmt.Sprintf("network_scan:%s", namespace)
 		v, err := ksServer.doScanChan(ctx, key, func(scanCtx context.Context) (interface{}, error) {
 			return networkScanFn(ksServer, scanCtx, namespace)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run Network scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "Network", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
@@ -1146,53 +1155,40 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			},
 		}, nil
 	case "get_configuration_drift":
-		namespace, ok := arguments["namespace"]
-		if !ok {
-			namespace = "default"
+		namespaceStr, toolErr := mcpStringArg(arguments, "namespace")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		namespaceStr, ok := namespace.(string)
-		if !ok {
-			return mcp.NewToolResultError("namespace must be a string"), nil
+		if namespaceStr == "" {
+			namespaceStr = "default"
 		}
-		profileName, ok := arguments["profile_name"]
-		if !ok {
-			return mcp.NewToolResultError("profile_name is required"), nil
+		profileNameStr, toolErr := mcpRequiredStringArg(arguments, "profile_name")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		profileNameStr, ok := profileName.(string)
-		if !ok {
-			return mcp.NewToolResultError("profile_name must be a string"), nil
+		workloadNameStr, toolErr := mcpRequiredStringArg(arguments, "workload_name")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		workloadName, ok := arguments["workload_name"]
-		if !ok {
-			return mcp.NewToolResultError("workload_name is required"), nil
-		}
-		workloadNameStr, ok := workloadName.(string)
-		if !ok {
-			return mcp.NewToolResultError("workload_name must be a string"), nil
-		}
-		workloadKind, ok := arguments["workload_kind"]
-		if !ok {
-			return mcp.NewToolResultError("workload_kind is required"), nil
-		}
-		workloadKindStr, ok := workloadKind.(string)
-		if !ok {
-			return mcp.NewToolResultError("workload_kind must be a string"), nil
+		workloadKindStr, toolErr := mcpRequiredStringArg(arguments, "workload_kind")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 
 		ksClient, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to storage client: %v", ksErr)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to connect to storage client: %v", ksErr), nil), nil
 		}
 		profile, err := ksClient.ContainerProfiles(namespaceStr).Get(ctx, profileNameStr, metav1.GetOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get container profile: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to get container profile: %v", err), nil), nil
 		}
 
 		var rawManifest []byte
 		var workloadObj any
 		k8sClient, k8sErr := ksServer.getK8sClient()
 		if k8sErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubernetes cluster: %v", k8sErr)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to connect to Kubernetes cluster: %v", k8sErr), nil), nil
 		}
 		switch strings.ToLower(workloadKindStr) {
 		case "pod":
@@ -1210,15 +1206,15 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		case "cronjob":
 			workloadObj, err = k8sClient.KubernetesClient.BatchV1().CronJobs(namespaceStr).Get(ctx, workloadNameStr, metav1.GetOptions{})
 		default:
-			return mcp.NewToolResultError(fmt.Sprintf("unsupported workload kind: %s", workloadKindStr)), nil
+			return mcpToolError(ErrCodeUnsupportedResource, fmt.Sprintf("unsupported workload kind: %s", workloadKindStr), map[string]any{"kind": workloadKindStr}), nil
 		}
 
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get workload manifest: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to get workload manifest: %v", err), nil), nil
 		}
 		rawManifest, err = jsonMarshal(workloadObj)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal workload manifest: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal workload manifest: %v", err), nil), nil
 		}
 
 		containerName := ""
@@ -1228,16 +1224,16 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			profileName := profile.GetLabels()["kubescape.io/workload-name"]
 
 			if profileKind != "" && !strings.EqualFold(profileKind, workloadKindStr) {
-				return mcp.NewToolResultError(fmt.Sprintf("profile workload kind mismatch: expected %s, got %s", workloadKindStr, profileKind)), nil
+				return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("profile workload kind mismatch: expected %s, got %s", workloadKindStr, profileKind), map[string]any{"expected_kind": workloadKindStr, "got_kind": profileKind}), nil
 			}
 			if profileName != "" && profileName != workloadNameStr {
-				return mcp.NewToolResultError(fmt.Sprintf("profile workload name mismatch: expected %s, got %s", workloadNameStr, profileName)), nil
+				return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("profile workload name mismatch: expected %s, got %s", workloadNameStr, profileName), map[string]any{"expected_name": workloadNameStr, "got_name": profileName}), nil
 			}
 		}
 		fixes := fixhandler.DetectProfileDrift(rawManifest, profile, workloadKindStr, containerName, 0)
 		fixesJson, err := json.MarshalIndent(fixes, "", "  ")
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal drift result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal drift result: %v", err), nil), nil
 		}
 
 		return &mcp.CallToolResult{
@@ -1251,19 +1247,11 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 	case "run_framework_security_scan":
 		namespace, err := mcpScanNamespace(arguments)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return mcpToolError(ErrCodeInvalidArgument, err.Error(), map[string]any{"argument": "namespace"}), nil
 		}
-		frameworkName, ok := arguments["framework_name"]
-		if !ok {
-			return mcp.NewToolResultError("framework_name argument is required"), nil
-		}
-		frameworkNameStr, ok := frameworkName.(string)
-		if !ok {
-			return mcp.NewToolResultError("framework_name argument must be a string"), nil
-		}
-		frameworkNameStr = strings.TrimSpace(frameworkNameStr)
-		if frameworkNameStr == "" {
-			return mcp.NewToolResultError("framework_name argument must not be empty"), nil
+		frameworkNameStr, toolErr := mcpRequiredStringArg(arguments, "framework_name")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 		if namespace == "*" {
 			namespace = ""
@@ -1273,18 +1261,16 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return frameworkScanFn(ksServer, scanCtx, namespace, frameworkNameStr)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run framework scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "framework", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		responseBytes := v.([]byte)
 		return mcp.NewToolResultText(string(responseBytes)), nil
 	case "scan_controls":
-		namespace := ""
-		if ns, ok := arguments["namespace"]; ok {
-			nsStr, ok := ns.(string)
-			if !ok {
-				return mcp.NewToolResultError("namespace argument must be a string"), nil
-			}
-			namespace = nsStr
+		namespace, toolErr := mcpStringArg(arguments, "namespace")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 		if namespace == "*" {
 			namespace = ""
@@ -1299,16 +1285,15 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return ksServer.ScanControls(scanCtx, namespace, controlIDs)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run control scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "control", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "scan_workload":
-		workload, toolErr := mcpStringArg(arguments, "workload")
+		workload, toolErr := mcpRequiredStringArg(arguments, "workload")
 		if toolErr != nil {
 			return toolErr, nil
-		}
-		if workload == "" {
-			return mcp.NewToolResultError("workload argument is required and cannot be empty"), nil
 		}
 		// Read namespace with mcpStringArg rather than mcpScanNamespace: this
 		// tool has a second source of namespace (the workload identifier), so it
@@ -1336,19 +1321,21 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 			return workloadScanFn(ksServer, scanCtx, workload, namespace, path, framework)
 		})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to run workload scan: %v", err)), nil
+			code := classifyScanError(err)
+			msg := classifyScanErrorMessage(code, "workload", err)
+			return mcpToolError(code, msg, nil), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "list_frameworks":
 		result, err := ksServer.ListFrameworks(ctx)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list frameworks: %v", err)), nil
+			return mcpToolError(ErrCodeScanFailed, fmt.Sprintf("failed to list frameworks: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(result)), nil
 	case "list_controls":
 		result, err := ksServer.ListControls(ctx)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list controls: %v", err)), nil
+			return mcpToolError(ErrCodeScanFailed, fmt.Sprintf("failed to list controls: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(result)), nil
 	default:
@@ -1401,7 +1388,8 @@ func mcpServerEntrypoint(transport string, port int) error {
 	createAdvancedTools(ksServer)
 
 	// Start the server
-	if transport == "sse" {
+	switch transport {
+	case "sse":
 		sseServer := server.NewSSEServer(s)
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 		logger.L().Info("Starting SSE server", helpers.String("addr", addr))
@@ -1409,12 +1397,12 @@ func mcpServerEntrypoint(transport string, port int) error {
 			return fmt.Errorf("sse server error: %w", err)
 		}
 		return nil
-	} else if transport == "stdio" {
+	case "stdio":
 		if err := server.ServeStdio(s); err != nil {
 			return fmt.Errorf("server error: %w", err)
 		}
 		return nil
-	} else {
+	default:
 		return fmt.Errorf("unsupported transport '%s': must be 'sse' or 'stdio'", transport)
 	}
 }

--- a/cmd/mcpserver/mcpserver_arguments_test.go
+++ b/cmd/mcpserver/mcpserver_arguments_test.go
@@ -40,7 +40,10 @@ func TestRegisteredStorageToolsRejectMalformedArguments(t *testing.T) {
 				t.Run(tt.name, func(t *testing.T) {
 					result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, tool, tt.arguments))
 					assert.True(t, result.IsError)
-					assert.Equal(t, "arguments must be a JSON object", toolResultText(t, result))
+					var toolErr ToolError
+					require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
+					assert.Equal(t, ErrCodeInvalidArgument, toolErr.Code)
+					assert.Equal(t, "arguments must be a JSON object", toolErr.Message)
 				})
 			}
 		})

--- a/cmd/mcpserver/mcpserver_test.go
+++ b/cmd/mcpserver/mcpserver_test.go
@@ -284,14 +284,14 @@ func TestCallTool_RunFrameworkScan(t *testing.T) {
 			arguments: map[string]any{
 				"framework_name": "",
 			},
-			wantErrString: "framework_name argument must not be empty",
+			wantErrString: "framework_name argument is required and cannot be empty",
 		},
 		{
 			name: "whitespace framework_name",
 			arguments: map[string]any{
 				"framework_name": "   ",
 			},
-			wantErrString: "framework_name argument must not be empty",
+			wantErrString: "framework_name argument is required and cannot be empty",
 		},
 		{
 			name: "allcontrols framework_name rejected (case-insensitive)",

--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -298,3 +298,25 @@ func TestGetConfigurationDrift_SupportsAllWorkloadKinds(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConfigurationDrift_WhitespaceArgumentsRejected(t *testing.T) {
+	ksServer := &KubescapeMcpserver{}
+	requiredArgs := []string{"profile_name", "workload_name", "workload_kind"}
+	for _, arg := range requiredArgs {
+		t.Run(arg, func(t *testing.T) {
+			args := map[string]any{
+				"profile_name":  "test-profile",
+				"workload_name": "test-workload",
+				"workload_kind": "pod",
+			}
+			args[arg] = "   "
+			result, err := ksServer.CallTool(context.Background(), "get_configuration_drift", args)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.IsError)
+			var toolErr ToolError
+			require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
+			assert.Equal(t, ErrCodeInvalidArgument, toolErr.Code)
+		})
+	}
+}

--- a/cmd/mcpserver/mutating_policy_impact.go
+++ b/cmd/mcpserver/mutating_policy_impact.go
@@ -52,15 +52,15 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 
 		name, ok := args["name"].(string)
 		if !ok || name == "" {
-			return mcp.NewToolResultError("name is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "name is required", map[string]any{"argument": "name"}), nil
 		}
 		apiVersion, ok := args["api_version"].(string)
 		if !ok || apiVersion == "" {
-			return mcp.NewToolResultError("api_version is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "api_version is required", map[string]any{"argument": "api_version"}), nil
 		}
 		resource, ok := args["resource"].(string)
 		if !ok || resource == "" {
-			return mcp.NewToolResultError("resource is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "resource is required", map[string]any{"argument": "resource"}), nil
 		}
 		apiGroup, _ := args["api_group"].(string)
 		namespace, _ := args["namespace"].(string)
@@ -71,10 +71,10 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		// read as "nothing mutates this".
 		subresource, subresourceErr := optionalStringArg(args, "subresource")
 		if subresourceErr != nil {
-			return mcp.NewToolResultError(subresourceErr.Error()), nil
+			return mcpToolError(ErrCodeInvalidArgument, subresourceErr.Error(), map[string]any{"argument": "subresource"}), nil
 		}
 		if strings.Contains(subresource, "/") {
-			return mcp.NewToolResultError(fmt.Sprintf("subresource must name one subresource without the parent resource (got %q, want e.g. %q)", subresource, "status")), nil
+			return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("subresource must name one subresource without the parent resource (got %q, want e.g. %q)", subresource, "status"), map[string]any{"argument": "subresource"}), nil
 		}
 
 		// A Namespace object is itself cluster-scoped ("Namespace API
@@ -87,7 +87,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 		effectiveClusterScoped := clusterScoped || isNamespaceResource
 
 		if !effectiveClusterScoped && namespace == "" {
-			return mcp.NewToolResultError("namespace is required unless cluster_scoped is true"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "namespace is required unless cluster_scoped is true", map[string]any{"argument": "namespace"}), nil
 		}
 
 		operation := admissionregistrationv1alpha1.Create
@@ -95,14 +95,14 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 			normalized := strings.ToUpper(rawOp)
 			op, known := mutatingAdmissionPolicyOperations[normalized]
 			if !known {
-				return mcp.NewToolResultError(fmt.Sprintf("operation must be one of CREATE, UPDATE, CONNECT (got %q)", rawOp)), nil
+				return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("operation must be one of CREATE, UPDATE, CONNECT (got %q)", rawOp), map[string]any{"argument": "operation", "supported_values": []string{"CREATE", "UPDATE", "CONNECT"}}), nil
 			}
 			operation = op
 		}
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 
 		policies, bindings, decodeErrs, err := mapreconcile.Collect(ctx, k8sClient)
@@ -110,7 +110,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 			if errors.Is(err, mapreconcile.ErrUnsupported) {
 				return mcp.NewToolResultText(`{"supported":false,"reason":"cluster does not serve MutatingAdmissionPolicy resources"}`), nil
 			}
-			return mcp.NewToolResultError(fmt.Sprintf("failed to collect MutatingAdmissionPolicy resources: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to collect MutatingAdmissionPolicy resources: %v", err), nil), nil
 		}
 
 		gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resource}
@@ -125,7 +125,12 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 			obj, getErr = resourceInterface.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 		}
 		if getErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get resource %s/%s (%s): %v", namespace, name, gvr.String(), getErr)), nil
+			if apierrors.IsNotFound(getErr) {
+				// ErrCodeResourceNotFound: the requested target object does not exist in the cluster.
+				// Semantics align with classifyScanError: agent recovery action is to verify kind/name/ns.
+				return mcpToolError(ErrCodeResourceNotFound, fmt.Sprintf("resource %s/%s (%s) not found: %v", namespace, name, gvr.String(), getErr), map[string]any{"resource_type": resource, "namespace": namespace, "name": name}), nil
+			}
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get resource %s/%s (%s): %v", namespace, name, gvr.String(), getErr), map[string]any{"resource_type": resource, "namespace": namespace, "name": name}), nil
 		}
 
 		info := mapreconcile.ObjectInfo{
@@ -147,7 +152,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 				info.NamespaceLabels = nsObj.GetLabels()
 				info.NamespaceLabelsKnown = true
 			} else if !apierrors.IsNotFound(nsErr) {
-				return mcp.NewToolResultError(fmt.Sprintf("failed to get namespace %s: %v", namespace, nsErr)), nil
+				return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get namespace %s: %v", namespace, nsErr), map[string]any{"namespace": namespace}), nil
 			}
 		}
 
@@ -169,7 +174,7 @@ func createMutatingAdmissionPolicyTools(ksServer *KubescapeMcpserver) {
 
 		resBytes, err := json.Marshal(result)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal result: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})

--- a/cmd/mcpserver/network_reachability.go
+++ b/cmd/mcpserver/network_reachability.go
@@ -41,37 +41,39 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 			args = map[string]any{}
 		}
 
-		srcNS, ok := args["source_namespace"].(string)
-		if !ok || srcNS == "" {
-			return mcp.NewToolResultError("source_namespace is required"), nil
+		srcNS, toolErr := mcpRequiredStringArg(args, "source_namespace")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		srcName, ok := args["source_pod"].(string)
-		if !ok || srcName == "" {
-			return mcp.NewToolResultError("source_pod is required"), nil
+		srcName, toolErr := mcpRequiredStringArg(args, "source_pod")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		dstNS, ok := args["destination_namespace"].(string)
-		if !ok || dstNS == "" {
-			return mcp.NewToolResultError("destination_namespace is required"), nil
+		dstNS, toolErr := mcpRequiredStringArg(args, "destination_namespace")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		dstName, ok := args["destination_pod"].(string)
-		if !ok || dstName == "" {
-			return mcp.NewToolResultError("destination_pod is required"), nil
+		dstName, toolErr := mcpRequiredStringArg(args, "destination_pod")
+		if toolErr != nil {
+			return toolErr, nil
 		}
 
 		var port *networkpolicy.PortSpec
 		if raw, ok := args["port"]; ok {
 			f, ok := raw.(float64)
 			if !ok || f <= 0 || f > 65535 || f != float64(int64(f)) {
-				return mcp.NewToolResultError("port must be a positive integer between 1 and 65535"), nil
+				return mcpToolError(ErrCodeInvalidArgument, "port must be a positive integer between 1 and 65535", map[string]any{"argument": "port"}), nil
 			}
 			proto := corev1.ProtocolTCP
-			if rawProto, ok := args["protocol"].(string); ok && rawProto != "" {
+			if rawProto, toolErr := mcpStringArg(args, "protocol"); toolErr != nil {
+				return toolErr, nil
+			} else if rawProto != "" {
 				normalized := corev1.Protocol(strings.ToUpper(rawProto))
 				switch normalized {
 				case corev1.ProtocolTCP, corev1.ProtocolUDP, corev1.ProtocolSCTP:
 					proto = normalized
 				default:
-					return mcp.NewToolResultError(fmt.Sprintf("protocol must be one of TCP, UDP, SCTP (got %q)", rawProto)), nil
+					return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("protocol must be one of TCP, UDP, SCTP (got %q)", rawProto), map[string]any{"argument": "protocol", "supported_values": []string{"TCP", "UDP", "SCTP"}}), nil
 				}
 			}
 			port = &networkpolicy.PortSpec{Protocol: proto, Port: int32(f)}
@@ -79,25 +81,25 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 		dynClient := k8sClient.DynamicClient
 
 		policyList, err := dynClient.Resource(networkPolicyGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list NetworkPolicy objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list NetworkPolicy objects: %v", err), map[string]any{"resource_type": "NetworkPolicy"}), nil
 		}
 		namespaceList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list Namespace objects: %v", err), map[string]any{"resource_type": "Namespace"}), nil
 		}
 		srcPodObj, err := dynClient.Resource(podGVR).Namespace(srcNS).Get(ctx, srcName, metav1.GetOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get source pod %s/%s: %v", srcNS, srcName, err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to get source pod %s/%s: %v", srcNS, srcName, err), map[string]any{"resource_type": "Pod", "namespace": srcNS, "name": srcName}), nil
 		}
 		dstPodObj, err := dynClient.Resource(podGVR).Namespace(dstNS).Get(ctx, dstName, metav1.GetOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get destination pod %s/%s: %v", dstNS, dstName, err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to get destination pod %s/%s: %v", dstNS, dstName, err), map[string]any{"resource_type": "Pod", "namespace": dstNS, "name": dstName}), nil
 		}
 
 		resources := make(map[string]workloadinterface.IMetadata, len(policyList.Items)+len(namespaceList.Items))
@@ -159,7 +161,7 @@ func createNetworkReachabilityTools(ksServer *KubescapeMcpserver) {
 
 		resBytes, err := json.Marshal(result)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal result: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})

--- a/cmd/mcpserver/network_reachability_test.go
+++ b/cmd/mcpserver/network_reachability_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -274,4 +275,26 @@ func TestAnalyzeNetworkReachability_MalformedPodSelectorDowngradesVerdictToUnkno
 	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &parsed))
 	require.Equal(t, "unknown", parsed["verdict"], "a dropped, unparseable policy must downgrade the verdict, not silently report a confident allowed")
 	require.NotEmpty(t, parsed["decode_warnings"])
+}
+
+func TestAnalyzeNetworkReachability_WhitespaceArgumentsRejected(t *testing.T) {
+	ksServer := newReachabilityTestServer()
+
+	requiredArgs := []string{"source_namespace", "source_pod", "destination_namespace", "destination_pod"}
+	for _, arg := range requiredArgs {
+		t.Run(arg, func(t *testing.T) {
+			args := map[string]any{
+				"source_namespace":      "prod",
+				"source_pod":            "client",
+				"destination_namespace": "prod",
+				"destination_pod":       "server",
+			}
+			args[arg] = "   "
+			result := registeredToolResult(t, dispatchRegisteredTool(t, ksServer, "analyze_network_reachability", args))
+			require.True(t, result.IsError)
+			var toolErr ToolError
+			require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
+			assert.Equal(t, ErrCodeInvalidArgument, toolErr.Code)
+		})
+	}
 }

--- a/cmd/mcpserver/rbac_escalation.go
+++ b/cmd/mcpserver/rbac_escalation.go
@@ -52,7 +52,7 @@ func createRBACEscalationTools(ksServer *KubescapeMcpserver) {
 		subjectKindStr, _ := args["subject_kind"].(string)
 		name, ok := args["name"].(string)
 		if !ok || name == "" {
-			return mcp.NewToolResultError("name is required"), nil
+			return mcpToolError(ErrCodeInvalidArgument, "name is required", map[string]any{"argument": "name"}), nil
 		}
 		namespace, _ := args["namespace"].(string)
 
@@ -61,24 +61,24 @@ func createRBACEscalationTools(ksServer *KubescapeMcpserver) {
 		case string(rbacgraph.KindServiceAccount):
 			kind = rbacgraph.KindServiceAccount
 			if namespace == "" {
-				return mcp.NewToolResultError("namespace is required when subject_kind is ServiceAccount"), nil
+				return mcpToolError(ErrCodeInvalidArgument, "namespace is required when subject_kind is ServiceAccount", map[string]any{"argument": "namespace"}), nil
 			}
 		case string(rbacgraph.KindUser):
 			kind = rbacgraph.KindUser
 		case string(rbacgraph.KindGroup):
 			kind = rbacgraph.KindGroup
 		default:
-			return mcp.NewToolResultError(fmt.Sprintf("subject_kind must be one of ServiceAccount, User, Group; got %q", subjectKindStr)), nil
+			return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("subject_kind must be one of ServiceAccount, User, Group; got %q", subjectKindStr), map[string]any{"argument": "subject_kind", "supported_values": []string{"ServiceAccount", "User", "Group"}}), nil
 		}
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 
 		resources, err := listRBACResources(ctx, k8sClient.DynamicClient)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return mcpToolError(ErrCodeK8sClientError, err.Error(), nil), nil
 		}
 
 		roles, clusterRoles, roleBindings, clusterRoleBindings, serviceAccounts, decodeErrs := rbacgraph.FromResources(resources)
@@ -106,7 +106,7 @@ func createRBACEscalationTools(ksServer *KubescapeMcpserver) {
 
 		resBytes, err := json.Marshal(out)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal result: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})

--- a/cmd/mcpserver/service_exposure.go
+++ b/cmd/mcpserver/service_exposure.go
@@ -52,29 +52,32 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 			args = map[string]any{}
 		}
 
-		namespace, ok := args["namespace"].(string)
-		if !ok || namespace == "" {
-			return mcp.NewToolResultError("namespace is required"), nil
+		namespace, toolErr := mcpRequiredStringArg(args, "namespace")
+		if toolErr != nil {
+			return toolErr, nil
 		}
-		serviceName, _ := args["service_name"].(string)
+		serviceName, toolErr := mcpStringArg(args, "service_name")
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 		dynClient := k8sClient.DynamicClient
 
 		serviceList, err := dynClient.Resource(serviceGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Service objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list Service objects: %v", err), map[string]any{"resource_type": "Service"}), nil
 		}
 		ingressList, err := dynClient.Resource(ingressGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Ingress objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list Ingress objects: %v", err), map[string]any{"resource_type": "Ingress"}), nil
 		}
 		namespaceList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list Namespace objects: %v", err), map[string]any{"resource_type": "Namespace"}), nil
 		}
 
 		resources := make(map[string]workloadinterface.IMetadata, len(serviceList.Items)+len(ingressList.Items)+len(namespaceList.Items))
@@ -110,7 +113,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		gatewayResources := map[string]workloadinterface.IMetadata{}
 		routeList, routeErr := listGatewayKind(ctx, dynClient, httpRouteGVR, httpRouteGVRv1beta1)
 		if routeErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list HTTPRoute objects: %v", routeErr)), nil
+			return mcpToolError(classifyScanError(routeErr), fmt.Sprintf("failed to list HTTPRoute objects: %v", routeErr), map[string]any{"resource_type": "HTTPRoute"}), nil
 		}
 		for i := range routeList.Items {
 			w := workloadinterface.NewWorkloadObj(routeList.Items[i].Object)
@@ -118,7 +121,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		}
 		grpcRouteList, grpcRouteErr := listGatewayKind(ctx, dynClient, grpcRouteGVR, grpcRouteGVRv1alpha2)
 		if grpcRouteErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list GRPCRoute objects: %v", grpcRouteErr)), nil
+			return mcpToolError(classifyScanError(grpcRouteErr), fmt.Sprintf("failed to list GRPCRoute objects: %v", grpcRouteErr), map[string]any{"resource_type": "GRPCRoute"}), nil
 		}
 		for i := range grpcRouteList.Items {
 			w := workloadinterface.NewWorkloadObj(grpcRouteList.Items[i].Object)
@@ -133,7 +136,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 		// invisible to idx.routeAttachesToAGateway.
 		gwList, gwErr := listGatewayKind(ctx, dynClient, gatewayGVR, gatewayGVRv1beta1)
 		if gwErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Gateway objects: %v", gwErr)), nil
+			return mcpToolError(classifyScanError(gwErr), fmt.Sprintf("failed to list Gateway objects: %v", gwErr), map[string]any{"resource_type": "Gateway"}), nil
 		}
 		for i := range gwList.Items {
 			w := workloadinterface.NewWorkloadObj(gwList.Items[i].Object)
@@ -177,7 +180,7 @@ func createServiceExposureTools(ksServer *KubescapeMcpserver) {
 
 		resBytes, err := json.Marshal(result)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal result: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})

--- a/cmd/mcpserver/vulnerability_exposure.go
+++ b/cmd/mcpserver/vulnerability_exposure.go
@@ -53,29 +53,36 @@ func createVulnerabilityExposureTools(ksServer *KubescapeMcpserver) {
 			args = map[string]any{}
 		}
 
-		namespace, _ := args["namespace"].(string)
+		namespace, toolErr := mcpStringArg(args, "namespace")
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
 		minSeverity := vulnexposure.SeverityHigh
-		if raw, ok := args["min_severity"].(string); ok && raw != "" {
+		raw, toolErr := mcpStringArg(args, "min_severity")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		if raw != "" {
 			minSeverity = vulnexposure.ParseSeverity(raw)
 			if minSeverity == vulnexposure.SeverityUnknown {
-				return mcp.NewToolResultError(fmt.Sprintf("min_severity must be one of Critical, High, Medium, Low, Negligible (got %q)", raw)), nil
+				return mcpToolError(ErrCodeInvalidArgument, fmt.Sprintf("min_severity must be one of Critical, High, Medium, Low, Negligible (got %q)", raw), map[string]any{"argument": "min_severity", "supported_values": []string{"Critical", "High", "Medium", "Low", "Negligible"}}), nil
 			}
 		}
 
 		ksClient, ksErr := ksServer.getKsClient()
 		if ksErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to connect to Kubescape storage: %v", ksErr)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to connect to Kubescape storage: %v", ksErr), nil), nil
 		}
 		k8sClient, err := ksServer.getK8sClient()
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s client: %v", err)), nil
+			return mcpToolError(ErrCodeK8sClientError, fmt.Sprintf("failed to get k8s client: %v", err), nil), nil
 		}
 
 		listNamespace := namespace
 		manifests, err := ksClient.VulnerabilityManifests(listNamespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list VulnerabilityManifest objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list VulnerabilityManifest objects: %v", err), map[string]any{"resource_type": "VulnerabilityManifest"}), nil
 		}
 
 		vulnsByWorkload := make(map[vulnexposure.Workload][]storagev1beta1.Vulnerability)
@@ -107,11 +114,11 @@ func createVulnerabilityExposureTools(ksServer *KubescapeMcpserver) {
 		npGVR := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
 		npList, err := dynClient.Resource(npGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list NetworkPolicy objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list NetworkPolicy objects: %v", err), map[string]any{"resource_type": "NetworkPolicy"}), nil
 		}
 		nsList, err := dynClient.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to list Namespace objects: %v", err)), nil
+			return mcpToolError(classifyScanError(err), fmt.Sprintf("failed to list Namespace objects: %v", err), map[string]any{"resource_type": "Namespace"}), nil
 		}
 
 		resources := make(map[string]workloadinterface.IMetadata, len(npList.Items)+len(nsList.Items))
@@ -123,6 +130,7 @@ func createVulnerabilityExposureTools(ksServer *KubescapeMcpserver) {
 			w := workloadinterface.NewWorkloadObj(nsList.Items[i].Object)
 			resources[w.GetID()] = w
 		}
+
 		policies, namespaces, decodeErrs := networkpolicy.FromResources(resources)
 		idx, indexErrs := networkpolicy.NewIndex(policies, namespaces)
 
@@ -156,7 +164,7 @@ func createVulnerabilityExposureTools(ksServer *KubescapeMcpserver) {
 
 		resBytes, err := json.Marshal(result)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+			return mcpToolError(ErrCodeMarshalError, fmt.Sprintf("failed to marshal result: %v", err), nil), nil
 		}
 		return mcp.NewToolResultText(string(resBytes)), nil
 	})

--- a/cmd/mcpserver/workload_scan_test.go
+++ b/cmd/mcpserver/workload_scan_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/cautils/getter"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -355,6 +357,7 @@ func TestRunWorkloadScan_NotFoundInFile(t *testing.T) {
 	_, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/absent", "", "testdata/deployment.yaml", "nsa")
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "not found")
+	assert.True(t, errors.Is(err, resourcehandler.ErrResourceNotFound), "expected ErrResourceNotFound sentinel in error chain")
 }
 
 func TestRunWorkloadScan_AmbiguousInFile(t *testing.T) {
@@ -366,6 +369,7 @@ func TestRunWorkloadScan_AmbiguousInFile(t *testing.T) {
 	_, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "", "testdata/two-workloads.yaml", "nsa")
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "more than one")
+	assert.True(t, errors.Is(err, resourcehandler.ErrAmbiguousResource), "expected ErrAmbiguousResource sentinel in error chain")
 }
 
 func TestRunWorkloadScan_NamespaceDisambiguates(t *testing.T) {
@@ -525,12 +529,12 @@ func TestCallTool_ScanWorkload_ForwardsArguments(t *testing.T) {
 }
 
 // TestCallTool_ScanWorkload_ScanFailureIsToolError asserts a failing scan comes
-// back as a tool error the agent can read, not a transport-level Go error.
+// back as a structured tool error the agent can read, not a transport-level Go error.
 func TestCallTool_ScanWorkload_ScanFailureIsToolError(t *testing.T) {
 	orig := workloadScanFn
 	t.Cleanup(func() { workloadScanFn = orig })
 	workloadScanFn = func(_ *KubescapeMcpserver, _ context.Context, _, _, _, _ string) ([]byte, error) {
-		return nil, errors.New("resource nginx was not found")
+		return nil, fmt.Errorf("resource nginx was not found: %w", resourcehandler.ErrResourceNotFound)
 	}
 	ksServer := newWorkloadToolServer(t)
 
@@ -539,8 +543,10 @@ func TestCallTool_ScanWorkload_ScanFailureIsToolError(t *testing.T) {
 	require.NotNil(t, res)
 	assert.True(t, res.IsError)
 	text := toolResultText(t, res)
-	assert.Contains(t, text, "failed to run workload scan")
-	assert.Contains(t, text, "was not found", "the underlying reason must survive to the caller")
+	var toolErr ToolError
+	require.NoError(t, json.Unmarshal([]byte(text), &toolErr))
+	assert.Equal(t, ErrCodeResourceNotFound, toolErr.Code)
+	assert.Contains(t, toolErr.Message, "was not found", "the underlying reason must survive to the caller")
 }
 
 func TestCreateWorkloadScanningTools_RegistersScanWorkload(t *testing.T) {

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -136,6 +136,22 @@ func addCommitData(input string, workloadIDToSource map[string]reporthandling.So
 }
 */
 
+func isWorkloadMetadata(r workloadinterface.IMetadata) bool {
+	if r == nil {
+		return false
+	}
+	group, _ := k8sinterface.SplitApiVersion(r.GetApiVersion())
+	if group == "" || cautils.IsBuiltinGroup(group) {
+		switch strings.ToLower(cautils.NormalizeWorkloadKind(r.GetKind())) {
+		case "pod", "deployment", "daemonset", "statefulset", "job", "cronjob", "replicaset", "replicationcontroller":
+			return k8sinterface.IsTypeWorkload(r.GetObject())
+		default:
+			return false
+		}
+	}
+	return k8sinterface.IsTypeWorkload(r.GetObject())
+}
+
 // findScanObjectResource finds the requested k8s object to be scanned in the resources map
 func findScanObjectResource(mappedResources map[string][]workloadinterface.IMetadata, resource *objectsenvelopes.ScanObject) (workloadinterface.IWorkload, error) {
 	if resource == nil {
@@ -144,8 +160,13 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 
 	logger.L().Debug("Single resource scan", helpers.String("resource", resource.GetID()))
 
-	collectMatches := func(kindPredicate func(r workloadinterface.IMetadata) bool) []workloadinterface.IWorkload {
-		var wls []workloadinterface.IWorkload
+	type matchResult struct {
+		workloads    []workloadinterface.IWorkload
+		nonWorkloads []workloadinterface.IMetadata
+	}
+
+	collectMatches := func(kindPredicate func(r workloadinterface.IMetadata) bool) matchResult {
+		var res matchResult
 		seenResources := make(map[string]struct{})
 		for _, resources := range mappedResources {
 			for _, r := range resources {
@@ -167,20 +188,22 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 					continue
 				}
 
-				if k8sinterface.IsTypeWorkload(r.GetObject()) {
+				seenResources[r.GetID()] = struct{}{}
+				if isWorkloadMetadata(r) {
 					wl := workloadinterface.NewWorkloadObj(r.GetObject())
-					wls = append(wls, wl)
-					seenResources[r.GetID()] = struct{}{}
+					res.workloads = append(res.workloads, wl)
+				} else {
+					res.nonWorkloads = append(res.nonWorkloads, r)
 				}
 			}
 		}
-		return wls
+		return res
 	}
 
 	// Pass 1: Direct case-insensitive match on the requested kind.
 	// This preserves bare CRD Kinds (e.g. Deploy for an example.com/v1 resource)
 	// without alias normalization colliding or rewriting the kind.
-	wls := collectMatches(func(r workloadinterface.IMetadata) bool {
+	matches := collectMatches(func(r workloadinterface.IMetadata) bool {
 		return strings.EqualFold(r.GetKind(), resource.GetKind())
 	})
 
@@ -188,23 +211,39 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 	// If direct matching finds no candidates and the requested kind is a recognized
 	// alias/short name for a built-in workload (e.g. "deploy", "po", "ds"), attempt
 	// matching against built-in API group resources with the canonical kind.
-	if len(wls) == 0 {
+	if len(matches.workloads) == 0 && len(matches.nonWorkloads) == 0 {
 		normalizedKind := cautils.NormalizeWorkloadKind(resource.GetKind())
 		if !strings.EqualFold(normalizedKind, resource.GetKind()) {
-			wls = collectMatches(func(r workloadinterface.IMetadata) bool {
+			matches = collectMatches(func(r workloadinterface.IMetadata) bool {
 				group, _ := k8sinterface.SplitApiVersion(r.GetApiVersion())
 				return cautils.IsBuiltinGroup(group) && strings.EqualFold(r.GetKind(), normalizedKind)
 			})
 		}
 	}
 
-	if len(wls) == 0 {
-		return nil, fmt.Errorf("k8s resource '%s' not found", getReadableID(resource))
-	} else if len(wls) > 1 {
-		return nil, fmt.Errorf("more than one k8s resource found for '%s'", getReadableID(resource))
+	if len(matches.workloads) == 0 && len(matches.nonWorkloads) == 0 {
+		// mcpserver-sentinel: ErrResourceNotFound — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("k8s resource '%s' not found: %w", getReadableID(resource), ErrResourceNotFound)
 	}
 
-	return wls[0], nil
+	if len(matches.workloads) == 0 && len(matches.nonWorkloads) > 0 {
+		for _, r := range matches.nonWorkloads {
+			group, _ := k8sinterface.SplitApiVersion(r.GetApiVersion())
+			if strings.EqualFold(r.GetKind(), "secret") && (group == "" || cautils.IsBuiltinGroup(group)) {
+				// mcpserver-sentinel: ErrSecretScanDenied — do not change without updating cmd/mcpserver/mcperror_classify.go
+				return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s: %w", getReadableID(resource), ErrSecretScanDenied)
+			}
+		}
+		// mcpserver-sentinel: ErrNotWorkload — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("%s is not a valid Kubernetes workload: %w", getReadableID(resource), ErrNotWorkload)
+	}
+
+	if len(matches.workloads) > 1 {
+		// mcpserver-sentinel: ErrAmbiguousResource — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("more than one k8s resource found for '%s': %w", getReadableID(resource), ErrAmbiguousResource)
+	}
+
+	return matches.workloads[0], nil
 }
 
 // TODO: move this to k8s-interface

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -1,6 +1,7 @@
 package resourcehandler
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -223,6 +224,12 @@ func TestFindScanObjectResource(t *testing.T) {
 			localWorkloadWithPath("apps/v1", "Deployment", "default", "nginx", "/fileD.yaml"),
 			localWorkloadWithPath("apps/v1", "Deployment", "default", "web", "/fileF.yaml"),
 		},
+		"/v1/secrets": {
+			localWorkloadWithPath("v1", "Secret", "default", "my-secret", "/secret.yaml"),
+		},
+		"/v1/configmaps": {
+			localWorkloadWithPath("v1", "ConfigMap", "default", "my-config", "/config.yaml"),
+		},
 	}
 	tt := []struct {
 		name                 string
@@ -232,6 +239,7 @@ func TestFindScanObjectResource(t *testing.T) {
 		expectedApiVersion   string
 		expectErr            bool
 		expectedErrorString  string
+		expectedSentinel     error
 	}{
 		{
 			name:                 "scan object is nil",
@@ -369,6 +377,37 @@ func TestFindScanObjectResource(t *testing.T) {
 			expectedResourceName: "",
 			expectErr:            true,
 			expectedErrorString:  "not found",
+			expectedSentinel:     ErrResourceNotFound,
+		},
+		{
+			name: "matched Secret returns ErrSecretScanDenied",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Secret",
+				ApiVersion: "v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "default",
+					Name:      "my-secret",
+				},
+			},
+			expectedResourceName: "",
+			expectErr:            true,
+			expectedErrorString:  "scanning Secret resources via single resource scan is not supported",
+			expectedSentinel:     ErrSecretScanDenied,
+		},
+		{
+			name: "matched non-workload ConfigMap returns ErrNotWorkload",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "ConfigMap",
+				ApiVersion: "v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "default",
+					Name:      "my-config",
+				},
+			},
+			expectedResourceName: "",
+			expectErr:            true,
+			expectedErrorString:  "is not a valid Kubernetes workload",
+			expectedSentinel:     ErrNotWorkload,
 		},
 	}
 
@@ -382,6 +421,9 @@ func TestFindScanObjectResource(t *testing.T) {
 
 			if tc.expectErr {
 				assert.ErrorContains(t, err, tc.expectedErrorString)
+				if tc.expectedSentinel != nil {
+					assert.True(t, errors.Is(err, tc.expectedSentinel), "expected error to wrap sentinel %v, got %v", tc.expectedSentinel, err)
+				}
 			}
 
 			if tc.expectedResourceName != "" {

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -44,6 +44,21 @@ var cloudResourceGetterMapping = map[string]cloudResourceGetter{
 	cloudapis.CloudProviderPolicyVersionKind:           cloudsupport.GetPolicyVersionFromCloudProvider,
 }
 
+// Sentinel errors for single-resource scan outcomes. The MCP server's
+// error classifier (cmd/mcpserver/mcperror_classify.go) uses errors.Is
+// against these values to produce machine-readable error codes.
+//
+// If you rename, remove, or stop wrapping one of these sentinels,
+// TestResourceHandlerSentinels_WrappingSitesExist will fail.
+var (
+	ErrResourceNotFound       = errors.New("resource not found")
+	ErrAmbiguousResource      = errors.New("ambiguous resource")
+	ErrResourceHasParent      = errors.New("resource has parent")
+	ErrNotWorkload            = errors.New("not a workload")
+	ErrSecretScanDenied       = errors.New("secret scan denied")
+	ErrResourceNotInDiscovery = errors.New("resource not in discovery")
+)
+
 var _ IResourceHandler = &K8sResourceHandler{}
 
 type K8sResourceHandler struct {
@@ -631,7 +646,8 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		resolved = resolver(g, v, resource.GetKind())
 	}
 	if len(resolved) != 1 {
-		return nil, fmt.Errorf("resource not found in Kubernetes discovery: %s", getReadableID(resource))
+		// mcpserver-sentinel: ErrResourceNotInDiscovery — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("resource not found in Kubernetes discovery: %s: %w", getReadableID(resource), ErrResourceNotInDiscovery)
 	}
 	apiGroup, apiVersion, resourceName := k8sinterface.StringToResourceGroup(resolved[0].groupVersionResourceTriplet)
 	if apiGroup == "" && resourceName == "secrets" {
@@ -647,7 +663,8 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		// The GVR is resolved from cluster discovery, not from the
 		// client-supplied kind string, so this check cannot be sidestepped with
 		// casing or aliasing tricks.
-		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", getReadableID(resource))
+		// mcpserver-sentinel: ErrSecretScanDenied — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s: %w", getReadableID(resource), ErrSecretScanDenied)
 	}
 	gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resourceName}
 	isNamespaced := (resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))
@@ -661,7 +678,8 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 			targetNS = resource.GetName()
 		}
 		if globalFieldSelector != nil && !globalFieldSelector.AllowsNamespace(&gvr, targetNS, resolved[0].namespaced) {
-			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+			// mcpserver-sentinel: ErrResourceNotFound — do not change without updating cmd/mcpserver/mcperror_classify.go
+			return nil, fmt.Errorf("resource %s was not found: %w", getReadableID(resource), ErrResourceNotFound)
 		}
 
 		var clientResource dynamic.ResourceInterface = k8sHandler.k8s.DynamicClient.Resource(gvr)
@@ -676,19 +694,23 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 					objNS = uObj.GetName()
 				}
 				if !globalFieldSelector.AllowsNamespace(&gvr, objNS, resolved[0].namespaced) {
-					return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+					// mcpserver-sentinel: ErrResourceNotFound — do not change without updating cmd/mcpserver/mcperror_classify.go
+					return nil, fmt.Errorf("resource %s was not found: %w", getReadableID(resource), ErrResourceNotFound)
 				}
 			}
 			if k8sinterface.IsTypeWorkload(uObj.Object) && k8sinterface.WorkloadHasParent(workloadinterface.NewWorkloadObj(uObj.Object)) {
-				return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+				// mcpserver-sentinel: ErrResourceHasParent — do not change without updating cmd/mcpserver/mcperror_classify.go
+				return nil, fmt.Errorf("resource %s has a parent and cannot be scanned: %w", getReadableID(resource), ErrResourceHasParent)
 			}
 			if !k8sinterface.IsTypeWorkload(uObj.Object) {
-				return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
+				// mcpserver-sentinel: ErrNotWorkload — do not change without updating cmd/mcpserver/mcperror_classify.go
+				return nil, fmt.Errorf("%s is not a valid Kubernetes workload: %w", getReadableID(resource), ErrNotWorkload)
 			}
 			return workloadinterface.NewWorkloadObj(uObj.Object), nil
 		}
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+			// mcpserver-sentinel: ErrResourceNotFound — do not change without updating cmd/mcpserver/mcperror_classify.go
+			return nil, fmt.Errorf("resource %s was not found: %w", getReadableID(resource), ErrResourceNotFound)
 		}
 		// If Get failed with another error (e.g. Forbidden if the account was granted
 		// 'list' but not 'get', or an unexpected API issue), log and fall back to
@@ -706,7 +728,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	}
 	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, "", fieldSelectors, globalFieldSelector, resolved[0].namespaced)
 	if len(result) == 0 && len(selectorErrs) > 0 {
-		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
+		return nil, fmt.Errorf("failed to get resource %s, reason: %w", getReadableID(resource), selectorErrs[0].err)
 	}
 	for _, se := range selectorErrs {
 		logger.L().Warning("partial collection during single resource scan",
@@ -716,20 +738,24 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+		// mcpserver-sentinel: ErrResourceNotFound — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("resource %s was not found: %w", getReadableID(resource), ErrResourceNotFound)
 	}
 
 	metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
 	if len(metaObjs) == 0 {
-		return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+		// mcpserver-sentinel: ErrResourceHasParent — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("resource %s has a parent and cannot be scanned: %w", getReadableID(resource), ErrResourceHasParent)
 	}
 
 	if len(metaObjs) > 1 {
-		return nil, fmt.Errorf("more than one resource found for %s", getReadableID(resource))
+		// mcpserver-sentinel: ErrAmbiguousResource — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("more than one resource found for %s: %w", getReadableID(resource), ErrAmbiguousResource)
 	}
 
 	if !k8sinterface.IsTypeWorkload(metaObjs[0].GetObject()) {
-		return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
+		// mcpserver-sentinel: ErrNotWorkload — do not change without updating cmd/mcpserver/mcperror_classify.go
+		return nil, fmt.Errorf("%s is not a valid Kubernetes workload: %w", getReadableID(resource), ErrNotWorkload)
 	}
 
 	wl := workloadinterface.NewWorkloadObj(metaObjs[0].GetObject())

--- a/core/pkg/resourcehandler/sentinel_sync_test.go
+++ b/core/pkg/resourcehandler/sentinel_sync_test.go
@@ -1,0 +1,74 @@
+package resourcehandler
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceHandlerSentinels_Distinct(t *testing.T) {
+	sentinels := []error{
+		ErrResourceNotFound,
+		ErrAmbiguousResource,
+		ErrResourceHasParent,
+		ErrNotWorkload,
+		ErrSecretScanDenied,
+		ErrResourceNotInDiscovery,
+	}
+
+	for i, s1 := range sentinels {
+		require.NotNil(t, s1, "sentinel %d must not be nil", i)
+		for j, s2 := range sentinels {
+			if i != j {
+				assert.NotEqual(t, s1, s2, "sentinels at index %d and %d must be distinct", i, j)
+			}
+		}
+	}
+}
+
+func TestResourceHandlerSentinels_WrappingSitesExist(t *testing.T) {
+	// Note: this is a source-level heuristic check, not a formal AST proof,
+	// designed to catch accidental deletion of wrapping sites.
+	//
+	// It verifies that each sentinel name appears inside a fmt.Errorf call
+	// containing %w as a format verb and passing the sentinel as an operand.
+
+	sentinelNames := []string{
+		"ErrResourceNotFound",
+		"ErrAmbiguousResource",
+		"ErrResourceHasParent",
+		"ErrNotWorkload",
+		"ErrSecretScanDenied",
+		"ErrResourceNotInDiscovery",
+	}
+
+	sourceFiles := []string{
+		"k8sresources.go",
+		"filesloaderutils.go",
+	}
+
+	for _, name := range sentinelNames {
+		found := false
+		pattern := regexp.MustCompile(`fmt\.Errorf\(.*%w.*,\s*` + regexp.QuoteMeta(name) + `\)`)
+		for _, file := range sourceFiles {
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+			for _, line := range regexp.MustCompile(`\r?\n`).Split(string(content), -1) {
+				if pattern.MatchString(line) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			t.Errorf("sentinel %s is not wrapped with %%w in any source file; "+
+				"the MCP error classifier depends on this wrapping", name)
+		}
+	}
+}


### PR DESCRIPTION

## Overview
This PR improves error handling across all MCP server tools by replacing unstructured plain-text error strings with structured JSON payloads containing machine-readable error codes, clear messages, and sanitized details. It introduces typed sentinel errors for common failure scenarios (resource not found, invalid arguments, RBAC permissions, ambiguous resources), implements standardized required argument validation, and adds CI protection to prevent regression to unstructured error returns.

## Additional Information
- **Error Structure**: Errors now conform to `ToolError` with `code`, `message`, and sanitized `details` fields
- **Error Codes**: Machine-readable constants like `INVALID_ARGUMENT`, `RESOURCE_NOT_FOUND`, `AMBIGUOUS_RESOURCE`, `RBAC_DENIED` for client-side handling
- **Detail Sanitization**: `sanitizeDetails` ensures error details only contain scalar types and string slices (parameter names, resource identifiers) to prevent leaking internal structures
- **Protocol Compatibility**: Maintains standard MCP protocol compatibility (`CallToolResult` with `IsError: true`)
- **CI Protection**: Static check script in `.github/scripts/check_mcp_errors.sh` scans for bare `mcp.NewToolResultError` calls

## How to Test
1. **Run Unit Tests**:
   ```bash
   go test -v ./cmd/mcpserver/... ./core/pkg/resourcehandler/...
   ```
2. **Run MCP Static Error Check**:
   ```bash
   bash .github/scripts/check_mcp_errors.sh
   ```
3. **Verify Structured Error Output**: Call any MCP tool with missing/invalid inputs or against non-existent resources to receive structured JSON error responses.

## Examples/Screenshots
Example of a structured error payload for invalid argument:
```json
{
  "code": "INVALID_ARGUMENT",
  "message": "target argument is required and cannot be empty",
  "details": {
    "argument": "target"
  }
}
```

Example for resource not found:
```json
{
  "code": "RESOURCE_NOT_FOUND",
  "message": "resource not found: resource default/pod/unknown-workload was not found",
  "details": {
    "kind": "pod",
    "name": "unknown-workload",
    "namespace": "default"
  }
}
```

## Related issues/PRs
* Resolved #3770

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP tools now return structured error responses with machine-readable codes, clearer messages, and relevant context.
  - Invalid or missing arguments, including whitespace-only values, are reported consistently with supported values where applicable.
  - Scan failures distinguish conditions such as missing, ambiguous, unsupported, unauthorized, and inaccessible resources.
  - Error details are filtered to avoid exposing sensitive information.

- **Bug Fixes**
  - Improved handling and reporting of Kubernetes, resource lookup, serialization, and scan execution failures.
  - Resource scans now more accurately handle non-workload resources and denied Secret scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->