### PR TITLE
Refactor: Move getReadableID to k8sinterface

### DIFF
--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -165,26 +165,12 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 	}
 
 	if len(wls) == 0 {
-		return nil, fmt.Errorf("k8s resource '%s' not found", getReadableID(resource))
+		return nil, fmt.Errorf("k8s resource '%s' not found", k8sinterface.GetReadableID(resource))
 	} else if len(wls) > 1 {
-		return nil, fmt.Errorf("more than one k8s resource found for '%s'", getReadableID(resource))
+		return nil, fmt.Errorf("more than one k8s resource found for '%s'", k8sinterface.GetReadableID(resource))
 	}
 
 	return wls[0], nil
 }
 
-// TODO: move this to k8s-interface
-func getReadableID(obj *objectsenvelopes.ScanObject) string {
-	var ID string
-	if obj.GetApiVersion() != "" {
-		ID += fmt.Sprintf("%s/", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(obj.GetApiVersion())))
-	}
 
-	if obj.GetNamespace() != "" {
-		ID += fmt.Sprintf("%s/", obj.GetNamespace())
-	}
-
-	ID += fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
-
-	return ID
-}

--- a/core/pkg/resourcehandler/k8sresources.go
+++ b/core/pkg/resourcehandler/k8sresources.go
@@ -631,7 +631,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		resolved = resolver(g, v, resource.GetKind())
 	}
 	if len(resolved) != 1 {
-		return nil, fmt.Errorf("resource not found in Kubernetes discovery: %s", getReadableID(resource))
+		return nil, fmt.Errorf("resource not found in Kubernetes discovery: %s", k8sinterface.GetReadableID(resource))
 	}
 	apiGroup, apiVersion, resourceName := k8sinterface.StringToResourceGroup(resolved[0].groupVersionResourceTriplet)
 	if apiGroup == "" && resourceName == "secrets" {
@@ -647,7 +647,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 		// The GVR is resolved from cluster discovery, not from the
 		// client-supplied kind string, so this check cannot be sidestepped with
 		// casing or aliasing tricks.
-		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", getReadableID(resource))
+		return nil, fmt.Errorf("scanning Secret resources via single resource scan is not supported: %s", k8sinterface.GetReadableID(resource))
 	}
 	gvr := schema.GroupVersionResource{Group: apiGroup, Version: apiVersion, Resource: resourceName}
 	isNamespaced := (resolved[0].namespaced != nil && *resolved[0].namespaced) || (resolved[0].namespaced == nil && k8sinterface.IsNamespaceScope(&gvr))
@@ -661,7 +661,7 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 			targetNS = resource.GetName()
 		}
 		if globalFieldSelector != nil && !globalFieldSelector.AllowsNamespace(&gvr, targetNS, resolved[0].namespaced) {
-			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+			return nil, fmt.Errorf("resource %s was not found", k8sinterface.GetReadableID(resource))
 		}
 
 		var clientResource dynamic.ResourceInterface = k8sHandler.k8s.DynamicClient.Resource(gvr)
@@ -676,25 +676,25 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 					objNS = uObj.GetName()
 				}
 				if !globalFieldSelector.AllowsNamespace(&gvr, objNS, resolved[0].namespaced) {
-					return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+					return nil, fmt.Errorf("resource %s was not found", k8sinterface.GetReadableID(resource))
 				}
 			}
 			if k8sinterface.IsTypeWorkload(uObj.Object) && k8sinterface.WorkloadHasParent(workloadinterface.NewWorkloadObj(uObj.Object)) {
-				return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+				return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", k8sinterface.GetReadableID(resource))
 			}
 			if !k8sinterface.IsTypeWorkload(uObj.Object) {
-				return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
+				return nil, fmt.Errorf("%s is not a valid Kubernetes workload", k8sinterface.GetReadableID(resource))
 			}
 			return workloadinterface.NewWorkloadObj(uObj.Object), nil
 		}
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+			return nil, fmt.Errorf("resource %s was not found", k8sinterface.GetReadableID(resource))
 		}
 		// If Get failed with another error (e.g. Forbidden if the account was granted
 		// 'list' but not 'get', or an unexpected API issue), log and fall back to
 		// pullSingleResource for backwards compatibility.
 		logger.L().Debug("direct get failed, falling back to list",
-			helpers.String("resource", getReadableID(resource)),
+			helpers.String("resource", k8sinterface.GetReadableID(resource)),
 			helpers.Error(err))
 	}
 
@@ -706,30 +706,30 @@ func (k8sHandler *K8sResourceHandler) findScanObjectResource(ctx context.Context
 	}
 	result, selectorErrs := k8sHandler.pullSingleResource(ctx, &gvr, "", fieldSelectors, globalFieldSelector, resolved[0].namespaced)
 	if len(result) == 0 && len(selectorErrs) > 0 {
-		return nil, fmt.Errorf("failed to get resource %s, reason: %v", getReadableID(resource), selectorErrs[0].err)
+		return nil, fmt.Errorf("failed to get resource %s, reason: %v", k8sinterface.GetReadableID(resource), selectorErrs[0].err)
 	}
 	for _, se := range selectorErrs {
 		logger.L().Warning("partial collection during single resource scan",
-			helpers.String("resource", getReadableID(resource)),
+			helpers.String("resource", k8sinterface.GetReadableID(resource)),
 			helpers.String("selector", se.selector),
 			helpers.Error(se.err))
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("resource %s was not found", getReadableID(resource))
+		return nil, fmt.Errorf("resource %s was not found", k8sinterface.GetReadableID(resource))
 	}
 
 	metaObjs := ConvertMapListToMeta(k8sinterface.ConvertUnstructuredSliceToMap(result))
 	if len(metaObjs) == 0 {
-		return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", getReadableID(resource))
+		return nil, fmt.Errorf("resource %s has a parent and cannot be scanned", k8sinterface.GetReadableID(resource))
 	}
 
 	if len(metaObjs) > 1 {
-		return nil, fmt.Errorf("more than one resource found for %s", getReadableID(resource))
+		return nil, fmt.Errorf("more than one resource found for %s", k8sinterface.GetReadableID(resource))
 	}
 
 	if !k8sinterface.IsTypeWorkload(metaObjs[0].GetObject()) {
-		return nil, fmt.Errorf("%s is not a valid Kubernetes workload", getReadableID(resource))
+		return nil, fmt.Errorf("%s is not a valid Kubernetes workload", k8sinterface.GetReadableID(resource))
 	}
 
 	wl := workloadinterface.NewWorkloadObj(metaObjs[0].GetObject())

--- a/core/pkg/resourcehandler/k8sresourcesutils.go
+++ b/core/pkg/resourcehandler/k8sresourcesutils.go
@@ -198,5 +198,5 @@ func getWorkloadFromScanObject(resource *objectsenvelopes.ScanObject) (workloadi
 	if k8sinterface.IsTypeWorkload(obj) {
 		return workloadinterface.NewWorkloadObj(obj), nil
 	}
-	return nil, fmt.Errorf("resource %s is not a valid workload", getReadableID(resource))
+	return nil, fmt.Errorf("resource %s is not a valid workload", k8sinterface.GetReadableID(resource))
 }


### PR DESCRIPTION
## Overview
This PR cleans up technical debt by moving the locally-scoped `getReadableID` function out of `core/pkg/resourcehandler/filesloaderutils.go`. It replaces all internal calls across the resource handler package to use the generic `k8sinterface.GetReadableID` instead.

This resolves the existing `TODO` in `filesloaderutils.go` and ensures we are properly reusing the shared `k8s-interface` module for generic Kubernetes object utilities.

## Additional Information
> Note: For this to compile cleanly, the corresponding PR adding `GetReadableID` to `kubescape/k8s-interface` must be merged first, and the dependency bumped here.

## How to Test
1. Pull the branch locally.
2. Run `make build` (requires the `k8s-interface` dependency bump).
3. Run `make test` to ensure that all the file loader and k8s resource utilities still behave exactly as they did before the refactor.

## Examples/Screenshots
N/A - backend refactoring only.

## Related issues/PRs:
Resolved #3777 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency and readability of resource identifiers shown in Kubernetes scan error messages.
  - Standardized error details across resource discovery, filtering, retrieval, and workload validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->