### PR TITLE
fix(exceptions): generate suppressing exception baselines

### DIFF
--- a/core/pkg/resultshandling/printer/v2/exceptionsprinter.go
+++ b/core/pkg/resultshandling/printer/v2/exceptionsprinter.go
@@ -116,7 +116,7 @@ func buildExceptionPolicies(ctx context.Context, opaSessionObj *cautils.OPASessi
 			PortalBase:      armotypes.PortalBase{Name: "exclude-" + controlID},
 			PolicyType:      exceptionPolicyType,
 			CreationTime:    creationTime.UTC().Format(time.RFC3339),
-			Actions:         []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
+			Actions:         []armotypes.PostureExceptionPolicyActions{armotypes.Disable},
 			Resources:       designators(failures[controlID]),
 			PosturePolicies: []armotypes.PosturePolicy{{ControlID: regexp.QuoteMeta(controlID)}},
 		})

--- a/core/pkg/resultshandling/printer/v2/exceptionsprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/exceptionsprinter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	"github.com/kubescape/opa-utils/exceptions"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -98,7 +99,7 @@ func TestBuildExceptionPoliciesGroupsResourcesByControl(t *testing.T) {
 
 	for _, policy := range policies {
 		assert.Equal(t, exceptionPolicyType, policy.PolicyType)
-		assert.Equal(t, []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly}, policy.Actions)
+		assert.Equal(t, []armotypes.PostureExceptionPolicyActions{armotypes.Disable}, policy.Actions)
 		assert.Equal(t, "2026-03-04T05:06:07Z", policy.CreationTime)
 		require.Len(t, policy.PosturePolicies, 1)
 	}
@@ -225,8 +226,42 @@ func TestExceptionDocumentsRoundTripIntoTheConsumedType(t *testing.T) {
 		assert.Equal(t, policies[i].Resources, parsed[i].Resources)
 		require.Len(t, parsed[i].PosturePolicies, 1)
 		assert.Equal(t, policies[i].PosturePolicies[0].ControlID, parsed[i].PosturePolicies[0].ControlID)
-		assert.True(t, parsed[i].IsAlertOnly())
+		assert.True(t, parsed[i].IsDisable())
 	}
+}
+
+// TestGeneratedExceptionDocumentsSuppressBaselineFindings protects the
+// baseline contract end to end: generated JSON must parse through the public
+// exception type and suppress the same finding when applied by the real
+// exception processor.
+func TestGeneratedExceptionDocumentsSuppressBaselineFindings(t *testing.T) {
+	policies := buildExceptionPolicies(context.Background(), exceptionsSession(t))
+
+	encoded, err := json.Marshal(exceptionDocuments(policies))
+	require.NoError(t, err)
+
+	var parsed []armotypes.PostureExceptionPolicy
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+
+	workload := exceptionsWorkload(t, "Deployment", "prod", "api")
+	result := resourcesresults.Result{
+		ResourceID: "api",
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0002",
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Name: "failed-rule", Status: apis.StatusFailed},
+				},
+			},
+		},
+	}
+
+	result.SetExceptions(workload, parsed, "", map[string]reporthandling.Control{"C-0002": {}})
+
+	status := result.AssociatedControls[0].GetStatus(nil)
+	assert.Equal(t, apis.StatusPassed, status.Status())
+	assert.Equal(t, apis.SubStatusException, status.GetSubStatus())
 }
 
 func keysOf(m map[string]any) []string {
@@ -292,7 +327,7 @@ func TestActionPrintWritesAFileThatParsesBack(t *testing.T) {
 	require.NoError(t, json.Unmarshal(contents, &parsed))
 	require.Len(t, parsed, 2)
 	assert.Equal(t, "exclude-C-0001", parsed[0].Name)
-	assert.True(t, parsed[0].IsAlertOnly())
+	assert.True(t, parsed[0].IsDisable())
 	assert.Equal(t, byte('\n'), contents[len(contents)-1], "file should end with a newline")
 }
 

--- a/core/pkg/resultshandling/printer/v2/junit_test.go
+++ b/core/pkg/resultshandling/printer/v2/junit_test.go
@@ -16,11 +16,16 @@ import (
 	"github.com/anchore/grype/grype/match"
 	grypepkg "github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	helpersv1 "github.com/kubescape/opa-utils/reporthandling/helpers/v1"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,6 +128,90 @@ func TestTestSuites(t *testing.T) {
 	assert.Equal(t, listTestsSuite(results), junitTestSuites.Suites)
 	assert.Equal(t, results.Report.SummaryDetails.NumberOfControls().All(), junitTestSuites.Tests)
 	assert.Equal(t, "Kubescape Scanning", junitTestSuites.Name)
+}
+
+func TestJunitExceptionActionsPreserveFailureSemantics(t *testing.T) {
+	type finding struct {
+		resourceID  string
+		controlID   string
+		controlName string
+		action      *armotypes.PostureExceptionPolicyActions
+	}
+
+	disable := armotypes.Disable
+	alertOnly := armotypes.AlertOnly
+	findings := []finding{
+		{resourceID: "disabled", controlID: "C-DISABLE", controlName: "Disabled finding", action: &disable},
+		{resourceID: "acknowledged", controlID: "C-ALERT", controlName: "Acknowledged finding", action: &alertOnly},
+		{resourceID: "unrelated", controlID: "C-OTHER", controlName: "Unrelated finding"},
+	}
+
+	session := &cautils.OPASessionObj{
+		Report: &reporthandlingv2.PostureReport{
+			SummaryDetails: reportsummary.SummaryDetails{Controls: reportsummary.ControlSummaries{}},
+		},
+		AllResources: map[string]workloadinterface.IMetadata{},
+	}
+
+	for _, finding := range findings {
+		workload := exceptionsWorkload(t, "Pod", "default", finding.resourceID)
+		result := resourcesresults.Result{
+			ResourceID: finding.resourceID,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{
+					ControlID: finding.controlID,
+					Name:      finding.controlName,
+					Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+					ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+						{Name: "failed-rule", Status: apis.StatusFailed},
+					},
+				},
+			},
+		}
+
+		if finding.action != nil {
+			policy := armotypes.PostureExceptionPolicy{
+				PortalBase: armotypes.PortalBase{Name: "exception-" + finding.resourceID},
+				Actions:    []armotypes.PostureExceptionPolicyActions{*finding.action},
+				Resources: []identifiers.PortalDesignator{
+					{
+						DesignatorType: identifiers.DesignatorAttributes,
+						Attributes: map[string]string{
+							identifiers.AttributeKind:      "Pod",
+							identifiers.AttributeNamespace: "default",
+							identifiers.AttributeName:      finding.resourceID,
+						},
+					},
+				},
+				PosturePolicies: []armotypes.PosturePolicy{{ControlID: finding.controlID}},
+			}
+			result.SetExceptions(workload, []armotypes.PostureExceptionPolicy{policy}, "", map[string]reporthandling.Control{finding.controlID: {}})
+		}
+
+		session.AllResources[finding.resourceID] = workload
+		session.Report.Results = append(session.Report.Results, result)
+		session.Report.SummaryDetails.Controls[finding.controlID] = reportsummary.ControlSummary{
+			ControlID: finding.controlID,
+			Name:      finding.controlName,
+		}
+	}
+
+	session.Report.InitializeSummary()
+	suites := testsSuites(session)
+	require.Len(t, suites.Suites, 1)
+	assert.Equal(t, 3, suites.Suites[0].Tests)
+	assert.Equal(t, 2, suites.Suites[0].Failures)
+
+	testCases := map[string]JUnitTestCase{}
+	for _, testCase := range suites.Suites[0].TestCases {
+		testCases[testCase.Name] = testCase
+	}
+	require.Contains(t, testCases, "Disabled finding")
+	require.Contains(t, testCases, "Acknowledged finding")
+	require.Contains(t, testCases, "Unrelated finding")
+	assert.Nil(t, testCases["Disabled finding"].Failure, "disable must remove the JUnit failure")
+	assert.NotNil(t, testCases["Acknowledged finding"].Failure, "alertOnly must remain a JUnit failure")
+	assert.NotNil(t, testCases["Unrelated finding"].Failure, "unrelated findings must remain JUnit failures")
 }
 
 func TestJunitActionPrintCombinedScanIncludesPostureAndImages(t *testing.T) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -163,7 +163,11 @@ The file holds one policy per failed control, listing the resources that failed
 it by `kind`, `namespace` and `name`, in the same shape as the samples under
 [examples/exceptions](../examples/exceptions). Designators carry no `cluster`
 attribute, so the same file applies wherever those workloads run. Policies use
-the `alertOnly` action.
+the `disable` action, which suppresses the baseline findings as passed with
+exceptions. For evaluated findings, use `alertOnly` in a hand-written policy
+when a finding should be acknowledged but remain failed and continue
+contributing to the compliance score. Manual-review controls have separate
+status handling.
 
 It is a normal output format, so it composes with the others and honours
 `--output`, writing `scan-result.json` and `scan-result.exceptions.json`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,7 +206,11 @@ kubescape scan https://github.com/kubescape/kubescape
 kubescape scan --exceptions examples/exceptions/exclude-kube-namespaces.json
 ```
 
-Objects with exceptions will be presented as `exclude` and not `fail`.
+Objects matched by a `disable` exception are presented as passed with
+exceptions instead of failed. For evaluated findings, an `alertOnly` exception
+acknowledges a finding, but the object remains failed and continues
+contributing to the compliance score. Manual-review controls have separate
+status handling.
 
 [See more examples about exceptions.](../examples/exceptions/README.md)
 

--- a/docs/ics-ot-workloads.md
+++ b/docs/ics-ot-workloads.md
@@ -89,7 +89,7 @@ When a finding represents a documented and risk-accepted OT deviation, suppress 
     {
         "name": "exclude-ot-sector-host-network",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -115,7 +115,7 @@ The C-0041 finding against `modbus-controller` moves out of the failed set (it a
 
 ## Network Policies for OT Namespaces
 
-Suppressing a Kubescape finding does not remove the underlying risk, it only acknowledges it. For every OT exception, document a compensating control. The most common compensating control in OT namespaces is a NetworkPolicy that restricts which pods may open a session to the protocol port.
+Suppressing a Kubescape finding does not remove the underlying risk; it records that the risk was accepted. For every OT exception, document a compensating control. The most common compensating control in OT namespaces is a NetworkPolicy that restricts which pods may open a session to the protocol port.
 
 The following pattern works for Modbus controllers: default-deny all ingress to the `ot-modbus` namespace, then allow TCP/502 only from the HMI namespace.
 

--- a/examples/exceptions/README.md
+++ b/examples/exceptions/README.md
@@ -1,6 +1,6 @@
 # Kubescape Exceptions
 
-Kubescape Exceptions allow you to exclude specific resources from affecting your security risk score. This is useful when certain resources intentionally deviate from security best practices and you want to acknowledge this without impacting your overall compliance metrics.
+Kubescape Exceptions let you suppress or acknowledge findings for specific resources. For evaluated findings, use `disable` when an accepted finding should pass with exceptions and stop affecting the compliance score. Use `alertOnly` when the finding should be annotated as acknowledged but remain failed and continue affecting the score. Manual-review controls have separate status handling.
 
 ## Table of Contents
 
@@ -30,7 +30,7 @@ An exception file is a JSON array containing one or more exception objects:
     {
         "name": "exception-name",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [...],
         "posturePolicies": [...]
     }
@@ -43,9 +43,9 @@ An exception file is a JSON array containing one or more exception objects:
 |-------|-------------|
 | `name` | Unique name for this exception |
 | `policyType` | Must be `"postureExceptionPolicy"` |
-| `actions` | List of actions. Currently only `"alertOnly"` is supported |
+| `actions` | List of actions. `"disable"` suppresses a finding; `"alertOnly"` acknowledges it but keeps it failed |
 | `resources` | List of resources to apply this exception to |
-| `posturePolicies` | List of policies/controls to exclude |
+| `posturePolicies` | List of policies/controls targeted by the exception |
 
 ### Resource Attributes
 
@@ -81,7 +81,7 @@ Find framework names in the [frameworks directory](https://github.com/kubescape/
 kubescape scan --exceptions /path/to/exceptions.json
 ```
 
-Resources matching exceptions will be marked as `excluded` rather than `failed` in the results.
+For evaluated findings, resources matching `disable` exceptions are reported as passed with exceptions rather than failed. Resources matching `alertOnly` exceptions remain failed with exceptions and continue contributing to the compliance score. Manual-review controls have separate status handling.
 
 ### Logic Rules
 
@@ -123,7 +123,7 @@ Exclude control [C-0048 (HostPath mount)](https://kubescape.io/docs/controls/c-0
     {
         "name": "exclude-hostpath-control",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -150,7 +150,7 @@ Exclude all resources in the `kube-system` namespace from all frameworks:
     {
         "name": "exclude-kube-system",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -175,7 +175,7 @@ Exclude all resources in the `kube-system` namespace from all frameworks:
     {
         "name": "exclude-deployments-in-default",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -203,7 +203,7 @@ Exclude resources with label `environment=dev` from NSA and MITRE frameworks:
     {
         "name": "exclude-dev-environment",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -233,7 +233,7 @@ Exclude nginx resources in a minikube cluster:
     {
         "name": "exclude-nginx-minikube",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -261,7 +261,7 @@ You can combine multiple exceptions in a single file:
     {
         "name": "exclude-kube-namespaces",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -285,7 +285,7 @@ You can combine multiple exceptions in a single file:
     {
         "name": "exclude-privileged-control-for-monitoring",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",
@@ -314,7 +314,7 @@ The example below scopes the exception narrowly: it suppresses only C-0041 (`hos
     {
         "name": "exclude-ot-sector-host-network",
         "policyType": "postureExceptionPolicy",
-        "actions": ["alertOnly"],
+        "actions": ["disable"],
         "resources": [
             {
                 "designatorType": "Attributes",

--- a/examples/exceptions/exclude-allowed-hostPath-control.json
+++ b/examples/exceptions/exclude-allowed-hostPath-control.json
@@ -3,7 +3,7 @@
         "name": "exclude-allowed-hostPath-control",
         "policyType": "postureExceptionPolicy",
         "actions": [
-            "alertOnly"
+            "disable"
         ],
         "resources": [
             {

--- a/examples/exceptions/exclude-deployments-in-ns-default.json
+++ b/examples/exceptions/exclude-deployments-in-ns-default.json
@@ -3,7 +3,7 @@
         "name": "exclude-deployments-in-ns-default",
         "policyType": "postureExceptionPolicy",
         "actions": [
-            "alertOnly"
+            "disable"
         ],
         "resources": [
             {

--- a/examples/exceptions/exclude-kube-namespaces.json
+++ b/examples/exceptions/exclude-kube-namespaces.json
@@ -3,7 +3,7 @@
         "name": "ignore-kube-namespaces",
         "policyType": "postureExceptionPolicy",
         "actions": [
-            "alertOnly"
+            "disable"
         ],
         "resources": [
             {

--- a/examples/exceptions/exclude-nginx-in-minikube.json
+++ b/examples/exceptions/exclude-nginx-in-minikube.json
@@ -3,7 +3,7 @@
         "name": "exclude-nginx-in-minikube",
         "policyType": "postureExceptionPolicy",
         "actions": [
-            "alertOnly"
+            "disable"
         ],
         "resources": [
             {

--- a/examples/exceptions/ics-ot-exceptions.json
+++ b/examples/exceptions/ics-ot-exceptions.json
@@ -3,7 +3,7 @@
         "name": "exclude-ot-sector-host-network",
         "policyType": "postureExceptionPolicy",
         "actions": [
-            "alertOnly"
+            "disable"
         ],
         "resources": [
             {


### PR DESCRIPTION

  ## Overview

  Generated exception baselines currently use the `alertOnly` action. Since the exception semantics changed, `alertOnly` acknowledges a finding but keeps it failed
  and included in the compliance score. As a result, feeding a generated baseline back through `--exceptions` no longer suppresses existing findings.

  This PR restores the baseline workflow by:

  - Generating exception policies with `disable`, which reports matching findings as passed with exceptions.
  - Adding an end-to-end unit test covering generation, JSON serialization, parsing, and application through the real exception processor.
  - Adding JUnit regression coverage confirming that:
    - `disable` removes the corresponding JUnit failure.
    - `alertOnly` remains a JUnit failure.
    - Unrelated findings remain failures.
  - Updating the in-repository documentation and exception examples to explain and use the correct action semantics.

  ## Additional Information

  This change preserves the current distinction between exception actions:

  - `disable`: suppresses an evaluated finding and reports it as `passed (w/exceptions)`.
  - `alertOnly`: acknowledges an evaluated finding while keeping it `failed (w/exceptions)` and included in the compliance score.

  No JUnit production code was changed because its existing status-based behavior is correct.

  Manual-review controls have separate status handling and are intentionally outside the scope of this fix. Public website documentation in the separate
  `kubescape.io` repository should be updated in a companion PR.

  ## How to Test

  Run the automated verification:

  ```bash
  go test -count=1 ./core/pkg/resultshandling/printer/v2/...
  go test -count=1 ./core/...
  go test -race -count=1 ./...
  go vet ./...
  jq empty examples/exceptions/*.json
  git diff --check
```

  The following CLI behavior was also verified using the same ICS/OT manifests:

  No exception:
  C-0041 → failed
  C-0041 → JUnit failure

  actions: ["disable"]:
  C-0041 → passed (w/exceptions)
  C-0041 → no JUnit failure
  Unrelated findings → remain failed

  actions: ["alertOnly"]:
  C-0041 → failed (w/exceptions)
  C-0041 → remains a JUnit failure

  Generated exceptions baseline:
  All generated policies → actions: ["disable"]

  Generated baseline applied to the original scan:
  38 controls → passed (w/exceptions)
  0 failed controls
  0 JUnit failures

  ## Related issues/PRs:

  - Resolved #3771

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests
  - [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Generated exception policies now use `disable`, marking matching baseline findings as passed with exceptions and removing them from compliance scores.
  * `alertOnly` exceptions continue to acknowledge findings while leaving them failed and included in compliance scores.
  * JUnit results now correctly exclude disabled findings from failures while preserving failures for alert-only and unrelated findings.

* **Documentation**
  * Updated exception guides and examples to explain both actions and their status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->