### PR TITLE
feat(printer): resolve fix-path line numbers in --show-evidence output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -221,7 +221,17 @@ func annotateFixPathLines(paths *[]string, control *resourcesresults.ResourceAss
 		return
 	}
 
+	// fixPathsToString does not deduplicate, and one control's rules can name
+	// the same field more than once, while the rendered list this annotates has
+	// already been deduplicated. Resolving a path twice would append the line
+	// twice to the single entry that survived.
+	seen := make(map[string]bool)
 	for _, fixPath := range fixPathsToString(control, true) {
+		if seen[fixPath] {
+			continue
+		}
+		seen[fixPath] = true
+
 		line, ok := lineFor(fixPath)
 		if !ok {
 			continue

--- a/core/pkg/resultshandling/printer/v2/resourcetable.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,16 +27,60 @@ const (
 	_resourceRowLen        = iota
 )
 
-func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASessionObj) {
+// failedResourcesInPrintOrder collects the failed resources the table will
+// print, paired with the manifest each came from, and orders them so every
+// resource of one manifest is visited consecutively.
+//
+// The order matters beyond tidiness. Evidence line numbers are resolved through
+// fixcache's manifestCache, which keeps exactly one manifest's decoded
+// documents alive and drops them when the walk reaches the next file. Ranging
+// over ResourcesResult directly hands them over in Go's randomised map order,
+// which would rebuild a file's resolver once per resource instead of once per
+// file. Sorting also makes the printed order reproducible between runs, which
+// map order never was.
+//
+// Unlike the SARIF collector, a resource with no source path is kept rather
+// than skipped: cluster scans have no manifests at all, and those resources
+// still belong in this table. They carry an empty absPath and simply resolve no
+// lines.
+func failedResourcesInPrintOrder(opaSessionObj *cautils.OPASessionObj) []scannedResource {
+	basePath := getBasePathFromMetadata(*opaSessionObj)
 
+	failed := make([]scannedResource, 0, len(opaSessionObj.ResourcesResult))
 	for resourceID, result := range opaSessionObj.ResourcesResult {
 		if !result.GetStatus(nil).IsFailed() {
 			continue
 		}
-		resource, ok := opaSessionObj.AllResources[resourceID]
-		if !ok {
+		if _, ok := opaSessionObj.AllResources[resourceID]; !ok {
 			continue
 		}
+
+		resourceSource := opaSessionObj.ResourceSource[resourceID]
+		relPath := resourceSource.RelativePath
+
+		var absPath string
+		if relPath != "" {
+			absPath = filepath.Join(effectiveBasePath(resourceSource, basePath), relPath)
+		}
+
+		failed = append(failed, scannedResource{
+			resourceID: resourceID,
+			relPath:    relPath,
+			absPath:    absPath,
+		})
+	}
+
+	return groupByManifest(failed)
+}
+
+func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASessionObj) {
+
+	var caches manifestCache
+	for _, scanned := range failedResourcesInPrintOrder(opaSessionObj) {
+		resourceID := scanned.resourceID
+		result := opaSessionObj.ResourcesResult[resourceID]
+		resource := opaSessionObj.AllResources[resourceID]
+
 		fmt.Fprintf(prettyPrinter.writer, "\n%s\n", getSeparator("#"))
 
 		if source, ok := opaSessionObj.ResourceSource[resourceID]; ok {
@@ -62,7 +107,8 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 		if src, ok := opaSessionObj.ResourceSource[resourceID]; ok {
 			sourcePath = src.RelativePath
 		}
-		resourceRows := generateResourceRows(result.ListControls(), &opaSessionObj.Report.SummaryDetails, resource, prettyPrinter.showEvidence, prettyPrinter.showSecrets, sourcePath)
+		lineFor := prettyPrinter.fixPathLineResolver(opaSessionObj, &caches, scanned)
+		resourceRows := generateResourceRows(result.ListControls(), &opaSessionObj.Report.SummaryDetails, resource, prettyPrinter.showEvidence, prettyPrinter.showSecrets, sourcePath, lineFor)
 
 		short := utils.CheckShortTerminalWidth(resourceRows, generateResourceHeader(false))
 		if short {
@@ -77,7 +123,51 @@ func (prettyPrinter *PrettyPrinter) resourceTable(opaSessionObj *cautils.OPASess
 
 }
 
-func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata, showEvidence bool, showSecrets bool, sourcePath string) []table.Row {
+// fixPathLineResolver returns the lookup generateResourceRows uses to turn a
+// fix path into a line in the manifest, or nil when no line can be resolved for
+// this resource. Three things have to hold, and each rules out a real case:
+//
+//   - --show-evidence is set. Without it no evidence is printed at all, so
+//     opening and decoding manifests would be work whose result is discarded.
+//   - The resource came from a file. Cluster-scanned resources have no manifest
+//     to point into, and asking the cache for an empty path would try to open
+//     "", fail, and warn once per scan about something that was never possible.
+//   - The document index is known. getDocIndex reads the "<path>:<index>"
+//     convention, which Helm-rendered resources do not carry, and it only
+//     applies to LocalWorkload at all.
+//
+// A nil return is the caller's signal to print paths exactly as before.
+func (prettyPrinter *PrettyPrinter) fixPathLineResolver(opaSessionObj *cautils.OPASessionObj, caches *manifestCache, scanned scannedResource) func(string) (int, bool) {
+	if !prettyPrinter.showEvidence || scanned.absPath == "" {
+		return nil
+	}
+
+	docIndex, ok := getDocIndex(opaSessionObj, scanned.resourceID)
+	if !ok {
+		return nil
+	}
+
+	resolver := caches.get(scanned.absPath).locationResolver(scanned.absPath, "evidence")
+	if resolver == nil {
+		return nil
+	}
+
+	return func(fixPath string) (int, bool) {
+		// ResolveLocation is called directly rather than through
+		// resolveFixLocation, which defaults to line 1 when nothing resolves.
+		// A fabricated line is worse than none for an auditor reading this
+		// column, so an unresolved path degrades to today's bare output -
+		// the same choice resolveReviewPathLocations makes for SARIF's
+		// related locations.
+		location, err := resolver.ResolveLocation(fixPath, docIndex)
+		if err != nil || location.Line == 0 {
+			return 0, false
+		}
+		return location.Line, true
+	}
+}
+
+func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl, summaryDetails *reportsummary.SummaryDetails, resource workloadinterface.IMetadata, showEvidence bool, showSecrets bool, sourcePath string, lineFor func(string) (int, bool)) []table.Row {
 	var rows []table.Row
 
 	for i := range controls {
@@ -91,6 +181,7 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 		if showEvidence {
 			paths := AssistedRemediationPathsWithCurrentValuesFiltered(&controls[i], resource, showSecrets)
 			addContainerNameToAssistedRemediation(resource, &paths)
+			annotateFixPathLines(&paths, &controls[i], lineFor)
 			if sourcePath != "" {
 				paths = append([]string{"@ " + sourcePath}, paths...)
 			}
@@ -106,6 +197,42 @@ func generateResourceRows(controls []resourcesresults.ResourceAssociatedControl,
 	}
 
 	return rows
+}
+
+// annotateFixPathLines appends " (line N)" to the assisted-remediation entries
+// that came from a FixPath and resolve to a line in the manifest.
+//
+// It has to re-derive which entries those are.
+// AssistedRemediationPathsWithCurrentValuesFiltered returns fix, delete and
+// review paths already rendered into one flat, deduplicated []string, so by
+// this point the path type is no longer visible: a fix path reads
+// "<path>=<value>", a delete path is bare, and a review path carries
+// " (current: <value>)". fixPathsToString with onlyPath re-reads the control
+// for the bare fix paths, and matching on "<path>=" pins the annotation to
+// those entries alone - the "=" is what stops "spec.a" from also matching
+// "spec.ab=x".
+//
+// Deriving it here, rather than having the path builders return structured
+// values, keeps this local to the pretty-printer: those builders are shared
+// with the SARIF, GitLab SAST, HTML and CSV printers, and changing their
+// output would change four report formats to annotate one table.
+func annotateFixPathLines(paths *[]string, control *resourcesresults.ResourceAssociatedControl, lineFor func(string) (int, bool)) {
+	if lineFor == nil || len(*paths) == 0 {
+		return
+	}
+
+	for _, fixPath := range fixPathsToString(control, true) {
+		line, ok := lineFor(fixPath)
+		if !ok {
+			continue
+		}
+		prefix := fixPath + "="
+		for i := range *paths {
+			if strings.HasPrefix((*paths)[i], prefix) {
+				(*paths)[i] += fmt.Sprintf(" (line %d)", line)
+			}
+		}
+	}
 }
 
 func addContainerNameToAssistedRemediation(resource workloadinterface.IMetadata, paths *[]string) {

--- a/core/pkg/resultshandling/printer/v2/resourcetable_lines_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_lines_test.go
@@ -100,6 +100,20 @@ func TestAnnotateFixPathLines(t *testing.T) {
 			want:    []string{"spec.containers[0].image=nginx:1 (app) (line 9)"},
 		},
 		{
+			// A control can carry the same fix path more than once across its
+			// rules, and fixPathsToString does not deduplicate while the
+			// rendered list does. Resolving per bare path would then stamp the
+			// one surviving entry twice.
+			name:  "a fix path repeated across rules is annotated once",
+			paths: []string{"spec.hostPID=false"},
+			control: fixPathControl(
+				armotypes.FixPath{Path: "spec.hostPID", Value: "false"},
+				armotypes.FixPath{Path: "spec.hostPID", Value: "false"},
+			),
+			lineFor: stubLineFor(map[string]int{"spec.hostPID": 23}),
+			want:    []string{"spec.hostPID=false (line 23)"},
+		},
+		{
 			name:    "empty path list is a no-op",
 			paths:   nil,
 			control: fixPathControl(armotypes.FixPath{Path: "spec.hostPID", Value: "false"}),

--- a/core/pkg/resultshandling/printer/v2/resourcetable_lines_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_lines_test.go
@@ -1,0 +1,316 @@
+package printer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLineFor builds a lineFor lookup from a fixed path->line map, so the
+// annotation logic can be tested without a manifest on disk.
+func stubLineFor(lines map[string]int) func(string) (int, bool) {
+	return func(path string) (int, bool) {
+		line, ok := lines[path]
+		return line, ok
+	}
+}
+
+func fixPathControl(paths ...armotypes.FixPath) *resourcesresults.ResourceAssociatedControl {
+	posture := make([]armotypes.PosturePaths, 0, len(paths))
+	for _, p := range paths {
+		posture = append(posture, armotypes.PosturePaths{FixPath: p})
+	}
+	return &resourcesresults.ResourceAssociatedControl{
+		ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{{Paths: posture}},
+	}
+}
+
+func TestAnnotateFixPathLines(t *testing.T) {
+	cases := []struct {
+		name    string
+		paths   []string
+		control *resourcesresults.ResourceAssociatedControl
+		lineFor func(string) (int, bool)
+		want    []string
+	}{
+		{
+			name:    "resolved fix path is annotated",
+			paths:   []string{"spec.hostPID=false"},
+			control: fixPathControl(armotypes.FixPath{Path: "spec.hostPID", Value: "false"}),
+			lineFor: stubLineFor(map[string]int{"spec.hostPID": 23}),
+			want:    []string{"spec.hostPID=false (line 23)"},
+		},
+		{
+			name:    "unresolved fix path is left alone",
+			paths:   []string{"spec.hostPID=false"},
+			control: fixPathControl(armotypes.FixPath{Path: "spec.hostPID", Value: "false"}),
+			lineFor: stubLineFor(nil),
+			want:    []string{"spec.hostPID=false"},
+		},
+		{
+			name:    "nil lookup leaves every path untouched",
+			paths:   []string{"spec.hostPID=false"},
+			control: fixPathControl(armotypes.FixPath{Path: "spec.hostPID", Value: "false"}),
+			lineFor: nil,
+			want:    []string{"spec.hostPID=false"},
+		},
+		{
+			// PR scope is FixPath only. A review path renders as
+			// "<path> (current: <value>)" and a delete path renders bare, so
+			// neither carries the "<path>=" shape the annotation matches on.
+			name:  "review and delete paths are not annotated",
+			paths: []string{"spec.hostPID (current: true)", "spec.hostNetwork"},
+			control: fixPathControl(
+				armotypes.FixPath{Path: "spec.hostPID", Value: "false"},
+				armotypes.FixPath{Path: "spec.hostNetwork", Value: "false"},
+			),
+			lineFor: stubLineFor(map[string]int{"spec.hostPID": 12, "spec.hostNetwork": 14}),
+			want:    []string{"spec.hostPID (current: true)", "spec.hostNetwork"},
+		},
+		{
+			// The "=" in the match is what keeps a shorter path from claiming
+			// a longer one that merely starts the same way.
+			name:  "a shorter path does not claim a longer one",
+			paths: []string{"spec.host=a", "spec.hostPID=false"},
+			control: fixPathControl(
+				armotypes.FixPath{Path: "spec.host", Value: "a"},
+				armotypes.FixPath{Path: "spec.hostPID", Value: "false"},
+			),
+			lineFor: stubLineFor(map[string]int{"spec.host": 7}),
+			want:    []string{"spec.host=a (line 7)", "spec.hostPID=false"},
+		},
+		{
+			// annotateFixPathLines runs after addContainerNameToAssistedRemediation,
+			// so the line lands last and the container hint keeps its place.
+			name:    "line is appended after an existing container-name suffix",
+			paths:   []string{"spec.containers[0].image=nginx:1 (app)"},
+			control: fixPathControl(armotypes.FixPath{Path: "spec.containers[0].image", Value: "nginx:1"}),
+			lineFor: stubLineFor(map[string]int{"spec.containers[0].image": 9}),
+			want:    []string{"spec.containers[0].image=nginx:1 (app) (line 9)"},
+		},
+		{
+			name:    "empty path list is a no-op",
+			paths:   nil,
+			control: fixPathControl(armotypes.FixPath{Path: "spec.hostPID", Value: "false"}),
+			lineFor: stubLineFor(map[string]int{"spec.hostPID": 3}),
+			want:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := tc.paths
+			annotateFixPathLines(&paths, tc.control, tc.lineFor)
+			assert.Equal(t, tc.want, paths)
+		})
+	}
+}
+
+// TestFailedResourcesInPrintOrder pins the ordering the manifest cache depends
+// on: resources of one file must arrive together, and the order must not vary
+// between runs the way ranging over the results map did.
+func TestFailedResourcesInPrintOrder(t *testing.T) {
+	session := cautils.NewOPASessionObjMock()
+	// NewOPASessionObjMock leaves ResourceSource nil.
+	session.ResourceSource = make(map[string]reporthandling.Source)
+
+	add := func(resourceID, relPath string, failed bool) {
+		status := apis.StatusPassed
+		if failed {
+			status = apis.StatusFailed
+		}
+		session.AllResources[resourceID] = workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": map[string]any{"name": resourceID},
+		})
+		session.ResourcesResult[resourceID] = resourcesresults.Result{
+			ResourceID: resourceID,
+			AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+				{ControlID: "C-0001", Status: apis.StatusInfo{InnerStatus: status}},
+			},
+		}
+		if relPath != "" {
+			session.ResourceSource[resourceID] = reporthandling.Source{RelativePath: relPath, Path: "/base"}
+		}
+	}
+
+	add("b-second-in-b", "b.yaml", true)
+	add("a-only-in-a", "a.yaml", true)
+	add("b-first-in-b", "b.yaml", true)
+	add("z-no-source", "", true)
+	add("passing", "a.yaml", false)
+
+	var ids []string
+	for _, r := range failedResourcesInPrintOrder(session) {
+		ids = append(ids, r.resourceID)
+	}
+
+	// Pathless resources sort first on an empty absPath, then each manifest's
+	// resources arrive consecutively and in a stable order within the file.
+	assert.Equal(t, []string{"z-no-source", "a-only-in-a", "b-first-in-b", "b-second-in-b"}, ids)
+	assert.NotContains(t, ids, "passing", "only failed resources belong in the table")
+
+	// The same session must produce the same order on a second pass.
+	var again []string
+	for _, r := range failedResourcesInPrintOrder(session) {
+		again = append(again, r.resourceID)
+	}
+	assert.Equal(t, ids, again)
+}
+
+const lineNumberManifest = "apiVersion: apps/v1\n" +
+	"kind: Deployment\n" +
+	"metadata:\n" +
+	"  name: demo\n" +
+	"spec:\n" +
+	"  template:\n" +
+	"    spec:\n" +
+	"      containers:\n" +
+	"        - name: app\n" +
+	"          image: nginx:1\n" +
+	"          securityContext:\n" +
+	"            privileged: true\n"
+
+// resourceTableLineNumberSession writes a real manifest and returns a session
+// whose single failed resource points into it, so the full path runs: doc index
+// parsing, resolver construction and yq evaluation against the file on disk.
+func resourceTableLineNumberSession(t *testing.T, manifest, docSuffix string) *cautils.OPASessionObj {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(manifest), 0o600))
+
+	resourceID := "apps/v1/default/Deployment/demo"
+	lw := localworkload.NewLocalWorkload(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{"name": "demo", "namespace": "default"},
+		"spec":       map[string]interface{}{},
+	})
+	lw.SetPath("deploy.yaml" + docSuffix)
+
+	session := cautils.NewOPASessionObjMock()
+	// NewOPASessionObjMock leaves ResourceSource nil.
+	session.ResourceSource = make(map[string]reporthandling.Source)
+	session.AllResources[resourceID] = lw
+	session.ResourceSource[resourceID] = reporthandling.Source{RelativePath: "deploy.yaml", Path: dir}
+	session.ResourcesResult[resourceID] = resourcesresults.Result{
+		ResourceID: resourceID,
+		AssociatedControls: []resourcesresults.ResourceAssociatedControl{
+			{
+				ControlID: "C-0001",
+				Name:      "Privileged container",
+				Status:    apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{
+						Name:   "privileged-container",
+						Status: apis.StatusFailed,
+						Paths: []armotypes.PosturePaths{
+							{FixPath: armotypes.FixPath{
+								Path:  "spec.template.spec.containers[0].securityContext.privileged",
+								Value: "false",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	session.Report.SummaryDetails = reportsummary.SummaryDetails{
+		Controls: reportsummary.ControlSummaries{
+			"C-0001": {ControlID: "C-0001", Name: "Privileged container", ScoreFactor: 8.0},
+		},
+	}
+	return session
+}
+
+func renderResourceTable(t *testing.T, session *cautils.OPASessionObj, showEvidence bool) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "resource-table-*.txt")
+	require.NoError(t, err)
+
+	pp := &PrettyPrinter{writer: f, showEvidence: showEvidence}
+	pp.resourceTable(session)
+
+	require.NoError(t, f.Close())
+	out, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	return string(out)
+}
+
+// TestResourceTable_FixPathResolvesToLine is the end-to-end case: a fix path
+// pointing at a field that exists in the manifest renders with its line.
+func TestResourceTable_FixPathResolvesToLine(t *testing.T) {
+	out := renderResourceTable(t, resourceTableLineNumberSession(t, lineNumberManifest, ":0"), true)
+
+	assert.Contains(t, out, "(line 12)", "privileged: true is line 12 of the fixture")
+}
+
+// TestResourceTable_UnresolvableFixPathDegrades covers a fix path whose field
+// is absent, which is the normal case for a fix that adds something. The path
+// still prints; it just carries no line.
+func TestResourceTable_UnresolvableFixPathDegrades(t *testing.T) {
+	manifest := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: demo\n"
+
+	out := renderResourceTable(t, resourceTableLineNumberSession(t, manifest, ":0"), true)
+
+	assert.Contains(t, out, "privileged=false")
+	assert.NotContains(t, out, "(line ", "an unresolved path must not be given a fabricated line")
+}
+
+// TestResourceTable_WithoutShowEvidenceHasNoLines keeps the non -E path
+// unchanged: no evidence column, and no manifest is opened to build one.
+func TestResourceTable_WithoutShowEvidenceHasNoLines(t *testing.T) {
+	out := renderResourceTable(t, resourceTableLineNumberSession(t, lineNumberManifest, ":0"), false)
+
+	assert.NotContains(t, out, "(line ")
+	assert.NotContains(t, out, "privileged=false")
+}
+
+// TestResourceTable_MissingDocIndexDegrades covers Helm-rendered resources,
+// whose path carries no ":<index>" suffix, so getDocIndex reports nothing and
+// the resolver is never reached.
+func TestResourceTable_MissingDocIndexDegrades(t *testing.T) {
+	out := renderResourceTable(t, resourceTableLineNumberSession(t, lineNumberManifest, ""), true)
+
+	assert.Contains(t, out, "privileged=false")
+	assert.NotContains(t, out, "(line ")
+}
+
+// TestResourceTable_SecondDocumentResolvesAgainstItsOwnDocument checks the doc
+// index is honoured rather than always reading the first document: the same
+// field sits at a different line in each document of the file.
+func TestResourceTable_SecondDocumentResolvesAgainstItsOwnDocument(t *testing.T) {
+	multiDoc := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: filler\n---\n" + lineNumberManifest
+
+	out := renderResourceTable(t, resourceTableLineNumberSession(t, multiDoc, ":1"), true)
+
+	// The first document and its separator take five lines, so the field that is
+	// line 12 on its own is line 17 here. That it moved at all is the point:
+	// the resolver honoured the document index instead of reading document 0.
+	assert.Contains(t, out, "(line 17)")
+}
+
+// TestResourceTable_ClusterResourceHasNoLines covers a resource with no source
+// manifest at all, which is every resource in a cluster scan.
+func TestResourceTable_ClusterResourceHasNoLines(t *testing.T) {
+	session := resourceTableLineNumberSession(t, lineNumberManifest, ":0")
+	for id := range session.ResourceSource {
+		delete(session.ResourceSource, id)
+	}
+
+	out := renderResourceTable(t, session, true)
+
+	assert.Contains(t, out, "privileged=false")
+	assert.NotContains(t, out, "(line ")
+}

--- a/core/pkg/resultshandling/printer/v2/resourcetable_test.go
+++ b/core/pkg/resultshandling/printer/v2/resourcetable_test.go
@@ -527,7 +527,7 @@ func TestGenerateResourceRows_Loop(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rows := generateResourceRows(tt.controls, &tt.summaryDetails, tt.resource, true, false, "")
+			rows := generateResourceRows(tt.controls, &tt.summaryDetails, tt.resource, true, false, "", nil)
 			assert.Equal(t, tt.expectedLen, len(rows))
 			//remediation is the last column of the first row
 			if len(rows) != 0 {


### PR DESCRIPTION
## Overview

The evidence column told you which file a finding came from, but not where in it so following a fix path meant searching the manifest by hand. Fix paths now carry their line:

```
@ deployment.yaml
spec.template.spec.containers[0].securityContext.privileged=false (api) (line 20)
```

Resolution reuses what the SARIF and GitLab SAST printers already use: `fixcache`'s per-manifest resolver cache and the document index from the `<path>:<index>` convention.

## Additional Information

Two things worth flagging rather than leaving to be discovered:

**Resource order is now deterministic.** The cache keeps one manifest's documents alive at a time, so the table collects failed resources and orders them by manifest before printing instead of ranging over the results map. Content is unchanged; the ordering just no longer varies between runs.

**Unresolved paths degrade, they don't guess.** `ResolveLocation` is called directly rather than through `resolveFixLocation`, which defaults to line 1 — a confidently wrong line is worse than none in an auditor-facing column, the same reasoning `resolveReviewPathLocations` applies to SARIF. Cluster resources, Helm-rendered resources with no document index, unreadable files, and paths the resolver can't parse (bracketed keys like `metadata.labels[app]`) all print exactly as they do today.

Scope is FixPath only. Review and delete paths arrive in the same flat string list already rendered, so fix paths are re-derived from the control and matched on `<path>=` to annotate those alone.

## How to Test

```
kubescape scan <dir-with-manifests> --view resource -v -E
```

Fix paths on fields present in the manifest show `(line N)`; everything else prints unchanged.

```
go test ./core/pkg/resultshandling/printer/v2/
```

## Related issues/PRs:

* Relates to #1563

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Failed resources now appear in a consistent, manifest-grouped order for easier review.
  * Assisted-remediation fix paths can include the relevant manifest line number when available.
  * Repeated fix paths are annotated only once for clearer output.
  * Line annotations appear only when reliable source information exists, avoiding misleading references for unresolved paths or resources without manifests.
* **Bug Fixes**
  * Improved handling of multi-document manifests and resources without source files in remediation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->