### PR TITLE
fix(opaprocessor): fix AllResources data race in celParamObjectFinder

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -717,7 +717,7 @@ func (scope evaluationScope) matchedObjects(rule *reporthandling.PolicyRule) []w
 // so aggregator write-back during evaluation cannot re-bucket namespaces
 // mid-scan.
 func (opap *OPAProcessor) evaluationScopes() []evaluationScope {
-	resident, batches := cautils.PartitionResources(opap.initialResourceCount, opap.K8SResources, opap.ExternalResources, opap.AllResources, opap.largeClusterSizeThreshold)
+	resident, batches := cautils.PartitionResources(opap.initialResourceCount, opap.K8SResources, opap.ExternalResources, opap.snapshotAllResources(), opap.largeClusterSizeThreshold)
 
 	residentGroups := newResidentIndex(resident)
 
@@ -746,9 +746,24 @@ func (opap *OPAProcessor) wholeClusterScope() evaluationScope {
 		Scope:             cautils.ClusterScope,
 		K8SResources:      opap.K8SResources,
 		ExternalResources: opap.ExternalResources,
-		AllResources:      opap.AllResources,
+		AllResources:      opap.snapshotAllResources(),
 	}
 	return newEvaluationScope(cautils.ClusterScope, nil, newResidentIndex(batch))
+}
+
+// snapshotAllResources returns a shallow copy of opap.AllResources, taken
+// under opap.mu. AllResources is grown concurrently mid-scan by aggregator
+// write-back (processRuleOnScope), so any caller that hands the map to code
+// outside opap.mu's protection — rather than doing a single guarded map
+// lookup itself — must work from a private copy, not the live map.
+func (opap *OPAProcessor) snapshotAllResources() map[string]workloadinterface.IMetadata {
+	opap.mu.Lock()
+	defer opap.mu.Unlock()
+	snapshot := make(map[string]workloadinterface.IMetadata, len(opap.AllResources))
+	for k, v := range opap.AllResources {
+		snapshot[k] = v
+	}
+	return snapshot
 }
 
 type policyControl struct {
@@ -1052,7 +1067,9 @@ func (opap *OPAProcessor) processControl(ctx context.Context, control *reporthan
 
 	if len(ruleErrs) == 0 && opap.incrementalCache != nil && controlCacheEligible(control) {
 		for resourceID, result := range resourcesAssociatedControl {
+			opap.mu.Lock()
 			resource, ok := opap.AllResources[resourceID]
+			opap.mu.Unlock()
 			if !ok {
 				continue
 			}

--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -1918,11 +1918,21 @@ func (opap *OPAProcessor) celParamObjectFinder() func(apiVersion, kind, namespac
 	if opap.OPASessionObj == nil {
 		return func(apiVersion, kind, namespace, name string) (map[string]any, bool) { return nil, false }
 	}
+
+	// AllResources is grown concurrently mid-scan by other rules' aggregator
+	// write-back (processRuleOnScope, guarded by opap.mu) while this rule's CEL
+	// evaluation snapshots it here. Without the same lock this is an
+	// unsynchronized concurrent map read/write, which Go's runtime can turn
+	// into a process-wide crash (fatal error: concurrent map iteration and map
+	// write), not just a race-detector warning.
+	opap.mu.Lock()
 	idx := make(map[string]map[string]any, len(opap.AllResources))
 	for _, res := range opap.AllResources {
 		key := res.GetApiVersion() + "/" + res.GetKind() + "/" + res.GetNamespace() + "/" + res.GetName()
 		idx[key] = res.GetObject()
 	}
+	opap.mu.Unlock()
+
 	return func(apiVersion, kind, namespace, name string) (map[string]any, bool) {
 		obj, ok := idx[apiVersion+"/"+kind+"/"+namespace+"/"+name]
 		return obj, ok

--- a/core/pkg/opaprocessor/processorhandler_allresources_race_test.go
+++ b/core/pkg/opaprocessor/processorhandler_allresources_race_test.go
@@ -1,0 +1,56 @@
+package opaprocessor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
+)
+
+// TestCelParamObjectFinderRacesAggregatorWriteback reproduces a crash seen in
+// production: a scan evaluating a mix of CEL and Rego rules can panic with
+// "fatal error: concurrent map iteration and map write".
+//
+// processRuleOnScope grows opap.AllResources mid-scan with aggregator-produced
+// resources (rule.go, guarded by opap.mu), while a different rule's CEL
+// evaluation concurrently calls celParamObjectFinder, which iterates
+// opap.AllResources to build its lookup index. celParamObjectFinder does not
+// take opap.mu, so the two goroutines access the map unsynchronized.
+//
+// This test drives exactly that pattern: one goroutine repeatedly calls
+// celParamObjectFinder (the unguarded reader) while the main goroutine writes
+// to AllResources through the same opap.mu the real write-back path uses. Run
+// with `-race` to see it flagged as a data race; a plain run can also trip
+// Go's runtime map-corruption check, matching the CI panic.
+func TestCelParamObjectFinderRacesAggregatorWriteback(t *testing.T) {
+	opap := paramRefProcessor()
+	opap.AllResources = map[string]workloadinterface.IMetadata{}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				opap.celParamObjectFinder()
+			}
+		}
+	}()
+
+	for i := 0; i < 5000; i++ {
+		obj := objectsenvelopes.NewObject(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      fmt.Sprintf("cm-%d", i),
+				"namespace": "default",
+			},
+		})
+		opap.mu.Lock()
+		opap.AllResources[obj.GetID()] = obj
+		opap.mu.Unlock()
+	}
+	close(done)
+}

--- a/core/pkg/opaprocessor/processorhandler_allresources_race_test.go
+++ b/core/pkg/opaprocessor/processorhandler_allresources_race_test.go
@@ -1,11 +1,16 @@
 package opaprocessor
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/pkg/scancache"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/resources"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCelParamObjectFinderRacesAggregatorWriteback reproduces a crash seen in
@@ -28,7 +33,10 @@ func TestCelParamObjectFinderRacesAggregatorWriteback(t *testing.T) {
 	opap.AllResources = map[string]workloadinterface.IMetadata{}
 
 	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-done:
@@ -53,4 +61,52 @@ func TestCelParamObjectFinderRacesAggregatorWriteback(t *testing.T) {
 		opap.mu.Unlock()
 	}
 	close(done)
+	wg.Wait()
+}
+
+// TestProcessControlRacesAggregatorWriteback covers the second unguarded
+// reader of opap.AllResources: when the incremental cache is attached,
+// processControl looks up each result's resource by ID (to hash it for the
+// cache entry) with no lock, while a sibling worker's processRuleOnScope can
+// concurrently grow the same map under opap.mu (processScope fans control
+// evaluation out across a worker pool, so both readers and the aggregator
+// writer run concurrently in a real scan). Run with `-race`.
+func TestProcessControlRacesAggregatorWriteback(t *testing.T) {
+	sess, _, _ := nsCacheSession(t)
+	store, err := scancache.Load(t.TempDir(), "v1")
+	require.NoError(t, err)
+	opap := NewOPAProcessor(sess, resources.NewRegoDependenciesDataMock(), "test", "", "", false, nil)
+	opap.SetIncrementalCache(store)
+	ctrl := nsCacheControl()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, _ = opap.processControl(context.Background(), ctrl, evaluationScope{})
+			}
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		obj := workloadinterface.NewWorkloadObj(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      fmt.Sprintf("cm-%d", i),
+				"namespace": "default",
+			},
+		})
+		opap.mu.Lock()
+		opap.AllResources[obj.GetID()] = obj
+		opap.mu.Unlock()
+	}
+	close(done)
+	wg.Wait()
 }


### PR DESCRIPTION
## Overview
Fixes a data race that can crash a scan with `fatal error: concurrent map iteration and map write` when CEL and Rego rules run in the same scan (surfaced by regolibrary PR https://github.com/kubescape/regolibrary/pull/813's CI, `scan_git_repository_and_submit_to_backend` against `AllControls`).

`processRuleOnScope` grows `opap.AllResources` mid-scan with aggregator-produced resources, guarded by `opap.mu`. Three other places read that same map without taking the lock:

1. `celParamObjectFinder` (used by the CEL engine to resolve `ValidatingAdmissionPolicy` param objects) iterates it to build a lookup index — this is the exact crash CI hit.
2. `processControl`'s incremental-cache path looks up a resource by ID to hash it — found by code review on this PR, reachable because `processScope` fans control evaluation across a worker pool.
3. `evaluationScopes`/`wholeClusterScope` hand the live map straight to `cautils.PartitionResources` / `ResourceBatch`, which iterates it entirely outside `opap.mu`.

## Commits
1. **test:** reproduces the `celParamObjectFinder` race — fails under `-race` with the same crash signature seen in CI.
2. **fix:** locks the `AllResources` snapshot in `celParamObjectFinder`.
3. **test+fix:** adds `TestProcessControlRacesAggregatorWriteback` (reproduces race #2), adds a `snapshotAllResources()` helper (locked shallow copy) used for #2 and #3, and fixes a goroutine leak in the first commit's test.

## How to Test
```
go test -race ./core/pkg/opaprocessor/...
```
Passes clean after all three commits (`ok ... opaprocessor 24.257s`, `ok ... opaprocessor/cel`).

## Related issues/PRs
- Surfaced by CI on https://github.com/kubescape/regolibrary/pull/813

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFjW8iHNQCZZPjgMBqfkBN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resource data is updated concurrently, preventing crashes caused by simultaneous reads and writes.

* **Tests**
  * Added coverage for concurrent resource updates to help detect race conditions and map-access failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->