### PR TITLE
fix(getter): fail on checksum verification errors

### DIFF
--- a/core/cautils/getter/downloadreleasedpolicy.go
+++ b/core/cautils/getter/downloadreleasedpolicy.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -78,6 +79,9 @@ func (drp *DownloadReleasedPolicy) ShouldPersistPolicyArtifacts() bool {
 func (drp *DownloadReleasedPolicy) SetRegoObjectsWithFallback() (fallback bool, err error) {
 	if err := drp.SetRegoObjects(); err != nil {
 		if drp.version != "" {
+			return false, err
+		}
+		if errors.Is(err, gitregostore.ErrChecksumVerification) {
 			return false, err
 		}
 		return true, nil

--- a/core/cautils/getter/downloadreleasedpolicy_test.go
+++ b/core/cautils/getter/downloadreleasedpolicy_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/kubescape/kubescape/v4/internal/testutils"
+	"github.com/kubescape/regolibrary/v2/gitregostore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -230,5 +233,42 @@ func TestSetRegoObjectsWithFallback(t *testing.T) {
 		require.Error(t, err)
 		require.False(t, fallback)
 		require.Contains(t, err.Error(), "v0.0.0-does-not-exist")
+	})
+}
+
+func TestSetRegoObjectsWithFallbackChecksumVerificationFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/download/checksums.txt", r.URL.Path)
+		_, err := fmt.Fprintln(w, "not-a-valid-checksum-manifest")
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Run("unversioned release does not fall back on checksum failure", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("")
+		p.gs.URL = server.URL + "/download"
+
+		fallback, err := p.SetRegoObjectsWithFallback()
+
+		require.Error(t, err)
+		require.False(t, fallback)
+		require.True(t, errors.Is(err, gitregostore.ErrChecksumVerification))
+	})
+
+	t.Run("pinned release returns checksum failure", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewDownloadReleasedPolicyWithVersion("v2.0.301")
+		p.gs.URL = server.URL + "/download"
+
+		fallback, err := p.SetRegoObjectsWithFallback()
+
+		require.Error(t, err)
+		require.False(t, fallback)
+		require.True(t, errors.Is(err, gitregostore.ErrChecksumVerification))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/kubescape/k8s-interface v0.0.220
 	github.com/kubescape/opa-utils v0.0.312
 	github.com/kubescape/rbac-utils v0.0.21
-	github.com/kubescape/regolibrary/v2 v2.0.1
+	github.com/kubescape/regolibrary/v2 v2.0.35-0.20260908055419-b5a54be48d8a
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73
 	github.com/kubescape/storage v0.0.305
 	github.com/mark3labs/mcp-go v1.0.0
@@ -630,3 +630,5 @@ replace github.com/google/go-containerregistry => github.com/matthyx/go-containe
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
 
 replace github.com/distribution/reference => github.com/distribution/reference v0.5.0
+
+replace github.com/kubescape/regolibrary/v2 => ../regolibrary

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/kubescape/k8s-interface v0.0.220
 	github.com/kubescape/opa-utils v0.0.312
 	github.com/kubescape/rbac-utils v0.0.21
-	github.com/kubescape/regolibrary/v2 v2.0.35-0.20260908055419-b5a54be48d8a
+	github.com/kubescape/regolibrary/v2 v2.0.36-0.20260910055212-64b3775e7c88
 	github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73
 	github.com/kubescape/storage v0.0.305
 	github.com/mark3labs/mcp-go v1.0.0
@@ -630,5 +630,3 @@ replace github.com/google/go-containerregistry => github.com/matthyx/go-containe
 replace github.com/containerd/containerd => github.com/Retr0-Xd/containerd v0.0.0-20260322054632-16583c73e9b8
 
 replace github.com/distribution/reference => github.com/distribution/reference v0.5.0
-
-replace github.com/kubescape/regolibrary/v2 => ../regolibrary

--- a/go.sum
+++ b/go.sum
@@ -1211,8 +1211,6 @@ github.com/kubescape/rbac-utils v0.0.21 h1:iRaGX8WKBd94dg31vpX10LHWoQZ/QKO5AMLzQ
 github.com/kubescape/rbac-utils v0.0.21/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.317-0.20240320124840-1d84ac7186ea h1:hLUe+1bdhiBD7xM/jliQozVd1NLYn1afQLxl5trQdPk=
 github.com/kubescape/regolibrary v1.0.317-0.20240320124840-1d84ac7186ea/go.mod h1:RK9dHjllKFnISDmVExQlI1B1z93TlQsAu/Kq9c0mt2U=
-github.com/kubescape/regolibrary/v2 v2.0.1 h1:7lKj171gslgTbbcmmGVHk34AZNqxForOXZIINoQfdzQ=
-github.com/kubescape/regolibrary/v2 v2.0.1/go.mod h1:s0/Mi9PYw7s91vIf1VJTkuu1Blsl5ZLpYn5UA7yk/vM=
 github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73 h1:XEAryANSWXNEytHoPITzlCTOR2S4bpa30keR39qMNRI=
 github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73/go.mod h1:raFzO50jkNPNdBCFNTMn2EGQtmAOcBDvzVTJiArQvfo=
 github.com/kubescape/storage v0.0.305 h1:Ofuoi3V6OW/7CApr7yuzYlcBQP0flBDY2zRzXs3N3Ls=

--- a/go.sum
+++ b/go.sum
@@ -1211,6 +1211,8 @@ github.com/kubescape/rbac-utils v0.0.21 h1:iRaGX8WKBd94dg31vpX10LHWoQZ/QKO5AMLzQ
 github.com/kubescape/rbac-utils v0.0.21/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
 github.com/kubescape/regolibrary v1.0.317-0.20240320124840-1d84ac7186ea h1:hLUe+1bdhiBD7xM/jliQozVd1NLYn1afQLxl5trQdPk=
 github.com/kubescape/regolibrary v1.0.317-0.20240320124840-1d84ac7186ea/go.mod h1:RK9dHjllKFnISDmVExQlI1B1z93TlQsAu/Kq9c0mt2U=
+github.com/kubescape/regolibrary/v2 v2.0.36-0.20260910055212-64b3775e7c88 h1:CPEkkDw7sHvBxv6nRdJMo2fkipd9VFJbnCTWAhAs1ak=
+github.com/kubescape/regolibrary/v2 v2.0.36-0.20260910055212-64b3775e7c88/go.mod h1:s7k7XQFiV0jlg29fICLPZ5BaU8BUt9tTqcZoFf5o3/A=
 github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73 h1:XEAryANSWXNEytHoPITzlCTOR2S4bpa30keR39qMNRI=
 github.com/kubescape/sizing-checker v0.0.0-20250323151332-73a18561dc73/go.mod h1:raFzO50jkNPNdBCFNTMn2EGQtmAOcBDvzVTJiArQvfo=
 github.com/kubescape/storage v0.0.305 h1:Ofuoi3V6OW/7CApr7yuzYlcBQP0flBDY2zRzXs3N3Ls=


### PR DESCRIPTION
Fixes : :  #3735.
## Overview

Prevents Kubescape from silently falling back when released artifact checksum verification fails.

`GitRegoStore` performs the actual SHA-256 verification, while Kubescape treats `ErrChecksumVerification` as a hard failure. This keeps artifact integrity verification at the RegoLibrary acquisition boundary and avoids duplicating checksum logic in Kubescape.

## Dependency

This PR depends on [`[kubescape/regolibrary#816](https://github.com/kubescape/regolibrary/pull/816)`](https://github.com/kubescape/regolibrary/pull/816), which exposes `ErrChecksumVerification` for consumers.

**https://github.com/kubescape/regolibrary/pull/816 has been merged ** , this PR will bump the RegoLibrary dependency to the upstream version and remove the temporary local replacement.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Checksum verification failures are now reported as errors instead of triggering fallback to the bundled policy cache.
  - Policy downloads with invalid checksum manifests no longer proceed through fallback behavior, helping prevent use of unverified policy data.
  - This behavior applies to both unversioned and pinned policy releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->