### PR TITLE
fix(opaprocessor): select whole controls in --skip-controls/--include-controls

### DIFF
--- a/core/pkg/opaprocessor/processorhandler.go
+++ b/core/pkg/opaprocessor/processorhandler.go
@@ -234,29 +234,29 @@ func (opap *OPAProcessor) SetIncrementalCache(cache *scancache.Store) {
 	opap.incrementalCache = cache
 }
 
-// effectiveExcludedRules merges the session's rule exclusions with the
-// --skip-controls and --include-controls filters. Both the eager and the
-// streaming entry point build AllPolicies from it, so the same cluster is
+// effectivePolicies returns the session's frameworks with the
+// --skip-controls and --include-controls filters applied. Both the eager and
+// the streaming entry point build AllPolicies from it, so the same cluster is
 // scanned against the same control set whichever path a scan takes.
 // It returns a hard error when the filter leaves nothing to scan, preventing
 // a 0-control, exit-0 result that would silently pass a CI gate.
-func (opap *OPAProcessor) effectiveExcludedRules() (map[string]bool, error) {
+func (opap *OPAProcessor) effectivePolicies() ([]reporthandling.Framework, error) {
 	if opap.SkipControls == "" && opap.IncludeControls == "" {
-		return opap.ExcludedRules, nil
+		return opap.Policies, nil
 	}
-	return buildControlExcludedRules(opap.ExcludedRules, opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
+	return filterFrameworkControls(opap.Policies, split(opap.SkipControls), split(opap.IncludeControls))
 }
 
 func (opap *OPAProcessor) ProcessRulesListener(ctx context.Context, progressListener IJobProgressNotificationClient) error {
 	scanningScope := cautils.GetScanningScope(opap.Metadata.ContextMetadata)
 
-	excludedRules, err := opap.effectiveExcludedRules()
+	frameworks, err := opap.effectivePolicies()
 	if err != nil {
 		return err
 	}
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, scanningScope)
+	opap.AllPolicies = convertFrameworksToPolicies(frameworks, opap.ExcludedRules, scanningScope)
 
-	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
+	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, frameworks, opap.AllPolicies)
 
 	// process
 	processErr := opap.Process(ctx, opap.AllPolicies, progressListener)
@@ -314,12 +314,12 @@ func (opap *OPAProcessor) ProcessWithStreaming(ctx context.Context, batchChan <-
 	opap.loggerStartScanning()
 	defer opap.loggerDoneScanning()
 
-	excludedRules, err := opap.effectiveExcludedRules()
+	frameworks, err := opap.effectivePolicies()
 	if err != nil {
 		return err
 	}
-	opap.AllPolicies = convertFrameworksToPolicies(opap.Policies, excludedRules, cautils.GetScanningScope(opap.Metadata.ContextMetadata))
-	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, opap.Policies, opap.AllPolicies)
+	opap.AllPolicies = convertFrameworksToPolicies(frameworks, opap.ExcludedRules, cautils.GetScanningScope(opap.Metadata.ContextMetadata))
+	ConvertFrameworksToSummaryDetails(&opap.Report.SummaryDetails, frameworks, opap.AllPolicies)
 
 	scopeControlIDs, wholeClusterControlIDs := splitWholeClusterControls(opap.AllPolicies, sortedControlIDs(opap.AllPolicies))
 

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -802,10 +802,17 @@ func controlMatchesAny(control *reporthandling.Control, set map[string]struct{})
 	return false
 }
 
-// buildControlExcludedRules merges the existing rule-exclusion map with any
-// --skip-controls or --include-controls filters. The resulting map marks
-// individual rule names with `true` so that convertFrameworksToPolicies drops
-// them. Include is a whitelist; skip is a blacklist and wins over include.
+// filterFrameworkControls applies the --skip-controls and --include-controls
+// filters to frameworks and returns copies with the deselected controls
+// removed. Include is a whitelist; skip is a blacklist and wins over include.
+//
+// The filter operates on whole controls, never on their rules. Rules are
+// shared across controls in the policy library (for example
+// non-root-containers backs both C-0013 and C-0211), so expressing "skip
+// C-0211" as "exclude every rule C-0211 uses" would silently drop every other
+// control built on those rules too, and "include C-0013" would strip C-0013's
+// own rule while excluding its siblings. This mirrors
+// policyhandler.excludeControls, which --exclude-controls uses.
 //
 // Matching is case-insensitive and accepts either identifier a control can be
 // named by, mirroring --exclude-controls (see policyhandler/controlfilter.go's
@@ -814,14 +821,13 @@ func controlMatchesAny(control *reporthandling.Control, set map[string]struct{})
 // --include-controls treats "not in the include set" as "exclude", a single
 // mistyped case produces a silently empty scan instead of the requested
 // control.
-func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling.Framework, skip, include []string) (map[string]bool, error) {
-	excludedRules := make(map[string]bool, len(base)+4)
-	for k, v := range base {
-		excludedRules[k] = v
-	}
-
+//
+// The returned frameworks share their Control values with the input but never
+// its Controls backing arrays, so the caller's slice (which may be a cached
+// policy set reused across scans) is left untouched.
+func filterFrameworkControls(frameworks []reporthandling.Framework, skip, include []string) ([]reporthandling.Framework, error) {
 	if len(skip) == 0 && len(include) == 0 {
-		return excludedRules, nil
+		return frameworks, nil
 	}
 
 	skipSet := make(map[string]struct{}, len(skip))
@@ -872,28 +878,23 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 		}
 	}
 
-	if len(includeSet) > 0 {
-		for _, fw := range frameworks {
-			for i := range fw.Controls {
-				if controlMatchesAny(&fw.Controls[i], includeSet) {
-					continue
-				}
-				for r := range fw.Controls[i].Rules {
-					excludedRules[fw.Controls[i].Rules[r].Name] = true
-				}
-			}
-		}
-	}
-
+	filtered := make([]reporthandling.Framework, 0, len(frameworks))
+	remaining := 0
 	for _, fw := range frameworks {
+		kept := make([]reporthandling.Control, 0, len(fw.Controls))
 		for i := range fw.Controls {
-			if !controlMatchesAny(&fw.Controls[i], skipSet) {
+			control := &fw.Controls[i]
+			if len(includeSet) > 0 && !controlMatchesAny(control, includeSet) {
 				continue
 			}
-			for r := range fw.Controls[i].Rules {
-				excludedRules[fw.Controls[i].Rules[r].Name] = true
+			if controlMatchesAny(control, skipSet) {
+				continue
 			}
+			kept = append(kept, *control)
 		}
+		fw.Controls = kept
+		remaining += len(kept)
+		filtered = append(filtered, fw)
 	}
 
 	// Guard against a filter that leaves nothing to scan. This can happen
@@ -901,26 +902,9 @@ func buildControlExcludedRules(base map[string]bool, frameworks []reporthandling
 	// --skip-controls, or when --skip-controls alone excludes every loaded
 	// control. Mirroring excludeControls' remaining==0 check prevents a
 	// 0-control, 0-failure, exit-0 scan that silently passes a CI gate.
-	if countRemainingControls(frameworks, excludedRules) == 0 {
+	if remaining == 0 {
 		return nil, errNoControlsAfterFilter
 	}
 
-	return excludedRules, nil
-}
-
-// countRemainingControls returns the number of controls that still have at
-// least one rule not marked excluded.
-func countRemainingControls(frameworks []reporthandling.Framework, excludedRules map[string]bool) int {
-	count := 0
-	for _, fw := range frameworks {
-		for i := range fw.Controls {
-			for r := range fw.Controls[i].Rules {
-				if !excludedRules[fw.Controls[i].Rules[r].Name] {
-					count++
-					break
-				}
-			}
-		}
-	}
-	return count
+	return filtered, nil
 }

--- a/core/pkg/opaprocessor/processorhandlerutils_test.go
+++ b/core/pkg/opaprocessor/processorhandlerutils_test.go
@@ -1395,7 +1395,19 @@ func TestUpdateResults_ScopeLessExceptionSuppressesResourceBackedFinding(t *test
 	})
 }
 
-func TestBuildControlExcludedRules(t *testing.T) {
+// keptControlIDs flattens the control IDs that survive filterFrameworkControls,
+// in framework order, so tests can assert on the selected control set.
+func keptControlIDs(frameworks []reporthandling.Framework) []string {
+	ids := []string{}
+	for _, fw := range frameworks {
+		for i := range fw.Controls {
+			ids = append(ids, fw.Controls[i].ControlID)
+		}
+	}
+	return ids
+}
+
+func TestFilterFrameworkControls(t *testing.T) {
 	framework := []reporthandling.Framework{{
 		Controls: []reporthandling.Control{
 			{ControlID: "C-0001", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
@@ -1405,73 +1417,116 @@ func TestBuildControlExcludedRules(t *testing.T) {
 	}}
 
 	tests := []struct {
-		name          string
-		base          map[string]bool
-		skip          []string
-		include       []string
-		excludedRules []string
-		notExcluded   []string
+		name    string
+		skip    []string
+		include []string
+		want    []string
 	}{
 		{
-			name:          "no filters",
-			base:          map[string]bool{"rule-a": false},
-			excludedRules: nil,
-			notExcluded:   []string{"rule-a", "rule-b", "rule-c"},
+			name: "no filters",
+			want: []string{"C-0001", "C-0002", "C-0003"},
 		},
 		{
-			name:          "skip one control",
-			skip:          []string{"C-0002"},
-			excludedRules: []string{"rule-b"},
-			notExcluded:   []string{"rule-a", "rule-c"},
+			name: "skip one control",
+			skip: []string{"C-0002"},
+			want: []string{"C-0001", "C-0003"},
 		},
 		{
-			name:          "include only two controls",
-			include:       []string{"C-0001", "C-0002"},
-			excludedRules: []string{"rule-c"},
-			notExcluded:   []string{"rule-a", "rule-b"},
+			name:    "include only two controls",
+			include: []string{"C-0001", "C-0002"},
+			want:    []string{"C-0001", "C-0002"},
 		},
 		{
-			name:          "include two and skip one of them",
-			include:       []string{"C-0001", "C-0002"},
-			skip:          []string{"C-0002"},
-			excludedRules: []string{"rule-b", "rule-c"},
-			notExcluded:   []string{"rule-a"},
+			name:    "include two and skip one of them",
+			include: []string{"C-0001", "C-0002"},
+			skip:    []string{"C-0002"},
+			want:    []string{"C-0001"},
 		},
 		{
-			name:          "unknown control ids are ignored",
-			skip:          []string{"C-9999"},
-			excludedRules: nil,
-			notExcluded:   []string{"rule-a", "rule-b", "rule-c"},
+			name: "unknown control ids are ignored",
+			skip: []string{"C-9999"},
+			want: []string{"C-0001", "C-0002", "C-0003"},
 		},
 		{
-			name:          "include matches regardless of case",
-			include:       []string{"c-0002"},
-			excludedRules: []string{"rule-a", "rule-c"},
-			notExcluded:   []string{"rule-b"},
+			name:    "include matches regardless of case",
+			include: []string{"c-0002"},
+			want:    []string{"C-0002"},
 		},
 		{
-			name:          "skip matches regardless of case",
-			skip:          []string{"c-0002"},
-			excludedRules: []string{"rule-b"},
-			notExcluded:   []string{"rule-a", "rule-c"},
+			name: "skip matches regardless of case",
+			skip: []string{"c-0002"},
+			want: []string{"C-0001", "C-0003"},
+		},
+		{
+			name: "blank entries are ignored",
+			skip: []string{" ", "", "C-0002"},
+			want: []string{"C-0001", "C-0003"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildControlExcludedRules(tt.base, framework, tt.skip, tt.include)
+			got, err := filterFrameworkControls(framework, tt.skip, tt.include)
 			require.NoError(t, err)
-			for _, rule := range tt.excludedRules {
-				assert.True(t, got[rule], "expected rule %q to be excluded", rule)
-			}
-			for _, rule := range tt.notExcluded {
-				assert.False(t, got[rule], "expected rule %q not to be excluded", rule)
-			}
+			assert.Equal(t, tt.want, keptControlIDs(got))
 		})
 	}
 }
 
-func TestBuildControlExcludedRules_IncludeNoMatchReturnsError(t *testing.T) {
+// TestFilterFrameworkControls_SharedRulesStayWithOtherControls guards the
+// reason the filter selects whole controls rather than rule names. The policy
+// library shares rules between controls (non-root-containers backs both
+// C-0013 and C-0211, for example), so skipping one control must not remove
+// the rules of every other control that happens to use them, and including a
+// control must keep its rules even when a sibling that shares them is dropped.
+func TestFilterFrameworkControls_SharedRulesStayWithOtherControls(t *testing.T) {
+	shared := reporthandling.PolicyRule{PortalBase: armotypes.PortalBase{Name: "non-root-containers"}}
+	framework := []reporthandling.Framework{{
+		Controls: []reporthandling.Control{
+			{ControlID: "C-0013", Rules: []reporthandling.PolicyRule{shared}},
+			{ControlID: "C-0211", Rules: []reporthandling.PolicyRule{shared, {PortalBase: armotypes.PortalBase{Name: "rule-privilege-escalation"}}}},
+			{ControlID: "C-0057", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-privilege-escalation"}}}},
+		},
+	}}
+
+	t.Run("skip keeps the siblings that share the skipped control's rules", func(t *testing.T) {
+		got, err := filterFrameworkControls(framework, []string{"C-0211"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"C-0013", "C-0057"}, keptControlIDs(got))
+		assert.Equal(t, []string{"non-root-containers"}, ruleNames(got[0].Controls[0]))
+		assert.Equal(t, []string{"rule-privilege-escalation"}, ruleNames(got[0].Controls[1]))
+	})
+
+	t.Run("include keeps the requested control's rules intact", func(t *testing.T) {
+		got, err := filterFrameworkControls(framework, nil, []string{"C-0013"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"C-0013"}, keptControlIDs(got))
+		assert.Equal(t, []string{"non-root-containers"}, ruleNames(got[0].Controls[0]))
+	})
+
+	t.Run("the selected controls survive conversion to policies", func(t *testing.T) {
+		got, err := filterFrameworkControls(framework, []string{"C-0211"}, nil)
+		require.NoError(t, err)
+		policies := convertFrameworksToPolicies(got, nil, reporthandling.ScopeCluster)
+		assert.Contains(t, policies.Controls, "C-0013")
+		assert.Contains(t, policies.Controls, "C-0057")
+		assert.NotContains(t, policies.Controls, "C-0211")
+	})
+}
+
+func ruleNames(control reporthandling.Control) []string {
+	names := make([]string, 0, len(control.Rules))
+	for _, rule := range control.Rules {
+		names = append(names, rule.Name)
+	}
+	return names
+}
+
+// TestFilterFrameworkControls_DoesNotMutateInput guards the cached policy set:
+// the frameworks handed to the processor may be reused across scans, so the
+// filter must hand back new Controls slices instead of compacting the
+// caller's backing array in place.
+func TestFilterFrameworkControls_DoesNotMutateInput(t *testing.T) {
 	framework := []reporthandling.Framework{{
 		Controls: []reporthandling.Control{
 			{ControlID: "C-0001", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
@@ -1479,38 +1534,51 @@ func TestBuildControlExcludedRules_IncludeNoMatchReturnsError(t *testing.T) {
 		},
 	}}
 
-	_, err := buildControlExcludedRules(nil, framework, nil, []string{"C-9999"})
+	got, err := filterFrameworkControls(framework, []string{"C-0001"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"C-0002"}, keptControlIDs(got))
+	assert.Equal(t, []string{"C-0001", "C-0002"}, keptControlIDs(framework), "input frameworks must be left untouched")
+}
+
+func TestFilterFrameworkControls_IncludeNoMatchReturnsError(t *testing.T) {
+	framework := []reporthandling.Framework{{
+		Controls: []reporthandling.Control{
+			{ControlID: "C-0001", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
+			{ControlID: "C-0002", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-b"}}}},
+		},
+	}}
+
+	_, err := filterFrameworkControls(framework, nil, []string{"C-9999"})
 	require.ErrorIs(t, err, errIncludeControlsNoMatch)
 
-	_, err = buildControlExcludedRules(nil, framework, nil, []string{"c-9999"})
+	_, err = filterFrameworkControls(framework, nil, []string{"c-9999"})
 	require.ErrorIs(t, err, errIncludeControlsNoMatch)
 
-	_, err = buildControlExcludedRules(nil, framework, nil, []string{"C-9999", "C-8888"})
+	_, err = filterFrameworkControls(framework, nil, []string{"C-9999", "C-8888"})
 	require.ErrorIs(t, err, errIncludeControlsNoMatch)
 
 	// Mixed: one valid + one invalid should NOT error, invalid is warned but valid keeps scan alive
-	got, err := buildControlExcludedRules(nil, framework, nil, []string{"C-0001", "C-9999"})
+	got, err := filterFrameworkControls(framework, nil, []string{"C-0001", "C-9999"})
 	require.NoError(t, err)
-	assert.True(t, got["rule-b"], "rule-b should be excluded (not included)")
-	assert.False(t, got["rule-a"], "rule-a should not be excluded")
+	assert.Equal(t, []string{"C-0001"}, keptControlIDs(got))
 
 	// Include valid then skip same => leaves zero controls => noControlsAfterFilter
-	_, err = buildControlExcludedRules(nil, framework, []string{"C-0001"}, []string{"C-0001"})
+	_, err = filterFrameworkControls(framework, []string{"C-0001"}, []string{"C-0001"})
 	require.ErrorIs(t, err, errNoControlsAfterFilter)
 
 	// Skip all controls via skip alone => leaves zero
-	_, err = buildControlExcludedRules(nil, framework, []string{"C-0001", "C-0002"}, nil)
+	_, err = filterFrameworkControls(framework, []string{"C-0001", "C-0002"}, nil)
 	require.ErrorIs(t, err, errNoControlsAfterFilter)
 }
 
-// TestBuildControlExcludedRules_MatchesCISSectionNumber guards the identifier
+// TestFilterFrameworkControls_MatchesCISSectionNumber guards the identifier
 // parity between --skip-controls/--include-controls and --exclude-controls.
 // CIS controls carry their section number in Control_ID (JSON "id", e.g.
 // "CIS-3.1.1") rather than in ControlID; matching only on ControlID made
 // --skip-controls CIS-3.1.1 a silent no-op while --exclude-controls CIS-3.1.1
 // worked, and made a mixed --include-controls list silently drop the section
 // -numbered entry without erroring.
-func TestBuildControlExcludedRules_MatchesCISSectionNumber(t *testing.T) {
+func TestFilterFrameworkControls_MatchesCISSectionNumber(t *testing.T) {
 	framework := []reporthandling.Framework{{
 		Controls: []reporthandling.Control{
 			{ControlID: "C-0286", Control_ID: "CIS-3.1.1", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
@@ -1520,68 +1588,56 @@ func TestBuildControlExcludedRules_MatchesCISSectionNumber(t *testing.T) {
 	}}
 
 	tests := []struct {
-		name          string
-		skip          []string
-		include       []string
-		excludedRules []string
-		notExcluded   []string
+		name    string
+		skip    []string
+		include []string
+		want    []string
 	}{
 		{
-			name:          "skip by CIS section number",
-			skip:          []string{"CIS-3.1.1"},
-			excludedRules: []string{"rule-a"},
-			notExcluded:   []string{"rule-b", "rule-c"},
+			name: "skip by CIS section number",
+			skip: []string{"CIS-3.1.1"},
+			want: []string{"C-0287", "C-0003"},
 		},
 		{
-			name:          "skip by CIS section number regardless of case",
-			skip:          []string{"cis-3.1.1"},
-			excludedRules: []string{"rule-a"},
-			notExcluded:   []string{"rule-b", "rule-c"},
+			name: "skip by CIS section number regardless of case",
+			skip: []string{"cis-3.1.1"},
+			want: []string{"C-0287", "C-0003"},
 		},
 		{
-			name:          "include by CIS section number",
-			include:       []string{"CIS-3.1.1"},
-			excludedRules: []string{"rule-b", "rule-c"},
-			notExcluded:   []string{"rule-a"},
+			name:    "include by CIS section number",
+			include: []string{"CIS-3.1.1"},
+			want:    []string{"C-0286"},
 		},
 		{
-			name:          "control ID still matches when a section number is present",
-			skip:          []string{"C-0286"},
-			excludedRules: []string{"rule-a"},
-			notExcluded:   []string{"rule-b", "rule-c"},
+			name: "control ID still matches when a section number is present",
+			skip: []string{"C-0286"},
+			want: []string{"C-0287", "C-0003"},
 		},
 		{
-			name:          "mixed include list keeps the section-numbered control",
-			include:       []string{"C-0287", "CIS-3.1.1"},
-			excludedRules: []string{"rule-c"},
-			notExcluded:   []string{"rule-a", "rule-b"},
+			name:    "mixed include list keeps the section-numbered control",
+			include: []string{"C-0287", "CIS-3.1.1"},
+			want:    []string{"C-0286", "C-0287"},
 		},
 		{
-			name:          "naming a control by both its forms at once excludes it exactly once",
-			skip:          []string{"C-0286", "CIS-3.1.1"},
-			excludedRules: []string{"rule-a"},
-			notExcluded:   []string{"rule-b", "rule-c"},
+			name: "naming a control by both its forms at once excludes it exactly once",
+			skip: []string{"C-0286", "CIS-3.1.1"},
+			want: []string{"C-0287", "C-0003"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildControlExcludedRules(nil, framework, tt.skip, tt.include)
+			got, err := filterFrameworkControls(framework, tt.skip, tt.include)
 			require.NoError(t, err)
-			for _, rule := range tt.excludedRules {
-				assert.True(t, got[rule], "expected rule %q to be excluded", rule)
-			}
-			for _, rule := range tt.notExcluded {
-				assert.False(t, got[rule], "expected rule %q not to be excluded", rule)
-			}
+			assert.Equal(t, tt.want, keptControlIDs(got))
 		})
 	}
 }
 
-// TestBuildControlExcludedRules_CISSectionIsAKnownID checks that a section
+// TestFilterFrameworkControls_CISSectionIsAKnownID checks that a section
 // number counts as a known identifier, so --include-controls CIS-3.1.1 alone
 // is not mistaken for a typo and rejected by errIncludeControlsNoMatch.
-func TestBuildControlExcludedRules_CISSectionIsAKnownID(t *testing.T) {
+func TestFilterFrameworkControls_CISSectionIsAKnownID(t *testing.T) {
 	framework := []reporthandling.Framework{{
 		Controls: []reporthandling.Control{
 			{ControlID: "C-0286", Control_ID: "CIS-3.1.1", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
@@ -1589,12 +1645,12 @@ func TestBuildControlExcludedRules_CISSectionIsAKnownID(t *testing.T) {
 		},
 	}}
 
-	got, err := buildControlExcludedRules(nil, framework, nil, []string{"CIS-3.1.1"})
+	got, err := filterFrameworkControls(framework, nil, []string{"CIS-3.1.1"})
 	require.NoError(t, err)
-	assert.False(t, got["rule-a"])
+	assert.Equal(t, []string{"C-0286"}, keptControlIDs(got))
 
 	// A genuinely unknown section number must still be a hard error.
-	_, err = buildControlExcludedRules(nil, framework, nil, []string{"CIS-9.9.9"})
+	_, err = filterFrameworkControls(framework, nil, []string{"CIS-9.9.9"})
 	require.ErrorIs(t, err, errIncludeControlsNoMatch)
 }
 
@@ -1643,12 +1699,12 @@ func TestControlIdentifiers(t *testing.T) {
 	}
 }
 
-// TestBuildControlExcludedRules_IdentifierFormsAreInterchangeable asserts the
-// two ways of naming one control produce byte-identical exclusion maps. The
-// table case above cannot catch a one-sided regression: naming a control by
-// both forms at once still passes when only ControlID is honoured, because the
+// TestFilterFrameworkControls_IdentifierFormsAreInterchangeable asserts the
+// two ways of naming one control produce identical control sets. The table
+// case above cannot catch a one-sided regression: naming a control by both
+// forms at once still passes when only ControlID is honoured, because the
 // ControlID half carries the match on its own.
-func TestBuildControlExcludedRules_IdentifierFormsAreInterchangeable(t *testing.T) {
+func TestFilterFrameworkControls_IdentifierFormsAreInterchangeable(t *testing.T) {
 	framework := []reporthandling.Framework{{
 		Controls: []reporthandling.Control{
 			{ControlID: "C-0286", Control_ID: "CIS-3.1.1", Rules: []reporthandling.PolicyRule{{PortalBase: armotypes.PortalBase{Name: "rule-a"}}}},
@@ -1656,15 +1712,15 @@ func TestBuildControlExcludedRules_IdentifierFormsAreInterchangeable(t *testing.
 		},
 	}}
 
-	byControlID, err := buildControlExcludedRules(nil, framework, []string{"C-0286"}, nil)
+	byControlID, err := filterFrameworkControls(framework, []string{"C-0286"}, nil)
 	require.NoError(t, err)
-	bySectionNumber, err := buildControlExcludedRules(nil, framework, []string{"CIS-3.1.1"}, nil)
+	bySectionNumber, err := filterFrameworkControls(framework, []string{"CIS-3.1.1"}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, byControlID, bySectionNumber, "--skip-controls must treat a control's ID and its section number as the same control")
+	assert.Equal(t, keptControlIDs(byControlID), keptControlIDs(bySectionNumber), "--skip-controls must treat a control's ID and its section number as the same control")
 
-	includeByControlID, err := buildControlExcludedRules(nil, framework, nil, []string{"C-0286"})
+	includeByControlID, err := filterFrameworkControls(framework, nil, []string{"C-0286"})
 	require.NoError(t, err)
-	includeBySectionNumber, err := buildControlExcludedRules(nil, framework, nil, []string{"CIS-3.1.1"})
+	includeBySectionNumber, err := filterFrameworkControls(framework, nil, []string{"CIS-3.1.1"})
 	require.NoError(t, err)
-	assert.Equal(t, includeByControlID, includeBySectionNumber, "--include-controls must treat a control's ID and its section number as the same control")
+	assert.Equal(t, keptControlIDs(includeByControlID), keptControlIDs(includeBySectionNumber), "--include-controls must treat a control's ID and its section number as the same control")
 }

--- a/core/pkg/opaprocessor/streaming_control_filter_test.go
+++ b/core/pkg/opaprocessor/streaming_control_filter_test.go
@@ -26,7 +26,7 @@ func controlIDsInResults(opap *OPAProcessor) map[string]struct{} {
 // TestProcessWithStreaming_HonorsSkipControls runs the eager and streaming
 // pipelines over the same manifests with --skip-controls C-0013 and asserts
 // both drop the control. ProcessRulesListener applies the filter via
-// buildControlExcludedRules; ProcessWithStreaming must reach the same verdict,
+// filterFrameworkControls; ProcessWithStreaming must reach the same verdict,
 // otherwise the same cluster is scanned against a different control set once it
 // grows past the streaming threshold.
 func TestProcessWithStreaming_HonorsSkipControls(t *testing.T) {


### PR DESCRIPTION
## Overview

`kubescape scan --skip-controls` / `--include-controls` were applied as a rule-name exclusion map: every rule of a deselected control was marked excluded, and `Policies.Set` then removed that rule from every control that uses it. Rule names are shared across controls in the policy library (21 rules in `allcontrols`, e.g. `non-root-containers` backs both C-0013 and C-0211), so:

* `--skip-controls C-0211` also silently dropped C-0013, C-0016, C-0017 and C-0057 from the report, with exit 0.
* `--include-controls C-0013` failed with `--include-controls/--skip-controls left no controls to scan`, because excluding C-0211's rules stripped C-0013's only rule.

This PR replaces `buildControlExcludedRules` with `filterFrameworkControls`, which selects whole controls and returns filtered framework copies (new `Controls` slices, so the cached policy set is never mutated), mirroring what `policyhandler.excludeControls` already does for `--exclude-controls`. Both the eager and the streaming entry points build `AllPolicies` and the summary details from the filtered frameworks; the session's rule-exclusion map (`ExcludedRules`) keeps its original single-resource purpose and is passed through unchanged.

Warnings for unknown IDs, the `--include-controls matched no known control` error, the "nothing left to scan" guard, case-insensitive matching and CIS section-number matching all behave as before.

## How to Test

```sh
cat > pod.yaml <<'YAML'
apiVersion: v1
kind: Pod
metadata:
  name: demo
  namespace: default
spec:
  containers:
  - name: c
    image: nginx:1.25
YAML

kubescape scan framework allcontrols pod.yaml --format json -o base.json
kubescape scan framework allcontrols pod.yaml --skip-controls C-0211 --format json -o skip.json
kubescape scan framework allcontrols pod.yaml --include-controls C-0013 --format json -o inc.json

comm -23 <(jq -r '.summaryDetails.controls | keys[]' base.json) \
         <(jq -r '.summaryDetails.controls | keys[]' skip.json)
```

Before: the `comm` output lists C-0013, C-0016, C-0017, C-0057 and C-0211, and the `--include-controls` run exits 1.
After: the `comm` output is only `C-0211`, and the `--include-controls C-0013` run produces a report containing C-0013 alone.

Unit tests: `go test ./core/pkg/opaprocessor/ -run 'TestFilterFrameworkControls|TestProcessWithStreaming_HonorsSkipControls'`. The new `TestFilterFrameworkControls_SharedRulesStayWithOtherControls` fails against the previous implementation.

## Related issues/PRs:

* Resolved #3792

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Control filters now apply to complete controls, preventing shared rules from being removed unintentionally.
  - `--skip-controls` and `--include-controls` consistently affect policy processing, summaries, and streaming results.
  - Control matching remains case-insensitive and supports equivalent identifier formats, including CIS section numbers.
  - Clear errors are returned when include filters match no controls or filtering leaves no controls available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->