### PR TITLE
fix(printer): stream configuration scan JSON and SARIF output

### DIFF
--- a/core/pkg/resultshandling/printer/v2/jsonprinter.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/anchore/clio"
 	grypejson "github.com/anchore/grype/grype/presenter/json"
@@ -16,7 +20,9 @@ import (
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
 )
 
 const (
@@ -109,11 +115,28 @@ func presentImageScan(imageScanData cautils.ImageScanData, w io.Writer) error {
 }
 
 func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, jp *JsonPrinter) error {
-	// Finalize into the report owned by this renderer before adding image data.
-	// The same OPASessionObj is submitted after local output is written, so
-	// enriching opaSessionObj.Report here would make --format change the backend
-	// payload as a side effect.
-	finalizedReport := FinalizeResults(opaSessionObj)
+	return writeConfigurationJSON(jp.writer, opaSessionObj, imageScanData)
+}
+
+func writeConfigurationJSON(w io.Writer, opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData) error {
+	// Finalize only the header on a local value. FinalizeResults would allocate
+	// complete result/resource slices and sort shared controls in place.
+	finalizedReport := *opaSessionObj.Report
+	finalizedReport.Results = nil
+	finalizedReport.Resources = nil
+	finalizedReport.Metadata = reporthandlingv2.Metadata{}
+	if opaSessionObj.Metadata != nil {
+		finalizedReport.Metadata = *opaSessionObj.Metadata
+	}
+	if finalizedReport.ReportGenerationTime.IsZero() {
+		finalizedReport.ReportGenerationTime = time.Now().UTC()
+	}
+	if finalizedReport.ClusterName == "" {
+		finalizedReport.ClusterName = cautils.AdoptClusterName(scanContextName(opaSessionObj))
+	}
+	if finalizedReport.ReportID == "" {
+		finalizedReport.ReportID = opaSessionObj.SessionID
+	}
 
 	if imageScanData != nil {
 		imageScanSummary := buildMachineImageScanSummary(imageScanData)
@@ -123,13 +146,114 @@ func printConfigurationsScanning(opaSessionObj *cautils.OPASessionObj, imageScan
 		finalizedReport.SummaryDetails.Vulnerabilities.Images = imageScanSummary.Images
 	}
 
-	// Convert to PostureReportWithSeverity to add severity field to controls,
-	// extract specified labels from workloads, and attach scan coverage gaps.
-	reportWithSeverity := ConvertToPostureReportWithSeverityLabelsAndCoverage(finalizedReport, opaSessionObj.LabelsToCopy, opaSessionObj.AllResources, &opaSessionObj.ScanCoverage)
-	reportWithSeverity.ExceptionAudit = opaSessionObj.ExceptionAudit
-	reportWithSeverity.NamespaceSummaries = opaSessionObj.NamespaceSummaries
+	// Reuse the established header schema and coverage predicate, without
+	// constructing any of the three resource-sized output collections.
+	header := ConvertToPostureReportWithSeverityLabelsAndCoverage(&finalizedReport, nil, nil, &opaSessionObj.ScanCoverage)
+	s := newJSONStream(w)
+	s.raw("{")
+	first := true
+	s.field(&first, "generationTime", header.ReportGenerationTime)
+	s.field(&first, "clusterAPIServerInfo", header.ClusterAPIServerInfo)
+	s.field(&first, "clusterCloudProvider", header.ClusterCloudProvider)
+	s.field(&first, "customerGUID", header.CustomerGUID)
+	s.field(&first, "clusterName", header.ClusterName)
+	s.field(&first, "reportGUID", header.ReportID)
+	s.field(&first, "summaryDetails", header.SummaryDetails)
+	s.field(&first, "attributes", header.Attributes)
+	s.field(&first, "metadata", header.Metadata)
+	if header.ScanCoverage != nil {
+		s.field(&first, "scanCoverage", header.ScanCoverage)
+	}
+	if opaSessionObj.ExceptionAudit != nil {
+		s.field(&first, "exceptionAudit", opaSessionObj.ExceptionAudit)
+	}
+	if len(opaSessionObj.NamespaceSummaries) > 0 {
+		s.field(&first, "namespaceSummaries", opaSessionObj.NamespaceSummaries)
+	}
+	if s.err != nil {
+		return s.err
+	}
 
-	return json.NewEncoder(jp.writer).Encode(reportWithSeverity)
+	resourceIDs := make([]string, 0, len(opaSessionObj.ResourcesResult))
+	for id := range opaSessionObj.ResourcesResult {
+		resourceIDs = append(resourceIDs, id)
+	}
+	sort.Strings(resourceIDs)
+	if len(resourceIDs) > 0 {
+		s.key(&first, "results")
+		s.raw("[")
+		firstResult := true
+		for _, id := range resourceIDs {
+			if s.err != nil {
+				return s.err
+			}
+			result := opaSessionObj.ResourcesResult[id]
+			if prioritized, ok := opaSessionObj.ResourcesPrioritized[id]; ok {
+				result.PrioritizedResource = &prioritized
+			}
+			enriched := enrichResultWithSeverity(result, opaSessionObj.Report.SummaryDetails.Controls, opaSessionObj.AllResources[result.ResourceID])
+			slices.SortFunc(enriched.AssociatedControls, func(a, b ResourceAssociatedControlWithSeverity) int {
+				return strings.Compare(a.ControlID, b.ControlID)
+			})
+			s.separator(&firstResult)
+			s.value(enriched)
+		}
+		s.raw("]")
+	}
+	if !opaSessionObj.OmitRawResources {
+		firstResource := true
+		for _, id := range resourceIDs {
+			if s.err != nil {
+				return s.err
+			}
+			result := opaSessionObj.ResourcesResult[id]
+			obj, ok := opaSessionObj.AllResources[result.ResourceID]
+			if !ok {
+				continue
+			}
+			if firstResource {
+				s.key(&first, "resources")
+				s.raw("[")
+			}
+			resource := reporthandling.NewResourceIMetadata(obj)
+			if source, ok := opaSessionObj.ResourceSource[result.ResourceID]; ok {
+				resource.SetSource(&source)
+			}
+			s.separator(&firstResource)
+			s.value(resource)
+		}
+		if !firstResource {
+			s.raw("]")
+		}
+	}
+	if len(opaSessionObj.LabelsToCopy) > 0 && s.err == nil {
+		// Labels apply to all resources, including those without a result.
+		ids := make([]string, 0, len(opaSessionObj.AllResources))
+		for id := range opaSessionObj.AllResources {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		firstLabels := true
+		for _, id := range ids {
+			if s.err != nil {
+				return s.err
+			}
+			labels := extractResourceLabelsForResource(opaSessionObj.AllResources[id], opaSessionObj.LabelsToCopy)
+			if len(labels) == 0 {
+				continue
+			}
+			if firstLabels {
+				s.key(&first, "resourceLabels")
+				s.raw("{")
+			}
+			s.field(&firstLabels, id, labels)
+		}
+		if !firstLabels {
+			s.raw("}")
+		}
+	}
+	s.raw("}\n")
+	return s.err
 }
 
 func convertToPackageScores(packageScores map[string]*imageprinter.PackageScore) map[string]*reportsummary.PackageSummary {

--- a/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/jsonprinter_test.go
@@ -1,16 +1,25 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"math"
 	"os"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/anchore/grype/grype/match"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer/v2/prettyprinter/tableprinter/imageprinter"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/prioritization"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
 	reporthandlingv2 "github.com/kubescape/opa-utils/reporthandling/v2"
@@ -550,4 +559,309 @@ func TestEnrichResultsWithSeverity_NoResourceMatchLeavesEvidenceNil(t *testing.T
 
 	require.Len(t, enrichedResults, 1)
 	assert.Nil(t, enrichedResults[0].AssociatedControls[0].Evidence)
+}
+
+// The reference uses the established report conversion on an independent
+// fixture: FinalizeResults mutates defaults and shared control slice order.
+func TestConfigurationJSONStreamingMatchesConversion(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		size      int
+		configure func(*cautils.OPASessionObj)
+	}{
+		{name: "empty"},
+		{name: "single", size: 1},
+		{name: "multiple", size: 3},
+		{name: "omit raw", size: 3, configure: func(s *cautils.OPASessionObj) { s.OmitRawResources = true }},
+		{name: "missing raw", size: 3, configure: func(s *cautils.OPASessionObj) { delete(s.AllResources, "resource-000001") }},
+		{name: "all raw missing", size: 1, configure: func(s *cautils.OPASessionObj) { clear(s.AllResources) }},
+		{name: "labels without results", size: 3, configure: func(s *cautils.OPASessionObj) {
+			s.LabelsToCopy = []string{"app", "absent"}
+			delete(s.ResourcesResult, "resource-000001")
+		}},
+		{name: "no matching labels", size: 1, configure: func(s *cautils.OPASessionObj) { s.LabelsToCopy = []string{"absent"} }},
+		{name: "key differs from resource ID", size: 2, configure: func(s *cautils.OPASessionObj) {
+			r := s.ResourcesResult["resource-000000"]
+			delete(s.ResourcesResult, "resource-000000")
+			r.PrioritizedResource = &prioritization.PrioritizedResource{Score: 1}
+			s.ResourcesResult["different-key"] = r
+			s.ResourcesPrioritized["different-key"] = prioritization.PrioritizedResource{Score: 42, ResourceID: r.ResourceID}
+		}},
+		{name: "unsorted and unknown controls", size: 2, configure: func(s *cautils.OPASessionObj) {
+			delete(s.Report.SummaryDetails.Controls, "C-0000")
+			for _, r := range s.ResourcesResult {
+				slices.Reverse(r.AssociatedControls)
+			}
+		}},
+		{name: "optional sections", size: 1, configure: func(s *cautils.OPASessionObj) {
+			s.ExceptionAudit = &cautils.ExceptionAudit{Generated: true, Items: []cautils.ExceptionAuditItem{{Name: "exception", MatchCount: 1, MatchedResources: []cautils.ExceptionAuditMatch{{ResourceID: "resource-000000", ControlID: "C-0000"}}}}}
+			s.NamespaceSummaries = cautils.NamespaceSummaries{{Namespace: "default", ResourceCount: 1}}
+			s.ScanCoverage.VacuousFrameworks = []string{"example"}
+			s.Report.Attributes = []reportsummary.PostureAttributes{{Attribute: "example", Values: []string{"value"}}}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy, session := configurationOutputFixture(t, tc.size), configurationOutputFixture(t, tc.size)
+			for id, source := range legacy.ResourceSource {
+				session.ResourceSource[id] = source
+			}
+			if tc.configure != nil {
+				tc.configure(legacy)
+				tc.configure(session)
+			}
+			before := snapshotJSONSession(t, session)
+			expected := ConvertToPostureReportWithSeverityLabelsAndCoverage(FinalizeResults(legacy), legacy.LabelsToCopy, legacy.AllResources, &legacy.ScanCoverage)
+			expected.ExceptionAudit = legacy.ExceptionAudit
+			expected.NamespaceSummaries = legacy.NamespaceSummaries
+			want, err := json.Marshal(expected)
+			require.NoError(t, err)
+			var output bytes.Buffer
+			require.NoError(t, writeConfigurationJSON(&output, session, nil))
+			require.NoError(t, checkJSONDocument(output.Bytes()))
+			require.JSONEq(t, string(want), output.String())
+			require.Equal(t, before, snapshotJSONSession(t, session))
+			var again bytes.Buffer
+			require.NoError(t, writeConfigurationJSON(&again, session, nil))
+			require.Equal(t, output.String(), again.String())
+		})
+	}
+}
+
+func snapshotJSONSession(t *testing.T, s *cautils.OPASessionObj) string {
+	t.Helper()
+	// Capture raw objects as well as result/control ordering. Marshaling the
+	// whole session would omit the objects behind its metadata interfaces.
+	objects := map[string]any{}
+	for id, r := range s.AllResources {
+		objects[id] = r.GetObject()
+	}
+	b, err := json.Marshal([]any{s.Report, s.Metadata, s.ResourcesResult, s.ResourcesPrioritized, s.ResourceSource, objects, s.ScanCoverage, s.ExceptionAudit, s.NamespaceSummaries})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestConfigurationJSONDefaultsStayLocal(t *testing.T) {
+	s := cautils.NewOPASessionObjMock()
+	s.SessionID = "session-id"
+	s.Metadata = nil
+	before := snapshotJSONSession(t, s)
+	var output bytes.Buffer
+	start := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, writeConfigurationJSON(&output, s, nil))
+	var doc PostureReportWithSeverity
+	require.NoError(t, json.Unmarshal(output.Bytes(), &doc))
+	generated, err := time.Parse(time.RFC3339, doc.ReportGenerationTime)
+	require.NoError(t, err)
+	require.False(t, generated.Before(start))
+	require.Equal(t, s.SessionID, doc.ReportID)
+	require.Equal(t, cautils.AdoptClusterName(scanContextName(s)), doc.ClusterName)
+	require.Equal(t, reporthandlingv2.Metadata{}, doc.Metadata)
+	require.Equal(t, before, snapshotJSONSession(t, s))
+}
+
+func TestConfigurationJSONImageSummaryStaysLocal(t *testing.T) {
+	s := configurationOutputFixture(t, 1)
+	before := snapshotJSONSession(t, s)
+	image := buildSeverityExceptionImageScanData()
+	matches := image.Matches.Sorted()
+	for i := range matches {
+		matches[i].Vulnerability.Metadata = image.VulnerabilityProvider.(severityRegressionVulnerabilityProvider).metadataByID[matches[i].Vulnerability.ID]
+	}
+	image.Matches = match.NewMatches(matches...)
+	var output bytes.Buffer
+	require.NoError(t, writeConfigurationJSON(&output, s, []cautils.ImageScanData{image}))
+	var doc PostureReportWithSeverity
+	require.NoError(t, json.Unmarshal(output.Bytes(), &doc))
+	summary := buildMachineImageScanSummary([]cautils.ImageScanData{image})
+	require.Equal(t, convertToCVESummary(summary.CVEs), doc.SummaryDetails.Vulnerabilities.CVESummary)
+	require.Equal(t, convertToPackageScores(summary.PackageScores), map[string]*reportsummary.PackageSummary(doc.SummaryDetails.Vulnerabilities.PackageScores))
+	require.Equal(t, summary.Images, doc.SummaryDetails.Vulnerabilities.Images)
+	require.Equal(t, before, snapshotJSONSession(t, s))
+}
+
+// checkJSONDocument rejects duplicate keys, including nested ones, and any
+// second document. json.Unmarshal alone accepts duplicate object properties.
+func checkJSONDocument(data []byte) error {
+	d := json.NewDecoder(bytes.NewReader(data))
+	var walk func() error
+	walk = func() error {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		delim, container := token.(json.Delim)
+		if !container {
+			return nil
+		}
+		switch delim {
+		case '{':
+			seen := map[string]bool{}
+			for d.More() {
+				key, err := d.Token()
+				if err != nil {
+					return err
+				}
+				name, ok := key.(string)
+				if !ok {
+					return fmt.Errorf("non-string object key")
+				}
+				if seen[name] {
+					return fmt.Errorf("duplicate key %q", name)
+				}
+				seen[name] = true
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+		case '[':
+			for d.More() {
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unexpected delimiter %q", delim)
+		}
+		_, err = d.Token()
+		return err
+	}
+	if err := walk(); err != nil {
+		return err
+	}
+	if _, err := d.Token(); err != io.EOF {
+		return fmt.Errorf("expected EOF, got %v", err)
+	}
+	return nil
+}
+
+func TestCheckJSONDocument(t *testing.T) {
+	for _, bad := range []string{`{"runs":[{"results":[],"results":[]}]}`, `{"a":{"x":1,"x":2}}`, `{} {}`, `{"a":[`} {
+		require.Error(t, checkJSONDocument([]byte(bad)))
+	}
+	require.NoError(t, checkJSONDocument([]byte(`{"a":[{"x":1},{"x":2}]}`)))
+}
+
+var errOutputTest = errors.New("output failed")
+
+type failAfterWriter struct {
+	remaining         int
+	failed            bool
+	callsAfterFailure int
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if w.failed {
+		w.callsAfterFailure++
+		return 0, errOutputTest
+	}
+	if len(p) > w.remaining {
+		n := w.remaining
+		w.failed = true
+		return n, errOutputTest
+	}
+	w.remaining -= len(p)
+	return len(p), nil
+}
+
+type shortOutputWriter struct{}
+
+func (shortOutputWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+func TestConfigurationJSONWriteFailures(t *testing.T) {
+	s := configurationOutputFixture(t, 2)
+	s.LabelsToCopy = []string{"app"}
+	before := snapshotJSONSession(t, s)
+	var output bytes.Buffer
+	require.NoError(t, writeConfigurationJSON(&output, s, nil))
+	cuts := []int{0, 1, output.Len() - 1}
+	for _, marker := range []string{`"summaryDetails":`, `"results":[`, `"resourceID":"resource-000001"`, `"resources":[`, `"resourceLabels":{`} {
+		index := strings.Index(output.String(), marker)
+		require.NotEqual(t, -1, index, marker)
+		cuts = append(cuts, index, index+len(marker)+1)
+	}
+	for _, cut := range cuts {
+		w := &failAfterWriter{remaining: cut}
+		require.ErrorIs(t, writeConfigurationJSON(w, s, nil), errOutputTest, "cut %d", cut)
+		require.Zero(t, w.callsAfterFailure)
+		require.Equal(t, before, snapshotJSONSession(t, s))
+	}
+	require.ErrorIs(t, writeConfigurationJSON(shortOutputWriter{}, s, nil), io.ErrShortWrite)
+}
+
+func TestConfigurationJSONEncodingFailures(t *testing.T) {
+	for _, stage := range []string{"header", "result", "raw resource"} {
+		t.Run(stage, func(t *testing.T) {
+			s := configurationOutputFixture(t, 2)
+			switch stage {
+			case "header":
+				s.Report.SummaryDetails.Score = float32(math.NaN())
+			case "result":
+				s.ResourcesPrioritized["resource-000000"] = prioritization.PrioritizedResource{Score: math.NaN()}
+			case "raw resource":
+				s.AllResources["resource-000000"].GetObject()["unsupported"] = make(chan int)
+			}
+			var output bytes.Buffer
+			err := writeConfigurationJSON(&output, s, nil)
+			require.Error(t, err)
+			require.Error(t, checkJSONDocument(output.Bytes()))
+		})
+	}
+}
+
+type observedResource struct {
+	workloadinterface.IMetadata
+	observe func()
+}
+
+func (r observedResource) GetObject() map[string]interface{} {
+	r.observe()
+	return r.IMetadata.GetObject()
+}
+
+type stopAtResultWriter struct {
+	bytes.Buffer
+	marker string
+}
+
+func (w *stopAtResultWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte(w.marker)) {
+		return 0, errOutputTest
+	}
+	return w.Buffer.Write(p)
+}
+
+func TestConfigurationJSONStopsBeforeTransformingLaterResources(t *testing.T) {
+	s := configurationOutputFixture(t, 2)
+	w := &stopAtResultWriter{marker: `"resourceID":"resource-000000"`}
+	reads := [2]int{}
+	for i := range reads {
+		id := fmt.Sprintf("resource-%06d", i)
+		s.AllResources[id] = observedResource{s.AllResources[id], func() {
+			require.Contains(t, w.String(), `"results":[`)
+			reads[i]++
+		}}
+	}
+	require.ErrorIs(t, writeConfigurationJSON(w, s, nil), errOutputTest)
+	require.Positive(t, reads[0])
+	require.Zero(t, reads[1])
+}
+
+func TestConfigurationJSONCoverageMatchesConversion(t *testing.T) {
+	for _, coverage := range []string{
+		`{}`, `{"failedGVRPulls":[{}]}`, `{"notEvaluatedControls":[{}]}`,
+		`{"partialGVRPulls":[{}]}`, `{"policyDegradations":[{}]}`,
+		`{"skippedManifests":[{}]}`, `{"vacuousFrameworks":["example"]}`,
+	} {
+		t.Run(coverage, func(t *testing.T) {
+			legacy, session := configurationOutputFixture(t, 0), configurationOutputFixture(t, 0)
+			require.NoError(t, json.Unmarshal([]byte(coverage), &legacy.ScanCoverage))
+			require.NoError(t, json.Unmarshal([]byte(coverage), &session.ScanCoverage))
+			expected := ConvertToPostureReportWithSeverityLabelsAndCoverage(FinalizeResults(legacy), nil, nil, &legacy.ScanCoverage)
+			want, err := json.Marshal(expected)
+			require.NoError(t, err)
+			var output bytes.Buffer
+			require.NoError(t, writeConfigurationJSON(&output, session, nil))
+			require.JSONEq(t, string(want), output.String())
+		})
+	}
 }

--- a/core/pkg/resultshandling/printer/v2/jsonstream.go
+++ b/core/pkg/resultshandling/printer/v2/jsonstream.go
@@ -1,0 +1,67 @@
+package printer
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// jsonStream only frames objects and arrays; encoding/json still owns the
+// encoding of every value. Keep large collections out of individual values.
+type jsonStream struct {
+	writer  io.Writer
+	encoder *json.Encoder
+	err     error
+}
+
+func newJSONStream(w io.Writer) *jsonStream {
+	s := &jsonStream{writer: w}
+	s.encoder = json.NewEncoder(s)
+	return s
+}
+
+func (s *jsonStream) Write(p []byte) (int, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	n, err := s.writer.Write(p)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	s.err = err
+	return n, err
+}
+
+func (s *jsonStream) raw(text string) {
+	if s.err == nil {
+		_, s.err = io.WriteString(s, text)
+	}
+}
+
+func (s *jsonStream) value(value any) {
+	if s.err == nil {
+		s.err = s.encoder.Encode(value)
+	}
+}
+
+func (s *jsonStream) separator(first *bool) {
+	if !*first {
+		s.raw(",")
+	}
+	*first = false
+}
+
+func (s *jsonStream) key(first *bool, name string) {
+	if s.err != nil {
+		return
+	}
+	s.separator(first)
+	// Strings cannot fail JSON encoding. Unlike strconv.Quote, this also
+	// preserves JSON escaping for resource IDs used as object keys.
+	key, _ := json.Marshal(name)
+	s.raw(string(key) + ":")
+}
+
+func (s *jsonStream) field(first *bool, name string, value any) {
+	s.key(first, name)
+	s.value(value)
+}

--- a/core/pkg/resultshandling/printer/v2/sarifprinter.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter.go
@@ -6,9 +6,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -117,11 +119,11 @@ func (sp *SARIFPrinter) addRule(scanRun *sarif.Run, control reportsummary.IContr
 		})
 }
 
-// addResult adds a result of checking a rule to the scan run based on the given control summary.
+// createResult builds one finding without retaining it in a run.
 // reviewPathLocations, when non-empty, adds one relatedLocation per resolved ReviewPath so each
 // field that actually caused the failure gets its own precise location in the manifest, distinct
 // from the single primary location (which points at the fix, not necessarily at every failed field).
-func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resourceID string, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
+func (sp *SARIFPrinter) createResult(ctl reportsummary.IControlSummary, filepath string, location locationresolver.Location, ac *resourcesresults.ResourceAssociatedControl, resourceID string, resource workloadinterface.IMetadata, reviewPathLocations map[string]locationresolver.Location) *sarif.Result {
 	msg := ctl.GetDescription()
 	if resource != nil {
 		if paths := AssistedRemediationPathsWithCurrentValuesFiltered(ac, resource, sp.showSecrets); len(paths) > 0 {
@@ -129,7 +131,7 @@ func (sp *SARIFPrinter) addResult(scanRun *sarif.Run, ctl reportsummary.IControl
 			msg += "\n\nAffected fields:\n" + strings.Join(paths, "\n")
 		}
 	}
-	result := scanRun.CreateResultForRule(ctl.GetID()).
+	result := sarif.NewRuleResult(ctl.GetID()).
 		WithMessage(sarif.NewTextMessage(msg)).
 		WithLocations([]*sarif.Location{
 			sarif.NewLocationWithPhysicalLocation(
@@ -563,6 +565,10 @@ func (sp *SARIFPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.
 }
 
 func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionObj *cautils.OPASessionObj) error {
+	return sp.writeConfigurationSARIF(ctx, sp.writer, opaSessionObj)
+}
+
+func (sp *SARIFPrinter) writeConfigurationSARIF(ctx context.Context, w io.Writer, opaSessionObj *cautils.OPASessionObj) error {
 	startedAt := opaSessionObj.Report.ReportGenerationTime
 	if startedAt.IsZero() {
 		startedAt = time.Now().UTC()
@@ -599,12 +605,50 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 		})
 	}
 
+	ordered := groupByManifest(failed)
+	// Rules are compact and precede results. Retain their indexes, not a
+	// second graph of findings, locations and fixes.
+	ruleIndexes := make(map[string]int)
+	for _, resource := range ordered {
+		for _, ac := range sortedSARIFControls(opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls) {
+			if !ac.GetStatus(nil).IsFailed() {
+				continue
+			}
+			ctl := opaSessionObj.Report.SummaryDetails.Controls.GetControl(reportsummary.EControlCriteriaID, ac.GetID())
+			if ctl == nil {
+				continue
+			}
+			if _, exists := ruleIndexes[ctl.GetID()]; !exists {
+				ruleIndexes[ctl.GetID()] = len(run.Tool.Driver.Rules)
+				sp.addRule(run, ctl)
+			}
+		}
+	}
+	stream := newJSONStream(w)
+	stream.raw("{\n  \"version\":")
+	stream.value(report.Version)
+	stream.raw(",\n  \"$schema\":")
+	stream.value(report.Schema)
+	stream.raw(",\n  \"runs\": [\n    {\n      \"tool\": ")
+	stream.encoder.SetIndent("      ", "  ")
+	stream.value(run.Tool)
+	// Run.Results has no omitempty tag. Never marshal the run as a header:
+	// that would emit a second results key before the streamed array.
+	stream.raw(",\n      \"results\": [")
+	stream.encoder.SetIndent("        ", "  ")
+	firstResult := true
 	var caches manifestCache
-	for _, resource := range groupByManifest(failed) {
+	for _, resource := range ordered {
+		if stream.err != nil {
+			return fmt.Errorf("failed to write SARIF report: %w", stream.err)
+		}
 		cache := caches.get(resource.absPath)
 		locationResolver := cache.locationResolver(resource.absPath, "SARIF")
 
-		for _, toPin := range opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls {
+		for _, toPin := range sortedSARIFControls(opaSessionObj.ResourcesResult[resource.resourceID].AssociatedControls) {
+			if stream.err != nil {
+				return fmt.Errorf("failed to write SARIF report: %w", stream.err)
+			}
 			ac := toPin
 
 			if ac.GetStatus(nil).IsFailed() {
@@ -615,9 +659,9 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 				}
 				location := resolveFixLocation(opaSessionObj, locationResolver, &ac, resource.resourceID)
 				reviewPathLocations := resolveReviewPathLocations(opaSessionObj, locationResolver, &ac, resource.resourceID)
-				sp.addRule(run, ctl)
 				rsrc := opaSessionObj.AllResources[resource.resourceID]
-				r := sp.addResult(run, ctl, resource.relPath, location, &ac, resource.resourceID, rsrc, reviewPathLocations)
+				r := sp.createResult(ctl, resource.relPath, location, &ac, resource.resourceID, rsrc, reviewPathLocations)
+				r.WithRuleIndex(ruleIndexes[ctl.GetID()])
 				// kind stays "" when rsrc is nil (the resource lookup missed) --
 				// collectFixes below treats an unresolved kind as sensitive,
 				// the same fail-closed rule csvControlPaths applies.
@@ -626,6 +670,9 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 					kind = rsrc.GetKind()
 				}
 				collectFixes(ctx, cache, r, ac, opaSessionObj, resource.resourceID, resource.relPath, resource.absPath, kind, sp.showSecrets)
+				stream.separator(&firstResult)
+				stream.raw("\n        ")
+				stream.value(r)
 			}
 		}
 	}
@@ -638,14 +685,22 @@ func (sp *SARIFPrinter) printConfigurationScan(ctx context.Context, opaSessionOb
 		ExecutionSuccessful: &executionSuccessful,
 	})
 
-	report.AddRun(run)
-
-	// Surface write failures instead of silently leaving an empty/partial file.
-	if err := report.PrettyWrite(sp.writer); err != nil {
-		return fmt.Errorf("failed to write SARIF report: %w", err)
+	stream.raw("\n      ],\n      \"invocations\": ")
+	stream.encoder.SetIndent("      ", "  ")
+	stream.value(run.Invocations)
+	stream.raw("\n    }\n  ]\n}\n")
+	if stream.err != nil {
+		return fmt.Errorf("failed to write SARIF report: %w", stream.err)
 	}
-
 	return nil
+}
+
+func sortedSARIFControls(controls []resourcesresults.ResourceAssociatedControl) []resourcesresults.ResourceAssociatedControl {
+	ordered := slices.Clone(controls)
+	slices.SortFunc(ordered, func(a, b resourcesresults.ResourceAssociatedControl) int {
+		return strings.Compare(a.ControlID, b.ControlID)
+	})
+	return ordered
 }
 
 // resolveFixLocation resolves a failed control's location in the manifest, falling back to line 1. Shared by the SARIF and GitLab SAST printers

--- a/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/sarifprinter_test.go
@@ -1,11 +1,14 @@
 package printer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -385,7 +388,6 @@ func TestAddRule_SetsSecuritySeverity(t *testing.T) {
 }
 
 func TestAddResult_AnnotatesInitAndEphemeralContainerNames(t *testing.T) {
-	run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
 	control := &reportsummary.ControlSummary{
 		ControlID:   "C-0057",
 		Name:        "Privileged container",
@@ -394,12 +396,11 @@ func TestAddResult_AnnotatesInitAndEphemeralContainerNames(t *testing.T) {
 	}
 
 	sp := NewSARIFPrinter(false)
-	sp.addRule(run, control)
 
 	ac := makeControlWithPaths(privilegedInitAndEphemeralPaths(), nil)
 	ac.ControlID = "C-0057"
 
-	result := sp.addResult(run, control, "pod.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "apps/v1/Deployment/default/demo", privilegedInitAndEphemeralPod(), nil)
+	result := sp.createResult(control, "pod.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "apps/v1/Deployment/default/demo", privilegedInitAndEphemeralPod(), nil)
 	require.NotNil(t, result.Message)
 	require.NotNil(t, result.Message.Text)
 	for _, path := range privilegedInitAndEphemeralNamedPaths() {
@@ -433,20 +434,16 @@ func TestAddResult_RedactsSecretFixPathValueUnlessShowSecrets(t *testing.T) {
 	}
 
 	t.Run("redacted by default", func(t *testing.T) {
-		run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
 		sp := NewSARIFPrinter(false)
-		sp.addRule(run, control)
-		result := sp.addResult(run, control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
+		result := sp.createResult(control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
 		require.NotNil(t, result.Message.Text)
 		assert.NotContains(t, *result.Message.Text, "s3cr3t-plaintext-password")
 		assert.Contains(t, *result.Message.Text, "[redacted]")
 	})
 
 	t.Run("revealed with showSecrets", func(t *testing.T) {
-		run := sarif.NewRunWithInformationURI(toolName, toolInfoURI)
 		sp := NewSARIFPrinter(true)
-		sp.addRule(run, control)
-		result := sp.addResult(run, control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
+		result := sp.createResult(control, "secret.yaml", locationresolver.Location{Line: 1, Column: 1}, ac, "v1/Secret/default/demo", resource, nil)
 		require.NotNil(t, result.Message.Text)
 		assert.Contains(t, *result.Message.Text, "s3cr3t-plaintext-password")
 	})
@@ -1705,4 +1702,118 @@ func TestPrintImageScan_MultipleImagesAggregatesRuns(t *testing.T) {
 		require.NotNil(t, run.Tool.Driver)
 		assert.Equal(t, "Kubescape", run.Tool.Driver.Name, "driver name must be Kubescape for run %d", i)
 	}
+}
+
+func TestConfigurationSARIFStreamingStructureAndOrdering(t *testing.T) {
+	for _, count := range []int{0, 1, 3} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			s := configurationOutputFixture(t, count)
+			before := snapshotJSONSession(t, s)
+			sp := NewSARIFPrinter(false)
+			var output bytes.Buffer
+			require.NoError(t, sp.writeConfigurationSARIF(context.Background(), &output, s))
+			require.NoError(t, checkJSONDocument(output.Bytes()))
+			var report sarif.Report
+			require.NoError(t, json.Unmarshal(output.Bytes(), &report))
+			expectedEnvelope, err := sarif.New(sarif.Version210)
+			require.NoError(t, err)
+			require.Equal(t, expectedEnvelope.Version, report.Version)
+			require.Equal(t, expectedEnvelope.Schema, report.Schema)
+			require.Len(t, report.Runs, 1)
+			run := report.Runs[0]
+			require.NotNil(t, run.Results, "empty results must be [] rather than null")
+			require.Len(t, run.Results, count*10)
+			if count > 0 {
+				require.Len(t, run.Tool.Driver.Rules, 10)
+			}
+			for i, result := range run.Results {
+				require.NotNil(t, result.RuleIndex)
+				require.Less(t, int(*result.RuleIndex), len(run.Tool.Driver.Rules))
+				require.Equal(t, *result.RuleID, run.Tool.Driver.Rules[*result.RuleIndex].ID)
+				require.Equal(t, fmt.Sprintf("C-%04d", i%10), *result.RuleID)
+				require.NotEmpty(t, result.PartialFingerprints["kubescapeFindingFingerprint"])
+				require.Equal(t, "pod.yaml", *result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+			}
+			require.Len(t, run.Invocations, 1)
+			require.Equal(t, s.Report.ReportGenerationTime, *run.Invocations[0].StartTimeUTC)
+			require.True(t, *run.Invocations[0].ExecutionSuccessful)
+			require.Equal(t, before, snapshotJSONSession(t, s))
+			for id, r := range s.ResourcesResult {
+				slices.Reverse(r.AssociatedControls)
+				delete(s.ResourcesResult, id)
+				s.ResourcesResult[id] = r
+			}
+			var again bytes.Buffer
+			require.NoError(t, sp.writeConfigurationSARIF(context.Background(), &again, s))
+			require.NoError(t, checkJSONDocument(again.Bytes()))
+			var next sarif.Report
+			require.NoError(t, json.Unmarshal(again.Bytes(), &next))
+			report.Runs[0].Invocations[0].EndTimeUTC = nil
+			next.Runs[0].Invocations[0].EndTimeUTC = nil
+			require.Equal(t, report, next)
+		})
+	}
+}
+
+func TestConfigurationSARIFStreamingSkipsIneligibleFindings(t *testing.T) {
+	s := configurationOutputFixture(t, 3)
+	delete(s.Report.SummaryDetails.Controls, "C-0000")
+	delete(s.ResourceSource, "resource-000000")
+	for i := range s.ResourcesResult["resource-000001"].AssociatedControls {
+		s.ResourcesResult["resource-000001"].AssociatedControls[i].Status = apis.StatusInfo{InnerStatus: apis.StatusPassed}
+	}
+	var output bytes.Buffer
+	require.NoError(t, NewSARIFPrinter(false).writeConfigurationSARIF(context.Background(), &output, s))
+	require.NoError(t, checkJSONDocument(output.Bytes()))
+	var report sarif.Report
+	require.NoError(t, json.Unmarshal(output.Bytes(), &report))
+	require.Len(t, report.Runs[0].Results, 9)
+	require.Len(t, report.Runs[0].Tool.Driver.Rules, 9)
+}
+
+func TestConfigurationSARIFWriteFailures(t *testing.T) {
+	s := configurationOutputFixture(t, 2)
+	before := snapshotJSONSession(t, s)
+	sp := NewSARIFPrinter(false)
+	var output bytes.Buffer
+	require.NoError(t, sp.writeConfigurationSARIF(context.Background(), &output, s))
+	cuts := []int{0, 1}
+	for _, marker := range []string{`"tool":`, `"results": [`, `"kubescapeFindingFingerprint":`, `"invocations":`} {
+		index := strings.Index(output.String(), marker)
+		require.NotEqual(t, -1, index)
+		cuts = append(cuts, index, index+len(marker)+1)
+	}
+	for _, cut := range cuts {
+		w := &failAfterWriter{remaining: cut}
+		require.ErrorIs(t, sp.writeConfigurationSARIF(context.Background(), w, s), errOutputTest)
+		require.Zero(t, w.callsAfterFailure)
+		require.Equal(t, before, snapshotJSONSession(t, s))
+	}
+	closing := &stopAtResultWriter{marker: "\n    }\n  ]\n}\n"}
+	require.ErrorIs(t, sp.writeConfigurationSARIF(context.Background(), closing, s), errOutputTest)
+	require.ErrorIs(t, sp.writeConfigurationSARIF(context.Background(), shortOutputWriter{}, s), io.ErrShortWrite)
+	var buffer bytes.Buffer
+	stream := newJSONStream(&buffer)
+	result := sarif.NewRuleResult("C-0000")
+	result.Properties = sarif.Properties{"unsupported": make(chan int)}
+	stream.value(result)
+	require.Error(t, stream.err)
+	stream.raw("}")
+	require.Empty(t, buffer.String(), "encoding failures must stop framing too")
+}
+
+func TestConfigurationSARIFStopsBeforeTransformingLaterResources(t *testing.T) {
+	s := configurationOutputFixture(t, 2)
+	w := &stopAtResultWriter{marker: `"kubescapeFindingFingerprint":`}
+	reads := [2]int{}
+	for i := range reads {
+		id := fmt.Sprintf("resource-%06d", i)
+		s.AllResources[id] = observedResource{s.AllResources[id], func() {
+			require.Contains(t, w.String(), `"results": [`)
+			reads[i]++
+		}}
+	}
+	require.ErrorIs(t, NewSARIFPrinter(false).writeConfigurationSARIF(context.Background(), w, s), errOutputTest)
+	require.Positive(t, reads[0])
+	require.Zero(t, reads[1])
 }

--- a/core/pkg/resultshandling/printer/v2/streaming_benchmark_test.go
+++ b/core/pkg/resultshandling/printer/v2/streaming_benchmark_test.go
@@ -1,0 +1,141 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/kubescape/v4/core/cautils"
+	"github.com/kubescape/opa-utils/reporthandling"
+	"github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/require"
+)
+
+// Run each size/format in a fresh process with -benchtime=1x for RSS comparisons.
+// KS_PRINTER_SAMPLE_HEAP enables sampling outside normal allocation benchmarks.
+// KS_PRINTER_CAPTURE_DIR optionally keeps a representative output for comparison.
+func BenchmarkConfigurationOutput(b *testing.B) {
+	for _, format := range []string{"fixture", "json", "json-omit", "json-labels-audit", "sarif"} {
+		for _, size := range []int{10, 1000, 10000, 50000} {
+			b.Run(fmt.Sprintf("%s/%d", format, size), func(b *testing.B) {
+				session := configurationOutputFixture(b, size)
+				session.OmitRawResources = format == "json-omit"
+				if format == "json-labels-audit" {
+					session.LabelsToCopy = []string{"app"}
+					session.ExceptionAudit = &cautils.ExceptionAudit{Generated: true}
+					for i := 0; i < size; i++ {
+						session.ExceptionAudit.Items = append(session.ExceptionAudit.Items, cautils.ExceptionAuditItem{
+							Name: fmt.Sprintf("exception-%06d", i), Status: "matched", MatchCount: 1,
+							MatchedResources: []cautils.ExceptionAuditMatch{{ResourceID: fmt.Sprintf("resource-%06d", i), ControlID: "C-0000"}},
+						})
+					}
+				}
+				var f *os.File
+				var err error
+				if dir := os.Getenv("KS_PRINTER_CAPTURE_DIR"); dir != "" {
+					root, openErr := os.OpenRoot(dir)
+					require.NoError(b, openErr)
+					defer root.Close()
+					f, err = root.Create(fmt.Sprintf("%s-%d.json", format, size))
+				} else {
+					f, err = os.Create(os.DevNull)
+				}
+				require.NoError(b, err)
+				defer f.Close()
+				runtime.GC()
+				var before runtime.MemStats
+				runtime.ReadMemStats(&before)
+				stop, done := make(chan struct{}), make(chan uint64)
+				sampling := os.Getenv("KS_PRINTER_SAMPLE_HEAP") != ""
+				if sampling {
+					go func() {
+						peak := before.HeapAlloc
+						ticker := time.NewTicker(time.Millisecond)
+						defer ticker.Stop()
+						for {
+							var m runtime.MemStats
+							runtime.ReadMemStats(&m)
+							peak = max(peak, m.HeapAlloc)
+							select {
+							case <-stop:
+								done <- peak
+								return
+							case <-ticker.C:
+							}
+						}
+					}()
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					switch format {
+					case "fixture":
+					case "sarif":
+						err = (&SARIFPrinter{writer: f}).ActionPrint(context.Background(), session, nil)
+					default:
+						err = (&JsonPrinter{writer: f}).ActionPrint(context.Background(), session, nil)
+					}
+					if err != nil {
+						break
+					}
+				}
+				b.StopTimer()
+				if sampling {
+					close(stop)
+					b.ReportMetric(float64(<-done), "peak-heap-B")
+					b.ReportMetric(float64(before.HeapAlloc), "input-heap-B")
+				}
+				runtime.KeepAlive(session)
+				require.NoError(b, err)
+			})
+		}
+	}
+}
+
+func configurationOutputFixture(t testing.TB, size int) *cautils.OPASessionObj {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pod.yaml"), []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: example\nspec:\n  hostNetwork: true\n"), 0600))
+	session := cautils.NewOPASessionObjMock()
+	session.Report.ReportGenerationTime = time.Date(2026, 1, 2, 3, 4, 5, 123, time.UTC)
+	session.Report.ClusterName = "benchmark"
+	session.Report.ReportID = "benchmark-report"
+	session.Report.SummaryDetails.Controls = reportsummary.ControlSummaries{}
+	session.ResourceSource = map[string]reporthandling.Source{}
+	for c := 0; c < 10; c++ {
+		id := fmt.Sprintf("C-%04d", c)
+		session.Report.SummaryDetails.Controls[id] = reportsummary.ControlSummary{
+			ControlID: id, Name: "Example control", Description: "Example description", Remediation: "Example remediation", ScoreFactor: 8,
+		}
+	}
+	for i := 0; i < size; i++ {
+		id := fmt.Sprintf("resource-%06d", i)
+		obj := workloadinterface.NewWorkloadObj(map[string]interface{}{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": map[string]interface{}{"name": id, "namespace": "default", "labels": map[string]interface{}{"app": "example"}},
+			"spec":     map[string]interface{}{"hostNetwork": true, "description": strings.Repeat("x", 4096)},
+		})
+		session.AllResources[id] = obj
+		session.ResourceSource[id] = reporthandling.Source{RelativePath: "pod.yaml", Path: dir}
+		result := resourcesresults.Result{ResourceID: id}
+		for c := 0; c < 10; c++ {
+			result.AssociatedControls = append(result.AssociatedControls, resourcesresults.ResourceAssociatedControl{
+				ControlID: fmt.Sprintf("C-%04d", c), Status: apis.StatusInfo{InnerStatus: apis.StatusFailed},
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{{
+					Name: "example-rule", Status: apis.StatusFailed,
+					Paths: []armotypes.PosturePaths{{FailedPath: "spec.hostNetwork", ReviewPath: "spec.hostNetwork"}},
+				}},
+			})
+		}
+		session.ResourcesResult[id] = result
+	}
+	return session
+}

--- a/core/pkg/resultshandling/printer/v2/utils.go
+++ b/core/pkg/resultshandling/printer/v2/utils.go
@@ -138,27 +138,30 @@ func enrichControlsWithSeverity(controls reportsummary.ControlSummaries) map[str
 func enrichResultsWithSeverity(results []resourcesresults.Result, controlSummaries reportsummary.ControlSummaries, allResources map[string]workloadinterface.IMetadata) []ResultWithSeverity {
 	enrichedResults := make([]ResultWithSeverity, len(results))
 	for i, result := range results {
-		resource := allResources[result.ResourceID]
-		enrichedControls := make([]ResourceAssociatedControlWithSeverity, len(result.AssociatedControls))
-		for j, control := range result.AssociatedControls {
-			// Get the severity from the control summary
-			severity := "Unknown"
-			if controlSummary, exists := controlSummaries[control.GetID()]; exists {
-				severity = apis.ControlSeverityToString(controlSummary.GetScoreFactor())
-			}
-			enrichedControls[j] = ResourceAssociatedControlWithSeverity{
-				ResourceAssociatedControl: control,
-				Severity:                  severity,
-				Evidence:                  failedPathValues(&control, resource),
-			}
-		}
-		enrichedResults[i] = ResultWithSeverity{
-			ResourceID:          result.ResourceID,
-			AssociatedControls:  enrichedControls,
-			PrioritizedResource: result.PrioritizedResource,
-		}
+		enrichedResults[i] = enrichResultWithSeverity(result, controlSummaries, allResources[result.ResourceID])
 	}
 	return enrichedResults
+}
+
+func enrichResultWithSeverity(result resourcesresults.Result, controlSummaries reportsummary.ControlSummaries, resource workloadinterface.IMetadata) ResultWithSeverity {
+	enrichedControls := make([]ResourceAssociatedControlWithSeverity, len(result.AssociatedControls))
+	for j, control := range result.AssociatedControls {
+		// Get the severity from the control summary
+		severity := "Unknown"
+		if controlSummary, exists := controlSummaries[control.GetID()]; exists {
+			severity = apis.ControlSeverityToString(controlSummary.GetScoreFactor())
+		}
+		enrichedControls[j] = ResourceAssociatedControlWithSeverity{
+			ResourceAssociatedControl: control,
+			Severity:                  severity,
+			Evidence:                  failedPathValues(&control, resource),
+		}
+	}
+	return ResultWithSeverity{
+		ResourceID:          result.ResourceID,
+		AssociatedControls:  enrichedControls,
+		PrioritizedResource: result.PrioritizedResource,
+	}
 }
 
 // severityRank returns a comparable rank for a severity string; unknown values rank lowest.
@@ -266,23 +269,7 @@ func extractResourceLabels(allResources map[string]workloadinterface.IMetadata, 
 	resourceLabels := make(map[string]map[string]string)
 
 	for resourceID, resource := range allResources {
-		// IMetadata doesn't have GetLabels, need to cast to IBasicWorkload
-		basicWorkload, ok := resource.(workloadinterface.IBasicWorkload)
-		if !ok {
-			continue
-		}
-
-		labels := basicWorkload.GetLabels()
-		if labels == nil {
-			continue
-		}
-
-		extractedLabels := make(map[string]string)
-		for _, labelKey := range labelsToCopy {
-			if value, exists := labels[labelKey]; exists {
-				extractedLabels[labelKey] = value
-			}
-		}
+		extractedLabels := extractResourceLabelsForResource(resource, labelsToCopy)
 
 		// Only add to result if at least one label was found
 		if len(extractedLabels) > 0 {
@@ -291,6 +278,27 @@ func extractResourceLabels(allResources map[string]workloadinterface.IMetadata, 
 	}
 
 	return resourceLabels
+}
+
+func extractResourceLabelsForResource(resource workloadinterface.IMetadata, labelsToCopy []string) map[string]string {
+	// IMetadata doesn't have GetLabels, need to cast to IBasicWorkload
+	basicWorkload, ok := resource.(workloadinterface.IBasicWorkload)
+	if !ok {
+		return nil
+	}
+
+	labels := basicWorkload.GetLabels()
+	if labels == nil {
+		return nil
+	}
+
+	extractedLabels := make(map[string]string)
+	for _, labelKey := range labelsToCopy {
+		if value, exists := labels[labelKey]; exists {
+			extractedLabels[labelKey] = value
+		}
+	}
+	return extractedLabels
 }
 
 // scanContextName returns the kube context this scan actually ran against.


### PR DESCRIPTION
## Overview

  Stream v2 configuration scan JSON and SARIF output to reduce peak memory on large clusters.

  JSON now writes enriched results, raw resources and resource labels incrementally. SARIF collects rule definitions first, then generates and writes individual findings without accumulating a complete results array.

  Preserves enrichment, deterministic ordering, omission rules and writer-error propagation without mutating scan data. Adds compatibility,  duplicate-key, error-handling and streaming regression tests.

  ## Additional Information

  Synthetic benchmarks with 50,000 resources reduced maximum RSS:

  - JSON: 1,906 MiB → 887 MiB
  - SARIF: 3,468 MiB → 1,172 MiB

  Changes are limited to the v2 printer package, with no dependency changes. Standalone image exporters are unchanged.

  ## How to Test

  go test ./core/pkg/resultshandling/printer/v2
  go test -race ./core/pkg/resultshandling/printer/v2
  go test ./...

  Run the synthetic output benchmarks explicitly:

  go test ./core/pkg/resultshandling/printer/v2 \
    -run '^$' -bench '^BenchmarkConfigurationOutput$' \
    -benchtime=1x -benchmem

  Local verification passed for full repository tests, targeted race tests, CLI build, printer lint, JSON/SARIF file and stdout  comparisons, and SARIF 2.1.0 schema validation.

  Repository-wide lint reports 29 findings in untouched files. The optional smoke suite timed out after 180 seconds.

  ## Related issues/PRs

  - Resolved #3518
  - Previous attempt: #3519

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests
  - [x] New and existing unit tests pass locally with my changes
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration scan results can now be generated as streaming JSON and SARIF output.
  * Reports include consistent ordering for results, controls, resources, severity data, labels, and metadata.
  * SARIF output now provides stable rule references and deterministic report structure.

* **Bug Fixes**
  * Output generation preserves session data and avoids partial continuation after write failures.
  * JSON and SARIF output now correctly skip ineligible findings and propagate output errors.

* **Performance**
  * Large configuration reports can be processed with reduced memory usage through incremental output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->