### PR TITLE
fix(printer): support multi-image scan output in YAML printer

### DIFF
--- a/core/pkg/resultshandling/printer/v2/yamlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter.go
@@ -3,12 +3,10 @@ package printer
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
-	"github.com/anchore/clio"
-	grypejson "github.com/anchore/grype/grype/presenter/json"
-	"github.com/anchore/grype/grype/presenter/models"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubescape/v4/core/cautils"
@@ -58,22 +56,7 @@ func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	if opaSessionObj != nil {
 		err = printConfigurationsScanningYaml(opaSessionObj, imageScanData, yp)
 	} else if len(imageScanData) > 0 {
-		model, err2 := models.NewDocument(clio.Identification{}, imageScanData[0].Packages, imageScanData[0].Context,
-			imageScanData[0].Matches, imageScanData[0].IgnoredMatches, imageScanData[0].VulnerabilityProvider, nil, nil, models.DefaultSortStrategy, false)
-		if err2 != nil {
-			return fmt.Errorf("failed to create document: %w", err2)
-		}
-
-		// Use grype json presenter and convert json to yaml
-		var buf bytes.Buffer
-		err = grypejson.NewPresenter(models.PresenterConfig{Document: model, SBOM: imageScanData[0].SBOM}).Present(&buf)
-		if err == nil {
-			var yamlData []byte
-			yamlData, err = yaml.JSONToYAML(buf.Bytes())
-			if err == nil {
-				_, err = yp.writer.Write(yamlData)
-			}
-		}
+		err = printImageScanningYaml(imageScanData, yp)
 	} else {
 		err = fmt.Errorf("no data provided")
 	}
@@ -85,6 +68,43 @@ func (yp *YamlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 
 	printer.LogOutputFile(yp.writer.Name())
 	return nil
+}
+
+func printImageScanningYaml(imageScanData []cautils.ImageScanData, yp *YamlPrinter) error {
+	if len(imageScanData) == 1 {
+		var buf bytes.Buffer
+		if err := presentImageScan(imageScanData[0], &buf); err != nil {
+			return fmt.Errorf("failed to create document: %w", err)
+		}
+		yamlData, err := yaml.JSONToYAML(buf.Bytes())
+		if err != nil {
+			return fmt.Errorf("failed to convert json to yaml: %w", err)
+		}
+		_, err = yp.writer.Write(yamlData)
+		return err
+	}
+
+	documents := make([]json.RawMessage, 0, len(imageScanData))
+	for i := range imageScanData {
+		var buf bytes.Buffer
+		if err := presentImageScan(imageScanData[i], &buf); err != nil {
+			return err
+		}
+		documents = append(documents, json.RawMessage(bytes.TrimSpace(buf.Bytes())))
+	}
+
+	encoded, err := json.MarshalIndent(documents, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal multi-image json output: %w", err)
+	}
+
+	yamlData, err := yaml.JSONToYAML(encoded)
+	if err != nil {
+		return fmt.Errorf("failed to convert multi-image json to yaml: %w", err)
+	}
+
+	_, err = yp.writer.Write(yamlData)
+	return err
 }
 
 func printConfigurationsScanningYaml(opaSessionObj *cautils.OPASessionObj, imageScanData []cautils.ImageScanData, yp *YamlPrinter) error {

--- a/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/yamlprinter_test.go
@@ -214,3 +214,89 @@ func TestActionPrint_ImageScan_Yaml(t *testing.T) {
 
 	assert.Equal(t, gotJson, gotYaml)
 }
+
+func TestActionPrint_MultiImageScan_Yaml(t *testing.T) {
+	// A populated []cautils.ImageScanData with multiple distinct images.
+	// Image itself is never serialized (presentImageScan in jsonprinter.go
+	// only consumes Packages, Context, Matches, IgnoredMatches,
+	// VulnerabilityProvider and SBOM), so the fixtures must also differ in
+	// one of those fields - otherwise an implementation that emits the first
+	// document twice would still pass.
+	first := buildSeverityExceptionImageScanData()
+	first.Image = "test-image:one"
+
+	second := buildSeverityExceptionImageScanData()
+	second.Image = "test-image:two"
+	second.Packages[0].Version = "2.0.0" // pkg-CVE-KEPT: distinct, serialized version
+
+	imageScanData := []cautils.ImageScanData{first, second}
+
+	tmpYaml, err := os.CreateTemp("", "yaml-multiimagescan-*.yaml")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpYaml.Name())
+	}()
+
+	yp := NewYamlPrinter()
+	yp.writer = tmpYaml
+	err = yp.ActionPrint(context.Background(), nil, imageScanData)
+	assert.NoError(t, err)
+	assert.NoError(t, tmpYaml.Close())
+
+	rawYaml, err := os.ReadFile(tmpYaml.Name())
+	assert.NoError(t, err)
+
+	var gotYaml []interface{}
+	err = yaml.Unmarshal(rawYaml, &gotYaml)
+	assert.NoError(t, err, "output must be valid YAML array")
+	require.Len(t, gotYaml, 2, "multi-image YAML output must contain all scanned images")
+
+	assert.Equal(t, "1.0.0", findArtifactVersion(t, gotYaml[0], "pkg-CVE-KEPT"),
+		"first YAML element must reflect the first image's package version")
+	assert.Equal(t, "2.0.0", findArtifactVersion(t, gotYaml[1], "pkg-CVE-KEPT"),
+		"second YAML element must reflect the second image's package version")
+
+	tmpJson, err := os.CreateTemp("", "json-multiimagescan-*.json")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.Remove(tmpJson.Name())
+	}()
+
+	jp := NewJsonPrinter()
+	jp.writer = tmpJson
+	err = jp.ActionPrint(context.Background(), nil, imageScanData)
+	assert.NoError(t, err)
+	assert.NoError(t, tmpJson.Close())
+
+	rawJson, err := os.ReadFile(tmpJson.Name())
+	assert.NoError(t, err)
+
+	var gotJson interface{}
+	err = json.Unmarshal(rawJson, &gotJson)
+	assert.NoError(t, err, "output must be valid JSON")
+
+	assert.Equal(t, gotJson, gotYaml)
+}
+
+// findArtifactVersion returns the "version" of the matches[].artifact entry
+// named packageName within a decoded image-scan document (YAML or JSON,
+// both unmarshal into plain map[string]interface{} / []interface{}).
+func findArtifactVersion(t *testing.T, doc interface{}, packageName string) string {
+	t.Helper()
+	m, ok := doc.(map[string]interface{})
+	require.True(t, ok, "expected a document mapping")
+	matches, ok := m["matches"].([]interface{})
+	require.True(t, ok, "expected a matches array")
+	for _, raw := range matches {
+		match, ok := raw.(map[string]interface{})
+		require.True(t, ok, "expected a match mapping")
+		artifact, ok := match["artifact"].(map[string]interface{})
+		require.True(t, ok, "expected an artifact mapping")
+		if artifact["name"] == packageName {
+			version, _ := artifact["version"].(string)
+			return version
+		}
+	}
+	t.Fatalf("package %q not found in matches", packageName)
+	return ""
+}


### PR DESCRIPTION
## Overview
When performing image scans across multiple images (`kubescape scan image img1 img2 --format yaml`), `YamlPrinter` hardcoded `imageScanData[0]`, resulting in only the first image's scan results being output while all remaining images were silently dropped.

This PR refactors `YamlPrinter`'s image scanning code path to mirror `JsonPrinter`, `CycloneDXPrinter`, and `SPDXPrinter`, ensuring all scanned images are included in the YAML output document list.

## Additional Information
- `JsonPrinter`, `CycloneDXPrinter`, and `SPDXPrinter` already present multi-image scan datasets as document arrays.
- This change aligns `YamlPrinter` with existing multi-image presenter standards without changing any posture/configuration scanning output.

## How to Test
Run the new multi-image YAML printer unit test:
```bash
go test -v -race -cover ./core/pkg/resultshandling/printer/v2/ -run TestActionPrint_MultiImageScan_Yaml
```
Or run all printer tests:
```bash
go test -v -race -cover ./core/pkg/resultshandling/printer/v2/...
```

## Related issues/PRs:
* Fixes # NONE

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YAML output for image scans containing multiple images.
  - Multi-image scan results are now emitted as a valid YAML array, with each image represented as a separate entry.
  - YAML output is aligned with the corresponding JSON output for consistent results across formats.
  - Single-image scan output continues to be rendered correctly.

- **Tests**
  - Added coverage to verify that multiple image results remain distinct and correctly formatted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->