### PR TITLE
fix(printer): parse bracketed path keys instead of splitting on every…

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathparse.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse.go
@@ -1,0 +1,166 @@
+package printer
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Path parsing for the paths regolibrary rules emit.
+//
+// A rule reports a finding against a field by its path through the resource:
+// "spec.template.spec.containers[0].image". Splitting that on "." is right up
+// until a key contains a "." of its own, which Kubernetes label and annotation
+// keys routinely do - "metadata.labels[pod-security.kubernetes.io/enforce]"
+// splits into six meaningless fragments. Surveying every path the rules emit
+// (their test fixtures, so the substituted output rather than the sprintf
+// templates) found ten such paths, in two shapes:
+//
+//   - keys carrying dots, which a "."-split shatters:
+//     metadata.labels[pod-security.kubernetes.io/enforce]
+//     spec.template.metadata.labels[app.kubernetes.io/name]
+//     metadata.annotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert']
+//
+//   - plain keys, where the bracket is dropped instead:
+//     metadata.labels[app]
+//     spec.template.metadata.labels[YOUR_LABEL]
+//
+// The second shape is the more dangerous of the two. Nothing shatters, so the
+// path still resolves - but to the whole labels map rather than the one key
+// asked for, which reads as a successful lookup of the wrong thing.
+//
+// parsePath scans the string instead of splitting it, so a bracket is read as a
+// unit and its contents never reach the "." rule.
+
+// pathSegment is one step of a parsed path: a map key, optionally indexed when
+// the path selects an element of a list at that key.
+//
+// An index belongs to the segment it indexes rather than standing alone as its
+// own segment: "containers[0]" is one step, not two. Callers depend on that.
+// matchesSafeField compares a field's parent segments positionally against the
+// canonical location its Kubernetes schema defines, so splitting an index into
+// a separate segment would shift every parent path by one and quietly unmatch
+// every safe-field rule guarding redaction.
+
+// parsePath splits a path into its segments.
+//
+// A bracket holds either a list index or a map key. All-digit contents are read
+// as an index and attached to the preceding segment; anything else is a key and
+// becomes a segment of its own, with surrounding quotes stripped. That keeps
+// "containers[0].image" at two segments while giving "labels[app]" three, which
+// is what each one means.
+//
+// Assisted-remediation strings arrive as "<path>=<value>" and only the path is
+// parseable, so everything from the first "=" outside a bracket is dropped. A
+// "=" inside a bracket is part of the key and survives.
+//
+// Malformed input is parsed as far as it makes sense rather than rejected:
+// these paths come from rules the scanner does not control, and a path that
+// resolves to nothing is already handled everywhere downstream. An unclosed
+// bracket takes the rest of the string as its contents; empty segments from a
+// leading or doubled "." are skipped.
+func parsePath(path string) []pathSegment {
+	path = truncateAtValueSeparator(path)
+
+	var (
+		segments []pathSegment
+		key      strings.Builder
+		started  bool
+	)
+
+	// flush ends the segment being read. started tracks whether a segment is
+	// open at all, so that "a..b" skips the empty middle rather than emitting
+	// a segment with an empty key, while "labels[app]" can still close the
+	// bracket key as its own segment.
+	flush := func() {
+		if !started {
+			return
+		}
+		segments = append(segments, pathSegment{key: key.String(), index: -1})
+		key.Reset()
+		started = false
+	}
+
+	for i := 0; i < len(path); i++ {
+		switch path[i] {
+		case '.':
+			flush()
+		case '[':
+			contents, next := readBracket(path, i)
+			i = next
+
+			if index, err := strconv.Atoi(contents); err == nil && index >= 0 {
+				// An index qualifies the segment it follows. Without one -
+				// a path opening with "[0]" - there is nothing to qualify,
+				// so it is dropped rather than inventing an empty segment.
+				if started {
+					segments = append(segments, pathSegment{key: key.String(), index: index})
+					key.Reset()
+					started = false
+				}
+				continue
+			}
+
+			flush()
+			if contents != "" {
+				segments = append(segments, pathSegment{key: contents, index: -1})
+			}
+		default:
+			key.WriteByte(path[i])
+			started = true
+		}
+	}
+	flush()
+
+	return segments
+}
+
+// readBracket reads the contents of the bracket opening at open, returning the
+// contents with any surrounding quotes stripped and the index of the closing
+// bracket. An unclosed bracket yields the rest of the string, so a malformed
+// path degrades to a lookup that finds nothing rather than to a panic.
+func readBracket(path string, open int) (contents string, closing int) {
+	end := strings.IndexByte(path[open+1:], ']')
+	if end < 0 {
+		return unquote(path[open+1:]), len(path) - 1
+	}
+	end += open + 1
+	return unquote(path[open+1 : end]), end
+}
+
+// unquote strips one layer of matching single or double quotes, which rules use
+// for keys that would otherwise be ambiguous: metadata.annotations['%v'].
+func unquote(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// truncateAtValueSeparator drops the "=<value>" half of an assisted-remediation
+// string, along with any leading ".".
+//
+// The split has to be on the first "=" that is not inside a bracket. Fix values
+// routinely contain "=" themselves - the CIS control-plane rules emit
+// "--anonymous-auth=false" - so a later separator must not be mistaken for the
+// first, and an annotation key holding an "=" must not be cut in half.
+func truncateAtValueSeparator(path string) string {
+	depth := 0
+	for i := 0; i < len(path); i++ {
+		switch path[i] {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		case '=':
+			if depth == 0 {
+				return strings.TrimPrefix(path[:i], ".")
+			}
+		}
+	}
+	return strings.TrimPrefix(path, ".")
+}

--- a/core/pkg/resultshandling/printer/v2/pathparse_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_test.go
@@ -1,0 +1,386 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func seg(key string, index int) pathSegment {
+	return pathSegment{key: key, index: index}
+}
+
+// TestParsePath_EmittedByRules covers every path shape a regolibrary rule
+// actually emits that the previous "."-splitting parser could not read. The
+// inputs are taken verbatim from the rules' own test fixtures, so they are the
+// substituted output rather than the sprintf templates in raw.rego.
+func TestParsePath_EmittedByRules(t *testing.T) {
+	cases := []struct {
+		name string
+		rule string
+		path string
+		want []pathSegment
+	}{
+		// Keys carrying dots. A "."-split shattered these into fragments that
+		// matched nothing.
+		{
+			name: "pod security admission label",
+			rule: "pod-security-admission-restricted-applied-2",
+			path: "metadata.labels[pod-security.kubernetes.io/enforce]",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("pod-security.kubernetes.io/enforce", -1)},
+		},
+		{
+			name: "ingress class annotation",
+			rule: "ingress-no-tls",
+			path: "metadata.annotations[kubernetes.io/ingress.class]",
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("kubernetes.io/ingress.class", -1)},
+		},
+		{
+			name: "azure internal load balancer annotation",
+			rule: "ensure-https-loadbalancers-encrypted-with-tls-azure",
+			path: "metadata.annotations[service.beta.kubernetes.io/azure-load-balancer-internal]",
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("service.beta.kubernetes.io/azure-load-balancer-internal", -1)},
+		},
+		{
+			// Dotted and quoted at once, the only emitted path that is both.
+			name: "aws ssl cert annotation is quoted and dotted",
+			rule: "ensure-https-loadbalancers-encrypted-with-tls-aws",
+			path: "metadata.annotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert']",
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("service.beta.kubernetes.io/aws-load-balancer-ssl-cert", -1)},
+		},
+		{
+			name: "common label through a pod template",
+			rule: "k8s-common-labels-usage",
+			path: "spec.template.metadata.labels[app.kubernetes.io/name]",
+			want: []pathSegment{seg("spec", -1), seg("template", -1), seg("metadata", -1), seg("labels", -1), seg("app.kubernetes.io/name", -1)},
+		},
+		{
+			name: "common label through a CronJob job template",
+			rule: "k8s-common-labels-usage",
+			path: "spec.jobTemplate.spec.template.metadata.labels[app.kubernetes.io/name]",
+			want: []pathSegment{seg("spec", -1), seg("jobTemplate", -1), seg("spec", -1), seg("template", -1), seg("metadata", -1), seg("labels", -1), seg("app.kubernetes.io/name", -1)},
+		},
+
+		// Plain keys. Nothing shattered here, which is what made these worse:
+		// the bracket was dropped and the path resolved to the whole labels
+		// map, reading as a successful lookup of the wrong field.
+		{
+			name: "plain label key is kept, not dropped",
+			rule: "label-usage-for-resources",
+			path: "metadata.labels[app]",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("app", -1)},
+		},
+		{
+			name: "placeholder label key is kept, not dropped",
+			rule: "label-usage-for-resources",
+			path: "metadata.labels[YOUR_LABEL]",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("YOUR_LABEL", -1)},
+		},
+		{
+			name: "plain label key through a pod template",
+			rule: "label-usage-for-resources",
+			path: "spec.template.metadata.labels[app]",
+			want: []pathSegment{seg("spec", -1), seg("template", -1), seg("metadata", -1), seg("labels", -1), seg("app", -1)},
+		},
+		{
+			name: "placeholder label key through a CronJob job template",
+			rule: "label-usage-for-resources",
+			path: "spec.jobTemplate.spec.template.metadata.labels[YOUR_LABEL]",
+			want: []pathSegment{seg("spec", -1), seg("jobTemplate", -1), seg("spec", -1), seg("template", -1), seg("metadata", -1), seg("labels", -1), seg("YOUR_LABEL", -1)},
+		},
+		{
+			// Secret data keys arrive bracketed too, and their names are
+			// exactly what the credential patterns look for.
+			name: "secret data key",
+			rule: "rule-credentials-in-env-var",
+			path: "data[aws_access_key_id]",
+			want: []pathSegment{seg("data", -1), seg("aws_access_key_id", -1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parsePath(tc.path), "path emitted by %s", tc.rule)
+		})
+	}
+}
+
+// TestParsePath_IndexBelongsToItsSegment pins the shape callers depend on: an
+// index qualifies the segment it follows rather than standing alone. Splitting
+// it out would shift every parent path by one and unmatch the safe-field rules
+// that gate redaction.
+func TestParsePath_IndexBelongsToItsSegment(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want []pathSegment
+	}{
+		{
+			name: "container index",
+			path: "spec.containers[0].image",
+			want: []pathSegment{seg("spec", -1), seg("containers", 0), seg("image", -1)},
+		},
+		{
+			name: "two indexes in one path",
+			path: "spec.containers[1].env[2].value",
+			want: []pathSegment{seg("spec", -1), seg("containers", 1), seg("env", 2), seg("value", -1)},
+		},
+		{
+			name: "indexed segment at the end",
+			path: "spec.containers[0]",
+			want: []pathSegment{seg("spec", -1), seg("containers", 0)},
+		},
+		{
+			name: "projected volume source keeps both indexes",
+			path: "spec.volumes[0].projected.sources[0].serviceAccountToken",
+			want: []pathSegment{seg("spec", -1), seg("volumes", 0), seg("projected", -1), seg("sources", 0), seg("serviceAccountToken", -1)},
+		},
+		{
+			// A non-numeric bracket is a key, so it becomes its own segment
+			// rather than an index. The lookup then finds nothing on a list,
+			// which is the honest answer.
+			name: "non-numeric bracket is a key, not an index",
+			path: "spec.containers[container_ndx].image",
+			want: []pathSegment{seg("spec", -1), seg("containers", -1), seg("container_ndx", -1), seg("image", -1)},
+		},
+		{
+			name: "negative index is treated as a key",
+			path: "spec.containers[-1].image",
+			want: []pathSegment{seg("spec", -1), seg("containers", -1), seg("-1", -1), seg("image", -1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parsePath(tc.path))
+		})
+	}
+}
+
+// TestParsePath_ValueSeparator covers the "<path>=<value>" form that
+// assisted-remediation strings arrive in.
+func TestParsePath_ValueSeparator(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want []pathSegment
+	}{
+		{
+			name: "value is dropped",
+			path: "spec.hostPID=false",
+			want: []pathSegment{seg("spec", -1), seg("hostPID", -1)},
+		},
+		{
+			// CIS control-plane rules emit values that contain "=" themselves,
+			// so the split has to be on the first separator.
+			name: "only the first separator splits",
+			path: "spec.containers[0].command=--anonymous-auth=false",
+			want: []pathSegment{seg("spec", -1), seg("containers", 0), seg("command", -1)},
+		},
+		{
+			// An "=" inside a bracket is part of the key.
+			name: "separator inside a bracket is part of the key",
+			path: "metadata.labels[a=b]=c",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("a=b", -1)},
+		},
+		{
+			name: "leading dot is trimmed",
+			path: ".spec.nodeName",
+			want: []pathSegment{seg("spec", -1), seg("nodeName", -1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parsePath(tc.path))
+		})
+	}
+}
+
+// TestParsePath_Malformed covers input the scanner does not control. These
+// paths come from rules, so the parser reads what it can rather than rejecting:
+// a path resolving to nothing is already handled by every caller.
+func TestParsePath_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want []pathSegment
+	}{
+		{name: "empty path", path: "", want: nil},
+		{name: "only a dot", path: ".", want: nil},
+		{name: "doubled dots are skipped", path: "spec..image", want: []pathSegment{seg("spec", -1), seg("image", -1)}},
+		{name: "trailing dot", path: "spec.image.", want: []pathSegment{seg("spec", -1), seg("image", -1)}},
+		{
+			name: "unclosed bracket takes the rest of the string",
+			path: "metadata.labels[app",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("app", -1)},
+		},
+		{
+			name: "empty brackets contribute nothing",
+			path: "metadata.labels[].app",
+			want: []pathSegment{seg("metadata", -1), seg("labels", -1), seg("app", -1)},
+		},
+		{
+			name: "leading index has nothing to qualify",
+			path: "[0].spec",
+			want: []pathSegment{seg("spec", -1)},
+		},
+		{
+			name: "double-quoted key is unquoted like a single-quoted one",
+			path: `metadata.annotations["a.b/c"]`,
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("a.b/c", -1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parsePath(tc.path))
+		})
+	}
+}
+
+// TestParsePath_SafeFieldPathsAreUnchanged is the redaction guard. matchesSafeField
+// compares a field's parents positionally against the canonical location its
+// Kubernetes schema defines, so if any of these paths parsed differently after
+// this change, the kind/path scoping protecting credential redaction would
+// silently loosen.
+func TestParsePath_SafeFieldPathsAreUnchanged(t *testing.T) {
+	cases := []struct {
+		path string
+		want []pathSegment
+	}{
+		{
+			path: "spec.automountServiceAccountToken",
+			want: []pathSegment{seg("spec", -1), seg("automountServiceAccountToken", -1)},
+		},
+		{
+			path: "spec.template.spec.automountServiceAccountToken",
+			want: []pathSegment{seg("spec", -1), seg("template", -1), seg("spec", -1), seg("automountServiceAccountToken", -1)},
+		},
+		{
+			path: "spec.jobTemplate.spec.template.spec.automountServiceAccountToken",
+			want: []pathSegment{seg("spec", -1), seg("jobTemplate", -1), seg("spec", -1), seg("template", -1), seg("spec", -1), seg("automountServiceAccountToken", -1)},
+		},
+		{
+			path: "spec.volumes[0].secret.secretName",
+			want: []pathSegment{seg("spec", -1), seg("volumes", 0), seg("secret", -1), seg("secretName", -1)},
+		},
+		{
+			path: "spec.volumes[0].projected.sources[0].serviceAccountToken.tokenExpirationSeconds",
+			want: []pathSegment{seg("spec", -1), seg("volumes", 0), seg("projected", -1), seg("sources", 0), seg("serviceAccountToken", -1), seg("tokenExpirationSeconds", -1)},
+		},
+		{
+			path: "spec.tls[0].secretName",
+			want: []pathSegment{seg("spec", -1), seg("tls", 0), seg("secretName", -1)},
+		},
+		{
+			path: "automountServiceAccountToken",
+			want: []pathSegment{seg("automountServiceAccountToken", -1)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, parsePath(tc.path))
+		})
+	}
+}
+
+// TestBracketedKeyIsResolved covers what reading the bracket buys: the value at
+// the key the path names, rather than the map containing it. Dropping the
+// bracket did not fail - it returned the whole map, which reads as a successful
+// lookup of the wrong field.
+func TestBracketedKeyIsResolved(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				"app":                                "payments-api",
+				"app.kubernetes.io/name":             "payments",
+				"pod-security.kubernetes.io/enforce": "privileged",
+			},
+		},
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "plain key", path: "metadata.labels[app]", want: "payments-api"},
+		{name: "dotted key", path: "metadata.labels[app.kubernetes.io/name]", want: "payments"},
+		{name: "pod security label", path: "metadata.labels[pod-security.kubernetes.io/enforce]", want: "privileged"},
+		{name: "quoted key", path: "metadata.labels['app']", want: "payments-api"},
+		{name: "path with a value suffix", path: "metadata.labels[app]=YOUR_VALUE", want: "payments-api"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractValueAtPath(obj, tc.path)
+			assert.True(t, ok, "path should resolve")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("absent key resolves to nothing rather than the whole map", func(t *testing.T) {
+		_, ok := extractValueAtPath(obj, "metadata.labels[absent]")
+		assert.False(t, ok)
+	})
+}
+
+// TestBracketedKeyRedaction documents the redaction change reading the bracket
+// causes, and is the reason this is not a behaviour-neutral refactor.
+//
+// The field name isSensitivePath tests is the path's last segment. While the
+// bracket was dropped that was the container - "labels", "data" - which is
+// never credential-shaped, so a bracketed key holding a credential was printed
+// in full. Reading the bracket makes the key itself the last segment, so the
+// name that gets tested is the one that actually describes the value.
+func TestBracketedKeyRedaction(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+		path string
+		want bool
+	}{
+		{
+			// Emitted by the credentials-in-env-var rules against Secret data.
+			name: "secret data key named like a credential is redacted",
+			kind: "Secret",
+			path: "data[aws_access_key_id]",
+			want: true,
+		},
+		{
+			name: "secret data key named like a password is redacted",
+			kind: "Secret",
+			path: "data[pwd]",
+			want: true,
+		},
+		{
+			name: "credential-shaped label key is redacted on any kind",
+			kind: "Deployment",
+			path: "metadata.labels[apiKey]",
+			want: true,
+		},
+		{
+			// The change only reaches keys that are credential-shaped. An
+			// ordinary label key stays visible, which is what makes the
+			// evidence useful.
+			name: "ordinary label key is still shown",
+			kind: "Deployment",
+			path: "metadata.labels[app]",
+			want: false,
+		},
+		{
+			name: "common label key is still shown",
+			kind: "Deployment",
+			path: "spec.template.metadata.labels[app.kubernetes.io/name]",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSensitivePath(tc.kind, tc.path))
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/pathparse_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_test.go
@@ -376,6 +376,60 @@ func TestBracketedKeyRedaction(t *testing.T) {
 			path: "spec.template.metadata.labels[app.kubernetes.io/name]",
 			want: false,
 		},
+		// Everything under a Secret's data is sensitive whatever the key is
+		// called. A bracketed key does not start with "data.", so the prefix
+		// test that used to gate this let any key through whose own name was
+		// not credential-shaped.
+		{
+			name: "secret data key with an ordinary name is still redacted",
+			kind: "Secret",
+			path: "data[username]",
+			want: true,
+		},
+		{
+			name: "secret stringData key with an ordinary name is still redacted",
+			kind: "Secret",
+			path: "stringData[config]",
+			want: true,
+		},
+		{
+			name: "quoted secret data key is redacted",
+			kind: "Secret",
+			path: "data['username']",
+			want: true,
+		},
+		{
+			name: "dotted secret data key is redacted",
+			kind: "Secret",
+			path: "data[my.config.file]",
+			want: true,
+		},
+		{
+			name: "dotted secret data path is still redacted",
+			kind: "Secret",
+			path: "data.username",
+			want: true,
+		},
+		{
+			// The Secret exception is scoped to its content, not to the kind.
+			name: "secret metadata is not redacted",
+			kind: "Secret",
+			path: "metadata.name",
+			want: false,
+		},
+		{
+			// A field merely starting with the same letters is not Secret data.
+			name: "a field named like data is not Secret data",
+			kind: "Secret",
+			path: "dataSomethingElse",
+			want: false,
+		},
+		{
+			name: "an ordinary key on a non-Secret kind is unaffected",
+			kind: "ConfigMap",
+			path: "data[username]",
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -403,9 +403,18 @@ func hasSecretShapedFieldName(kind, path string) bool {
 //     ConfigMap entry named apiKey, a CRD's spec.auth.token, and so on.
 func isSensitivePath(kind, path string) bool {
 	trimmed := truncateAtValueSeparator(path)
-	if kind == "Secret" && (trimmed == "data" || strings.HasPrefix(trimmed, "data.") ||
-		trimmed == "stringData" || strings.HasPrefix(trimmed, "stringData.")) {
-		return true
+
+	// Everything under a Secret's data or stringData is sensitive, whatever the
+	// individual key happens to be called. That is decided on the parsed first
+	// segment rather than a "data." string prefix, because a key can arrive
+	// bracketed: "data[username]" holds Secret content exactly as
+	// "data.password" does, but it does not start with "data." and its own name
+	// is not credential-shaped, so a prefix test let it through.
+	if kind == "Secret" {
+		if segments := splitPath(path); len(segments) > 0 &&
+			(segments[0].key == "data" || segments[0].key == "stringData") {
+			return true
+		}
 	}
 	// C-0012 plaintext credentials live on container env .value, not Secret.data.
 	if isContainerEnvValuePath(trimmed) {

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -18,32 +18,11 @@ type pathSegment struct {
 	index int
 }
 
+// splitPath parses a path into its segments. See parsePath in pathparse.go,
+// which it delegates to: bracket contents are read as a unit, so a key
+// containing a "." survives intact rather than being split apart by one.
 func splitPath(path string) []pathSegment {
-	path = strings.TrimPrefix(path, ".")
-	if i := strings.Index(path, "="); i >= 0 {
-		path = path[:i]
-	}
-
-	var segments []pathSegment
-	for _, part := range strings.Split(path, ".") {
-		if part == "" {
-			continue
-		}
-		seg := pathSegment{index: -1}
-		if i := strings.Index(part, "["); i >= 0 {
-			seg.key = part[:i]
-			tail := part[i+1:]
-			if j := strings.Index(tail, "]"); j >= 0 {
-				if n, err := strconv.Atoi(tail[:j]); err == nil {
-					seg.index = n
-				}
-			}
-		} else {
-			seg.key = part
-		}
-		segments = append(segments, seg)
-	}
-	return segments
+	return parsePath(path)
 }
 
 // anyToString converts a value to its string representation.
@@ -393,9 +372,7 @@ func matchesSafeField(kind, name string, parents []pathSegment) bool {
 // it (e.g. that same env var's "name"), which is a separate, harder problem
 // left out of scope here.
 func hasSecretShapedFieldName(kind, path string) bool {
-	if i := strings.Index(path, "="); i >= 0 {
-		path = path[:i]
-	}
+	// splitPath drops the "=<value>" half itself, and does so bracket-aware.
 	segments := splitPath(path)
 	if len(segments) == 0 {
 		return false
@@ -425,11 +402,7 @@ func hasSecretShapedFieldName(kind, path string) bool {
 //     a hardcoded secret can live in a plain field on any resource - a
 //     ConfigMap entry named apiKey, a CRD's spec.auth.token, and so on.
 func isSensitivePath(kind, path string) bool {
-	trimmed := path
-	if i := strings.Index(trimmed, "="); i >= 0 {
-		trimmed = trimmed[:i]
-	}
-	trimmed = strings.TrimLeft(trimmed, ".")
+	trimmed := truncateAtValueSeparator(path)
 	if kind == "Secret" && (trimmed == "data" || strings.HasPrefix(trimmed, "data.") ||
 		trimmed == "stringData" || strings.HasPrefix(trimmed, "stringData.")) {
 		return true


### PR DESCRIPTION
## Overview

`splitPath` splits on every `.`, but Kubernetes label and annotation keys contain dots of their own. Surveying the paths rules actually emit (from their `test/*/expected.json`, so substituted output rather than `sprintf` templates) found **10 of 191 distinct paths** that don't parse:

**Shattered by the split (6)**
```
metadata.labels[pod-security.kubernetes.io/enforce]
metadata.annotations[kubernetes.io/ingress.class]
metadata.annotations[service.beta.kubernetes.io/azure-load-balancer-internal]
metadata.annotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert']
spec.template.metadata.labels[app.kubernetes.io/name]
spec.jobTemplate.spec.template.metadata.labels[app.kubernetes.io/name]
```

**Bracket silently dropped (4)** — `metadata.labels[app]` and friends. Nothing shatters; the path resolves to the whole `labels` map instead of the one key, which reads as a successful lookup of the wrong field.

`parsePath` scans instead of splitting, so bracket contents are read as a unit. All-digit contents attach as an index to the preceding segment; anything else becomes its own key segment, quotes stripped. Three copies of `"<path>=<value>"` truncation collapse into one that splits on the first `=` outside a bracket.

## Additional Information

**This changes redaction.** `isSensitivePath` tests the path's last segment. While the bracket was dropped, that was the container (`data`, `labels`), which is never credential-shaped — so `data[aws_access_key_id]` on a Secret printed in full. It now redacts, because the key itself is the last segment. `metadata.labels[app]` stays visible; only credential-shaped names are affected.

`pathSegment` is unchanged and an index still belongs to the segment it follows — `containers[0]` is one segment, not two. `matchesSafeField` compares parent paths positionally, so splitting indexes out would have unmatched every safe-field rule guarding redaction. `TestParsePath_SafeFieldPathsAreUnchanged` pins that.

## How to Test

```
go test ./core/pkg/resultshandling/printer/v2/
```

All pre-existing tests pass unchanged, including `TestSplitPath` and the safe-field suite.

## Related issues/PRs:

* Relates to #1563

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource paths containing dotted, bracketed, quoted, or indexed keys.
  * Correctly resolves values for bracketed keys instead of their containing maps.
  * Improved parsing of paths that include associated values or malformed segments.
  * Enhanced sensitive-field detection so credential-shaped keys are redacted while ordinary keys remain visible.
  * Ensured Secret data and stringData values are redacted, including values accessed through bracketed keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->