### PR TITLE
fix(scan): default omitted workload namespace to 'default' and require '*' for cluster-wide search

### DIFF
--- a/cmd/mcpserver/mcpserver.go
+++ b/cmd/mcpserver/mcpserver.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -1323,7 +1324,13 @@ func (ksServer *KubescapeMcpserver) CallTool(ctx context.Context, name string, a
 		if err != nil {
 			code := classifyScanError(err)
 			msg := classifyScanErrorMessage(code, "workload", err)
-			return mcpToolError(code, msg, nil), nil
+			var extra map[string]any
+			var hinted interface{ Hint() string }
+			if errors.As(err, &hinted) && code == ErrCodeResourceNotFound {
+				msg = fmt.Sprintf("%s (%s)", msg, hinted.Hint())
+				extra = map[string]any{"hint": hinted.Hint()}
+			}
+			return mcpToolError(code, msg, extra), nil
 		}
 		return mcp.NewToolResultText(string(v.([]byte))), nil
 	case "list_frameworks":

--- a/cmd/mcpserver/scan_helper.go
+++ b/cmd/mcpserver/scan_helper.go
@@ -23,16 +23,25 @@ import (
 
 const maxFailedResources = 100
 
+type TargetResourceInfo struct {
+	Kind               string `json:"kind,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Namespace          string `json:"namespace,omitempty"`
+	NamespaceDefaulted bool   `json:"namespace_defaulted,omitempty"`
+}
+
 type scanResponse struct {
-	ComplianceScore      *float32      `json:"compliance_score,omitempty"`
-	FrameworkName        string        `json:"framework_name,omitempty"`
-	Degraded             bool          `json:"degraded"`
-	NotEvaluatedControls int           `json:"not_evaluated_controls"`
-	TotalControls        int           `json:"total_controls"`
-	TotalFailed          int           `json:"total_failed"`
-	ReturnedFailed       int           `json:"returned_failed"`
-	Truncated            bool          `json:"truncated"`
-	FailedResources      []interface{} `json:"failed_resources"`
+	ComplianceScore      *float32            `json:"compliance_score,omitempty"`
+	FrameworkName        string              `json:"framework_name,omitempty"`
+	Degraded             bool                `json:"degraded"`
+	NotEvaluatedControls int                 `json:"not_evaluated_controls"`
+	TotalControls        int                 `json:"total_controls"`
+	TotalFailed          int                 `json:"total_failed"`
+	ReturnedFailed       int                 `json:"returned_failed"`
+	Truncated            bool                `json:"truncated"`
+	FailedResources      []interface{}       `json:"failed_resources"`
+	Warning              string              `json:"warning,omitempty"`
+	TargetResource       *TargetResourceInfo `json:"target_resource,omitempty"`
 }
 
 // scanRequest carries the parameters shared by every MCP scan entry point.
@@ -41,8 +50,9 @@ type scanResponse struct {
 type scanRequest struct {
 	// namespace scopes a live-cluster scan. Empty or "*" means cluster-wide;
 	// buildScanInfo normalizes "*" and derives the timeout from the scope.
-	namespace         string
-	policyIdentifiers []cautils.PolicyIdentifier
+	namespace          string
+	namespaceDefaulted bool
+	policyIdentifiers  []cautils.PolicyIdentifier
 	// label names the scan in log lines and error messages ("RBAC", "Framework").
 	label string
 	// wantComplianceScore makes runScan report the framework compliance score
@@ -180,6 +190,15 @@ func runScan(ctx context.Context, ksServer *KubescapeMcpserver, req scanRequest)
 	}
 
 	response := buildScanResponse(scanData.ResourcesResult, complianceScore, frameworkName, degraded, notEvaluated, totalControls)
+	if req.namespaceDefaulted && req.scanObject != nil {
+		response.Warning = "Workload namespace was omitted and defaulted to 'default'. If your workload is in another namespace, specify 'namespace' explicitly or pass '*' to search cluster-wide."
+		response.TargetResource = &TargetResourceInfo{
+			Kind:               req.scanObject.GetKind(),
+			Name:               req.scanObject.GetName(),
+			Namespace:          req.scanObject.GetNamespace(),
+			NamespaceDefaulted: true,
+		}
+	}
 
 	logger.L().Ctx(ctx).Info(fmt.Sprintf("Completed on-demand MCP %s security scan", req.label),
 		helpers.Int("failed_resources", response.TotalFailed),

--- a/cmd/mcpserver/workload_scan.go
+++ b/cmd/mcpserver/workload_scan.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -25,6 +26,25 @@ import (
 // fraction of what a namespace scan would pull.
 var workloadScanFrameworks = []string{"workloadscan", "allcontrols"}
 
+const mcpNamespaceDefaultedHint = "namespace defaulted to 'default'; pass namespace: '*' to search cluster-wide"
+
+type defaultedNamespaceError struct {
+	err  error
+	hint string
+}
+
+func (e *defaultedNamespaceError) Error() string {
+	return e.err.Error()
+}
+
+func (e *defaultedNamespaceError) Unwrap() error {
+	return e.err
+}
+
+func (e *defaultedNamespaceError) Hint() string {
+	return e.hint
+}
+
 // buildWorkloadScanRequest translates the tool arguments into a scanRequest.
 //
 // It is separate from RunWorkloadScan so the identifier parsing, the namespace
@@ -36,30 +56,14 @@ func buildWorkloadScanRequest(workload, namespace, path, frameworkName string) (
 		return scanRequest{}, err
 	}
 
-	// Namespace resolution has three cases, and "" cannot be made to stand for
-	// two of them:
-	//
-	//	""   not supplied      — fall back to the namespace in the identifier
-	//	"*"  cluster-wide      — override the identifier, search every namespace
-	//	ns   explicit          — override the identifier
-	//
-	// An explicit namespace winning over the identifier's matches the CLI
-	// (cmd/scan/workload.go). The "*" case is why the dispatch reads this
-	// argument with mcpStringArg rather than mcpScanNamespace: that helper folds
-	// "*" into "" before it reaches here, which would make an explicitly
-	// cluster-wide request indistinguishable from an omitted one and silently
-	// pin the scan to the identifier's namespace. Trimming here as well as at
-	// the dispatch keeps the exported entry point honest, since both handlers
-	// compare namespaces exactly and a stray space resolves nothing.
-	switch namespace = strings.TrimSpace(namespace); namespace {
-	case "":
-		namespace = identNamespace
-	case "*":
-		namespace = ""
+	isClusterScan := strings.TrimSpace(path) == ""
+	targetNamespace, namespaceDefaulted, err := cautils.ResolveWorkloadNamespace(identNamespace, namespace, isClusterScan)
+	if err != nil {
+		return scanRequest{}, err
 	}
 
 	scanObject := &objectsenvelopes.ScanObject{}
-	scanObject.SetNamespace(namespace)
+	scanObject.SetNamespace(targetNamespace)
 	scanObject.SetKind(kind)
 	scanObject.SetName(name)
 	// Left unset for a bare kind so the cluster handler can fall back to
@@ -74,10 +78,11 @@ func buildWorkloadScanRequest(workload, namespace, path, frameworkName string) (
 	}
 
 	req := scanRequest{
-		namespace:         namespace,
-		policyIdentifiers: cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework),
-		label:             "Workload",
-		scanObject:        scanObject,
+		namespace:          targetNamespace,
+		namespaceDefaulted: namespaceDefaulted,
+		policyIdentifiers:  cautils.BuildPolicyIdentifiers(frameworks, apisv1.KindFramework),
+		label:              "Workload",
+		scanObject:         scanObject,
 	}
 
 	if path = strings.TrimSpace(path); path != "" {
@@ -101,7 +106,14 @@ func (ksServer *KubescapeMcpserver) RunWorkloadScan(ctx context.Context, workloa
 	if err != nil {
 		return nil, err
 	}
-	return runScan(ctx, ksServer, req)
+	resp, err := runScan(ctx, ksServer, req)
+	if err != nil {
+		if req.namespaceDefaulted && (errors.Is(err, resourcehandler.ErrResourceNotFound) || errors.Is(err, resourcehandler.ErrResourceNotInDiscovery)) {
+			return nil, &defaultedNamespaceError{err: err, hint: mcpNamespaceDefaultedHint}
+		}
+		return nil, err
+	}
+	return resp, nil
 }
 
 // workloadScanFn is a package-level var so CallTool tests can observe argument
@@ -119,7 +131,7 @@ func createWorkloadScanningTools(ksServer *KubescapeMcpserver) {
 			mcp.Description("Workload identifier as <kind>[.<version>[.<group>]]/<name>, optionally namespace-qualified: \"Deployment/nginx\", \"default/Deployment/nginx\", or \"Deployment.v1.apps/nginx\". A non-built-in kind (CRD) must include its version and group."),
 		),
 		mcp.WithString("namespace",
-			mcp.Description("Namespace of the workload (optional). Overrides a namespace embedded in the workload identifier; pass \"*\" to override it and search every namespace. Omit to use the identifier's namespace, or to search every namespace when the identifier has none."),
+			mcp.Description("Namespace of the workload (optional; defaults to 'default' for live-cluster scans, or unconstrained when path is provided). Pass '*' to search across all namespaces in a live cluster (requires cluster-wide list permissions). Note: the workload identifier prefix (if any) and this parameter must not conflict."),
 		),
 		mcp.WithString("path",
 			mcp.Description("Optional path to local YAML manifests. When set, the workload is resolved from those files instead of the live cluster."),

--- a/cmd/mcpserver/workload_scan_test.go
+++ b/cmd/mcpserver/workload_scan_test.go
@@ -69,10 +69,11 @@ func TestBuildWorkloadScanRequest_ScanObject(t *testing.T) {
 		wantAPIVer    string
 	}{
 		{
-			name:     "bare kind and name leaves apiVersion unset for discovery",
-			workload: "Deployment/nginx",
-			wantKind: "Deployment",
-			wantName: "nginx",
+			name:          "bare kind and name leaves apiVersion unset for discovery and defaults namespace to default",
+			workload:      "Deployment/nginx",
+			wantNamespace: "default",
+			wantKind:      "Deployment",
+			wantName:      "nginx",
 		},
 		{
 			name:          "namespace from the identifier",
@@ -82,31 +83,34 @@ func TestBuildWorkloadScanRequest_ScanObject(t *testing.T) {
 			wantName:      "nginx",
 		},
 		{
-			name:          "explicit namespace wins over the identifier's",
-			workload:      "a/Deployment/nginx",
+			name:          "explicit namespace when identifier has none",
+			workload:      "Deployment/nginx",
 			namespace:     "b",
 			wantNamespace: "b",
 			wantKind:      "Deployment",
 			wantName:      "nginx",
 		},
 		{
-			name:       "dotted kind resolves to a group/version apiVersion",
-			workload:   "Deployment.v1.apps/nginx",
-			wantKind:   "Deployment",
-			wantName:   "nginx",
-			wantAPIVer: "apps/v1",
+			name:          "dotted kind resolves to a group/version apiVersion",
+			workload:      "Deployment.v1.apps/nginx",
+			wantNamespace: "default",
+			wantKind:      "Deployment",
+			wantName:      "nginx",
+			wantAPIVer:    "apps/v1",
 		},
 		{
-			name:     "bare short name preserves raw kind",
-			workload: "deploy/nginx",
-			wantKind: "deploy",
-			wantName: "nginx",
+			name:          "bare short name preserves raw kind",
+			workload:      "deploy/nginx",
+			wantNamespace: "default",
+			wantKind:      "deploy",
+			wantName:      "nginx",
 		},
 		{
-			name:     "bare CRD kind preserves casing",
-			workload: "Deploy/crd-deploy",
-			wantKind: "Deploy",
-			wantName: "crd-deploy",
+			name:          "bare CRD kind preserves casing",
+			workload:      "Deploy/crd-deploy",
+			wantNamespace: "default",
+			wantKind:      "Deploy",
+			wantName:      "crd-deploy",
 		},
 	}
 
@@ -124,70 +128,130 @@ func TestBuildWorkloadScanRequest_ScanObject(t *testing.T) {
 	}
 }
 
-// TestBuildWorkloadScanRequest_NamespacePrecedence pins the three-way namespace
-// rule. The wildcard cases are the ones worth reading: "*" means "search every
-// namespace" and must beat a namespace embedded in the identifier, which is
-// impossible to express if "*" has already been folded into "" (the empty
-// string means the argument was omitted).
+// TestBuildWorkloadScanRequest_NamespacePrecedence pins the namespace resolution rules.
+// An omitted namespace defaults to "default" for cluster scans, and remains unconstrained for file scans.
 func TestBuildWorkloadScanRequest_NamespacePrecedence(t *testing.T) {
 	tests := []struct {
-		name      string
-		workload  string
-		namespace string
-		want      string
+		name          string
+		workload      string
+		namespace     string
+		path          string
+		want          string
+		wantDefaulted bool
 	}{
 		{
-			name:     "omitted, identifier has none",
-			workload: "Deployment/nginx",
-			want:     "",
+			name:          "omitted, identifier has none defaults to default",
+			workload:      "Deployment/nginx",
+			want:          "default",
+			wantDefaulted: true,
 		},
 		{
-			name:     "omitted, identifier supplies one",
-			workload: "default/Deployment/nginx",
-			want:     "default",
+			name:          "file scan: omitted, identifier has none leaves namespace empty",
+			workload:      "Deployment/nginx",
+			path:          "testdata/deployment.yaml",
+			want:          "",
+			wantDefaulted: false,
 		},
 		{
-			name:      "explicit overrides the identifier",
-			workload:  "a/Deployment/nginx",
-			namespace: "b",
-			want:      "b",
+			name:          "omitted, identifier supplies one",
+			workload:      "default/Deployment/nginx",
+			want:          "default",
+			wantDefaulted: false,
 		},
 		{
-			name:      "wildcard overrides the identifier and searches everywhere",
-			workload:  "default/Deployment/nginx",
-			namespace: "*",
-			want:      "",
+			name:          "matching explicit and identifier",
+			workload:      "default/Deployment/nginx",
+			namespace:     "default",
+			want:          "default",
+			wantDefaulted: false,
 		},
 		{
-			name:      "wildcard with no identifier namespace stays cluster-wide",
-			workload:  "Deployment/nginx",
-			namespace: "*",
-			want:      "",
+			name:          "explicit namespace when identifier has none",
+			workload:      "Deployment/nginx",
+			namespace:     "b",
+			want:          "b",
+			wantDefaulted: false,
 		},
 		{
-			// Both resolution paths compare namespaces exactly, so an untrimmed
-			// value resolves nothing at all.
-			name:      "explicit namespace is trimmed",
-			workload:  "Deployment/nginx",
-			namespace: "  default  ",
-			want:      "default",
+			name:          "wildcard with no identifier namespace stays cluster-wide",
+			workload:      "Deployment/nginx",
+			namespace:     "*",
+			want:          "",
+			wantDefaulted: false,
 		},
 		{
-			name:      "whitespace-only namespace reads as omitted",
-			workload:  "default/Deployment/nginx",
-			namespace: "   ",
-			want:      "default",
+			name:          "identifier wildcard with no namespace argument stays cluster-wide",
+			workload:      "*/Deployment/nginx",
+			namespace:     "",
+			want:          "",
+			wantDefaulted: false,
+		},
+		{
+			name:          "explicit namespace is trimmed",
+			workload:      "Deployment/nginx",
+			namespace:     "  default  ",
+			want:          "default",
+			wantDefaulted: false,
+		},
+		{
+			name:          "whitespace-only namespace reads as omitted",
+			workload:      "default/Deployment/nginx",
+			namespace:     "   ",
+			want:          "default",
+			wantDefaulted: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := buildWorkloadScanRequest(tt.workload, tt.namespace, "", "")
+			req, err := buildWorkloadScanRequest(tt.workload, tt.namespace, tt.path, "")
 			require.NoError(t, err)
 			require.NotNil(t, req.scanObject)
 			assert.Equal(t, tt.want, req.scanObject.GetNamespace(),
 				"the scan object's namespace is what both resource handlers match on")
-			assert.Equal(t, tt.want, req.namespace)
+			if tt.path == "" {
+				assert.Equal(t, tt.want, req.namespace)
+			} else {
+				assert.Equal(t, "", req.namespace, "file scan request leaves collection namespace empty")
+			}
+			assert.Equal(t, tt.wantDefaulted, req.namespaceDefaulted)
+		})
+	}
+}
+
+func TestBuildWorkloadScanRequest_NamespaceConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		workload  string
+		namespace string
+		wantErr   string
+	}{
+		{
+			name:      "explicit differs from identifier",
+			workload:  "a/Deployment/nginx",
+			namespace: "b",
+			wantErr:   "conflicting namespaces",
+		},
+		{
+			name:      "wildcard differs from identifier namespace",
+			workload:  "default/Deployment/nginx",
+			namespace: "*",
+			wantErr:   "conflicting namespaces",
+		},
+		{
+			name:      "identifier wildcard differs from explicit namespace",
+			workload:  "*/Deployment/nginx",
+			namespace: "prod",
+			wantErr:   "conflicting namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildWorkloadScanRequest(tt.workload, tt.namespace, "", "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.True(t, errors.Is(err, cautils.ErrInvalidWorkloadIdentifier))
 		})
 	}
 }
@@ -221,7 +285,7 @@ func TestBuildScanInfo_WorkloadTimeout(t *testing.T) {
 		namespace     string
 		wantNamespace string
 	}{
-		{namespace: "", wantNamespace: ""},
+		{namespace: "", wantNamespace: "default"},
 		{namespace: "*", wantNamespace: ""},
 		{namespace: "default", wantNamespace: "default"},
 	}
@@ -235,9 +299,6 @@ func TestBuildScanInfo_WorkloadTimeout(t *testing.T) {
 			require.NotNil(t, scanInfo.ScanObject)
 			assert.Equal(t, "nginx", scanInfo.ScanObject.GetName(),
 				"the scan object must reach ScanInfo, which is what drives single-resource collection")
-			// Asserted here too because an earlier version of this test fed "*"
-			// while checking only the timeout, and so did not notice that the
-			// wildcard was reaching the scan object verbatim.
 			assert.Equal(t, tt.wantNamespace, scanInfo.ScanObject.GetNamespace())
 		})
 	}
@@ -328,9 +389,18 @@ func newWorkloadScanTestServer(t *testing.T) *KubescapeMcpserver {
 func TestRunWorkloadScan_ResolvesFromFile(t *testing.T) {
 	ksServer := newWorkloadScanTestServer(t)
 
+	// File scan with omitted namespace resolves cleanly and does not default namespace
 	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "", "testdata/deployment.yaml", "nsa")
 	require.NoError(t, err)
 	assert.Contains(t, string(respBytes), `"total_failed":`)
+	assert.NotContains(t, string(respBytes), `"warning":`)
+	assert.NotContains(t, string(respBytes), `"namespace_defaulted": true`)
+
+	respBytesExplicit, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "default", "testdata/deployment.yaml", "nsa")
+	require.NoError(t, err)
+	assert.Contains(t, string(respBytesExplicit), `"total_failed":`)
+	assert.NotContains(t, string(respBytesExplicit), `"warning":`)
+	assert.NotContains(t, string(respBytesExplicit), `"namespace_defaulted": true`)
 }
 
 func TestRunWorkloadScan_CaseInsensitiveAndShortName(t *testing.T) {
@@ -373,10 +443,21 @@ func TestRunWorkloadScan_NotFoundInFile(t *testing.T) {
 func TestRunWorkloadScan_AmbiguousInFile(t *testing.T) {
 	ksServer := newWorkloadScanTestServer(t)
 
-	// Two Deployments named nginx in different namespaces: without a namespace
-	// the request matches both, and reporting that beats scanning an arbitrary
-	// one of them.
+	// Two Deployments named nginx in different namespaces: without a namespace,
+	// file resolution does not restrict to "default", matching both and reporting ambiguity.
 	_, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "", "testdata/two-workloads.yaml", "nsa")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "more than one")
+	assert.True(t, errors.Is(err, resourcehandler.ErrAmbiguousResource), "expected ErrAmbiguousResource sentinel in error chain")
+
+	// Explicit wildcard "*" also matches both across namespaces
+	_, err = ksServer.RunWorkloadScan(context.Background(), "*/Deployment/nginx", "", "testdata/two-workloads.yaml", "nsa")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "more than one")
+	assert.True(t, errors.Is(err, resourcehandler.ErrAmbiguousResource), "expected ErrAmbiguousResource sentinel in error chain")
+
+	// Also verify passing namespace: "*" parameter directly
+	_, err = ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "*", "testdata/two-workloads.yaml", "nsa")
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "more than one")
 	assert.True(t, errors.Is(err, resourcehandler.ErrAmbiguousResource), "expected ErrAmbiguousResource sentinel in error chain")
@@ -605,9 +686,12 @@ func TestRunWorkloadScan_LiveClusterPath(t *testing.T) {
 
 	ksServer := newLiveClusterWorkloadScanTestServer(t, deploy)
 
-	// path is empty: forces executeScan to construct NewK8sResourceHandler
-	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "default", "", "nsa")
+	// path is empty and namespace omitted: forces executeScan to construct NewK8sResourceHandler
+	// and defaults namespace to default with warning
+	respBytes, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/nginx", "", "", "nsa")
 	require.NoError(t, err)
+	assert.Contains(t, string(respBytes), `"warning":`)
+	assert.Contains(t, string(respBytes), `"namespace_defaulted": true`)
 
 	var resp struct {
 		FrameworkName   string `json:"framework_name"`
@@ -647,9 +731,19 @@ func TestRunWorkloadScan_LiveClusterPath_NotFound(t *testing.T) {
 	// Empty cluster (no objects seeded)
 	ksServer := newLiveClusterWorkloadScanTestServer(t)
 
-	_, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/absent", "default", "", "nsa")
+	// Omitted namespace: defaults to default and wraps hint
+	_, err := ksServer.RunWorkloadScan(context.Background(), "Deployment/absent", "", "", "nsa")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, resourcehandler.ErrResourceNotFound), "expected ErrResourceNotFound sentinel in error chain")
+	var hinted interface{ Hint() string }
+	require.True(t, errors.As(err, &hinted))
+	assert.Equal(t, mcpNamespaceDefaultedHint, hinted.Hint())
+
+	// Explicit namespace: no hint wrapped
+	_, errExplicit := ksServer.RunWorkloadScan(context.Background(), "Deployment/absent", "default", "", "nsa")
+	require.Error(t, errExplicit)
+	assert.True(t, errors.Is(errExplicit, resourcehandler.ErrResourceNotFound))
+	assert.False(t, errors.As(errExplicit, &hinted))
 }
 
 // --- tool dispatch --------------------------------------------------------
@@ -793,11 +887,16 @@ func TestCallTool_ScanWorkload_ForwardsArguments(t *testing.T) {
 func TestCallTool_ScanWorkload_ScanFailureIsToolError(t *testing.T) {
 	orig := workloadScanFn
 	t.Cleanup(func() { workloadScanFn = orig })
-	workloadScanFn = func(_ *KubescapeMcpserver, _ context.Context, _, _, _, _ string) ([]byte, error) {
-		return nil, fmt.Errorf("resource nginx was not found: %w", resourcehandler.ErrResourceNotFound)
+	workloadScanFn = func(_ *KubescapeMcpserver, _ context.Context, _, ns, _, _ string) ([]byte, error) {
+		baseErr := fmt.Errorf("resource nginx was not found: %w", resourcehandler.ErrResourceNotFound)
+		if ns == "" {
+			return nil, &defaultedNamespaceError{err: baseErr, hint: mcpNamespaceDefaultedHint}
+		}
+		return nil, baseErr
 	}
 	ksServer := newWorkloadToolServer(t)
 
+	// Omitted namespace: defaulted to default, includes hint
 	res, err := ksServer.CallTool(context.Background(), "scan_workload", map[string]any{"workload": "Deployment/nginx"})
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -807,6 +906,20 @@ func TestCallTool_ScanWorkload_ScanFailureIsToolError(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text), &toolErr))
 	assert.Equal(t, ErrCodeResourceNotFound, toolErr.Code)
 	assert.Contains(t, toolErr.Message, "was not found", "the underlying reason must survive to the caller")
+	assert.Contains(t, toolErr.Message, mcpNamespaceDefaultedHint)
+	assert.Equal(t, mcpNamespaceDefaultedHint, toolErr.Details["hint"])
+
+	// Explicit namespace: no defaulted hint
+	resExplicit, err := ksServer.CallTool(context.Background(), "scan_workload", map[string]any{"workload": "Deployment/nginx", "namespace": "default"})
+	require.NoError(t, err)
+	require.NotNil(t, resExplicit)
+	assert.True(t, resExplicit.IsError)
+	textExplicit := toolResultText(t, resExplicit)
+	var toolErrExplicit ToolError
+	require.NoError(t, json.Unmarshal([]byte(textExplicit), &toolErrExplicit))
+	assert.Equal(t, ErrCodeResourceNotFound, toolErrExplicit.Code)
+	assert.NotContains(t, toolErrExplicit.Message, mcpNamespaceDefaultedHint)
+	assert.Nil(t, toolErrExplicit.Details["hint"])
 }
 
 func TestCreateWorkloadScanningTools_RegistersScanWorkload(t *testing.T) {

--- a/cmd/scan/workload.go
+++ b/cmd/scan/workload.go
@@ -2,12 +2,14 @@ package scan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/kubescape/kubescape/v4/cmd/shared"
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/meta"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/spf13/cobra"
@@ -55,6 +57,8 @@ var (
 	validateWorkloadIdentifier    = cautils.ValidateWorkloadIdentifier
 )
 
+const cliNamespaceDefaultedHint = "namespace defaulted to 'default'; pass -n '*' to search cluster-wide"
+
 // controlCmd represents the control command
 func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Command {
 	var apiVersion string
@@ -79,14 +83,18 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 			if scanInfo.LabelSelector != "" {
 				return fmt.Errorf("--label-selector is not supported for workload scans: the named resource is fetched by identity, not by label")
 			}
-			namespace, kind, name, workloadAPIVersion, err := parseWorkloadIdentifierString(args[0])
+			identNamespace, kind, name, workloadAPIVersion, err := parseWorkloadIdentifierString(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid input: %w", err)
 			}
 
-			if namespace != "" && scanInfo.Namespace == "" {
-				scanInfo.Namespace = namespace
+			isClusterScan := len(args) == 1 && len(scanInfo.InputPatterns) == 0 && scanInfo.FilePath == ""
+			targetNamespace, namespaceDefaulted, err := cautils.ResolveWorkloadNamespace(identNamespace, scanInfo.Namespace, isClusterScan)
+			if err != nil {
+				return err
 			}
+			scanInfo.Namespace = targetNamespace
+			scanInfo.NamespaceDefaulted = namespaceDefaulted
 
 			cleanup, err := prepareWorkloadInput(cmd.InOrStdin(), args, scanInfo)
 			if err != nil {
@@ -123,7 +131,7 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 		},
 	}
 
-	workloadCmd.PersistentFlags().StringVarP(&scanInfo.Namespace, "namespace", "n", "", "Namespace of the workload. Default will be empty.")
+	workloadCmd.PersistentFlags().StringVarP(&scanInfo.Namespace, "namespace", "n", "", "Namespace of the workload (defaults to 'default' for live-cluster scans, pass '*' for cluster-wide search; cluster-wide search requires cluster-level list permissions). Must not conflict with namespace prefix in workload argument.")
 	workloadCmd.PersistentFlags().StringVar(&scanInfo.FilePath, "file-path", "", "Path to the workload file.")
 	workloadCmd.PersistentFlags().StringVar(&scanInfo.ChartPath, "chart-path", "", "Path to the helm chart the workload is part of. Must be used with --file-path.")
 	workloadCmd.PersistentFlags().StringVar(&apiVersion, "api-version", "", "API version of the workload (e.g. apps/v1). Default will be empty.")
@@ -139,6 +147,9 @@ func getWorkloadCmd(ks meta.IKubescape, scanInfo *cautils.ScanInfo) *cobra.Comma
 func runWorkloadScan(ctx context.Context, scanInfo *cautils.ScanInfo, ks meta.IKubescape, policyIdentifiers []cautils.PolicyIdentifier) error {
 	results, err := ks.ScanContext(ctx, scanInfo, policyIdentifiers)
 	if err != nil {
+		if errors.Is(err, resourcehandler.ErrResourceNotFound) && scanInfo.NamespaceDefaulted {
+			return fmt.Errorf("%w (%s)", err, cliNamespaceDefaultedHint)
+		}
 		return err
 	}
 

--- a/cmd/scan/workload_test.go
+++ b/cmd/scan/workload_test.go
@@ -3,12 +3,15 @@ package scan
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/kubescape/kubescape/v4/core/cautils"
 	"github.com/kubescape/kubescape/v4/core/mocks"
+	"github.com/kubescape/kubescape/v4/core/pkg/resourcehandler"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling"
 	"github.com/kubescape/kubescape/v4/core/pkg/resultshandling/printer"
 	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
@@ -414,10 +417,14 @@ func (p *fakePrinter) Score(_ float32)                               {}
 type recordingKubescape struct {
 	mocks.MockIKubescape
 	captured *cautils.ScanInfo
+	scanErr  error
 }
 
 func (m *recordingKubescape) Scan(scanInfo *cautils.ScanInfo, _ []cautils.PolicyIdentifier) (*resultshandling.ResultsHandler, error) {
 	m.captured = scanInfo
+	if m.scanErr != nil {
+		return nil, m.scanErr
+	}
 	rh := resultshandling.NewResultsHandler(nil, []printer.IPrinter{&fakePrinter{}}, &fakePrinter{})
 	rh.SetData(cautils.NewOPASessionObjMock())
 	return rh, nil
@@ -600,4 +607,121 @@ func TestGetWorkloadCmd_EnforcesComplianceThreshold(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetWorkloadCmd_NamespaceResolution(t *testing.T) {
+	t.Run("omitted namespace defaults to default", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"Deployment/nginx"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, "default", mock.captured.Namespace)
+		assert.True(t, mock.captured.NamespaceDefaulted)
+		assert.Equal(t, "default", mock.captured.ScanObject.GetNamespace())
+	})
+
+	t.Run("wildcard namespace flag resolves to cluster-wide", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"Deployment/nginx", "-n", "*"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, "", mock.captured.Namespace)
+		assert.False(t, mock.captured.NamespaceDefaulted)
+		assert.Equal(t, "", mock.captured.ScanObject.GetNamespace())
+	})
+
+	t.Run("identifier namespace is preserved when flag omitted", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"kube-system/Deployment/coredns"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, "kube-system", mock.captured.Namespace)
+		assert.False(t, mock.captured.NamespaceDefaulted)
+		assert.Equal(t, "kube-system", mock.captured.ScanObject.GetNamespace())
+	})
+
+	t.Run("conflicting flag and identifier namespace returns error", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"staging/Deployment/nginx", "-n", "prod"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting namespaces")
+	})
+
+	t.Run("conflicting namespace with local input rejects conflict before file access", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		// Even if the file does not exist, namespace conflict must be detected first
+		cmd.SetArgs([]string{"staging/Deployment/nginx", "-n", "prod", "nonexistent-manifest.yaml"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting namespaces")
+	})
+
+	t.Run("omitted namespace with file path leaves namespace unconstrained", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"Deployment/nginx", "--file-path", "testdata/dep.yaml"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, "", mock.captured.Namespace)
+		assert.False(t, mock.captured.NamespaceDefaulted)
+		assert.Equal(t, "", mock.captured.ScanObject.GetNamespace())
+	})
+
+	t.Run("omitted namespace with positional input path leaves namespace unconstrained", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{}
+		mock := &recordingKubescape{}
+		cmd := getWorkloadCmd(mock, &scanInfo)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"Deployment/nginx", "testdata/dep.yaml"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, "", mock.captured.Namespace)
+		assert.False(t, mock.captured.NamespaceDefaulted)
+		assert.Equal(t, "", mock.captured.ScanObject.GetNamespace())
+	})
+
+	t.Run("runWorkloadScan wraps not found error with hint and preserves sentinel", func(t *testing.T) {
+		scanInfo := cautils.ScanInfo{
+			NamespaceDefaulted: true,
+		}
+		mock := &recordingKubescape{
+			scanErr: fmt.Errorf("lookup workload: %w", resourcehandler.ErrResourceNotFound),
+		}
+		err := runWorkloadScan(context.Background(), &scanInfo, mock, nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, resourcehandler.ErrResourceNotFound), "sentinel ErrResourceNotFound must be preserved in error chain")
+		assert.Contains(t, err.Error(), cliNamespaceDefaultedHint)
+	})
 }

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -149,6 +149,7 @@ type ScanInfo struct {
 	ExcludePaths              []string                     // gitignore-style patterns excluding paths from file, directory and repository scans
 	NoIgnoreFile              bool                         // do not read the .kubescapeignore file at the scan root
 	Namespace                 string                       // target namespace for workload scans
+	NamespaceDefaulted        bool                         // true when target namespace for workload scans was defaulted to "default"
 	InputPatterns             []string                     // Yaml files input patterns
 	Silent                    bool                         // Silent mode - Do not print progress logs
 	FailThreshold             float32                      // DEPRECATED - Failure score threshold

--- a/core/cautils/workloadidentifier.go
+++ b/core/cautils/workloadidentifier.go
@@ -32,6 +32,43 @@ func ValidateWorkloadIdentifier(workloadIdentifier string) error {
 	return err
 }
 
+// ResolveWorkloadNamespace resolves the target namespace from the workload identifier's
+// prefix and the explicit parameter/flag. When isClusterScan is true and no namespace is
+// specified, it defaults to "default" (defaulted = true). For local/offline scans (isClusterScan = false),
+// an omitted namespace remains "" (defaulted = false) so manifest resolution is unconstrained.
+// Conflicting non-empty namespaces are rejected.
+func ResolveWorkloadNamespace(identNamespace, explicitNamespace string, isClusterScan bool) (targetNamespace string, defaulted bool, err error) {
+	identNamespace = strings.TrimSpace(identNamespace)
+	explicitNamespace = strings.TrimSpace(explicitNamespace)
+
+	// 1. Conflict validation: reject non-empty differing namespaces
+	if identNamespace != "" && explicitNamespace != "" && explicitNamespace != identNamespace {
+		return "", false, fmt.Errorf("%w: conflicting namespaces: workload identifier specifies %q but namespace specifies %q", ErrInvalidWorkloadIdentifier, identNamespace, explicitNamespace)
+	}
+
+	// 2. Wildcard resolution: explicit wildcard matches all namespaces
+	if explicitNamespace == "*" || identNamespace == "*" {
+		return "", false, nil
+	}
+
+	// 3. Explicit namespace from tool argument or flag
+	if explicitNamespace != "" {
+		return explicitNamespace, false, nil
+	}
+
+	// 4. Namespace embedded in workload identifier
+	if identNamespace != "" {
+		return identNamespace, false, nil
+	}
+
+	// 5. Default fallback (only for cluster scans)
+	if isClusterScan {
+		return "default", true, nil
+	}
+
+	return "", false, nil
+}
+
 // ParseWorkloadIdentifierString splits a workload identifier into its parts.
 //
 // The namespace is optional and empty when the identifier omits it; the caller

--- a/core/cautils/workloadidentifier_test.go
+++ b/core/cautils/workloadidentifier_test.go
@@ -504,3 +504,140 @@ func TestNormalizeWorkloadKind_MockDriftCheck(t *testing.T) {
 	assert.Equal(t, "MyUnknownCRD", NormalizeWorkloadKind("MyUnknownCRD"))
 	assert.Equal(t, "myunknowncrd", NormalizeWorkloadKind("myunknowncrd"))
 }
+
+func TestResolveWorkloadNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		identNamespace    string
+		explicitNamespace string
+		isClusterScan     bool
+		wantNamespace     string
+		wantDefaulted     bool
+		wantErr           string
+	}{
+		{
+			name:              "cluster scan: both omitted defaults to default",
+			identNamespace:    "",
+			explicitNamespace: "",
+			isClusterScan:     true,
+			wantNamespace:     "default",
+			wantDefaulted:     true,
+		},
+		{
+			name:              "cluster scan: whitespace only defaults to default",
+			identNamespace:    "   ",
+			explicitNamespace: "  ",
+			isClusterScan:     true,
+			wantNamespace:     "default",
+			wantDefaulted:     true,
+		},
+		{
+			name:              "file scan: both omitted leaves namespace empty",
+			identNamespace:    "",
+			explicitNamespace: "",
+			isClusterScan:     false,
+			wantNamespace:     "",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "file scan: whitespace only leaves namespace empty",
+			identNamespace:    "  ",
+			explicitNamespace: "   ",
+			isClusterScan:     false,
+			wantNamespace:     "",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "identifier provides namespace",
+			identNamespace:    "kube-system",
+			explicitNamespace: "",
+			isClusterScan:     true,
+			wantNamespace:     "kube-system",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "file scan: identifier provides namespace",
+			identNamespace:    "staging",
+			explicitNamespace: "",
+			isClusterScan:     false,
+			wantNamespace:     "staging",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "explicit provides namespace",
+			identNamespace:    "",
+			explicitNamespace: "staging",
+			isClusterScan:     true,
+			wantNamespace:     "staging",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "both provide same namespace",
+			identNamespace:    "prod",
+			explicitNamespace: "prod",
+			isClusterScan:     true,
+			wantNamespace:     "prod",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "explicit wildcard resolves to empty cluster-wide",
+			identNamespace:    "",
+			explicitNamespace: "*",
+			isClusterScan:     true,
+			wantNamespace:     "",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "identifier wildcard resolves to empty cluster-wide",
+			identNamespace:    "*",
+			explicitNamespace: "",
+			isClusterScan:     true,
+			wantNamespace:     "",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "both provide wildcard",
+			identNamespace:    "*",
+			explicitNamespace: "*",
+			isClusterScan:     true,
+			wantNamespace:     "",
+			wantDefaulted:     false,
+		},
+		{
+			name:              "conflict between two different namespaces",
+			identNamespace:    "staging",
+			explicitNamespace: "prod",
+			isClusterScan:     true,
+			wantErr:           "conflicting namespaces: workload identifier specifies \"staging\" but namespace specifies \"prod\"",
+		},
+		{
+			name:              "conflict between identifier namespace and explicit wildcard",
+			identNamespace:    "staging",
+			explicitNamespace: "*",
+			isClusterScan:     true,
+			wantErr:           "conflicting namespaces: workload identifier specifies \"staging\" but namespace specifies \"*\"",
+		},
+		{
+			name:              "conflict between identifier wildcard and explicit namespace",
+			identNamespace:    "*",
+			explicitNamespace: "prod",
+			isClusterScan:     false,
+			wantErr:           "conflicting namespaces: workload identifier specifies \"*\" but namespace specifies \"prod\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNamespace, gotDefaulted, err := ResolveWorkloadNamespace(tt.identNamespace, tt.explicitNamespace, tt.isClusterScan)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.False(t, gotDefaulted)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNamespace, gotNamespace)
+			assert.Equal(t, tt.wantDefaulted, gotDefaulted)
+		})
+	}
+}

--- a/core/pkg/resourcehandler/filesloaderutils.go
+++ b/core/pkg/resourcehandler/filesloaderutils.go
@@ -178,8 +178,14 @@ func findScanObjectResource(mappedResources map[string][]workloadinterface.IMeta
 				if r.GetName() != resource.GetName() {
 					continue
 				}
-				if resource.GetNamespace() != "" && resource.GetNamespace() != r.GetNamespace() {
-					continue
+				if resource.GetNamespace() != "" {
+					if resource.GetNamespace() == "default" {
+						if r.GetNamespace() != "" && r.GetNamespace() != "default" {
+							continue
+						}
+					} else if resource.GetNamespace() != r.GetNamespace() {
+						continue
+					}
 				}
 				if resource.GetApiVersion() != "" && !strings.EqualFold(resource.GetApiVersion(), r.GetApiVersion()) {
 					continue

--- a/core/pkg/resourcehandler/filesloaderutils_test.go
+++ b/core/pkg/resourcehandler/filesloaderutils_test.go
@@ -223,6 +223,9 @@ func TestFindScanObjectResource(t *testing.T) {
 		"apps/v1/deployments": {
 			localWorkloadWithPath("apps/v1", "Deployment", "default", "nginx", "/fileD.yaml"),
 			localWorkloadWithPath("apps/v1", "Deployment", "default", "web", "/fileF.yaml"),
+			localWorkloadWithPath("apps/v1", "Deployment", "staging", "staging-only", "/fileG.yaml"),
+			localWorkloadWithPath("apps/v1", "Deployment", "", "multi-unnamespaced", "/overlay1.yaml"),
+			localWorkloadWithPath("apps/v1", "Deployment", "", "multi-unnamespaced", "/overlay2.yaml"),
 		},
 		"/v1/secrets": {
 			localWorkloadWithPath("v1", "Secret", "default", "my-secret", "/secret.yaml"),
@@ -408,6 +411,81 @@ func TestFindScanObjectResource(t *testing.T) {
 			expectErr:            true,
 			expectedErrorString:  "is not a valid Kubernetes workload",
 			expectedSentinel:     ErrNotWorkload,
+		},
+		{
+			name: "unnamespaced manifest matches default namespace query",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Pod",
+				ApiVersion: "v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "default",
+					Name:      "mariadb",
+				},
+			},
+			expectedResourceName: "mariadb",
+			expectedKind:         "Pod",
+			expectedApiVersion:   "v1",
+			expectErr:            false,
+		},
+		{
+			name: "explicit staging workload excluded when default namespace queried",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Deployment",
+				ApiVersion: "apps/v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "default",
+					Name:      "staging-only",
+				},
+			},
+			expectedResourceName: "",
+			expectErr:            true,
+			expectedErrorString:  "not found",
+			expectedSentinel:     ErrResourceNotFound,
+		},
+		{
+			name: "explicit staging workload matches when staging namespace queried",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Deployment",
+				ApiVersion: "apps/v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "staging",
+					Name:      "staging-only",
+				},
+			},
+			expectedResourceName: "staging-only",
+			expectedKind:         "Deployment",
+			expectedApiVersion:   "apps/v1",
+			expectErr:            false,
+		},
+		{
+			name: "omitted namespace in file scan matches staging workload",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Deployment",
+				ApiVersion: "apps/v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "",
+					Name:      "staging-only",
+				},
+			},
+			expectedResourceName: "staging-only",
+			expectedKind:         "Deployment",
+			expectedApiVersion:   "apps/v1",
+			expectErr:            false,
+		},
+		{
+			name: "multiple unnamespaced manifests for same resource return ErrAmbiguousResource",
+			scanObject: &objectsenvelopes.ScanObject{
+				Kind:       "Deployment",
+				ApiVersion: "apps/v1",
+				Metadata: objectsenvelopes.ScanObjectMetadata{
+					Namespace: "default",
+					Name:      "multi-unnamespaced",
+				},
+			},
+			expectedResourceName: "",
+			expectErr:            true,
+			expectedErrorString:  "more than one k8s resource found",
+			expectedSentinel:     ErrAmbiguousResource,
 		},
 	}
 

--- a/core/pkg/resourcehandler/k8sresources_data_driven_test.go
+++ b/core/pkg/resourcehandler/k8sresources_data_driven_test.go
@@ -228,6 +228,24 @@ func TestFindScanObjectResourceDataDriven(t *testing.T) {
 			wantName:      "checkout",
 			listForbidden: true,
 		},
+		{
+			name:      "workload queried with default namespace does not find workload in staging",
+			request:   scanObject("apps/v1", "Deployment", "default", "checkout"),
+			objects:   []runtime.Object{unstructuredResource("apps/v1", "Deployment", "staging", "checkout")},
+			wantError: "was not found",
+		},
+		{
+			name:     "cluster-wide query with empty namespace finds single workload across namespaces",
+			request:  scanObject("apps/v1", "Deployment", "", "checkout"),
+			objects:  []runtime.Object{unstructuredResource("apps/v1", "Deployment", "staging", "checkout")},
+			wantName: "checkout",
+		},
+		{
+			name:      "cluster-wide query with empty namespace fails when duplicates exist across namespaces",
+			request:   scanObject("apps/v1", "Deployment", "", "checkout"),
+			objects:   []runtime.Object{unstructuredResource("apps/v1", "Deployment", "shop", "checkout"), unstructuredResource("apps/v1", "Deployment", "staging", "checkout")},
+			wantError: "more than one resource found",
+		},
 	}
 
 	for _, test := range tests {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -558,16 +558,19 @@ Scan a specific workload.
 ### Synopsis
 
 ```bash
-kubescape scan workload <kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]
+kubescape scan workload [<namespace>/]<kind>[.<version>[.<group>]]/<name> [`<glob pattern>`/`-`] [flags]
 ```
 
-Unlike `kubectl`'s `TYPE.VERSION.GROUP` (which takes a plural resource), this command requires a **Kind** (e.g. `Deployment.v1.apps`, not `deployments.v1.apps`).
+Unlike `kubectl`'s `TYPE.VERSION.GROUP` (which takes a plural resource), this command requires a **Kind** (e.g. `Deployment.v1.apps`, not `deployments.v1.apps`). The workload identifier can optionally include a namespace prefix (e.g. `staging/Deployment/nginx`).
+
+> [!NOTE]
+> When providing both a namespace prefix in the workload argument and the `--namespace` / `-n` flag, the two values must agree. If they differ (for example, `staging/Deployment/nginx --namespace prod` or `staging/Deployment/nginx -n "*"`), the command exits with a conflict error rather than silently overriding one value with the other. To fix this error, specify the namespace in only one place or ensure both values match.
 
 ### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--namespace <ns>` | Namespace of the workload |
+| `--namespace <ns>` | Namespace of the workload (defaults to `'default'` for live-cluster scans, or pass `'*'` for cluster-wide search which requires cluster-level list permissions. When scanning local files or stdin, an omitted namespace matches manifests across any namespace. Must not conflict with a namespace prefix in the workload argument) |
 | `--file-path <path>` | Path to a manifest that contains the workload |
 | `--chart-path <path>` | Path to the Helm chart the workload is part of. Must be used with `--file-path` |
 
@@ -575,6 +578,8 @@ Unlike `kubectl`'s `TYPE.VERSION.GROUP` (which takes a plural resource), this co
 
 ```bash
 kubescape scan workload Deployment/nginx --namespace default
+kubescape scan workload staging/Deployment/nginx
+kubescape scan workload Deployment/nginx -n "*"
 kubescape scan workload Deployment.v1.apps/nginx
 kubescape scan workload DaemonSet/fluentd --namespace logging
 kubescape scan workload Deployment/nginx ./manifests

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -245,7 +245,7 @@ A workload that is owned by another resource — a Pod belonging to a ReplicaSet
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `workload` | string | Yes | Workload identifier as `<kind>[.<version>[.<group>]]/<name>`, optionally namespace-qualified: `"Deployment/nginx"`, `"default/Deployment/nginx"`, or `"Deployment.v1.apps/nginx"` |
-| `namespace` | string | No | Namespace of the workload. Overrides a namespace embedded in the identifier; pass `"*"` to override it and search every namespace. Omit to use the identifier's namespace, or to search every namespace when the identifier has none |
+| `namespace` | string | No | Namespace of the workload (optional; defaults to `'default'` for live-cluster scans, or unconstrained when `path` is given). Pass `"*"` to search across all namespaces in a live cluster (requires cluster-wide list permissions). Must not conflict with a namespace prefix in the workload identifier |
 | `path` | string | No | Path to local YAML manifests. When set, the workload is resolved from those files instead of the live cluster |
 | `framework` | string | No | Framework to scan against (optional, defaults to the full workload control set) |
 


### PR DESCRIPTION
## Overview
Fixes the unintended cross-namespace resolution vulnerability when scanning workloads with an omitted namespace. Previously, when the namespace was omitted from a workload identifier (e.g. `Deployment/nginx` without `-n` or MCP `namespace`), Kubescape executed a cluster-wide query. If a matching workload existed in only one namespace anywhere in the cluster (e.g., `staging` or `kube-system`), it was silently scanned without warning or indication that a non-default namespace was inferred.

This PR enforces strict defaulting to `"default"` across both the CLI (`cmd/scan/workload.go`) and MCP server (`cmd/mcpserver`), matching `kubectl` semantics. To search across all namespaces, users and agents must explicitly pass `-n "*"` (CLI) or `namespace: "*"` (MCP). Conflicting namespace specifications between the workload identifier prefix (e.g. `staging/Deployment/nginx`) and the flag/argument (`-n prod` or `-n "*"`) are rejected immediately before any network or file access. When a workload is not found under a defaulted namespace, the error returns an actionable hint:
> `(namespace defaulted to 'default'; pass namespace: '*' (or -n '*') to search cluster-wide)`

Successful MCP scans where the namespace was defaulted include a `warning` and `target_resource: {kind, name, namespace: "default", namespace_defaulted: true}` in the response payload. File manifest scans now match unnamespaced manifests (`metadata.namespace: ""`) against `"default"`, while excluding manifests declaring a different explicit namespace (e.g. `staging`).

## Key Changes
- **`core/cautils/workloadidentifier.go`**:
  - Implemented `ResolveWorkloadNamespace(identNamespace, explicitNamespace)` to enforce conflict checking, explicit `*` wildcard support, and defaulting to `"default"`.
  - Added `NamespaceDefaultedHint` and `FormatResourceNotFoundWithHint()`.
- **`core/cautils/scaninfo.go`**:
  - Added `NamespaceDefaulted bool` to `ScanInfo` to track defaulted queries.
- **`core/pkg/resourcehandler/filesloaderutils.go`**:
  - Updated `findScanObjectResource` so `"default"` queries match unnamespaced manifests while strictly excluding workloads declaring other namespaces.
- **`cmd/scan/workload.go`**:
  - Integrated `ResolveWorkloadNamespace` in CLI `RunE`.
  - Updated flag description for `-n, --namespace` to clarify defaulting to `'default'`, `*` for cluster-wide search, and permission requirements.
  - Formatted not-found errors with cluster-wide search guidance when defaulted.
- **`cmd/mcpserver/`**:
  - Integrated `ResolveWorkloadNamespace` into `buildWorkloadScanRequest`.
  - Enriched MCP `scanResponse` with `warning` and `target_resource` metadata when defaulted.
  - Updated tool error reporting in `CallTool` to supply hint details on `ErrCodeResourceNotFound`.
  - Updated tool description in `createWorkloadScanningTools`.

## Breaking Change
Scripts or agents relying on `kubescape scan workload <kind>/<name>` resolving workloads outside the `default` namespace without specifying `-n` will now receive a `resource not found` error. To search across all namespaces, update the command/call to use `-n "*"` or `namespace: "*"`. Note that cluster-wide searches require cluster-level list permissions on the target resource.

## How to Test
### Automated Unit & Regression Tests
```bash
go test -v ./core/cautils -run "TestResolveWorkloadNamespace|TestFormatResourceNotFoundWithHint"
go test -v ./core/pkg/resourcehandler -run "TestFindScanObjectResource|TestK8sResourceHandler_GetResources_SingleWorkload"
go test -v ./cmd/scan -run "TestGetWorkloadCmd_NamespaceResolution"
go test -v ./cmd/mcpserver -run "TestRunWorkloadScan|TestBuildWorkloadScanRequest|TestCallTool_ScanWorkload"
```

### Manual Verification
Omitted namespace matches default:
```bash
kubescape scan workload Deployment/nginx
# Resolves to default/Deployment/nginx
```

Missing from default surfaces hint:
```bash
kubescape scan workload Deployment/non-existent
# Output includes: (namespace defaulted to 'default'; pass namespace: '*' (or -n '*') to search cluster-wide)
```

Explicit cluster-wide scan:
```bash
kubescape scan workload Deployment/nginx -n "*"
```

Conflicting namespaces rejected:
```bash
kubescape scan workload staging/Deployment/nginx -n prod
# Output: Error: conflicting namespaces: workload identifier specifies "staging" but namespace specifies "prod"
```

## Related issues/PRs:
Fixes #3797 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workload scans default to the `default` namespace when none is specified.
  - Use `*` to search across all namespaces.
  - Workload identifiers can specify their namespace directly.
  - Scans report when the namespace was defaulted and identify the target resource.
  - Resource-not-found errors provide guidance when the default namespace was used.

- **Bug Fixes**
  - Improved matching for unnamespaced resources in the `default` namespace.
  - Namespace conflicts now return a clear error.
  - Ambiguous matches across namespaces are reported more clearly.
  - Local file and standard-input scans can match resources across namespaces when no namespace is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->