### PR TITLE
fix(cautils): bound port-forward readiness wait to the Kubescape Operator pod

### DIFF
--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	v1 "k8s.io/api/core/v1"
@@ -18,17 +20,25 @@ import (
 const (
 	DefaultPortForwardPortEnv   string = "DEFAULT_PORT_FORWARDER_PORT"
 	DefaultPortForwardPortValue string = "4444"
+
+	// PortForwardReadyTimeoutEnv overrides how long StartPortForwarder waits
+	// for the port-forward to the operator pod to become ready before giving
+	// up. Same override pattern as DefaultPortForwardPortEnv.
+	PortForwardReadyTimeoutEnv string = "KS_PORT_FORWARD_READY_TIMEOUT_SECONDS"
+
+	defaultPortForwardReadyTimeout time.Duration = 30 * time.Second
 )
 
 type portForward struct {
 	*portforward.PortForwarder
-	localPort string
-	stopChan  chan struct{}
-	stopOnce  sync.Once
-	readyChan chan struct{}
-	errChan   chan error
-	out       *bytes.Buffer
-	errOut    *bytes.Buffer
+	localPort    string
+	stopChan     chan struct{}
+	stopOnce     sync.Once
+	readyChan    chan struct{}
+	errChan      chan error
+	out          *bytes.Buffer
+	errOut       *bytes.Buffer
+	readyTimeout time.Duration
 }
 
 func getPortForwardingPort() string {
@@ -36,6 +46,19 @@ func getPortForwardingPort() string {
 		return port
 	}
 	return DefaultPortForwardPortValue
+}
+
+// getPortForwardReadyTimeout resolves the readiness-wait budget once per
+// forwarder, mirroring getPortForwardingPort so the timeout used by
+// waitForPortForwardReadiness and the one used to bound the dial itself
+// cannot disagree if the environment changes mid-run.
+func getPortForwardReadyTimeout() time.Duration {
+	if raw, exist := os.LookupEnv(PortForwardReadyTimeoutEnv); exist {
+		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return defaultPortForwardReadyTimeout
 }
 
 func splitServerURL(host string) (string, string, string, error) {
@@ -67,7 +90,13 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 		return nil, err
 	}
 
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, serverURL)
+	// Resolve the readiness budget once, before the dialer is built, so the
+	// same value bounds both the initial SPDY upgrade dial (an ordinary HTTP
+	// request the returned client's Timeout already covers) and the
+	// waitForPortForwardReadiness fallback below, which exists for the case
+	// the dial succeeds but the port-forward never signals ready.
+	readyTimeout := getPortForwardReadyTimeout()
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper, Timeout: readyTimeout}, http.MethodPost, serverURL)
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{})
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 
@@ -88,10 +117,21 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 		errChan:       make(chan error, 1),
 		out:           out,
 		errOut:        errOut,
+		readyTimeout:  readyTimeout,
 	}, nil
 }
 
+// waitForPortForwardReadiness blocks until the port-forward is ready, fails,
+// or readyTimeout elapses. Without the timer case this can hang forever: the
+// dial's own Timeout (set in CreatePortForwarder) only bounds establishing
+// the SPDY upgrade, not a peer that accepts the connection and then never
+// completes it, or a ForwardPorts implementation that never closes readyChan
+// or errChan on some other stall path. The timer case is what turns that
+// silent hang into a diagnosable error instead.
 func (p *portForward) waitForPortForwardReadiness() error {
+	timer := time.NewTimer(p.readyTimeout)
+	defer timer.Stop()
+
 	select {
 	case <-p.readyChan:
 		return nil
@@ -100,6 +140,14 @@ func (p *portForward) waitForPortForwardReadiness() error {
 			err = fmt.Errorf("port-forward exited before becoming ready: %s", strings.TrimSpace(p.errOut.String()))
 		}
 		return err
+	case <-timer.C:
+		return fmt.Errorf(
+			"timed out after %s waiting for the port-forward to the Kubescape Operator pod to become ready; "+
+				"check network connectivity to the API server and that the operator pod is reachable "+
+				"(override the wait with %s)",
+			p.readyTimeout,
+			PortForwardReadyTimeoutEnv,
+		)
 	}
 }
 

--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -31,6 +32,13 @@ const (
 	PortForwardReadyTimeoutEnv string = "KS_PORT_FORWARD_READY_TIMEOUT_SECONDS"
 
 	defaultPortForwardReadyTimeout time.Duration = 30 * time.Second
+
+	// maxPortForwardReadyTimeoutSeconds is the largest value
+	// PortForwardReadyTimeoutEnv can hold without overflowing time.Duration
+	// (an int64 nanosecond count) when multiplied by time.Second. Anything
+	// above this wraps to a negative duration, which turns into a
+	// non-positive http.Client.Timeout -- i.e. no timeout at all.
+	maxPortForwardReadyTimeoutSeconds int64 = math.MaxInt64 / int64(time.Second)
 )
 
 // handshakeConnHolder lets the custom DialContext (running inside the
@@ -85,7 +93,7 @@ func getPortForwardingPort() string {
 // cannot disagree if the environment changes mid-run.
 func getPortForwardReadyTimeout() time.Duration {
 	if raw, exist := os.LookupEnv(PortForwardReadyTimeoutEnv); exist {
-		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 && int64(secs) <= maxPortForwardReadyTimeoutSeconds {
 			return time.Duration(secs) * time.Second
 		}
 	}

--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -2,7 +2,9 @@ package cautils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +15,8 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	v1 "k8s.io/api/core/v1"
+	apimachineryspdy "k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -29,16 +33,43 @@ const (
 	defaultPortForwardReadyTimeout time.Duration = 30 * time.Second
 )
 
+// handshakeConnHolder lets the custom DialContext (running inside the
+// background ForwardPorts goroutine) hand the raw dialed connection back to
+// waitForPortForwardReadiness (running on the caller's goroutine), so the
+// read deadline armed for the handshake can be cleared once the upgrade
+// actually succeeds -- otherwise it would still apply to the long-lived
+// port-forward stream afterward.
+type handshakeConnHolder struct {
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+func (h *handshakeConnHolder) store(conn net.Conn) {
+	h.mu.Lock()
+	h.conn = conn
+	h.mu.Unlock()
+}
+
+func (h *handshakeConnHolder) clearDeadline() {
+	h.mu.Lock()
+	conn := h.conn
+	h.mu.Unlock()
+	if conn != nil {
+		_ = conn.SetDeadline(time.Time{})
+	}
+}
+
 type portForward struct {
 	*portforward.PortForwarder
-	localPort    string
-	stopChan     chan struct{}
-	stopOnce     sync.Once
-	readyChan    chan struct{}
-	errChan      chan error
-	out          *bytes.Buffer
-	errOut       *bytes.Buffer
-	readyTimeout time.Duration
+	localPort     string
+	stopChan      chan struct{}
+	stopOnce      sync.Once
+	readyChan     chan struct{}
+	errChan       chan error
+	out           *bytes.Buffer
+	errOut        *bytes.Buffer
+	readyTimeout  time.Duration
+	handshakeConn *handshakeConnHolder // nil when the proxy-fallback path was used
 }
 
 func getPortForwardingPort() string {
@@ -85,17 +116,18 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 	}
 	serverURL := &url.URL{Scheme: scheme, Path: basePath + path, Host: hostIP}
 
-	roundTripper, upgrader, err := spdy.RoundTripperFor(k8sClient.K8SConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	// Resolve the readiness budget once, before the dialer is built, so the
 	// same value bounds both the initial SPDY upgrade dial (an ordinary HTTP
 	// request the returned client's Timeout already covers) and the
 	// waitForPortForwardReadiness fallback below, which exists for the case
 	// the dial succeeds but the port-forward never signals ready.
 	readyTimeout := getPortForwardReadyTimeout()
+
+	roundTripper, upgrader, handshakeConn, err := newPortForwardRoundTripper(k8sClient.K8SConfig, serverURL, readyTimeout)
+	if err != nil {
+		return nil, err
+	}
+
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper, Timeout: readyTimeout}, http.MethodPost, serverURL)
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{})
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
@@ -118,7 +150,80 @@ func CreatePortForwarder(k8sClient *k8sinterface.KubernetesApi, pod *v1.Pod, for
 		out:           out,
 		errOut:        errOut,
 		readyTimeout:  readyTimeout,
+		handshakeConn: handshakeConn,
 	}, nil
+}
+
+// newPortForwardRoundTripper builds the round tripper and upgrader used to
+// dial the SPDY upgrade request. Its own http.Client.Timeout only bounds the
+// dial and the request write; the SPDY libraries' hand-rolled response read
+// afterward (http.ReadResponse over a raw bufio reader) never checks that
+// timeout, so a peer that completes TCP/TLS but withholds the upgrade
+// response leaves that read -- and the goroutine and socket behind it --
+// blocked forever. See PR #3800 review.
+//
+// When no proxy applies to serverURL, this arms a deadline on the raw dialed
+// connection itself (via a custom DialContext plugged in as UpgradeTransport)
+// so the stalled read is bounded too; the deadline persists through the TLS
+// handshake and is cleared by waitForPortForwardReadiness once the upgrade
+// actually succeeds. Setting UpgradeTransport replaces the SPDY library's own
+// dialing -- including its proxy-CONNECT tunneling -- entirely, so when a
+// proxy does apply this falls back to the unbounded-read path unchanged
+// rather than reimplementing proxy tunneling here. That fallback keeps only
+// the pre-existing http.Client.Timeout, which does not cover a stalled
+// upgrade read: a disclosed, deliberate limitation, not an oversight.
+func newPortForwardRoundTripper(config *rest.Config, serverURL *url.URL, readyTimeout time.Duration) (http.RoundTripper, spdy.Upgrader, *handshakeConnHolder, error) {
+	proxyFunc := http.ProxyFromEnvironment
+	if config.Proxy != nil {
+		proxyFunc = config.Proxy
+	}
+	probeReq, err := http.NewRequest(http.MethodGet, serverURL.String(), nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	proxyURL, err := proxyFunc(probeReq)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if proxyURL != nil {
+		roundTripper, upgrader, err := spdy.RoundTripperFor(config)
+		return roundTripper, upgrader, nil, err
+	}
+
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	handshakeConn := &handshakeConnHolder{}
+	upgradeTransport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if err := conn.SetDeadline(time.Now().Add(readyTimeout)); err != nil {
+				conn.Close()
+				return nil, err
+			}
+			handshakeConn.store(conn)
+			return conn, nil
+		},
+	}
+
+	spdyUpgrader, err := apimachineryspdy.NewRoundTripperWithConfig(apimachineryspdy.RoundTripperConfig{
+		PingPeriod:       time.Second * 5,
+		UpgradeTransport: upgradeTransport,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	roundTripper, err := rest.HTTPWrappersForConfig(config, spdyUpgrader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return roundTripper, spdyUpgrader, handshakeConn, nil
 }
 
 // waitForPortForwardReadiness blocks until the port-forward is ready, fails,
@@ -134,6 +239,9 @@ func (p *portForward) waitForPortForwardReadiness() error {
 
 	select {
 	case <-p.readyChan:
+		if p.handshakeConn != nil {
+			p.handshakeConn.clearDeadline()
+		}
 		return nil
 	case err := <-p.errChan:
 		if err == nil {

--- a/core/cautils/portforwarder.go
+++ b/core/cautils/portforwarder.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	v1 "k8s.io/api/core/v1"
-	apimachineryspdy "k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	streamingspdy "k8s.io/streaming/pkg/httpstream/spdy"
 )
 
 const (
@@ -220,18 +220,18 @@ func newPortForwardRoundTripper(config *rest.Config, serverURL *url.URL, readyTi
 		},
 	}
 
-	spdyUpgrader, err := apimachineryspdy.NewRoundTripperWithConfig(apimachineryspdy.RoundTripperConfig{
+	spdyRoundTripper, err := streamingspdy.NewRoundTripperWithConfig(streamingspdy.RoundTripperConfig{
 		PingPeriod:       time.Second * 5,
 		UpgradeTransport: upgradeTransport,
 	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	roundTripper, err := rest.HTTPWrappersForConfig(config, spdyUpgrader)
+	roundTripper, err := rest.HTTPWrappersForConfig(config, spdyRoundTripper)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return roundTripper, spdyUpgrader, handshakeConn, nil
+	return roundTripper, spdy.NewUpgraderForStreaming(spdyRoundTripper), handshakeConn, nil
 }
 
 // waitForPortForwardReadiness blocks until the port-forward is ready, fails,

--- a/core/cautils/portforwarder_readiness_test.go
+++ b/core/cautils/portforwarder_readiness_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -140,12 +141,32 @@ func Test_getPortForwardReadyTimeout(t *testing.T) {
 			envValue: "soon",
 			want:     defaultPortForwardReadyTimeout,
 		},
+		{
+			// 9223372037 is the first value above maxPortForwardReadyTimeoutSeconds
+			// (math.MaxInt64 / time.Second): time.Duration(secs) * time.Second
+			// would wrap to a negative duration, silently disabling the
+			// http.Client.Timeout it is meant to bound.
+			name:     "value overflowing time.Duration falls back to default",
+			setEnv:   true,
+			envValue: "9223372037",
+			want:     defaultPortForwardReadyTimeout,
+		},
+		{
+			name:     "largest non-overflowing value is honored",
+			setEnv:   true,
+			envValue: strconv.FormatInt(maxPortForwardReadyTimeoutSeconds, 10),
+			want:     time.Duration(maxPortForwardReadyTimeoutSeconds) * time.Second,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setEnv {
 				t.Setenv(PortForwardReadyTimeoutEnv, tc.envValue)
+			} else {
+				// Isolate the default-case test from a KS_PORT_FORWARD_READY_TIMEOUT_SECONDS
+				// value set in the parent process's environment.
+				t.Setenv(PortForwardReadyTimeoutEnv, "")
 			}
 			assert.Equal(t, tc.want, getPortForwardReadyTimeout())
 		})

--- a/core/cautils/portforwarder_readiness_test.go
+++ b/core/cautils/portforwarder_readiness_test.go
@@ -1,7 +1,11 @@
 package cautils
 
 import (
+	"bufio"
 	"context"
+	"net"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -186,4 +190,97 @@ func TestCreatePortForwarder_ResolvesReadyTimeoutFromEnvOnce(t *testing.T) {
 	// "resolved once" guarantee for localPort.
 	t.Setenv(PortForwardReadyTimeoutEnv, "1")
 	assert.Equal(t, 7*time.Second, pf.readyTimeout)
+}
+
+// TestStartPortForwarder_WithheldUpgradeTerminatesSocketNotJustCaller
+// reproduces matthyx's PR #3800 review finding: k8s.io/streaming's
+// SpdyRoundTripper.RoundTrip reads the upgrade response via a hand-rolled
+// bufio/http.ReadResponse over the raw socket, which never checks the
+// request context or the merged http.Client.Timeout. A peer that completes
+// the TCP handshake and then withholds the upgrade response left that read
+// -- and the goroutine and socket behind it -- blocked forever, even though
+// waitForPortForwardReadiness's own timer correctly returned an error to the
+// caller. This proves both sides now unblock: the caller via the returned
+// error, and the socket via the deadline armed in newPortForwardRoundTripper.
+func TestStartPortForwarder_WithheldUpgradeTerminatesSocketNotJustCaller(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	serverConn := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Read and parse the upgrade request, then withhold the response
+		// entirely -- simulating a peer that completes the TCP handshake
+		// but never finishes the SPDY upgrade.
+		_, _ = http.ReadRequest(bufio.NewReader(conn))
+		serverConn <- conn
+		// deliberately: no response written, connection left open
+	}()
+
+	t.Setenv(PortForwardReadyTimeoutEnv, "1") // 1s, keep the test fast
+
+	k8sClient := &k8sinterface.KubernetesApi{
+		K8SConfig: &rest.Config{Host: "http://" + ln.Addr().String()},
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "operator"}}
+	connector, err := CreatePortForwarder(k8sClient, pod, "1234", "kubescape")
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = connector.StartPortForwarder()
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 3*time.Second, "must not hang past readyTimeout")
+
+	// Prove the SERVER side observes the connection actually close/reset --
+	// not just that the caller gave up. This is what distinguishes this test
+	// from the existing timeout tests, which only check the caller side.
+	select {
+	case conn := <-serverConn:
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+		buf := make([]byte, 1)
+		_, err := conn.Read(buf)
+		assert.Error(t, err, "server should observe the client closing the stalled connection")
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never accepted a connection")
+	}
+}
+
+// TestCreatePortForwarder_ProxyConfiguredUsesFallbackPath is the sanity check
+// for the deliberate scope boundary in newPortForwardRoundTripper: setting
+// UpgradeTransport (needed to arm the handshake deadline) bypasses the SPDY
+// library's own proxy-CONNECT tunneling entirely, so when a proxy applies to
+// the target, CreatePortForwarder must fall back to the unmodified
+// spdy.RoundTripperFor path -- not silently use the deadline path without
+// proxy support, and not error out.
+func TestCreatePortForwarder_ProxyConfiguredUsesFallbackPath(t *testing.T) {
+	k8sClient := k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewClientset(),
+		K8SConfig: &rest.Config{
+			Host: "any",
+			Proxy: func(*http.Request) (*url.URL, error) {
+				return url.Parse("http://proxy.example.com:8080")
+			},
+		},
+		Context: context.Background(),
+	}
+
+	operatorPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "first",
+			Labels: map[string]string{"app": "operator"},
+		},
+	}
+	createdPod, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &operatorPod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	connector, err := CreatePortForwarder(&k8sClient, createdPod, "1234", "any")
+	require.NoError(t, err)
+
+	pf, ok := connector.(*portForward)
+	require.True(t, ok)
+	assert.Nil(t, pf.handshakeConn, "a configured proxy must take the fallback path without a handshake-level deadline")
 }

--- a/core/cautils/portforwarder_readiness_test.go
+++ b/core/cautils/portforwarder_readiness_test.go
@@ -1,0 +1,189 @@
+package cautils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+// TestWaitForPortForwardReadiness_TimesOutInsteadOfHangingForever reproduces
+// the hang: a port-forward whose dial never closes readyChan and never sends
+// on errChan (e.g. the peer accepted the connection but never completed the
+// SPDY upgrade). Before the readyTimeout case existed, this blocked forever.
+func TestWaitForPortForwardReadiness_TimesOutInsteadOfHangingForever(t *testing.T) {
+	p := &portForward{
+		readyChan:    make(chan struct{}),
+		errChan:      make(chan error),
+		readyTimeout: 50 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- p.waitForPortForwardReadiness()
+	}()
+
+	// The watchdog is a much longer, generous bound (matching
+	// TestStopPortForwarder_Idempotent's pattern): if the fix regresses to an
+	// unbounded select, this fails the test instead of hanging the suite.
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+		assert.Contains(t, err.Error(), PortForwardReadyTimeoutEnv)
+		assert.Less(t, elapsed, 2*time.Second, "should return close to readyTimeout, not after it")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForPortForwardReadiness hung past its readyTimeout")
+	}
+}
+
+// TestWaitForPortForwardReadiness_ReadyBeforeTimeout is the happy-path
+// regression check: the new timer must not delay or interfere with an
+// ordinary successful readiness signal.
+func TestWaitForPortForwardReadiness_ReadyBeforeTimeout(t *testing.T) {
+	readyChan := make(chan struct{})
+	p := &portForward{
+		readyChan:    readyChan,
+		errChan:      make(chan error, 1),
+		readyTimeout: 5 * time.Second,
+	}
+	close(readyChan)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- p.waitForPortForwardReadiness()
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+		assert.Less(t, time.Since(start), 1*time.Second, "an already-ready forwarder must not wait on the timer")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForPortForwardReadiness did not return for an already-ready forwarder")
+	}
+}
+
+// TestWaitForPortForwardReadiness_ErrorBeforeTimeout: a fast ForwardPorts
+// failure must still be reported as that failure, not masked by the timer.
+func TestWaitForPortForwardReadiness_ErrorBeforeTimeout(t *testing.T) {
+	errChan := make(chan error, 1)
+	wantErr := assert.AnError
+	errChan <- wantErr
+
+	p := &portForward{
+		readyChan:    make(chan struct{}),
+		errChan:      errChan,
+		readyTimeout: 5 * time.Second,
+	}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- p.waitForPortForwardReadiness()
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, wantErr)
+		assert.Less(t, time.Since(start), 1*time.Second, "a fast ForwardPorts error must not wait on the timer")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForPortForwardReadiness did not return for a fast ForwardPorts error")
+	}
+}
+
+func Test_getPortForwardReadyTimeout(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		want     time.Duration
+	}{
+		{
+			name: "unset falls back to default",
+			want: defaultPortForwardReadyTimeout,
+		},
+		{
+			name:     "valid override is honored",
+			setEnv:   true,
+			envValue: "5",
+			want:     5 * time.Second,
+		},
+		{
+			name:     "zero falls back to default rather than firing instantly",
+			setEnv:   true,
+			envValue: "0",
+			want:     defaultPortForwardReadyTimeout,
+		},
+		{
+			name:     "negative falls back to default",
+			setEnv:   true,
+			envValue: "-5",
+			want:     defaultPortForwardReadyTimeout,
+		},
+		{
+			name:     "non-numeric falls back to default",
+			setEnv:   true,
+			envValue: "soon",
+			want:     defaultPortForwardReadyTimeout,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(PortForwardReadyTimeoutEnv, tc.envValue)
+			}
+			assert.Equal(t, tc.want, getPortForwardReadyTimeout())
+		})
+	}
+}
+
+// TestCreatePortForwarder_ResolvesReadyTimeoutFromEnvOnce checks the
+// forwarder actually carries the resolved timeout (not just that the helper
+// function computes it correctly), and that, like localPort, it is captured
+// once at construction rather than re-read later.
+func TestCreatePortForwarder_ResolvesReadyTimeoutFromEnvOnce(t *testing.T) {
+	t.Setenv(PortForwardReadyTimeoutEnv, "7")
+
+	k8sClient := k8sinterface.KubernetesApi{
+		KubernetesClient: fake.NewClientset(),
+		K8SConfig: &rest.Config{
+			Host: "any",
+		},
+		Context: context.Background(),
+	}
+
+	operatorPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "first",
+			Labels: map[string]string{
+				"app": "operator",
+			},
+		},
+	}
+	createdPod, err := k8sClient.KubernetesClient.CoreV1().Pods(kubescapeNamespace).Create(k8sClient.Context, &operatorPod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	connector, err := CreatePortForwarder(&k8sClient, createdPod, "1234", "any")
+	require.NoError(t, err)
+
+	pf, ok := connector.(*portForward)
+	require.True(t, ok)
+	assert.Equal(t, 7*time.Second, pf.readyTimeout)
+
+	// Mutating the environment after construction must not change the
+	// already-resolved timeout, matching GetPortForwardLocalhost's existing
+	// "resolved once" guarantee for localPort.
+	t.Setenv(PortForwardReadyTimeoutEnv, "1")
+	assert.Equal(t, 7*time.Second, pf.readyTimeout)
+}

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	k8s.io/apimachinery v0.37.0
 	k8s.io/apiserver v0.37.0
 	k8s.io/client-go v0.37.0
+	k8s.io/streaming v0.37.0
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kustomize/api v0.21.1
@@ -611,7 +612,6 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	k8s.io/kubectl v0.36.2 // indirect
-	k8s.io/streaming v0.37.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect


### PR DESCRIPTION
## Overview

When running `kubescape operator scan` or `kubescape operator remediate`, Kubescape connects to the in-cluster Kubescape Operator pod via SPDY port-forwarding. If the connection stalls or the remote endpoint never completes the handshake, `waitForPortForwardReadiness` waits on an unbounded `select`, causing the CLI command to hang indefinitely with no error or output.

This PR adds a configurable timeout bound to both the dialer HTTP client and `waitForPortForwardReadiness`, ensuring that stalled connections terminate with an informative error.

Fixes #3799

## Root cause

In `core/cautils/portforwarder.go`:
1. `waitForPortForwardReadiness` only selects on `readyChan` and `errChan`. If the peer accepts the connection but never finishes the SPDY upgrade, neither channel fires, blocking the select indefinitely.
2. The `http.Client` passed to `spdy.NewDialer` in `CreatePortForwarder` had no `Timeout` configured, leaving the underlying dial unbounded.

## Fix

1. Introduced `PortForwardReadyTimeoutEnv` (`KS_PORT_FORWARD_READY_TIMEOUT_SECONDS`) with a default of 30 seconds (`defaultPortForwardReadyTimeout`).
2. Added `getPortForwardReadyTimeout()` to resolve this duration once at forwarder construction (mirroring `getPortForwardingPort()`).
3. Set `Timeout: readyTimeout` on `http.Client` in `spdy.NewDialer`.
4. Added `time.NewTimer(p.readyTimeout)` case to `waitForPortForwardReadiness()` that returns a descriptive error guiding the user on how to troubleshoot or override the timeout.
5. Added unit tests in `core/cautils/portforwarder_readiness_test.go` covering timeout expiration, normal readiness before timeout, fast error propagation, and environment variable parsing.

## Testing

All targeted unit tests pass cleanly:
- `TestWaitForPortForwardReadiness_TimesOutInsteadOfHangingForever` (verifies timeout occurs and does not hang)
- `TestWaitForPortForwardReadiness_ReadyBeforeTimeout` (verifies happy path without delay)
- `TestWaitForPortForwardReadiness_ErrorBeforeTimeout` (verifies immediate error surfacing)
- `Test_getPortForwardReadyTimeout` (table-driven test for valid/invalid/empty env values)
- `TestCreatePortForwarder_ResolvesReadyTimeoutFromEnvOnce` (verifies timeout capture at construction)
- Existing tests (`TestStopPortForwarder_Idempotent`, `Test_CreatePortForwarder`, `Test_GetPortForwardLocalhost`, etc.) pass with zero regressions.

Code formatting and vetting:
- `gofmt -l` clean on modified and new files.
- `go vet ./core/cautils/...` clean.
- `go build ./...` clean.

## Known limitation

`KS_PORT_FORWARD_READY_TIMEOUT_SECONDS` applies to the initial port-forward readiness wait and SPDY dial. Ongoing traffic multiplexed over an already established, healthy port-forward stream is handled by client-go stream lifecycle and idle timeouts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port forwarding no longer hangs indefinitely when readiness is not reached.
  * Readiness failures now return a diagnostic timeout error.
  * Fast forwarding errors are reported promptly instead of being masked by a timeout.
  * Stalled connections are closed when the upgrade response is not received.

* **Configuration**
  * Added a configurable port-forward readiness timeout with a default value.
  * Invalid, negative, zero, or excessively large timeout values safely use the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->