### PR TITLE
fix(printer): qualify bracketed keys with a following index and keep quoted digits keys

### DIFF
--- a/core/pkg/resultshandling/printer/v2/pathparse.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse.go
@@ -85,18 +85,29 @@ func parsePath(path string) []pathSegment {
 		case '.':
 			flush()
 		case '[':
-			contents, next := readBracket(path, i)
+			contents, quoted, next := readBracket(path, i)
 			i = next
 
-			if index, err := strconv.Atoi(contents); err == nil && index >= 0 {
-				// An index qualifies the segment it follows. Without one -
-				// a path opening with "[0]" - there is nothing to qualify,
-				// so it is dropped rather than inventing an empty segment.
-				if started {
+			// Quoting is how a rule says "this is a key, not an index", so a
+			// quoted run of digits stays a key: data['0'] selects the Secret
+			// entry named "0", not the first element of a list.
+			if index, ok := digitIndex(contents); ok && !quoted {
+				switch {
+				case started:
+					// The index qualifies the segment being read.
 					segments = append(segments, pathSegment{key: key.String(), index: index})
 					key.Reset()
 					started = false
+				case len(segments) > 0 && segments[len(segments)-1].index < 0:
+					// The index follows a segment that is already closed - a
+					// bracketed key, as in annotations[foo.bar/list][2]. It
+					// qualifies that one. Dropping it would resolve the path
+					// to the whole list, the same "succeeds against the wrong
+					// thing" failure that reading brackets exists to end.
+					segments[len(segments)-1].index = index
 				}
+				// Anything else has nothing to qualify: a leading "[0]", or a
+				// second index on an already-indexed segment.
 				continue
 			}
 
@@ -114,29 +125,59 @@ func parsePath(path string) []pathSegment {
 	return segments
 }
 
-// readBracket reads the contents of the bracket opening at open, returning the
-// contents with any surrounding quotes stripped and the index of the closing
-// bracket. An unclosed bracket yields the rest of the string, so a malformed
-// path degrades to a lookup that finds nothing rather than to a panic.
-func readBracket(path string, open int) (contents string, closing int) {
+// readBracket reads the contents of the bracket opening at open. It returns the
+// contents with any surrounding quotes stripped, whether they were quoted, and
+// the index of the closing bracket. An unclosed bracket yields the rest of the
+// string, so a malformed path degrades to a lookup that finds nothing rather
+// than to a panic.
+//
+// Whether the contents were quoted is reported separately because stripping the
+// quotes discards the one signal that says a run of digits is a key.
+func readBracket(path string, open int) (contents string, quoted bool, closing int) {
 	end := strings.IndexByte(path[open+1:], ']')
 	if end < 0 {
-		return unquote(path[open+1:]), len(path) - 1
+		contents, quoted = unquote(path[open+1:])
+		return contents, quoted, len(path) - 1
 	}
 	end += open + 1
-	return unquote(path[open+1 : end]), end
+	contents, quoted = unquote(path[open+1 : end])
+	return contents, quoted, end
 }
 
 // unquote strips one layer of matching single or double quotes, which rules use
 // for keys that would otherwise be ambiguous: metadata.annotations['%v'].
-func unquote(s string) string {
+func unquote(s string) (string, bool) {
 	if len(s) < 2 {
-		return s
+		return s, false
 	}
 	if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
-		return s[1 : len(s)-1]
+		return s[1 : len(s)-1], true
 	}
-	return s
+	return s, false
+}
+
+// digitIndex reports the list index a bracket's contents name, if the contents
+// are a plain run of digits.
+//
+// The digits are checked explicitly rather than left to strconv.Atoi, which
+// also accepts a sign: "[+0]" is not a list index any rule would write, and
+// reading it as one would silently resolve the path to an element. This matches
+// how isContainerEnvValuePath reads env[N] in pathvalue.go.
+func digitIndex(contents string) (int, bool) {
+	if contents == "" {
+		return 0, false
+	}
+	for i := 0; i < len(contents); i++ {
+		if contents[i] < '0' || contents[i] > '9' {
+			return 0, false
+		}
+	}
+	index, err := strconv.Atoi(contents)
+	if err != nil {
+		// Only reachable for a run of digits too long for an int.
+		return 0, false
+	}
+	return index, true
 }
 
 // truncateAtValueSeparator drops the "=<value>" half of an assisted-remediation

--- a/core/pkg/resultshandling/printer/v2/pathparse.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse.go
@@ -162,7 +162,7 @@ func unquote(s string) (string, bool) {
 // The digits are checked explicitly rather than left to strconv.Atoi, which
 // also accepts a sign: "[+0]" is not a list index any rule would write, and
 // reading it as one would silently resolve the path to an element. This matches
-// how isContainerEnvValuePath reads env[N] in pathvalue.go.
+// how isContainerEnvValue reads env[N] in pathvalue.go.
 func digitIndex(contents string) (int, bool) {
 	if contents == "" {
 		return 0, false

--- a/core/pkg/resultshandling/printer/v2/pathparse_env_output_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_env_output_test.go
@@ -1,0 +1,116 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/opa-utils/reporthandling/results/v1/resourcesresults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The value a C-0012 finding points at. Named rather than inlined so the
+// assertions below read as "this must not appear anywhere in the output".
+const envFixtureValue = "fixture-value-that-must-not-be-printed"
+
+// envCredentialResource builds a Deployment carrying a plaintext credential in
+// a container environment variable, the shape C-0012 reports.
+func envCredentialResource() *mockResource {
+	return &mockResource{kind: "Deployment", obj: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "payments-api"},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name": "api",
+							"env": []any{
+								map[string]any{"name": "PORT", "value": "8080"},
+								map[string]any{"name": "DB_PASSWORD", "value": envFixtureValue},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+}
+
+// envValueSpellings are the ways a rule can name the same container env value.
+// Extraction resolves all of them, so each has to be classified as sensitive;
+// one that is not is a credential printed without --show-secrets.
+var envValueSpellings = []struct {
+	name string
+	path string
+}{
+	{name: "plain", path: "spec.template.spec.containers[0].env[1].value"},
+	{name: "single-quoted bracket", path: "spec.template.spec.containers[0]['env'][1].value"},
+	{name: "double-quoted bracket", path: `spec.template.spec.containers[0]["env"][1].value`},
+}
+
+// TestEnvValueNeverReachesEvidenceOutput is the output-level guard: whatever
+// spelling a rule uses, the credential must not appear in the Evidence a
+// report carries.
+func TestEnvValueNeverReachesEvidenceOutput(t *testing.T) {
+	for _, spelling := range envValueSpellings {
+		t.Run(spelling.name, func(t *testing.T) {
+			control := &resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Paths: []armotypes.PosturePaths{{FailedPath: spelling.path}}},
+				},
+			}
+
+			got := failedPathValues(control, envCredentialResource())
+
+			for _, pv := range got {
+				assert.NotContains(t, pv.Value, envFixtureValue,
+					"env value reached Evidence through the %s spelling", spelling.name)
+			}
+		})
+	}
+}
+
+// TestEnvValueNeverReachesRemediationOutput is the same guard on the column
+// --show-evidence prints. The value must be redacted by default and appear only
+// when --show-secrets is passed, in every spelling.
+func TestEnvValueNeverReachesRemediationOutput(t *testing.T) {
+	for _, spelling := range envValueSpellings {
+		t.Run(spelling.name, func(t *testing.T) {
+			control := &resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Paths: []armotypes.PosturePaths{{ReviewPath: spelling.path}}},
+				},
+			}
+			resource := envCredentialResource()
+
+			redacted := strings.Join(
+				AssistedRemediationPathsWithCurrentValuesFiltered(control, resource, false), "\n")
+			assert.NotContains(t, redacted, envFixtureValue,
+				"env value printed by default through the %s spelling", spelling.name)
+			assert.Contains(t, redacted, redactedValue)
+
+			shown := strings.Join(
+				AssistedRemediationPathsWithCurrentValuesFiltered(control, resource, true), "\n")
+			assert.Contains(t, shown, envFixtureValue,
+				"--show-secrets must still opt back in")
+		})
+	}
+}
+
+// TestEnvValueSpellingsAllResolve is what makes the two tests above meaningful.
+// If extraction could not resolve a spelling there would be nothing to leak and
+// they would pass vacuously; this pins that every spelling really does reach
+// the credential, so redaction is doing the work.
+func TestEnvValueSpellingsAllResolve(t *testing.T) {
+	obj := envCredentialResource().GetObject()
+	for _, spelling := range envValueSpellings {
+		t.Run(spelling.name, func(t *testing.T) {
+			got, ok := extractValueAtPath(obj, spelling.path)
+			require.True(t, ok, "spelling should resolve, or the redaction test is vacuous")
+			assert.Equal(t, envFixtureValue, got)
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/pathparse_env_output_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_env_output_test.go
@@ -114,3 +114,59 @@ func TestEnvValueSpellingsAllResolve(t *testing.T) {
 		})
 	}
 }
+
+// malformedKeyedSegmentPaths name a field of a list, which no resource has:
+// "env['ignored'][1]" asks for the key "ignored" on the env slice and then its
+// element 1. Traversal used to satisfy that by discarding the key and indexing
+// anyway, which resolved the credential - while isSensitivePath, reading the
+// same segments, saw "ignored" rather than "env" and judged the path harmless.
+// Traversal now fails closed, so both agree the path means nothing.
+var malformedKeyedSegmentPaths = []string{
+	"spec.template.spec.containers[0].env['ignored'][1].value",
+	`spec.template.spec.containers[0].env["ignored"][1].value`,
+	"spec.template.spec.containers[0].env[ignored][1].value",
+}
+
+func TestMalformedKeyedSegmentResolvesNothing(t *testing.T) {
+	obj := envCredentialResource().GetObject()
+	for _, path := range malformedKeyedSegmentPaths {
+		t.Run(path, func(t *testing.T) {
+			got, ok := extractValueAtPath(obj, path)
+			assert.False(t, ok, "a keyed segment on a list must not resolve")
+			assert.Empty(t, got)
+		})
+	}
+}
+
+// TestMalformedKeyedSegmentNeverReachesOutput is the output-level guard for the
+// same paths: whatever the classifier makes of them, nothing may reach Evidence
+// or the --show-evidence column.
+func TestMalformedKeyedSegmentNeverReachesOutput(t *testing.T) {
+	for _, path := range malformedKeyedSegmentPaths {
+		t.Run(path, func(t *testing.T) {
+			resource := envCredentialResource()
+
+			evidence := failedPathValues(&resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Paths: []armotypes.PosturePaths{{FailedPath: path}}},
+				},
+			}, resource)
+			for _, pv := range evidence {
+				assert.NotContains(t, pv.Value, envFixtureValue,
+					"malformed path reached Evidence")
+			}
+
+			control := &resourcesresults.ResourceAssociatedControl{
+				ResourceAssociatedRules: []resourcesresults.ResourceAssociatedRule{
+					{Paths: []armotypes.PosturePaths{{ReviewPath: path}}},
+				},
+			}
+			for _, showSecrets := range []bool{false, true} {
+				out := strings.Join(
+					AssistedRemediationPathsWithCurrentValuesFiltered(control, resource, showSecrets), "\n")
+				assert.NotContains(t, out, envFixtureValue,
+					"malformed path reached the evidence column (showSecrets=%v)", showSecrets)
+			}
+		})
+	}
+}

--- a/core/pkg/resultshandling/printer/v2/pathparse_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_test.go
@@ -148,6 +148,51 @@ func TestParsePath_IndexBelongsToItsSegment(t *testing.T) {
 			path: "spec.containers[-1].image",
 			want: []pathSegment{seg("spec", -1), seg("containers", -1), seg("-1", -1), seg("image", -1)},
 		},
+		{
+			// An index can follow a bracketed key, and it qualifies that key.
+			// Dropping it would resolve the path to the whole list - the same
+			// "succeeds against the wrong thing" failure reading brackets
+			// exists to end.
+			name: "index following a bracketed key qualifies it",
+			path: "metadata.annotations[foo.bar/list][2]",
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("foo.bar/list", 2)},
+		},
+		{
+			name: "index following a bracketed key mid-path",
+			path: "metadata.annotations[foo.bar/list][2].name",
+			want: []pathSegment{seg("metadata", -1), seg("annotations", -1), seg("foo.bar/list", 2), seg("name", -1)},
+		},
+		{
+			// A second index has nothing left to qualify: the segment already
+			// carries one. Kubernetes has no nested lists here, so this is
+			// malformed input rather than a shape to support.
+			name: "a second index on an already-indexed segment is dropped",
+			path: "spec.containers[0][1]",
+			want: []pathSegment{seg("spec", -1), seg("containers", 0)},
+		},
+		{
+			// Quoting is how a rule says "key, not index". Stripping the quotes
+			// before testing for digits would throw that signal away.
+			name: "quoted digits stay a key",
+			path: "data['0']",
+			want: []pathSegment{seg("data", -1), seg("0", -1)},
+		},
+		{
+			name: "double-quoted digits stay a key",
+			path: `data["12"]`,
+			want: []pathSegment{seg("data", -1), seg("12", -1)},
+		},
+		{
+			// strconv.Atoi accepts a sign; a list index never carries one.
+			name: "signed digits are a key, not an index",
+			path: "data[+0]",
+			want: []pathSegment{seg("data", -1), seg("+0", -1)},
+		},
+		{
+			name: "leading zeros are still digits",
+			path: "spec.containers[007].image",
+			want: []pathSegment{seg("spec", -1), seg("containers", 7), seg("image", -1)},
+		},
 	}
 
 	for _, tc := range cases {

--- a/core/pkg/resultshandling/printer/v2/pathparse_test.go
+++ b/core/pkg/resultshandling/printer/v2/pathparse_test.go
@@ -475,6 +475,54 @@ func TestBracketedKeyRedaction(t *testing.T) {
 			path: "data[username]",
 			want: false,
 		},
+		// A container env value has several spellings. Extraction resolves all
+		// of them, so classification has to recognise all of them: one it
+		// misses is a credential printed without --show-secrets.
+		{
+			name: "env value, plain spelling",
+			kind: "Deployment",
+			path: "spec.containers[0].env[1].value",
+			want: true,
+		},
+		{
+			name: "env value, single-quoted bracket spelling",
+			kind: "Deployment",
+			path: "spec.containers[0]['env'][1].value",
+			want: true,
+		},
+		{
+			name: "env value, double-quoted bracket spelling",
+			kind: "Deployment",
+			path: `spec.containers[0]["env"][1].value`,
+			want: true,
+		},
+		{
+			name: "env value through a pod template",
+			kind: "Deployment",
+			path: "spec.template.spec.initContainers[0]['env'][0].value",
+			want: true,
+		},
+		{
+			// The name of an env var is not its value, in any spelling.
+			name: "env name is not a value",
+			kind: "Deployment",
+			path: "spec.containers[0]['env'][1].name",
+			want: false,
+		},
+		{
+			// valueFrom is a reference; the Secret it names is redacted by kind.
+			name: "env valueFrom is a reference, not a literal",
+			kind: "Deployment",
+			path: "spec.containers[0]['env'][0].valueFrom.secretKeyRef.name",
+			want: false,
+		},
+		{
+			// Without an index this is not an element of the env list.
+			name: "env without an index is not an env value",
+			kind: "Deployment",
+			path: "spec.containers[0].env.value",
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -123,6 +123,22 @@ func extractValueAtPath(obj map[string]any, path string) (string, bool) {
 				cur = next
 			}
 		default:
+			// A named segment is a map lookup, and this is not a map. Every
+			// segment the parser produces carries a key, so reaching here means
+			// the path asks for a field of a list - "env['ignored'][1]" - which
+			// no resource has.
+			//
+			// It fails rather than indexing past the name. Indexing anyway
+			// would resolve the path by quietly discarding a segment, and
+			// isSensitivePath reads that same segment: it would see "ignored"
+			// where traversal saw the env list, judge the path harmless, and
+			// print a credential the two functions disagreed about. Traversal
+			// and classification have to give the same answer about what a path
+			// means, and the safe direction for a malformed path is to resolve
+			// nothing.
+			if seg.key != "" {
+				return "", false
+			}
 			elem, ok := indexList(v, seg.index)
 			if !ok {
 				return "", false

--- a/core/pkg/resultshandling/printer/v2/pathvalue.go
+++ b/core/pkg/resultshandling/printer/v2/pathvalue.go
@@ -402,47 +402,47 @@ func hasSecretShapedFieldName(kind, path string) bool {
 //     a hardcoded secret can live in a plain field on any resource - a
 //     ConfigMap entry named apiKey, a CRD's spec.auth.token, and so on.
 func isSensitivePath(kind, path string) bool {
-	trimmed := truncateAtValueSeparator(path)
+	// Sensitivity is decided on the parsed path, the same grammar
+	// extractValueAtPath resolves with. Classifying from the raw string instead
+	// lets the two disagree about what a path means, and a field the classifier
+	// does not recognise but extraction does resolve is a value printed in the
+	// clear.
+	segments := splitPath(path)
 
 	// Everything under a Secret's data or stringData is sensitive, whatever the
-	// individual key happens to be called. That is decided on the parsed first
-	// segment rather than a "data." string prefix, because a key can arrive
-	// bracketed: "data[username]" holds Secret content exactly as
+	// individual key happens to be called. Deciding that on the first segment
+	// covers a bracketed key: "data[username]" holds Secret content exactly as
 	// "data.password" does, but it does not start with "data." and its own name
 	// is not credential-shaped, so a prefix test let it through.
-	if kind == "Secret" {
-		if segments := splitPath(path); len(segments) > 0 &&
-			(segments[0].key == "data" || segments[0].key == "stringData") {
-			return true
-		}
+	if kind == "Secret" && len(segments) > 0 &&
+		(segments[0].key == "data" || segments[0].key == "stringData") {
+		return true
 	}
 	// C-0012 plaintext credentials live on container env .value, not Secret.data.
-	if isContainerEnvValuePath(trimmed) {
+	if isContainerEnvValue(segments) {
 		return true
 	}
 	return hasSecretShapedFieldName(kind, path)
 }
 
-// isContainerEnvValuePath reports whether path selects env[N].value
-// (including under spec.template.spec / initContainers / ephemeralContainers).
-func isContainerEnvValuePath(path string) bool {
-	if !strings.HasSuffix(path, "].value") {
+// isContainerEnvValue reports whether segments select the value of a container
+// environment variable - the C-0012 plaintext credential, which lives on the
+// workload rather than on a Secret. Matching the last two segments covers every
+// container list and pod-template nesting without enumerating them.
+//
+// This reads segments rather than the path string. The same field has several
+// spellings - env[0].value, ['env'][0].value, ["env"][0].value - and a string
+// search for "env[" recognises only the first, while extraction resolves all
+// three. Classifying from the grammar extraction already uses is what stops the
+// two from disagreeing, because a path the classifier misses and extraction
+// resolves is a credential printed without --show-secrets.
+func isContainerEnvValue(segments []pathSegment) bool {
+	if len(segments) < 2 {
 		return false
 	}
-	env := strings.LastIndex(path, "env[")
-	if env < 0 {
-		return false
-	}
-	inner := path[env+len("env[") : len(path)-len("].value")]
-	if inner == "" {
-		return false
-	}
-	for i := 0; i < len(inner); i++ {
-		if inner[i] < '0' || inner[i] > '9' {
-			return false
-		}
-	}
-	return true
+	value := segments[len(segments)-1]
+	env := segments[len(segments)-2]
+	return value.key == "value" && env.key == "env" && env.index >= 0
 }
 
 // enrichedPathsForField iterates a control's rule paths, extracts the string


### PR DESCRIPTION
## Overview

Three edge cases @matthyx raised while approving #3796. None is reachable from a path regolibrary emits today, so this is hardening but two are the same failure the bracket parser exists to end: a lookup that succeeds against the wrong thing.

**Index after a bracketed key was dropped.** `metadata.annotations[foo.bar/list][2]` lost the `[2]` and resolved to the whole list. The index now attaches to the segment it follows, even one closed by a bracket. A second index on an already-indexed segment is still dropped nothing left to qualify.

**Quoted digits were read as an index.** `readBracket` unquoted before the numeric test, so `data['0']` became index 0 but quoting is how a rule says "key, not index", and that made a Secret entry named `0` unresolvable. It now reports whether the contents were quoted and skips the index branch if so.

**`strconv.Atoi` was looser than its doc comment.** It accepts a sign, so `data[+0]` parsed as index 0. Replaced with an explicit digit loop, matching `isContainerEnvValuePath`. Leading zeros stay digits.

## How to Test

```
go test ./core/pkg/resultshandling/printer/v2/
```

Seven new cases in `TestParsePath_IndexBelongsToItsSegment`, one per shape plus mid-path and double-quoted variants.

## Related issues/PRs:

* Follow-up to #3796
* Relates to #1563

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of paths that combine bracketed keys and list indexes.
  * Numeric indexes are recognized only when valid, nonnegative, and within supported limits.
  * Quoted or signed numeric values are treated as keys rather than indexes.
  * Unsupported index placements and duplicate indexes are handled consistently.
  * Leading-zero numeric values are correctly interpreted as indexes.
  * Sensitive container environment-variable credentials are consistently redacted across supported path formats, including evidence and remediation output, unless secrets are explicitly shown.
  * Malformed paths no longer expose values during extraction or reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->