### PR TITLE
fix: make GetScanningContext side-effect free

### DIFF
--- a/core/cautils/remotegitutils_lifecycle_test.go
+++ b/core/cautils/remotegitutils_lifecycle_test.go
@@ -1,6 +1,7 @@
 package cautils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -234,6 +235,9 @@ func TestScanningContextClonesAndCleansEveryRemoteInput(t *testing.T) {
 	}
 	scanInfo := &ScanInfo{InputPatterns: inputs}
 	require.Equal(t, ContextGitRemote, scanInfo.GetScanningContext())
+	assert.Equal(t, int32(0), cloneCalls.Load())
+
+	require.NoError(t, scanInfo.MaterializeRemoteInputs(context.Background()))
 	assert.Equal(t, int32(2), cloneCalls.Load())
 
 	workspaces := make([]string, 0, len(inputs))
@@ -263,6 +267,9 @@ func TestScanningContextClonesTrailingRemoteInputAfterLocalInput(t *testing.T) {
 	remoteInput := "https://github.com/example/remote"
 	scanInfo := &ScanInfo{InputPatterns: []string{t.TempDir(), remoteInput}}
 	require.Equal(t, ContextDir, scanInfo.GetScanningContext())
+	assert.Equal(t, int32(0), cloneCalls.Load())
+
+	require.NoError(t, scanInfo.MaterializeRemoteInputs(context.Background()))
 	assert.Equal(t, int32(1), cloneCalls.Load())
 
 	workspace := GetClonedPath(remoteInput)
@@ -273,3 +280,76 @@ func TestScanningContextClonesTrailingRemoteInputAfterLocalInput(t *testing.T) {
 	assert.Empty(t, GetClonedPath(remoteInput))
 	assert.NoDirExists(t, workspace)
 }
+
+func TestMaterializeRemoteInputsPropagatesError(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		return nil, errors.New("authentication failed: 401 Unauthorized")
+	})
+
+	remoteInput := "https://github.com/example/private-repo"
+	scanInfo := &ScanInfo{InputPatterns: []string{remoteInput}}
+	require.Equal(t, ContextGitRemote, scanInfo.GetScanningContext())
+
+	err := scanInfo.MaterializeRemoteInputs(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to clone remote git repository")
+	assert.ErrorContains(t, err, "401 Unauthorized")
+	assert.Empty(t, GetClonedPath(remoteInput))
+}
+
+func TestScanInfoInitPropagatesCloneError(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		return nil, errors.New("repository not found")
+	})
+
+	remoteInput := "https://github.com/example/nonexistent-repo"
+	scanInfo := &ScanInfo{InputPatterns: []string{remoteInput}}
+	err := scanInfo.Init(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to clone remote git repository")
+	assert.ErrorContains(t, err, "repository not found")
+}
+
+// TestMaterializeRemoteInputsPreCloneCancellation verifies that a cancelled
+// context prevents any clone from starting. This is pre-clone cancellation
+// only; an already-running git.PlainClone is not interrupted because
+// CloneGitRepo does not accept a context today.
+func TestMaterializeRemoteInputsPreCloneCancellation(t *testing.T) {
+	resetRepoWorkspaceState(t)
+	var cloneCalls atomic.Int32
+	useFakeClone(t, func(path string, _ bool, options *git.CloneOptions) (*git.Repository, error) {
+		cloneCalls.Add(1)
+		return initializeCloneWorkspace(path, options)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanInfo := &ScanInfo{InputPatterns: []string{"https://github.com/example/repo"}}
+	err := scanInfo.MaterializeRemoteInputs(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(0), cloneCalls.Load())
+}
+
+// TestScanInfoCleanupSequentialIdempotency verifies that cleanup hooks are
+// consumed on first call, so repeated sequential calls are safe. This matters
+// because MaterializeRemoteInputs calls Cleanup() on failure to roll back
+// partial clones, and the outer scan lifecycle calls it again via defer.
+// Note: this is sequential idempotency, not concurrent safety.
+func TestScanInfoCleanupSequentialIdempotency(t *testing.T) {
+	var count int
+	scanInfo := &ScanInfo{}
+	scanInfo.AddCleanup(func() {
+		count++
+	})
+	scanInfo.Cleanup()
+	assert.Equal(t, 1, count)
+	scanInfo.Cleanup()
+	assert.Equal(t, 1, count)
+}
+
+

--- a/core/cautils/remotegitutils_lifecycle_test.go
+++ b/core/cautils/remotegitutils_lifecycle_test.go
@@ -351,5 +351,3 @@ func TestScanInfoCleanupSequentialIdempotency(t *testing.T) {
 	scanInfo.Cleanup()
 	assert.Equal(t, 1, count)
 }
-
-

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -237,11 +237,21 @@ func (scanInfo *ScanInfo) Init(ctx context.Context, policyIdentifiers []PolicyId
 	if scanInfo.ScanID == "" {
 		scanInfo.ScanID = uuid.NewString()
 	}
+	if err := scanInfo.MaterializeRemoteInputs(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 
+// Cleanup executes all registered cleanup hooks and clears the list so that
+// repeated sequential calls do not run the same hooks twice. This is important
+// because MaterializeRemoteInputs calls Cleanup on failure to roll back
+// partial clones, and the outer scan lifecycle (defer scanInfo.Cleanup()) may
+// call it again on return. This method is not safe for concurrent use.
 func (scanInfo *ScanInfo) Cleanup() {
-	for _, cleanup := range scanInfo.cleanups {
+	cleanups := scanInfo.cleanups
+	scanInfo.cleanups = nil
+	for _, cleanup := range cleanups {
 		cleanup()
 	}
 }
@@ -465,9 +475,6 @@ func (scanInfo *ScanInfo) GetScanningContext() ScanningContext {
 	if scanInfo.scanningContext == nil {
 		input := scanInfo.GetInputFiles()
 		scanningContext := scanInfo.getScanningContext(input)
-		if input != "" {
-			scanInfo.cloneAdditionalRemoteInputs(input)
-		}
 		scanInfo.scanningContext = &scanningContext
 	}
 	return *scanInfo.scanningContext
@@ -556,8 +563,8 @@ func (scanInfo *ScanInfo) GetClusterContextName() string {
 	return k8sinterface.GetContextName()
 }
 
-// getScanningContext get scanning context from the input param
-// this function should be called only once. Call GetScanningContext() to get the scanning context
+// getScanningContext gets the scanning context by inspecting the input parameter.
+// This is a pure classification function that performs no network or disk I/O.
 func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 	//  cluster
 	if input == "" {
@@ -567,28 +574,9 @@ func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 	// Check if input is a URL (http:// or https://)
 	isURL := isHTTPURL(input)
 
-	// git url
+	// git remote url
 	if _, err := giturl.NewGitURL(input); err == nil {
-		originalInput := input
-		if repo, err := CloneGitRepo(&input); err == nil {
-			if _, err := NewLocalGitRepository(repo); err == nil {
-				scanInfo.AddCleanup(func() {
-					if err := ReleaseClonedRepo(originalInput); err != nil {
-						logger.L().Warning("failed to clean up cloned repository", helpers.String("url", originalInput), helpers.Error(err))
-					}
-				})
-				return ContextGitRemote
-			}
-			if err := ReleaseClonedRepo(originalInput); err != nil {
-				logger.L().Warning("failed to clean up invalid cloned repository", helpers.String("url", originalInput), helpers.Error(err))
-			}
-		}
-		// If giturl.NewGitURL succeeded but cloning failed, the input is a git URL
-		// that couldn't be cloned. Don't treat it as a local path.
-		// The clone error was already logged by CloneGitRepo.
-		// Return ContextDir to prevent the URL from being joined with the current directory
-		// and to trigger a "no files found" error with the actual URL (not a mangled path).
-		return ContextDir
+		return ContextGitRemote
 	}
 
 	// If it looks like a URL but wasn't recognized as a git URL, still don't treat it as a local path
@@ -617,29 +605,49 @@ func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 	return ContextDir
 }
 
-// cloneAdditionalRemoteInputs prepares every remote input before file loading.
-// Previously only the first URL was cloned, so later URL inputs were interpreted
-// as local filesystem paths and silently skipped.
-func (scanInfo *ScanInfo) cloneAdditionalRemoteInputs(firstInput string) {
+// MaterializeRemoteInputs clones all remote git repositories declared in
+// InputPatterns, registers their cleanup hooks with ScanInfo, and returns
+// an error immediately if cloning fails.
+//
+// The ctx parameter provides pre-clone cancellation: if the context is
+// cancelled or expired, no further clones are attempted and any already-
+// cloned workspaces are cleaned up. Note that CloneGitRepo itself does
+// not accept a context (it delegates to git.PlainClone, not
+// git.PlainCloneContext), so an in-progress clone cannot be interrupted
+// mid-operation. Making the underlying clone context-aware is a possible
+// future improvement outside the scope of this refactor.
+func (scanInfo *ScanInfo) MaterializeRemoteInputs(ctx context.Context) error {
 	for _, candidate := range scanInfo.InputPatterns {
-		if candidate == firstInput {
-			continue
+		if err := ctx.Err(); err != nil {
+			scanInfo.Cleanup()
+			return err
 		}
 		if _, err := giturl.NewGitURL(candidate); err != nil {
 			continue
 		}
 
 		originalInput := candidate
-		if _, err := CloneGitRepo(&candidate); err != nil {
-			logger.L().Error("failed to clone additional git input", helpers.String("url", originalInput), helpers.Error(err))
-			continue
+		clonedDir, err := CloneGitRepo(&candidate)
+		if err != nil {
+			scanInfo.Cleanup()
+			return fmt.Errorf("failed to clone remote git repository %q: %w", originalInput, err)
 		}
+
+		if _, err := NewLocalGitRepository(clonedDir); err != nil {
+			if releaseErr := ReleaseClonedRepo(originalInput); releaseErr != nil {
+				logger.L().Warning("failed to clean up invalid cloned repository", helpers.String("url", originalInput), helpers.Error(releaseErr))
+			}
+			scanInfo.Cleanup()
+			return fmt.Errorf("cloned repository %q is not a valid git repository: %w", originalInput, err)
+		}
+
 		scanInfo.AddCleanup(func() {
 			if err := ReleaseClonedRepo(originalInput); err != nil {
 				logger.L().Warning("failed to clean up cloned repository", helpers.String("url", originalInput), helpers.Error(err))
 			}
 		})
 	}
+	return nil
 }
 
 func (scanInfo *ScanInfo) setContextMetadata(ctx context.Context, contextMetadata *reporthandlingv2.ContextMetadata) {

--- a/core/cautils/scaninfo.go
+++ b/core/cautils/scaninfo.go
@@ -563,8 +563,12 @@ func (scanInfo *ScanInfo) GetClusterContextName() string {
 	return k8sinterface.GetContextName()
 }
 
-// getScanningContext gets the scanning context by inspecting the input parameter.
-// This is a pure classification function that performs no network or disk I/O.
+// getScanningContext classifies the scan target type from the input string.
+// Remote URL classification (ContextGitRemote) is purely syntactic and performs
+// no network or disk I/O — in particular, it no longer clones the repository.
+// Local-path classification still inspects the filesystem (os.Getwd,
+// NewLocalGitRepository, isFile) to distinguish directories, files, and local
+// git repositories.
 func (scanInfo *ScanInfo) getScanningContext(input string) ScanningContext {
 	//  cluster
 	if input == "" {

--- a/core/cautils/scaninfo_test.go
+++ b/core/cautils/scaninfo_test.go
@@ -366,15 +366,7 @@ func TestGetHostname(t *testing.T) {
 }
 
 func TestGetScanningContext(t *testing.T) {
-	repoRoot, err := os.MkdirTemp("", "repo")
-	require.NoError(t, err)
-	defer func(name string) {
-		_ = os.Remove(name)
-	}(repoRoot)
-	_, err = git.PlainClone(repoRoot, false, &git.CloneOptions{
-		URL: "https://github.com/kubescape/http-request",
-	})
-	require.NoError(t, err)
+	repoRoot := newGitFixture(t, "https://github.com/kubescape/http-request")
 	tmpFile, err := os.CreateTemp("", "single.*.txt")
 	require.NoError(t, err)
 	defer func(name string) {
@@ -411,14 +403,14 @@ func TestGetScanningContext(t *testing.T) {
 			want:  ContextDir,
 		},
 		{
-			name:  "self-hosted GitLab URL that can't be cloned",
+			name:  "self-hosted GitLab URL",
 			input: "https://gitlab.private-domain.com/my-org/my-repo.git",
-			want:  ContextDir, // Should return ContextDir when clone fails, not try to treat as local path
+			want:  ContextGitRemote,
 		},
 		{
-			name:  "http URL that can't be cloned",
+			name:  "http URL git repo",
 			input: "http://gitlab.example.com/org/repo",
-			want:  ContextDir, // Should return ContextDir when clone fails, not try to treat as local path
+			want:  ContextGitRemote,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Decouple scan target classification from remote repository cloning in `core/cautils/scaninfo.go`. `GetScanningContext()` and `getScanningContext()` were performing network I/O (`CloneGitRepo`), creating temporary directories, mutating state, and registering cleanup hooks — all inside what should be a pure query function.

This PR separates identification (pure classification) from materialization (explicit cloning), fixing the Command-Query Separation violation described in #3784.

Fixes #3784

## Problem

`getScanningContext()` was designed as a classifier to identify the scan target type (`ContextCluster`, `ContextGitRemote`, `ContextDir`, etc.), but it:

1. **Violated CQS** — querying the context triggered heavy network and disk side effects.
2. **Masked errors** — if `CloneGitRepo` failed (offline, invalid token, private repo), `getScanningContext` swallowed the error and returned `ContextDir`, causing Kubescape to treat the URL as a local filesystem directory and emit confusing `"no files found in directory https://..."` errors.
3. **Executed prematurely** — early read-only checks (printer format validation, fleet scan pre-validation) triggered repository cloning before scans even initialized.
4. **Broke testability** — context classification couldn't be tested in hermetic offline unit tests without triggering network clones.

### Supporting Changes

- **`Cleanup()` is now sequentially idempotent**: hooks are consumed on first call, so `MaterializeRemoteInputs`'s rollback cleanup and the outer `defer scanInfo.Cleanup()` don't double-execute hooks.
- **Removed `cloneAdditionalRemoteInputs()`**: its split responsibility is now covered by the unified `MaterializeRemoteInputs` loop.

## Behavior Change

| Scenario | Before | After |
|:---|:---|:---|
| Invalid/private Git URL | Silently returns `ContextDir`, downstream emits `"no files found in directory https://..."` | Scan halts during Init with `failed to clone remote git repository "...": <actual git error>` |
| Printer format validation | Triggers full repository clone over the network | Pure enum check, no network I/O |
| Fleet scan pre-validation | Clones repo just to say `--kube-contexts requires a live cluster` | Pure check, no clone, no leaked `/tmp` dirs |

All existing test suites pass:
- `go test ./core/cautils/...` 
- `go test -run TestScan ./core/core` 
- `go test ./cmd/scan/...` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote Git inputs are now materialized during scan initialization instead of context detection.
  * Scans now report cloning failures and honor cancellation before remote operations begin.
  * Cleanup operations are idempotent and do not repeat completed actions.
  * Remote Git URLs are classified consistently, even when cloning is unavailable.
  * Scan context detection no longer performs unexpected remote repository operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->