### PR TITLE
fix(mcpserver): skip IaC scan tests if offline policies missing

### DIFF
--- a/cmd/mcpserver/workload_scan_test.go
+++ b/cmd/mcpserver/workload_scan_test.go
@@ -527,8 +527,12 @@ func getSharedLiveClusterPolicyGetter(t *testing.T) getter.IPolicyGetter {
 			sharedLiveClusterPolicyGetter = drp
 		}
 	})
-	if sharedLiveClusterPolicyGetterErr != nil {
-		t.Skipf("failed to initialize policy getter from network/disk fallback: %v", sharedLiveClusterPolicyGetterErr)
+	require.NoError(t, sharedLiveClusterPolicyGetterErr, "failed to initialize policy getter")
+	if _, err := sharedLiveClusterPolicyGetter.GetFramework("nsa"); err != nil {
+		t.Skipf("skipping test due to missing nsa framework: %v", err)
+	}
+	if _, err := sharedLiveClusterPolicyGetter.GetControl("C-0017"); err != nil {
+		t.Skipf("skipping test due to missing C-0017 control: %v", err)
 	}
 	if sharedLiveClusterPolicyFallback {
 		t.Log("using fallback policy store for live-cluster test")

--- a/cmd/mcpserver/workload_scan_test.go
+++ b/cmd/mcpserver/workload_scan_test.go
@@ -527,7 +527,9 @@ func getSharedLiveClusterPolicyGetter(t *testing.T) getter.IPolicyGetter {
 			sharedLiveClusterPolicyGetter = drp
 		}
 	})
-	require.NoError(t, sharedLiveClusterPolicyGetterErr, "failed to initialize policy getter from network/disk fallback")
+	if sharedLiveClusterPolicyGetterErr != nil {
+		t.Skipf("failed to initialize policy getter from network/disk fallback: %v", sharedLiveClusterPolicyGetterErr)
+	}
 	if sharedLiveClusterPolicyFallback {
 		t.Log("using fallback policy store for live-cluster test")
 	}


### PR DESCRIPTION
## Overview
Skips `mcpserver` IaC scan tests if offline policies (`nsa`, `C-0017`) are missing to prevent CI failures.

## Related issues/PRs:
* Resolved #3805

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated live-cluster policy validation tests to distinguish between fallback and required policy sources.
  - Tests now skip missing framework or control checks only when fallback policies are active.
  - When policy data is required, lookup failures now cause the test to fail instead of being skipped.
  - This improves test accuracy by identifying unexpected policy retrieval problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->