### PR TITLE
 test(mcpserver): assert rejected argument details in whitespace rejection subtests

### DIFF
--- a/cmd/mcpserver/mcpserver_unit_test.go
+++ b/cmd/mcpserver/mcpserver_unit_test.go
@@ -317,6 +317,7 @@ func TestGetConfigurationDrift_WhitespaceArgumentsRejected(t *testing.T) {
 			var toolErr ToolError
 			require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
 			assert.Equal(t, ErrCodeInvalidArgument, toolErr.Code)
+			assert.Equal(t, arg, toolErr.Details["argument"])
 		})
 	}
 }

--- a/cmd/mcpserver/network_reachability_test.go
+++ b/cmd/mcpserver/network_reachability_test.go
@@ -295,6 +295,7 @@ func TestAnalyzeNetworkReachability_WhitespaceArgumentsRejected(t *testing.T) {
 			var toolErr ToolError
 			require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &toolErr))
 			assert.Equal(t, ErrCodeInvalidArgument, toolErr.Code)
+			assert.Equal(t, arg, toolErr.Details["argument"])
 		})
 	}
 }


### PR DESCRIPTION

  ## Overview

  Strengthens the whitespace argument validation tests for the `get_configuration_drift` and `analyze_network_reachability` MCP tools.

  Previously, these subtests only verified the `INVALID_ARGUMENT` error code. Since every argument validation failure uses that code, a  test could pass even if the handler rejected a different argument.

  Each subtest now also verifies that `toolErr.Details["argument"]` matches the argument being tested. This ensures the tests cover the structured error contract and identify false-positive validation results.

  ## How to Test

  ```bash
  go test ./cmd/mcpserver -run '^(TestGetConfigurationDrift_WhitespaceArgumentsRejected|
  TestAnalyzeNetworkReachability_WhitespaceArgumentsRejected)$' -count=1
  go test ./cmd/mcpserver -count=1
  go test ./... -count=1
```
  All tests pass locally.

  ## Related issues/PRs:

  - Resolved #3780

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests
  - [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage to confirm that whitespace-only arguments identify the specific invalid argument in error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->