### PR TITLE
fix: complete V2 to V1 Control Report field mapping

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -52,10 +52,12 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 		crv1.Score = crv2.GetScore()
 		crv1.Control_ID = controlID
 
-		// TODO - add fields
-		crv1.Description = crv2.Description
-		crv1.Remediation = crv2.Remediation
+		crv1.Description = crv2.GetDescription()
+		crv1.Remediation = crv2.GetRemediation()
 
+		crv1.TotalResources = crv2.StatusCounters.PassedResources + crv2.StatusCounters.FailedResources + crv2.StatusCounters.SkippedResources + crv2.StatusCounters.ExcludedResources
+		crv1.FailedResources = crv2.StatusCounters.FailedResources
+		crv1.WarningResources = crv2.StatusCounters.SkippedResources + crv2.StatusCounters.ExcludedResources
 		rulesv1 := map[string]reporthandling.RuleReport{}
 		l := helpersv1.GetAllListsFromPool()
 		for resourceID := range crv2.ListResourcesIDs(l).All() {


### PR DESCRIPTION
Overview
This PR completes the field mapping from ControlSummary to ControlReport in core/cautils/reportv2tov1.go. It adds the missing resource counters.

Related issues/PRs:
Resolved #3811

Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Control reports now consistently display descriptions and remediation guidance.
  - Reports now accurately show evaluated resource totals, including failed, skipped, excluded, and warning counts.
  - Resource status counts are now consistently reflected in control reports across report formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->