### PR TITLE
fix(cautils): do not carry tenant identity across --kube-contexts scans

### DIFF
--- a/core/cautils/customerloader.go
+++ b/core/cautils/customerloader.go
@@ -576,11 +576,21 @@ func initializeCloudAPI(c ITenantConfig) *v1.KSCloudAPI {
 				logger.L().Warning("failed to apply KS Cloud Report URL from config", helpers.Error(err))
 			}
 		}
-		if val := c.GetAccountID(); val != "" && val != ksCloud.GetAccountID() {
+		// Identity is taken from the config as-is, empty included. The connector
+		// is a process global and --kube-contexts scans several clusters in one
+		// process, each reaching here through NewClusterConfig; guarded on
+		// non-empty like the URLs above, an unconfigured cluster kept whatever
+		// tenant the previous cluster left behind and, with --submit, reported
+		// under it (#3773). An empty account ID or access key means "not
+		// onboarded", not "same as last time". The URLs keep their guard on
+		// purpose: they name the backend rather than the tenant, and
+		// initializeSaaSEnv seeds them on the connector before any config
+		// exists — which is what the back-propagation block below relies on.
+		if val := c.GetAccountID(); val != ksCloud.GetAccountID() {
 			logger.L().Debug("updating Account ID from config", helpers.String("old", ksCloud.GetAccountID()), helpers.String("new", val))
 			ksCloud.SetAccountID(val)
 		}
-		if val := c.GetAccessKey(); val != "" && val != ksCloud.GetAccessKey() {
+		if val := c.GetAccessKey(); val != ksCloud.GetAccessKey() {
 			logger.L().Debug("updating Access Key from config", helpers.Int("old (len)", len(ksCloud.GetAccessKey())), helpers.Int("new (len)", len(val)))
 			ksCloud.SetAccessKey(val)
 		}

--- a/core/cautils/customerloader_test.go
+++ b/core/cautils/customerloader_test.go
@@ -235,6 +235,63 @@ func Test_initializeCloudAPI_backPropagatesURLsFromConnector(t *testing.T) {
 	assert.Equal(t, "https://api.example.com", cfg.configObj.CloudAPIURL)
 }
 
+// Test_initializeCloudAPI_identityFollowsEachClustersConfig guards #3773. The
+// connector is a process global, and --kube-contexts scans several clusters in
+// one process, each reaching initializeCloudAPI through NewClusterConfig. Each
+// case starts from the state the previously scanned cluster leaves behind — an
+// onboarded tenant on the connector — and asserts that the next cluster's
+// config fully determines the identity the connector ends up with. An
+// unconfigured cluster (no cached config, no in-cluster secret, no flag or env
+// var) must come out with no identity at all, not the previous tenant's; with
+// --submit that meant its report was filed under the wrong account.
+func Test_initializeCloudAPI_identityFollowsEachClustersConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		next          *ConfigObj
+		wantAccountID string
+		wantAccessKey string
+	}{
+		{
+			name:          "unconfigured cluster does not inherit the previous tenant",
+			next:          &ConfigObj{},
+			wantAccountID: "",
+			wantAccessKey: "",
+		},
+		{
+			name:          "onboarded cluster replaces the previous tenant outright",
+			next:          &ConfigObj{AccountID: "tenant-BBBB", AccessKey: "key-BBBB"},
+			wantAccountID: "tenant-BBBB",
+			wantAccessKey: "key-BBBB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := getter.GetKSCloudAPIConnector()
+			t.Cleanup(func() { getter.SetKSCloudAPIConnector(prev) })
+
+			// The previously scanned cluster was onboarded and left its tenant
+			// on the global connector.
+			previous, err := v1.NewKSCloudAPI("https://api.example.com", "https://report.example.com", "tenant-AAAA", "key-AAAA")
+			require.NoError(t, err)
+			getter.SetKSCloudAPIConnector(previous)
+
+			initializeCloudAPI(&ClusterConfig{configObj: tt.next})
+
+			got := getter.GetKSCloudAPIConnector()
+			assert.Equal(t, tt.wantAccountID, got.GetAccountID())
+			assert.Equal(t, tt.wantAccessKey, got.GetAccessKey())
+
+			// The URLs are deliberately outside this contract: they name the
+			// backend rather than the tenant, and initializeSaaSEnv seeds them
+			// on the connector before any config exists, so an empty config URL
+			// keeps the connector's rather than clearing it.
+			assert.Equal(t, "https://api.example.com", got.GetCloudAPIURL())
+			assert.Equal(t, "https://report.example.com", got.GetCloudReportURL())
+		})
+	}
+}
+
 func TestGetConfigMapNamespace(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Overview

`initializeCloudAPI` in `core/cautils/customerloader.go` updates the process-global KS Cloud connector from the tenant config of the cluster about to be scanned. Every field update was guarded on the incoming value being non-empty, so an empty account ID or access key did not reset the connector — it kept whatever the previously scanned cluster had left there.

**Current behavior:** with `--kube-contexts onboarded,unonboarded`, the second cluster's scan runs under the first cluster's account ID and access key. With `--submit` its report is filed under that tenant, and its exceptions and control inputs are fetched from that tenant's backend. Nothing in the output indicates the identity was inherited rather than configured.

**New behavior:** each cluster's config fully determines the identity on the connector. A cluster with no configured account is treated as unconfigured, not as a continuation of the cluster scanned before it.

The change is two conditions: `val != "" && val != ksCloud.GetAccountID()` → `val != ksCloud.GetAccountID()`, and the same for the access key.

## Additional Information

**Scope: identity only.** The issue notes that `CloudAPIURL` and `CloudReportURL` carry over by the same mechanism. They are deliberately left as they are. The URLs name the backend rather than the tenant, `initializeSaaSEnv` seeds them on the connector *before* any config exists, and the back-propagation block directly below the changed lines (and `Test_initializeCloudAPI_backPropagatesURLsFromConnector`) depend on that flow. Making URL assignment unconditional would break service-discovery setups. Both existing tests around that contract still pass; the new test asserts the URLs survive an empty config, so the asymmetry is pinned rather than accidental.

**Why the guard existed.** It dates from #1404 (2023), which introduced the update-in-place branch and mirrored the URL guard onto the identity fields without a stated reason. One process scanned one cluster then, so the carry-over was unreachable. `--kube-contexts` (#3438, #3440) made it reachable.

**Flows checked for reliance on the carry-over — none found:**
- `initializeSaaSEnv` (`cmd/rootutils.go`) seeds the connector with URLs and *empty* identity.
- Server mode (`httphandler`) sets identity on the connector at startup, but also passes the same account into every request's `scanInfo` → config, so the config carries it.
- `--submit` on an un-onboarded cluster generates an account and pushes it to the connector, but `GenerateAccountID` also persists it to the cached config file, which the next context's `NewClusterConfig` loads first. That flow is unchanged.

**Not in this PR.** The issue also observes that `getter.GetKSCloudAPIConnector()` never returns nil, making the `else` branch of `initializeCloudAPI` unreachable. That is a separate cleanup and is left alone to keep this diff to the reported bug.

## How to Test

The regression test reproduces the issue's own repro without a cluster: preset the global connector with cluster A's tenant, run `initializeCloudAPI` for a cluster B whose config is empty, and read the connector back.

```bash
go test ./core/cautils/ -run Test_initializeCloudAPI -v
```

Against `master`, `Test_initializeCloudAPI_identityFollowsEachClustersConfig/unconfigured_cluster_does_not_inherit_the_previous_tenant` fails with `expected: ""  actual: "tenant-AAAA"`. The companion case pins that an onboarded cluster replaces the previous tenant outright. `go test ./core/... ./cmd/... ./httphandler/...` and `golangci-lint v2.12.2` on the package both pass.

Through the CLI, with one onboarded and one un-onboarded context:

```bash
kubescape scan --kube-contexts onboarded-cluster,unonboarded-cluster --output report.json -l debug
```

Before: the second context logs no `updating Account ID from config` line and runs under the first context's account. After: it logs `updating Account ID from config old=<first tenant> new=` and runs unconfigured.

## Related issues/PRs

* Resolved #3773
* Context: #3438, #3440 (`--kube-contexts`), #1404 (origin of the guard)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cluster scans now correctly apply each cluster’s tenant identity, including clearing stale account and access key values for unconfigured clusters.
  - Configured clusters replace previously loaded tenant details instead of inheriting them.
  - Existing API and reporting URLs remain preserved while tenant identity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->