### PR TITLE
fix(printer): support combined posture and image scan output in Markdown and HTML printers

### DIFF
--- a/core/pkg/resultshandling/printer/v2/htmlprinter.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter.go
@@ -157,7 +157,8 @@ func (hp *HtmlPrinter) ActionPrint(ctx context.Context, opaSessionObj *cautils.O
 	var imageScanSummary *imageprinter.ImageScanSummary
 	if opaSessionObj != nil {
 		resourceTableView = buildResourceTableView(opaSessionObj, hp.showSecrets)
-	} else {
+	}
+	if len(imageScanData) > 0 {
 		imageScanSummary = buildImageScanSummary(imageScanData)
 	}
 

--- a/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/htmlprinter_test.go
@@ -218,3 +218,29 @@ func TestHtmlPrinter_ActionPrint_RiskScoreRounding(t *testing.T) {
 	assert.Contains(t, htmlContent, `<td class="controlRiskCell numericCell">1</td>`)
 	assert.NotContains(t, htmlContent, `<td class="controlRiskCell numericCell">0</td>`)
 }
+
+func TestHtmlPrinter_ActionPrint_CombinedPostureAndImageScan(t *testing.T) {
+	ctx := context.Background()
+	out := filepath.Join(t.TempDir(), "report.html")
+
+	hp := NewHtmlPrinter(false)
+	hp.SetWriter(ctx, out)
+
+	session := cautils.NewOPASessionObjMock()
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image: "registry.example.com/combined-html:v1",
+		},
+	}
+
+	assert.NoError(t, hp.ActionPrint(ctx, session, imageScanData))
+	assert.NoError(t, hp.CloseWriter())
+
+	content, err := os.ReadFile(out)
+	assert.NoError(t, err)
+	htmlContent := string(content)
+
+	assert.Contains(t, htmlContent, "<h1>Kubescape Scan Report</h1>")
+	assert.Contains(t, htmlContent, "<h2>Images scanned:</h2>")
+	assert.Contains(t, htmlContent, "registry.example.com/combined-html:v1")
+}

--- a/core/pkg/resultshandling/printer/v2/markdownprinter.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter.go
@@ -90,6 +90,11 @@ func (mp *MarkdownPrinter) ActionPrint(ctx context.Context, opaSessionObj *cauti
 	if err := mdWriteFailedSection(ctx, w, sorted, opaSessionObj); err != nil {
 		return err
 	}
+	if len(imageScanData) > 0 {
+		if err := mdWriteImageScanReport(w, imageScanData); err != nil {
+			return err
+		}
+	}
 
 	printer.LogOutputFile(w.Name())
 	return nil

--- a/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
+++ b/core/pkg/resultshandling/printer/v2/markdownprinter_test.go
@@ -670,3 +670,32 @@ func TestMdFixedIn(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkdownPrinter_ActionPrint_CombinedPostureAndImageScan(t *testing.T) {
+	ctx := context.Background()
+	tmp, err := os.CreateTemp("", "kubescape-md-combined-*.md")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+
+	mp := NewMarkdownPrinter()
+	mp.writer = tmp
+
+	session := mdSessionFixture()
+	imageScanData := []cautils.ImageScanData{
+		{
+			Image: "registry.example.com/combined:v1",
+		},
+	}
+
+	err = mp.ActionPrint(ctx, session, imageScanData)
+	require.NoError(t, err)
+	require.NoError(t, mp.CloseWriter())
+
+	content, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	text := string(content)
+
+	assert.Contains(t, text, "# Kubescape Security Report", "must contain posture report heading")
+	assert.Contains(t, text, "# Kubescape Image Scan Report", "must contain image scan report heading")
+	assert.Contains(t, text, "`registry.example.com/combined:v1`", "must contain scanned image name")
+}


### PR DESCRIPTION
## Overview
This PR fixes a bug in `MarkdownPrinter` and `HtmlPrinter` where container image scan results (`imageScanData`) were silently omitted whenever posture scan results (`opaSessionObj`) were present in combined scan mode.

### What was wrong?
1. In `MarkdownPrinter.ActionPrint`, `mdWriteImageScanReport` was only called if `opaSessionObj == nil`. When both posture scan results and image scan results were provided, `MarkdownPrinter` dropped the image scan section.
2. In `HtmlPrinter.ActionPrint`, `imageScanSummary = buildImageScanSummary(imageScanData)` was executed in an `else` branch of `if opaSessionObj != nil`. As a result, `imageScanSummary` was forced to `nil` whenever posture results were present, despite `report.gohtml` containing dedicated template logic (`{{ if .ImageScanSummary }}`) for image vulnerabilities.

### What changed?
- Updated `MarkdownPrinter.ActionPrint` to render `imageScanData` via `mdWriteImageScanReport` when `imageScanData` is non-empty, even when `opaSessionObj` is present.
- Updated `HtmlPrinter.ActionPrint` to build `imageScanSummary` whenever `imageScanData` is non-empty, allowing HTML reports to render both posture details and container image vulnerability sections.
- Added comprehensive unit tests in `markdownprinter_test.go` and `htmlprinter_test.go` verifying combined posture + image scan report generation.

## Additional Information
- Zero breaking changes; fully backwards compatible.
- Aligns `MarkdownPrinter` and `HtmlPrinter` with `JsonPrinter` and `YamlPrinter` multi-scan output behavior.

## How to Test
Run package unit tests:
```bash
go test -v -cover -run "TestMarkdownPrinter_ActionPrint_CombinedPostureAndImageScan|TestHtmlPrinter_ActionPrint_CombinedPostureAndImageScan" ./core/pkg/resultshandling/printer/v2
```

## Related issues/PRs:
Fixes # NONE

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

```release-note
fix(printer): support combined posture and image scan output in Markdown and HTML printers
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Combined posture and image scan reports now display together when both types of results are available.
  * HTML reports include the posture summary and an “Images scanned” section in the same output.
  * Markdown reports likewise include both report sections, including the names of scanned images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->