### PR TITLE
fix: print separator for control scans

### DIFF
--- a/core/cautils/reportv2tov1.go
+++ b/core/cautils/reportv2tov1.go
@@ -52,10 +52,12 @@ func controlReportV2ToV1(opaSessionObj *OPASessionObj, frameworkName string, con
 		crv1.Score = crv2.GetScore()
 		crv1.Control_ID = controlID
 
-		// TODO - add fields
-		crv1.Description = crv2.Description
-		crv1.Remediation = crv2.Remediation
+		crv1.Description = crv2.GetDescription()
+		crv1.Remediation = crv2.GetRemediation()
 
+		crv1.TotalResources = crv2.StatusCounters.PassedResources + crv2.StatusCounters.FailedResources + crv2.StatusCounters.SkippedResources + crv2.StatusCounters.ExcludedResources
+		crv1.FailedResources = crv2.StatusCounters.FailedResources
+		crv1.WarningResources = crv2.StatusCounters.SkippedResources + crv2.StatusCounters.ExcludedResources
 		rulesv1 := map[string]reporthandling.RuleReport{}
 		l := helpersv1.GetAllListsFromPool()
 		for resourceID := range crv2.ListResourcesIDs(l).All() {


### PR DESCRIPTION
Overview:
This PR improves the CLI's pretty printer logic for when to print separator lines for scans. It updates isPrintSeparatorType to use an explicit allowlist and removes an obsolete TODO comment.

Related issues/PRs:
* Resolved #3841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Converted reports now display control descriptions, remediation guidance, and accurate totals for resources that passed, failed, generated warnings, were skipped, or were excluded.
  * Output formatting now shows separators only for control and framework scans, preventing them from appearing for unsupported scan types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->